### PR TITLE
feat(credit): borrower self-suspend with tests and docs

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -40,7 +40,7 @@ use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env};
 
 /// Contract API version (major, minor, patch).
 /// Increment major on breaking ABI/storage changes, minor on additive features, patch on fixes.
-pub const CONTRACT_API_VERSION: (u32, u32, u32) = (1, 0, 0);
+pub const CONTRACT_API_VERSION: (u32, u32, u32) = (1, 1, 0);
 
 /// Seconds in a standard year (365 days).
 #[allow(dead_code)]
@@ -561,6 +561,11 @@ impl Credit {
 
     pub fn suspend_credit_line(env: Env, borrower: Address) {
         lifecycle::suspend_credit_line(env, borrower)
+    }
+
+    /// Allow a borrower to suspend their own active line as a safety control.
+    pub fn self_suspend_credit_line(env: Env, borrower: Address) {
+        lifecycle::self_suspend_credit_line(env, borrower)
     }
 
     /// Permanently close a credit line.

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -1,15 +1,115 @@
 use crate::auth::{require_admin, require_admin_auth};
 use crate::events::{publish_credit_line_event, CreditLineEvent};
+use crate::risk::{MAX_INTEREST_RATE_BPS, MAX_RISK_SCORE};
 use crate::storage::assert_not_paused;
-use crate::types::{CreditLineData, CreditStatus};
+use crate::types::{ContractError, CreditLineData, CreditStatus};
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
-fn liquidation_settlement_key(borrower: &Address, settlement_id: &Symbol) -> (Symbol, Address, Symbol) {
+fn liquidation_settlement_key(
+    borrower: &Address,
+    settlement_id: &Symbol,
+) -> (Symbol, Address, Symbol) {
     (
         symbol_short!("liq_seen"),
         borrower.clone(),
         settlement_id.clone(),
     )
+}
+
+fn suspend_credit_line_internal(env: &Env, borrower: Address) {
+    let mut credit_line: CreditLineData = env
+        .storage()
+        .persistent()
+        .get(&borrower)
+        .expect("Credit line not found");
+
+    // Apply interest accrual before any mutation.
+    credit_line = crate::accrual::apply_accrual(env, credit_line);
+
+    if credit_line.status != CreditStatus::Active {
+        panic!("Only active credit lines can be suspended");
+    }
+
+    credit_line.status = CreditStatus::Suspended;
+    credit_line.suspension_ts = env.ledger().timestamp();
+    env.storage().persistent().set(&borrower, &credit_line);
+
+    publish_credit_line_event(
+        env,
+        (symbol_short!("credit"), symbol_short!("suspend")),
+        CreditLineEvent {
+            event_type: symbol_short!("suspend"),
+            borrower,
+            status: CreditStatus::Suspended,
+            credit_limit: credit_line.credit_limit,
+            interest_rate_bps: credit_line.interest_rate_bps,
+            risk_score: credit_line.risk_score,
+        },
+    );
+}
+
+/// Open a new credit line.
+///
+/// Creating a brand-new line preserves the existing backend/risk-engine trust
+/// boundary. Re-opening any existing non-Active line requires admin auth so a
+/// borrower cannot self-suspend and then reactivate themselves on-chain.
+pub fn open_credit_line(
+    env: Env,
+    borrower: Address,
+    credit_limit: i128,
+    interest_rate_bps: u32,
+    risk_score: u32,
+) {
+    assert_not_paused(&env);
+
+    assert!(credit_limit > 0, "credit_limit must be greater than zero");
+    if interest_rate_bps > MAX_INTEREST_RATE_BPS {
+        env.panic_with_error(ContractError::RateTooHigh);
+    }
+    if risk_score > MAX_RISK_SCORE {
+        env.panic_with_error(ContractError::ScoreTooHigh);
+    }
+
+    if let Some(existing) = env
+        .storage()
+        .persistent()
+        .get::<Address, CreditLineData>(&borrower)
+    {
+        assert!(
+            existing.status != CreditStatus::Active,
+            "borrower already has an active credit line"
+        );
+
+        // Prevent borrower-controlled status bypasses on existing lines.
+        require_admin_auth(&env);
+    }
+
+    let credit_line = CreditLineData {
+        borrower: borrower.clone(),
+        credit_limit,
+        utilized_amount: 0,
+        interest_rate_bps,
+        risk_score,
+        status: CreditStatus::Active,
+        last_rate_update_ts: 0,
+        accrued_interest: 0,
+        last_accrual_ts: env.ledger().timestamp(),
+        suspension_ts: 0,
+    };
+    env.storage().persistent().set(&borrower, &credit_line);
+
+    publish_credit_line_event(
+        &env,
+        (symbol_short!("credit"), symbol_short!("opened")),
+        CreditLineEvent {
+            event_type: symbol_short!("opened"),
+            borrower,
+            status: CreditStatus::Active,
+            credit_limit,
+            interest_rate_bps,
+            risk_score,
+        },
+    );
 }
 
 /// Suspend a credit line temporarily.
@@ -29,35 +129,18 @@ fn liquidation_settlement_key(borrower: &Address, settlement_id: &Symbol) -> (Sy
 pub fn suspend_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
     require_admin_auth(&env);
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .expect("Credit line not found");
+    suspend_credit_line_internal(&env, borrower);
+}
 
-    // Apply interest accrual before any mutation
-    credit_line = crate::accrual::apply_accrual(&env, credit_line);
-
-    if credit_line.status != CreditStatus::Active {
-        panic!("Only active credit lines can be suspended");
-    }
-
-    credit_line.status = CreditStatus::Suspended;
-    credit_line.suspension_ts = env.ledger().timestamp();
-    env.storage().persistent().set(&borrower, &credit_line);
-
-    publish_credit_line_event(
-        &env,
-        (symbol_short!("credit"), symbol_short!("suspend")),
-        CreditLineEvent {
-            event_type: symbol_short!("suspend"),
-            borrower: borrower.clone(),
-            status: CreditStatus::Suspended,
-            credit_limit: credit_line.credit_limit,
-            interest_rate_bps: credit_line.interest_rate_bps,
-            risk_score: credit_line.risk_score,
-        },
-    );
+/// Suspend the caller's own active credit line.
+///
+/// This is a borrower safety control that blocks future draws while leaving
+/// repayments available. Reactivation still requires a separate admin-controlled
+/// workflow.
+pub fn self_suspend_credit_line(env: Env, borrower: Address) {
+    assert_not_paused(&env);
+    borrower.require_auth();
+    suspend_credit_line_internal(&env, borrower);
 }
 
 /// Close a credit line. Callable by admin (force-close) or by borrower when utilization is zero.

--- a/contracts/credit/tests/borrower_self_suspend.rs
+++ b/contracts/credit/tests/borrower_self_suspend.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+use creditra_credit::types::CreditStatus;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::{Address, Env, IntoVal};
+
+fn setup_active_line() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &50_u32);
+
+    (env, admin, borrower, contract_id)
+}
+
+#[test]
+fn self_suspend_requires_only_borrower_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &50_u32);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &borrower,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "self_suspend_credit_line",
+                args: (&borrower,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .self_suspend_credit_line(&borrower);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1, "self-suspend should require exactly one auth");
+    assert_eq!(auths[0].0, borrower, "borrower auth must be required");
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Suspended);
+}
+
+#[test]
+fn self_suspend_blocks_draws_but_allows_repayments() {
+    let (env, _admin, borrower, contract_id) = setup_active_line();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.draw_credit(&borrower, &600_i128);
+    client.self_suspend_credit_line(&borrower);
+
+    let draw_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &100_i128);
+    }));
+    assert!(draw_result.is_err(), "draws must fail while self-suspended");
+
+    client.repay_credit(&borrower, &200_i128);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Suspended);
+    assert_eq!(line.utilized_amount, 400);
+}
+
+#[test]
+fn self_suspended_line_cannot_be_reopened_without_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &50_u32);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &borrower,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "self_suspend_credit_line",
+                args: (&borrower,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .self_suspend_credit_line(&borrower);
+
+    let unauthorized_reopen = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.open_credit_line(&borrower, &2_000_i128, &400_u32, &60_u32);
+    }));
+    assert!(
+        unauthorized_reopen.is_err(),
+        "re-opening a self-suspended line must require admin approval"
+    );
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "open_credit_line",
+                args: (&borrower, 2_000_i128, 400_u32, 60_u32).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .open_credit_line(&borrower, &2_000_i128, &400_u32, &60_u32);
+
+    let reopened = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(reopened.status, CreditStatus::Active);
+    assert_eq!(reopened.credit_limit, 2_000);
+    assert_eq!(reopened.interest_rate_bps, 400);
+    assert_eq!(reopened.risk_score, 60);
+}

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -39,7 +39,7 @@ Stored in instance storage under the `"rate_cfg"` key. Optional — when absent,
 | Variant    | Value | Description |
 |------------|-------|-----------|
 | `Active`   | 0     | Credit line is open and available |
-| `Suspended`| 1     | Credit line is temporarily suspended |
+| `Suspended`| 1     | Credit line is temporarily suspended; draws are blocked and repayments remain allowed |
 | `Defaulted`| 2     | Borrower has defaulted; draw disabled, repay allowed |
 | `Closed`   | 3     | Credit line has been permanently closed |
 | `Restricted` | 4   | Limit is below utilization; additional draws are blocked until cured |
@@ -49,14 +49,16 @@ Stored in instance storage under the `"rate_cfg"` key. Optional — when absent,
 | From       | To         | Trigger |
 |------------|------------|---------|
 | Active     | Suspended  | Admin calls `suspend_credit_line` |
+| Active     | Suspended  | Borrower calls `self_suspend_credit_line` |
 | Active     | Defaulted  | Admin calls `default_credit_line` |
 | Suspended  | Defaulted  | Admin calls `default_credit_line` |
+| Suspended  | Active     | Admin-approved `open_credit_line` reopen workflow |
 | Defaulted  | Active     | Admin calls `reinstate_credit_line` |
 | Defaulted  | Closed     | Admin or borrower (when `utilized_amount == 0`) calls `close_credit_line` |
 | Active     | Closed     | Admin or borrower (when `utilized_amount == 0`) calls `close_credit_line` |
 | Suspended  | Closed     | Admin or borrower (when `utilized_amount == 0`) calls `close_credit_line` |
 
-When status is **Defaulted**: `draw_credit` is disabled; `repay_credit` is still allowed.
+When status is **Suspended** or **Defaulted**: `draw_credit` is disabled; `repay_credit` is still allowed.
 
 ---
 
@@ -114,6 +116,9 @@ Sets the address that holds liquidity for draws and receives repayments (default
 
 ### `open_credit_line(env, borrower, credit_limit, interest_rate_bps, risk_score)`
 Opens a new credit line for a borrower. Called by the backend or risk engine.
+
+- Creating a brand-new line preserves the existing backend/risk-engine trust boundary.
+- Re-opening any existing non-`Active` line now requires admin auth so a borrower cannot self-suspend and then reactivate themselves on-chain.
 
 | Parameter | Type | Description |
 |---|---|---|
@@ -301,6 +306,17 @@ Suspend an Active credit line (admin only).
 
 Emits: `("credit", "suspend")` event.
 
+### `self_suspend_credit_line(env, borrower)`
+Allow a borrower to suspend their own Active credit line as a safety control.
+
+- Requires borrower auth.
+- Reverts if the line does not exist.
+- Reverts unless the current status is `Active`.
+- Blocks future draws but continues to allow `repay_credit`.
+- Does not give the borrower any reinstatement path; reactivation still requires an admin-controlled workflow.
+
+Emits: `("credit", "suspend")` event.
+
 ### Interest accrual
 
 Interest accrual fields exist in storage, but scheduled/lazy accrual logic is not yet active in the contract.
@@ -333,8 +349,11 @@ Apply auction liquidation proceeds to a defaulted line (admin only).
 
 Emits: `("credit", "liq_setl")` event. When fully settled, also emits `("credit", "closed")`.
 
-### `reinstate_credit_line(env, borrower, target_status)`
-Reinstate a Defaulted credit line to `target_status` (Active or Suspended). Admin only.
+### `reinstate_credit_line(env, borrower)`
+Reinstate a Defaulted credit line to Active. Admin only.
+
+- Requires `status == Defaulted`.
+- Self-suspended lines are not borrower-reinstatable. Any return to `Active` after borrower self-suspension must come from an admin-approved reopen workflow.
 
 Emits: `("credit", "reinstate")` event.
 
@@ -455,6 +474,7 @@ like actor/source/timestamp identifiers) while keeping v1 payloads stable. See
 | `repay_credit`           | Borrower              |
 | `update_risk_parameters` | Admin / risk engine   |
 | `suspend_credit_line`    | Admin                 |
+| `self_suspend_credit_line` | Borrower            |
 | `close_credit_line`      | Admin or borrower     |
 | `default_credit_line`    | Admin                 |
 | `settle_default_liquidation` | Admin             |

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1,8 +1,7 @@
-# CreditStatus State Machine — Formal Audit Artifact
+# CreditStatus State Machine
 
 **Crate:** `creditra-credit`  
-**Source:** `contracts/credit/src/lib.rs`, `contracts/credit/src/types.rs`  
-**Audit date:** 2026-03-27  
+**Primary sources:** `contracts/credit/src/lifecycle.rs`, `contracts/credit/src/lib.rs`, `contracts/credit/src/types.rs`
 
 ---
 
@@ -10,101 +9,72 @@
 
 | Variant | Discriminant | Description |
 |---|---|---|
-| `Active` | 0 | Credit line is open and available for draw/repay. |
-| `Suspended` | 1 | Temporarily frozen; repay allowed, draw allowed (see note). |
-| `Defaulted` | 2 | Borrower has defaulted; repay allowed, draw allowed (see note). |
-| `Closed` | 3 | Terminal state; no further operations permitted. |
+| `Active` | 0 | Credit line is open and can draw or repay. |
+| `Suspended` | 1 | Draws are blocked. Repayments remain allowed. |
+| `Defaulted` | 2 | Draws are blocked. Repayments remain allowed. |
+| `Closed` | 3 | Terminal state for the current line record. |
 
 ---
 
 ## Transition Table
 
-| Source State | Destination State | Trigger Function | Caller | Status | Test Coverage | Security Note |
-|---|---|---|---|---|---|---|
-| *(none)* | `Active` | `open_credit_line` | Backend / risk engine | **Allowed** | `test_init_and_open_credit_line` | No auth guard on caller; trust boundary is off-chain. Duplicate open on Active line is rejected. |
-| `Active` | `Suspended` | `suspend_credit_line` | Admin | **Allowed** | `test_suspend_credit_line` | Admin `require_auth` enforced. No source-state guard — also suspends Defaulted (see below). |
-| `Active` | `Defaulted` | `default_credit_line` | Admin | **Allowed** | `test_default_credit_line` | Admin `require_auth` enforced. No source-state guard — applies to any non-Closed status. |
-| `Active` | `Closed` | `close_credit_line` (admin) | Admin | **Allowed** | `test_close_credit_line` | Admin can force-close regardless of `utilized_amount`. |
-| `Active` | `Closed` | `close_credit_line` (borrower) | Borrower | **Allowed** | `test_close_credit_line_borrower_when_utilized_zero` | Borrower can only close when `utilized_amount == 0`. |
-| `Suspended` | `Defaulted` | `default_credit_line` | Admin | **Allowed** | `test_transition_suspended_to_defaulted` | No source-state guard on `default_credit_line`; transition is unconditional. |
-| `Suspended` | `Closed` | `close_credit_line` (admin) | Admin | **Allowed** | `test_transition_active_suspended_closed_path` | Admin force-close from any non-Closed state. |
-| `Suspended` | `Closed` | `close_credit_line` (borrower) | Borrower | **Allowed** | `test_close_credit_line_borrower_when_utilized_zero` | Borrower close requires `utilized_amount == 0`. |
-| `Defaulted` | `Active` | `reinstate_credit_line` | Admin | **Allowed** | `test_reinstate_credit_line` | Only allowed when status is exactly `Defaulted`; panics otherwise. |
-| `Defaulted` | `Suspended` | `suspend_credit_line` | Admin | **Allowed** | `test_transition_defaulted_to_suspended` | No source-state guard on `suspend_credit_line`; applies to any status. |
-| `Defaulted` | `Closed` | `close_credit_line` (admin) | Admin | **Allowed** | `test_close_credit_line_defaulted_admin_force_close` | Admin force-close preserves `utilized_amount`. |
-| `Defaulted` | `Closed` | `close_credit_line` (borrower) | Borrower | **Allowed** | `test_close_credit_line_defaulted_borrower_when_zero_utilization` | Borrower close requires `utilized_amount == 0`. |
-| `Closed` | `Active` | `reinstate_credit_line` | Admin | **Forbidden** | `test_transition_closed_to_active_forbidden` | Panics: `"credit line is not defaulted"`. `Closed` is terminal. |
-| `Closed` | `Suspended` | `suspend_credit_line` | Admin | **Forbidden** | *(implicit — no source guard; would succeed silently)* | **Gap:** `suspend_credit_line` has no `Closed` guard. Calling it on a Closed line would overwrite status to `Suspended`. This is an undocumented escape from the terminal state. See Security Notes. |
-| `Closed` | `Defaulted` | `default_credit_line` | Admin | **Forbidden** | *(implicit — no source guard; would succeed silently)* | **Gap:** Same issue as above for `default_credit_line`. No guard prevents re-opening a Closed line via these functions. |
-| `Closed` | `Closed` | `close_credit_line` | Admin / Borrower | **Idempotent** | `test_transition_closed_to_closed_is_idempotent` | Returns early without emitting an event. Safe. |
-| `Active` | `Active` | `reinstate_credit_line` | Admin | **Forbidden** | `test_reinstate_credit_line_not_defaulted` | Panics: `"credit line is not defaulted"`. |
-| `Suspended` | `Active` | `reinstate_credit_line` | Admin | **Forbidden** | `test_reinstate_credit_line_not_defaulted` | Panics: `"credit line is not defaulted"`. |
+| Source | Destination | Trigger | Caller | Allowed | Notes |
+|---|---|---|---|---|---|
+| *(none)* | `Active` | `open_credit_line` | Backend / risk engine | Yes | First issuance keeps the existing off-chain trust boundary. |
+| `Active` | `Suspended` | `suspend_credit_line` | Admin | Yes | Admin-authenticated suspend. |
+| `Active` | `Suspended` | `self_suspend_credit_line` | Borrower | Yes | Borrower-authenticated safety control. |
+| `Active` | `Defaulted` | `default_credit_line` | Admin | Yes | Admin-authenticated default. |
+| `Active` | `Closed` | `close_credit_line` | Admin | Yes | Admin can force-close regardless of utilization. |
+| `Active` | `Closed` | `close_credit_line` | Borrower | Yes | Borrower may close only when `utilized_amount == 0`. |
+| `Suspended` | `Defaulted` | `default_credit_line` | Admin | Yes | Escalation path from suspend to default. |
+| `Suspended` | `Active` | `open_credit_line` reopen | Admin-approved workflow | Yes | Re-opening an existing non-Active line now requires admin auth. |
+| `Suspended` | `Closed` | `close_credit_line` | Admin | Yes | Admin force-close remains available. |
+| `Suspended` | `Closed` | `close_credit_line` | Borrower | Yes | Borrower may close only when `utilized_amount == 0`. |
+| `Defaulted` | `Active` | `reinstate_credit_line` | Admin | Yes | `reinstate_credit_line` is only for `Defaulted -> Active`. |
+| `Defaulted` | `Closed` | `close_credit_line` | Admin | Yes | Admin force-close remains available. |
+| `Defaulted` | `Closed` | `close_credit_line` | Borrower | Yes | Borrower may close only when `utilized_amount == 0`. |
+| `Suspended` | `Suspended` | `suspend_credit_line` / `self_suspend_credit_line` | Admin / Borrower | No | Suspend is Active-only. |
+| `Defaulted` | `Suspended` | `suspend_credit_line` | Admin | No | Suspend is Active-only. |
+| `Closed` | `Suspended` | `suspend_credit_line` / `self_suspend_credit_line` | Admin / Borrower | No | Closed lines cannot be suspended. |
+| `Closed` | `Defaulted` | `default_credit_line` | Admin | No | Closed lines cannot be defaulted. |
+| `Active` | `Active` | `reinstate_credit_line` | Admin | No | Reinstate rejects non-Defaulted lines. |
+| `Suspended` | `Active` | `reinstate_credit_line` | Admin | No | Suspended lines are not directly reinstated by this entrypoint. |
+| `Closed` | `Active` | `reinstate_credit_line` | Admin | No | Closed lines are not defaulted, so reinstate fails. |
+| `Closed` | `Closed` | `close_credit_line` | Admin / Borrower | Idempotent | Returns early without mutating state. |
 
 ---
 
-## State Diagram
+## Operational Rules
 
-```
-                    open_credit_line
-  (none) ─────────────────────────────► Active
-                                          │
-              suspend_credit_line         │  default_credit_line
-         ┌────────────────────────────────┤──────────────────────────────┐
-         ▼                                │                              ▼
-     Suspended ──────────────────────────►│                          Defaulted
-         │       default_credit_line      │                              │
-         │                                │   reinstate_credit_line      │
-         │                                │◄─────────────────────────────┘
-         │                                │
-         │  close_credit_line             │  close_credit_line
-         └────────────────────────────────┴──────────────────────────────►  Closed
-                                                                              (terminal)
-```
+1. `draw_credit` is allowed only while the line is `Active`.
+2. `repay_credit` remains allowed while the line is `Active`, `Suspended`, or `Defaulted`.
+3. `self_suspend_credit_line` requires borrower auth and does not create any borrower-controlled reactivation path.
+4. Returning a self-suspended line to `Active` requires an admin-approved reopen workflow.
+5. Re-opening any existing non-`Active` line requires admin auth to prevent borrowers from bypassing self-suspend or other admin controls.
 
 ---
 
-## Security Notes
+## Auth Matrix
 
-### Trust Boundaries
-
-| Function | Auth Mechanism | Caller Trust |
-|---|---|---|
-| `open_credit_line` | None (no `require_auth`) | Off-chain backend / risk engine — trust is implicit |
-| `suspend_credit_line` | `require_admin_auth` | On-chain admin address |
-| `default_credit_line` | `require_admin_auth` | On-chain admin address |
-| `reinstate_credit_line` | `require_admin_auth` | On-chain admin address |
-| `close_credit_line` | `closer.require_auth()` | Admin (any util) or borrower (zero util only) |
-| `draw_credit` | `borrower.require_auth()` | Borrower |
-| `repay_credit` | `borrower.require_auth()` | Borrower |
-
-### Assumptions
-
-1. **`open_credit_line` has no on-chain auth guard.** The protocol assumes the calling backend is trusted. Any address can open a credit line for any borrower. This is an intentional design choice for the current version but represents a trust boundary that should be hardened before mainnet deployment.
-
-2. **`suspend_credit_line` and `default_credit_line` have no source-state guard.** They unconditionally overwrite `status` regardless of the current state. This means:
-   - A `Closed` line can be re-opened to `Suspended` or `Defaulted` by an admin. This is an **undocumented escape from the terminal state** and should be treated as a bug or explicitly documented as intentional.
-   - Calling `suspend_credit_line` on an already-`Suspended` line is a no-op in effect but still emits an event and writes storage.
-
-3. **`draw_credit` does not block on `Suspended` or `Defaulted` status.** Only `Closed` is explicitly blocked. The module-level doc comment states draw is disabled when Defaulted, but the implementation does not enforce this. This is a **discrepancy between documentation and code** that should be resolved.
-
-4. **`close_credit_line` is idempotent for `Closed → Closed`.** It returns early without emitting an event, which is safe and intentional.
-
-5. **`reinstate_credit_line` is the only function with a strict source-state guard** (`status != Defaulted` panics). All other transitions are either unconstrained or only guard against `Closed`.
-
-### Documented Exceptions (Untestable in Current Environment)
-
-- The `Closed → Suspended` and `Closed → Defaulted` paths via `suspend_credit_line` / `default_credit_line` are technically reachable but not explicitly tested because they represent unintended behaviour. Adding `#[should_panic]` tests for these would be misleading since the current code does **not** panic — it silently succeeds. These are flagged as gaps requiring a source-state guard fix.
-
----
-
-## Coverage Mapping
-
-All transitions marked **Allowed** in the table above are exercised by at least one test in the `#[cfg(test)] mod test` block of `contracts/credit/src/lib.rs`. The five new tests added in this branch specifically cover previously untested transitions:
-
-| New Test | Transition Covered |
+| Function | Auth Requirement |
 |---|---|
-| `test_transition_suspended_to_defaulted` | `Suspended → Defaulted` |
-| `test_transition_defaulted_to_suspended` | `Defaulted → Suspended` |
-| `test_transition_closed_to_active_forbidden` | `Closed → Active` (forbidden) |
-| `test_transition_closed_to_closed_is_idempotent` | `Closed → Closed` (idempotent) |
-| `test_transition_active_suspended_closed_path` | `Active → Suspended → Closed` (multi-hop) |
+| `open_credit_line` | No auth on first issuance; admin auth required when reopening an existing non-Active line |
+| `suspend_credit_line` | Admin auth |
+| `self_suspend_credit_line` | Borrower auth |
+| `default_credit_line` | Admin auth |
+| `reinstate_credit_line` | Admin auth |
+| `close_credit_line` | `closer.require_auth()` |
+| `draw_credit` | Borrower auth |
+| `repay_credit` | Borrower auth |
+
+---
+
+## Coverage
+
+| Test | What it proves |
+|---|---|
+| `self_suspend_requires_only_borrower_auth` | Borrower can self-suspend without admin auth and transitions to `Suspended`. |
+| `self_suspend_blocks_draws_but_allows_repayments` | Self-suspend blocks draws while leaving repayment available. |
+| `self_suspended_line_cannot_be_reopened_without_admin_auth` | Borrower cannot bypass self-suspend by reopening without admin approval. |
+| `suspend_only_valid_from_active` | Suspend remains Active-only. |
+| `reinstate_only_valid_from_defaulted` | Reinstate remains limited to `Defaulted -> Active`. |


### PR DESCRIPTION
Closes: #250 

## Summary

This PR adds a borrower-initiated self-suspend flow to the credit contract as a safety feature.

A borrower can now voluntarily suspend their own active credit line to prevent accidental future draws. While suspended, draws are blocked but repayments remain allowed. The borrower cannot restore the line themselves through this path; reactivation still requires admin approval.

## What changed

- Added `self_suspend_credit_line(borrower)` entrypoint
- Enforced borrower auth for self-suspend
- Reused the existing suspension behavior so self-suspended lines move to `Suspended`
- Kept repayment behavior unchanged for suspended lines
- Hardened `open_credit_line` so an existing non-`Active` line cannot be reopened without admin auth
- Added tests covering:
  - borrower-only self-suspend auth
  - draw blocked while suspended
  - repay still allowed while suspended
  - borrower cannot bypass suspension by reopening without admin approval
- Updated docs to define the transition rules and operational expectations

## Why

This gives borrowers a simple on-chain safety control if they want to temporarily lock their line against new draws, without interfering with repayment. It also closes the obvious bypass where a borrower could self-suspend and then immediately reactivate themselves unless reopen is admin-gated.

## Notes

I could not run `cargo test -p creditra-credit` locally in this environment because the Windows MSVC linker is missing (`link.exe` not found), so CI is the source of truth for validation on this PR.