### PR TITLE
test(credit): add repay_credit rollback coverage for insufficient all…

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -503,6 +503,7 @@ mod test {
     use soroban_sdk::token::StellarAssetClient;
     use soroban_sdk::Symbol;
     use soroban_sdk::{TryFromVal, TryIntoVal};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     fn setup<'a>(
         env: &'a Env,
@@ -867,6 +868,67 @@ mod test {
         approve(&env, &token, &borrower, &contract_id, 200);
 
         client.repay_credit(&borrower, &200);
+    }
+
+    #[test]
+    fn repay_insufficient_allowance_does_not_change_credit_line_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 200);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &200);
+        approve(&env, &token, &borrower, &contract_id, 50);
+
+        let credit_line_before = client.get_credit_line(&borrower).unwrap();
+        let token_client = token::Client::new(&env, &token);
+        let balance_before = token_client.balance(&borrower);
+        let allowance_before = token_client.allowance(&borrower, &contract_id);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            client.repay_credit(&borrower, &200);
+        }));
+
+        assert!(result.is_err(), "expected repay_credit to panic on insufficient allowance");
+
+        let credit_line_after = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line_after.utilized_amount, credit_line_before.utilized_amount);
+        assert_eq!(credit_line_after.accrued_interest, credit_line_before.accrued_interest);
+        assert_eq!(credit_line_after.last_accrual_ts, credit_line_before.last_accrual_ts);
+
+        assert_eq!(token_client.balance(&borrower), balance_before);
+        assert_eq!(token_client.allowance(&borrower, &contract_id), allowance_before);
+    }
+
+    #[test]
+    fn repay_insufficient_balance_does_not_change_credit_line_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 200);
+
+        let token_client = token::Client::new(&env, &token);
+        let other = Address::generate(&env);
+        token_client.transfer(&borrower, &other, &150);
+        approve(&env, &token, &borrower, &contract_id, 200);
+
+        let credit_line_before = client.get_credit_line(&borrower).unwrap();
+        let balance_before = token_client.balance(&borrower);
+        let allowance_before = token_client.allowance(&borrower, &contract_id);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            client.repay_credit(&borrower, &200);
+        }));
+
+        assert!(result.is_err(), "expected repay_credit to panic on insufficient balance");
+
+        let credit_line_after = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line_after.utilized_amount, credit_line_before.utilized_amount);
+        assert_eq!(credit_line_after.accrued_interest, credit_line_before.accrued_interest);
+        assert_eq!(credit_line_after.last_accrual_ts, credit_line_before.last_accrual_ts);
+
+        assert_eq!(token_client.balance(&borrower), balance_before);
+        assert_eq!(token_client.allowance(&borrower, &contract_id), allowance_before);
     }
 
     // ── 10. RepaymentEvent schema ─────────────────────────────────────────────

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -135,6 +135,7 @@ Repay outstanding drawn funds.
 - The borrower must have approved the contract to pull tokens via `transfer_from`.
 - Effective repayment = `min(amount, utilized_amount)` (over-payments are safe).
 - Tokens are transferred **before** state is updated. If the transfer fails, the call reverts with no state change.
+- Repayment failures due to insufficient allowance or balance do not alter `utilized_amount`, `accrued_interest`, or the credit line record.
 - Works even when no liquidity token is configured (state-only update).
 
 Emits: `("credit", "repay")` event with `RepaymentEvent` payload containing the effective amount transferred and new `utilized_amount`.


### PR DESCRIPTION
Close #253 

## PR Description

**Summary**

- Added explicit negative tests for `repay_credit` in lib.rs covering:
  - insufficient token allowance
  - insufficient borrower token balance
- Verified rollback semantics by asserting:
  - `utilized_amount`, `accrued_interest`, and `last_accrual_ts` remain unchanged
  - borrower token balance and allowance remain unchanged
- Documented the expected behavior in credit.md:
  - repayment failures due to insufficient allowance or balance do not alter the credit line record

**Files Changed**

- lib.rs
- credit.md

**Testing**

Run:
```bash
cargo test -p creditra-credit repay_insufficient_allowance_does_not_change_credit_line_state repay_insufficient_balance_does_not_change_credit_line_state -- --nocapture
```

Or run the full package suite:
```bash
cargo test -p creditra-credit
```
