### PR TITLE
test: token transfer on draw_credit

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -565,8 +565,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 500, 1_000);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 500, 1_000);
         client.draw_credit(&borrower, &600);
     }
 
@@ -576,8 +575,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 500, 1_000);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 500, 1_000);
         client.draw_credit(&borrower, &400);
         client.draw_credit(&borrower, &200);
     }
@@ -662,8 +660,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.open_credit_line(&borrower, &2_000, &400_u32, &60_u32);
     }
 
@@ -730,8 +727,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         let line = client.get_credit_line(&borrower).unwrap();
         assert_eq!(line.borrower, borrower);
         assert_eq!(line.credit_limit, 1_000);
@@ -746,8 +742,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.suspend_credit_line(&borrower);
         assert_eq!(
             client.get_credit_line(&borrower).unwrap().status,
@@ -760,8 +755,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.close_credit_line(&borrower, &admin);
         assert_eq!(
             client.get_credit_line(&borrower).unwrap().status,
@@ -774,8 +768,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.default_credit_line(&borrower);
         assert_eq!(
             client.get_credit_line(&borrower).unwrap().status,
@@ -811,8 +804,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.close_credit_line(&borrower, &borrower);
         let line = client.get_credit_line(&borrower).unwrap();
         assert_eq!(line.status, CreditStatus::Closed);
@@ -850,8 +842,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.close_credit_line(&borrower, &admin);
         client.close_credit_line(&borrower, &admin);
         assert_eq!(
@@ -867,8 +858,7 @@ mod test {
         env.mock_all_auths();
         let borrower = Address::generate(&env);
         let other = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.close_credit_line(&borrower, &other);
     }
 
@@ -921,8 +911,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.update_risk_parameters(&borrower, &2_000, &400_u32, &85_u32);
         let line = client.get_credit_line(&borrower).unwrap();
         assert_eq!(line.credit_limit, 2_000);
@@ -976,8 +965,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.update_risk_parameters(&borrower, &-1, &300_u32, &70_u32);
     }
 
@@ -987,8 +975,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.update_risk_parameters(&borrower, &1_000, &10_001_u32, &70_u32);
     }
 
@@ -998,8 +985,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.update_risk_parameters(&borrower, &1_000, &300_u32, &101_u32);
     }
 
@@ -1008,8 +994,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.update_risk_parameters(&borrower, &1_000, &10_000_u32, &100_u32);
         let line = client.get_credit_line(&borrower).unwrap();
         assert_eq!(line.interest_rate_bps, 10_000);
@@ -1054,8 +1039,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.repay_credit(&borrower, &0);
     }
 
@@ -1079,8 +1063,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.close_credit_line(&borrower, &admin);
         client.repay_credit(&borrower, &100);
     }
@@ -1157,8 +1140,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         let _ = client;
         let events = env.events().all();
         let (_contract, topics, data) = events.last().unwrap();
@@ -1178,8 +1160,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.suspend_credit_line(&borrower);
         let events = env.events().all();
         let (_contract, topics, data) = events.last().unwrap();
@@ -1198,8 +1179,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.close_credit_line(&borrower, &admin);
         let events = env.events().all();
         let (_contract, topics, data) = events.last().unwrap();
@@ -1218,8 +1198,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, _admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, _admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         client.default_credit_line(&borrower);
         let events = env.events().all();
         let (_contract, topics, data) = events.last().unwrap();
@@ -1238,8 +1217,7 @@ mod test {
         let env = Env::default();
         env.mock_all_auths();
         let borrower = Address::generate(&env);
-        let (client, _token, admin) =
-            setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
+        let (client, _token, admin) = setup_contract_with_credit_line(&env, &borrower, 1_000, 0);
         let open_data: CreditLineEvent = env
             .events()
             .all()
@@ -1261,11 +1239,8 @@ mod test {
             .unwrap();
         assert_eq!(suspend_data.status, CreditStatus::Suspended);
         assert_eq!(
-            Symbol::try_from_val(
-                &env,
-                &env.events().all().last().unwrap().1.get(1).unwrap()
-            )
-            .unwrap(),
+            Symbol::try_from_val(&env, &env.events().all().last().unwrap().1.get(1).unwrap())
+                .unwrap(),
             symbol_short!("suspend")
         );
 


### PR DESCRIPTION
---

**test: token transfer on draw_credit**

Closes #39

Implements `draw_credit` (previously a stub) and adds a full test suite verifying that the correct amount of the protocol token is transferred from the contract's reserve to the borrower's address on each draw.

---

## Changes

### contracts/credit/src/lib.rs

**init() updated**
Accepts a `token: Address` parameter so the contract knows which token to transfer. Stored in instance storage on initialization.

**draw_credit implemented**
Requires borrower authorization via `require_auth()`. Validates the amount is positive, confirms the credit line exists and is Active, uses `checked_add` to prevent overflow when accumulating `utilized_amount`, and enforces the credit limit before any state change. Follows checks-effects-interactions — storage is updated before the token transfer. Transfers the token via `token::Client::transfer` from the contract to the borrower, then emits a `credit/draw` event with the borrower, amount, and new utilized total.

**Test helpers added**
`setup_token()` registers a Soroban test SAC and optionally mints a reserve to the contract. `setup_contract_with_credit_line()` handles full fixture setup in one call.

---

## Tests

Test — What it verifies

test_draw_transfers_correct_amount_to_borrower — Borrower balance increases by exact draw amount

test_draw_reduces_contract_reserve — Contract reserve decreases by exact draw amount

test_draw_updates_utilized_amount — utilized_amount in storage reflects the draw

test_draw_accumulates_across_multiple_draws — Sequential draws accumulate correctly

test_draw_exact_credit_limit — Drawing 100% of limit succeeds

test_draw_requires_borrower_auth — Borrower auth is recorded and required

test_draw_exceeds_credit_limit — Panics with "Exceeds credit limit"

test_draw_cumulative_exceeds_limit — Second draw over limit panics

test_draw_on_suspended_line_fails — Panics with "Credit line not active"

test_draw_on_closed_line_fails — Panics with "Credit line not active"

test_draw_on_defaulted_line_fails — Panics with "Credit line not active"

test_draw_zero_amount_fails — Panics with "Invalid amount"

test_draw_negative_amount_fails — Panics with "Invalid amount"

test_draw_no_credit_line_fails — Panics with "Credit line not found"

All pre-existing lifecycle tests updated to match the new init() signature and pass.

---

## Test output

running 23 tests ... ok
test result: ok. 23 passed; 0 failed

---


## Proof

<img width="1136" height="880" alt="Screenshot 2026-02-23 at 09 49 06" src="https://github.com/user-attachments/assets/d4feb057-c3d0-4432-b8c7-6be49085e59e" />


---

## Notes

draw_credit was a stub with no logic, so implementing it was a prerequisite for writing meaningful token transfer tests. The implementation is minimal and scoped to what the tests require — repay, risk parameter updates, and admin auth enforcement remain as TODOs for follow-up issues.