### PR TITLE
feat(credit): per-borrower utilization ratio cap

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -18,13 +18,6 @@ mod query;
 mod risk;
 mod storage;
 pub mod types;
-mod auth;
-mod storage;
-mod borrow;
-mod config;
-mod lifecycle;
-mod risk;
-mod query;
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol,
@@ -146,6 +139,7 @@ impl Credit {
             last_rate_update_ts: 0,
             accrued_interest: 0,
             last_accrual_ts: 0,
+            max_utilization_ratio_bps: 10000, // 100%
         };
 
         env.storage().persistent().set(&borrower, &credit_line);
@@ -237,9 +231,23 @@ impl Credit {
                 env.panic_with_error(ContractError::Overflow)
             });
 
-        if updated_utilized > credit_line.credit_limit {
+        // Calculate max allowed utilization based on ratio
+        let max_allowed = credit_line
+            .credit_limit
+            .checked_mul(credit_line.max_utilization_ratio_bps as i128)
+            .unwrap_or_else(|| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::Overflow)
+            })
+            .checked_div(10000)
+            .unwrap_or_else(|| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::Overflow)
+            });
+
+        if updated_utilized > max_allowed {
             clear_reentrancy_guard(&env);
-            panic!("exceeds credit limit");
+            panic!("exceeds max utilization ratio");
         }
 
         if let Some(token_address) = token_address {

--- a/contracts/credit/src/risk.rs
+++ b/contracts/credit/src/risk.rs
@@ -10,6 +10,16 @@ pub const MAX_INTEREST_RATE_BPS: u32 = 10_000;
 /// Maximum risk score (0–100 scale).
 pub const MAX_RISK_SCORE: u32 = 100;
 
+/// Calculate max utilization ratio based on risk score.
+/// High risk (>=80) gets 80%, others 100%.
+pub fn calculate_max_utilization_ratio(risk_score: u32) -> u32 {
+    if risk_score >= 80 {
+        8000 // 80%
+    } else {
+        10000 // 100%
+    }
+}
+
 pub fn update_risk_parameters(
     env: Env,
     borrower: Address,
@@ -66,6 +76,7 @@ pub fn update_risk_parameters(
     credit_line.credit_limit = credit_limit;
     credit_line.interest_rate_bps = interest_rate_bps;
     credit_line.risk_score = risk_score;
+    credit_line.max_utilization_ratio_bps = calculate_max_utilization_ratio(risk_score);
     env.storage().persistent().set(&borrower, &credit_line);
 
     publish_risk_parameters_updated(

--- a/contracts/credit/src/test.rs
+++ b/contracts/credit/src/test.rs
@@ -1719,3 +1719,114 @@ use soroban_sdk::{Address, Env};
         assert_eq!(liquidity.balance(&borrower), 550_i128);
         assert_eq!(liquidity.allowance(&borrower, &contract_id), 200_i128);
     }
+
+    // --- Utilization ratio cap tests ---
+
+    #[test]
+    fn test_draw_credit_respects_default_100_percent_utilization_ratio() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32); // risk 70 < 80, ratio 100%
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.max_utilization_ratio_bps, 10000);
+
+        client.draw_credit(&borrower, &1000_i128); // should succeed
+
+        assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, 1000);
+    }
+
+    #[test]
+    fn test_draw_credit_respects_80_percent_utilization_ratio_for_high_risk() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &85_u32); // risk 85 >= 80, ratio 80%
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.max_utilization_ratio_bps, 8000);
+
+        client.draw_credit(&borrower, &800_i128); // 80% of 1000, should succeed
+
+        assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, 800);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds max utilization ratio")]
+    fn test_draw_credit_rejects_exceeding_80_percent_utilization_ratio() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &85_u32); // risk 85, ratio 80%
+
+        client.draw_credit(&borrower, &801_i128); // exceeds 80%, should fail
+    }
+
+    #[test]
+    fn test_draw_credit_allows_exact_80_percent_utilization_ratio() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &85_u32); // risk 85, ratio 80%
+
+        client.draw_credit(&borrower, &800_i128); // exact 80%, should succeed
+
+        assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, 800);
+    }
+
+    #[test]
+    fn test_update_risk_parameters_updates_utilization_ratio() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32); // starts with 100%
+
+        client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &85_u32); // to 80%
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.max_utilization_ratio_bps, 8000);
+
+        client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &60_u32); // back to 100%
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.max_utilization_ratio_bps, 10000);
+    }

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -79,6 +79,10 @@ pub struct CreditLineData {
     /// Ledger timestamp of the last interest accrual calculation.
     /// Zero means no accrual has been calculated yet.
     pub last_accrual_ts: u64,
+    /// Maximum utilization ratio in basis points (1 bp = 0.01%).
+    /// Limits utilization to this percentage of credit_limit.
+    /// Default is 10000 (100%).
+    pub max_utilization_ratio_bps: u32,
 }
 
 /// Admin-configurable limits on interest-rate changes.

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -25,6 +25,7 @@ Stored in persistent storage keyed by the borrower's address.
 | `last_rate_update_ts`| `u64`    | Ledger timestamp of the last interest-rate change (0 = never updated) |
 | `accrued_interest`   | `i128`   | Cumulative capitalized interest recorded on the line |
 | `last_accrual_ts`    | `u64`    | Ledger timestamp of the last interest accrual checkpoint (0 = never accrued) |
+| `max_utilization_ratio_bps` | `u32` | Maximum utilization ratio in basis points (e.g. 8000 = 80%) |
 
 ### `RateChangeConfig`
 Stored in instance storage under the `"rate_cfg"` key. Optional — when absent, no rate-change limits are enforced.
@@ -57,6 +58,21 @@ Stored in instance storage under the `"rate_cfg"` key. Optional — when absent,
 | Suspended  | Closed     | Admin or borrower (when `utilized_amount == 0`) calls `close_credit_line` |
 
 When status is **Defaulted**: `draw_credit` is disabled; `repay_credit` is still allowed.
+
+### Utilization Ratio Cap
+
+Each credit line has a `max_utilization_ratio_bps` field that caps utilization at a percentage of the `credit_limit`. This provides an additional layer of risk control beyond the nominal limit.
+
+- **Default**: 10000 bps (100%) for new credit lines.
+- **Tiered by Risk Score**:
+  - Risk score < 80: 100% utilization allowed.
+  - Risk score ≥ 80: 80% utilization allowed.
+- **Enforcement**: In `draw_credit`, the effective limit is `min(credit_limit, (credit_limit * max_utilization_ratio_bps) / 10000)`.
+- **Updates**: `max_utilization_ratio_bps` is recalculated whenever `risk_score` changes via `update_risk_parameters`.
+
+**Example**:
+- Borrower with `credit_limit = 1000` and `risk_score = 85` can draw up to 800 (80%).
+- If `risk_score` is updated to 70, they can then draw up to the full 1000.
 
 ---
 


### PR DESCRIPTION
Close #268 

## PR Description

### Summary
This PR implements a per-borrower max utilization ratio cap for the Creditra credit contract. The feature adds an additional layer of risk control by limiting utilization to a percentage of the credit limit, tiered by borrower risk score.

### Changes
- **Data Model**: Added `max_utilization_ratio_bps` field to `CreditLineData` struct, defaulting to 10000 (100%).
- **Initialization**: New credit lines initialize with 100% utilization ratio.
- **Risk-Based Tiers**: 
  - Risk score < 80: 100% utilization allowed
  - Risk score ≥ 80: 80% utilization allowed
- **Enforcement**: `draw_credit` now checks against the effective limit: `min(credit_limit, (credit_limit * ratio) / 10000)`.
- **Updates**: Ratio recalculates automatically when `risk_score` changes via `update_risk_parameters`.
- **Tests**: Added comprehensive tests for boundary conditions, ratio enforcement, and configuration changes.
- **Documentation**: Updated credit.md with data model changes and utilization ratio cap section.

### Security
- Uses checked arithmetic to prevent overflow.
- Maintains existing reentrancy guards and authorization checks.
- Backward compatible: existing credit lines unaffected.

### Testing
Run the following to verify:
```bash
cargo test -p creditra-credit
cargo llvm-cov --workspace --all-targets --fail-under-lines 95
```

New tests cover:
- Default 100% ratio for low-risk borrowers
- 80% cap for high-risk borrowers
- Rejection when exceeding ratio
- Ratio updates on risk parameter changes

### Files Changed
- types.rs: Added `max_utilization_ratio_bps` to `CreditLineData`
- lib.rs: Updated `open_credit_line` and `draw_credit`
- risk.rs: Added ratio calculation logic
- test.rs: Added utilization ratio tests
- credit.md: Updated data model and added feature documentation

