### PR TITLE
feat: Emit credit line lifecycle events

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -21,6 +21,18 @@ pub struct CreditLineData {
     pub status: CreditStatus,
 }
 
+/// Event emitted when a credit line lifecycle event occurs
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineEvent {
+    pub event_type: Symbol,
+    pub borrower: Address,
+    pub status: CreditStatus,
+    pub credit_limit: i128,
+    pub interest_rate_bps: u32,
+    pub risk_score: u32,
+}
+
 #[contract]
 pub struct Credit;
 
@@ -33,14 +45,39 @@ impl Credit {
     }
 
     /// Open a new credit line for a borrower (called by backend/risk engine).
+    /// Emits a CreditLineOpened event.
     pub fn open_credit_line(
-        _env: Env,
-        _borrower: Address,
-        _credit_limit: i128,
-        _interest_rate_bps: u32,
-        _risk_score: u32,
+        env: Env,
+        borrower: Address,
+        credit_limit: i128,
+        interest_rate_bps: u32,
+        risk_score: u32,
     ) -> () {
-        // TODO: persist CreditLineData keyed by borrower
+        let credit_line = CreditLineData {
+            borrower: borrower.clone(),
+            credit_limit,
+            utilized_amount: 0,
+            interest_rate_bps,
+            risk_score,
+            status: CreditStatus::Active,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&borrower, &credit_line);
+
+        // Emit CreditLineOpened event
+        env.events().publish(
+            (symbol_short!("credit"), symbol_short!("opened")),
+            CreditLineEvent {
+                event_type: symbol_short!("opened"),
+                borrower: borrower.clone(),
+                status: CreditStatus::Active,
+                credit_limit,
+                interest_rate_bps,
+                risk_score,
+            },
+        );
         ()
     }
 
@@ -69,15 +106,95 @@ impl Credit {
     }
 
     /// Suspend a credit line (admin).
-    pub fn suspend_credit_line(_env: Env, _borrower: Address) -> () {
-        // TODO: set status to Suspended
+    /// Emits a CreditLineSuspended event.
+    pub fn suspend_credit_line(env: Env, borrower: Address) -> () {
+        let mut credit_line: CreditLineData = env
+            .storage()
+            .persistent()
+            .get(&borrower)
+            .expect("Credit line not found");
+
+        credit_line.status = CreditStatus::Suspended;
+        env.storage()
+            .persistent()
+            .set(&borrower, &credit_line);
+
+        // Emit CreditLineSuspended event
+        env.events().publish(
+            (symbol_short!("credit"), symbol_short!("suspend")),
+            CreditLineEvent {
+                event_type: symbol_short!("suspend"),
+                borrower: borrower.clone(),
+                status: CreditStatus::Suspended,
+                credit_limit: credit_line.credit_limit,
+                interest_rate_bps: credit_line.interest_rate_bps,
+                risk_score: credit_line.risk_score,
+            },
+        );
         ()
     }
 
     /// Close a credit line (admin or borrower when utilized is 0).
-    pub fn close_credit_line(_env: Env, _borrower: Address) -> () {
-        // TODO: set status to Closed
+    /// Emits a CreditLineClosed event.
+    pub fn close_credit_line(env: Env, borrower: Address) -> () {
+        let mut credit_line: CreditLineData = env
+            .storage()
+            .persistent()
+            .get(&borrower)
+            .expect("Credit line not found");
+
+        credit_line.status = CreditStatus::Closed;
+        env.storage()
+            .persistent()
+            .set(&borrower, &credit_line);
+
+        // Emit CreditLineClosed event
+        env.events().publish(
+            (symbol_short!("credit"), symbol_short!("closed")),
+            CreditLineEvent {
+                event_type: symbol_short!("closed"),
+                borrower: borrower.clone(),
+                status: CreditStatus::Closed,
+                credit_limit: credit_line.credit_limit,
+                interest_rate_bps: credit_line.interest_rate_bps,
+                risk_score: credit_line.risk_score,
+            },
+        );
         ()
+    }
+
+    /// Mark a credit line as defaulted (admin).
+    /// Emits a CreditLineDefaulted event.
+    pub fn default_credit_line(env: Env, borrower: Address) -> () {
+        let mut credit_line: CreditLineData = env
+            .storage()
+            .persistent()
+            .get(&borrower)
+            .expect("Credit line not found");
+
+        credit_line.status = CreditStatus::Defaulted;
+        env.storage()
+            .persistent()
+            .set(&borrower, &credit_line);
+
+        // Emit CreditLineDefaulted event
+        env.events().publish(
+            (symbol_short!("credit"), symbol_short!("default")),
+            CreditLineEvent {
+                event_type: symbol_short!("default"),
+                borrower: borrower.clone(),
+                status: CreditStatus::Defaulted,
+                credit_limit: credit_line.credit_limit,
+                interest_rate_bps: credit_line.interest_rate_bps,
+                risk_score: credit_line.risk_score,
+            },
+        );
+        ()
+    }
+
+    /// Get credit line data for a borrower (view function).
+    pub fn get_credit_line(env: Env, borrower: Address) -> Option<CreditLineData> {
+        env.storage().persistent().get(&borrower)
     }
 }
 
@@ -89,6 +206,8 @@ mod test {
     #[test]
     fn test_init_and_open_credit_line() {
         let env = Env::default();
+        env.mock_all_auths();
+        
         let admin = Address::generate(&env);
         let borrower = Address::generate(&env);
 
@@ -97,6 +216,222 @@ mod test {
 
         client.init(&admin);
         client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-        // Placeholder: no panic means stubs work
+
+        // Verify credit line was created
+        let credit_line = client.get_credit_line(&borrower);
+        assert!(credit_line.is_some());
+        let credit_line = credit_line.unwrap();
+        assert_eq!(credit_line.borrower, borrower);
+        assert_eq!(credit_line.credit_limit, 1000);
+        assert_eq!(credit_line.utilized_amount, 0);
+        assert_eq!(credit_line.interest_rate_bps, 300);
+        assert_eq!(credit_line.risk_score, 70);
+        assert_eq!(credit_line.status, CreditStatus::Active);
+    }
+
+    #[test]
+    fn test_suspend_credit_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.suspend_credit_line(&borrower);
+
+        // Verify status changed to Suspended
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.status, CreditStatus::Suspended);
+    }
+
+    #[test]
+    fn test_close_credit_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.close_credit_line(&borrower);
+
+        // Verify status changed to Closed
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.status, CreditStatus::Closed);
+    }
+
+    #[test]
+    fn test_default_credit_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.default_credit_line(&borrower);
+
+        // Verify status changed to Defaulted
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.status, CreditStatus::Defaulted);
+    }
+
+    #[test]
+    fn test_full_lifecycle() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+
+        // Open credit line
+        client.open_credit_line(&borrower, &5000_i128, &500_u32, &80_u32);
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.status, CreditStatus::Active);
+
+        // Suspend credit line
+        client.suspend_credit_line(&borrower);
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.status, CreditStatus::Suspended);
+
+        // Close credit line
+        client.close_credit_line(&borrower);
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.status, CreditStatus::Closed);
+    }
+
+    #[test]
+    fn test_event_data_integrity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &2000_i128, &400_u32, &75_u32);
+
+        // Verify credit line data matches what was passed
+        let credit_line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line.borrower, borrower);
+        assert_eq!(credit_line.status, CreditStatus::Active);
+        assert_eq!(credit_line.credit_limit, 2000);
+        assert_eq!(credit_line.interest_rate_bps, 400);
+        assert_eq!(credit_line.risk_score, 75);
+    }
+
+    #[test]
+    #[should_panic(expected = "Credit line not found")]
+    fn test_suspend_nonexistent_credit_line() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.suspend_credit_line(&borrower);
+    }
+
+    #[test]
+    #[should_panic(expected = "Credit line not found")]
+    fn test_close_nonexistent_credit_line() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.close_credit_line(&borrower);
+    }
+
+    #[test]
+    #[should_panic(expected = "Credit line not found")]
+    fn test_default_nonexistent_credit_line() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.default_credit_line(&borrower);
+    }
+
+    #[test]
+    fn test_multiple_borrowers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower1 = Address::generate(&env);
+        let borrower2 = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower1, &1000_i128, &300_u32, &70_u32);
+        client.open_credit_line(&borrower2, &2000_i128, &400_u32, &80_u32);
+
+        let credit_line1 = client.get_credit_line(&borrower1).unwrap();
+        let credit_line2 = client.get_credit_line(&borrower2).unwrap();
+
+        assert_eq!(credit_line1.credit_limit, 1000);
+        assert_eq!(credit_line2.credit_limit, 2000);
+        assert_eq!(credit_line1.status, CreditStatus::Active);
+        assert_eq!(credit_line2.status, CreditStatus::Active);
+    }
+
+    #[test]
+    fn test_lifecycle_transitions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+
+        // Test Active -> Defaulted
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().status,
+            CreditStatus::Active
+        );
+
+        client.default_credit_line(&borrower);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().status,
+            CreditStatus::Defaulted
+        );
     }
 }


### PR DESCRIPTION
This pr implement Soroban events when a credit line is opened, suspended, closed, or marked 

closes: #15 