### PR TITLE
Add auction refund balance conservation invariant test

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -3,6 +3,7 @@ mod tests {
     use super::super::*;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
     use soroban_sdk::{Env, Symbol, TryFromVal, TryIntoVal};
 
     #[test]
@@ -123,5 +124,94 @@ mod tests {
             assert_eq!(s.bidder, bidder);
             assert_eq!(s.amount, amount);
         }
+    }
+
+    #[test]
+    fn auction_refund_balance_conservation_invariant() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let carol = Address::generate(&env);
+
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin);
+        let bid_token = token_id.address();
+
+        env.as_contract(&contract_id, || {
+            env.storage().instance().set(&Symbol::new(&env, "bid_token"), &bid_token);
+        });
+
+        let sac = StellarAssetClient::new(&env, &bid_token);
+        let token_client = TokenClient::new(&env, &bid_token);
+
+        let initial_contract_balance = 1_000_i128;
+        let initial_bidder_balance = 500_i128;
+        sac.mint(&contract_id, &initial_contract_balance);
+        sac.mint(&alice, &initial_bidder_balance);
+        sac.mint(&bob, &initial_bidder_balance);
+        sac.mint(&carol, &initial_bidder_balance);
+
+        let bidders = [alice.clone(), bob.clone(), carol.clone()];
+        let total_initial_balance = token_client.balance(&contract_id)
+            + token_client.balance(&alice)
+            + token_client.balance(&bob)
+            + token_client.balance(&carol);
+
+        let auction_id = Symbol::new(&env, "invariant_auc");
+        let bids = [
+            (&alice, 100_i128),
+            (&bob, 200_i128),
+            (&carol, 400_i128),
+            (&alice, 500_i128),
+        ];
+
+        let mut previous_bid: Option<(Address, i128)> = None;
+        let mut total_refunded = 0_i128;
+
+        for (bidder, amount) in bids {
+            client.place_bid(&auction_id, bidder, &amount);
+
+            let total_balance = token_client.balance(&contract_id)
+                + token_client.balance(&alice)
+                + token_client.balance(&bob)
+                + token_client.balance(&carol);
+            assert_eq!(total_balance, total_initial_balance, "total token balance should be conserved after bid");
+
+            if let Some((prev_bidder, prev_amount)) = previous_bid.clone() {
+                total_refunded += prev_amount;
+                assert_eq!(token_client.balance(&contract_id), initial_contract_balance - total_refunded);
+
+                let mut found = false;
+                for (_contract, topics, data) in env.events().all().iter().rev() {
+                    let t0: Symbol = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+                    if t0 == Symbol::new(&env, "BID_RFDN") {
+                        let evt: events::BidRefundedEvent = data.try_into_val(&env).unwrap();
+                        assert_eq!(evt.prev_bidder, prev_bidder);
+                        assert_eq!(evt.amount, prev_amount);
+                        assert!(evt.amount <= prev_amount, "refund amount must not exceed previous bid");
+                        found = true;
+                        break;
+                    }
+                }
+                assert!(found, "expected BID_RFDN event after outbid");
+            }
+
+            previous_bid = Some((bidder.clone(), amount));
+        }
+
+        // Post-suite invariants: refunds never exceed all prior bids and final highest bid remains with no unexpected outflow.
+        let total_bid_amounts: i128 = bids.iter().map(|(_, amt)| *amt).sum();
+        assert!(total_refunded <= total_bid_amounts, "total refunded must not exceed total bids");
+        assert!(token_client.balance(&contract_id) >= 0, "contract balance should never go negative");
+        assert_eq!(token_client.balance(&contract_id), initial_contract_balance - total_refunded);
+        assert_eq!(token_client.balance(&alice)
+            + token_client.balance(&bob)
+            + token_client.balance(&carol)
+            + token_client.balance(&contract_id), total_initial_balance);
     }
 }


### PR DESCRIPTION
Closes #275 

Description

Add invariant coverage for the auction refund flow in test.rs.

- Introduces `auction_refund_balance_conservation_invariant`
- Validates total token balance conservation across contract + bidders
- Confirms refund events emit correct previous bidder and amount
- Ensures refunds never exceed prior bid amounts
- Verifies contract balance remains consistent after bid/outbid sequences