### PR TITLE
feat(credit): expose get_credit_line query with stable fields and tests

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -25,18 +25,17 @@ pub mod types;
 
 use crate::auth::{require_admin, require_admin_auth};
 use crate::events::{
-    publish_admin_rotation_accepted, publish_admin_rotation_proposed, publish_credit_line_event,
+    publish_admin_rotation_accepted, publish_admin_rotation_proposed,
     publish_drawn_event, publish_interest_accrued_event, publish_repayment_event,
-    AdminRotationAcceptedEvent, AdminRotationProposedEvent, CreditLineEvent, DrawnEvent,
+    AdminRotationAcceptedEvent, AdminRotationProposedEvent, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent,
 };
-use crate::risk::{MAX_INTEREST_RATE_BPS, MAX_RISK_SCORE};
 use crate::storage::{
-    admin_key, clear_reentrancy_guard, is_borrower_blocked, proposed_admin_key, proposed_at_key,
+    admin_key, assert_not_paused, clear_reentrancy_guard, proposed_admin_key, proposed_at_key,
     rate_cfg_key, set_reentrancy_guard, DataKey,
 };
-use crate::types::{ContractError, CreditLineData, CreditStatus, RateChangeConfig};
-use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env};
+use crate::types::{ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, ProtocolConfig, RateChangeConfig};
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
 
 /// Contract API version (major, minor, patch).
 /// Increment major on breaking ABI/storage changes, minor on additive features, patch on fixes.
@@ -155,54 +154,6 @@ impl Credit {
         lifecycle::open_credit_line(env, borrower, credit_limit, interest_rate_bps, risk_score)
     }
 
-    pub fn draw_credit(env: Env, borrower: Address, amount: i128) {
-        borrow::draw_credit(env, borrower, amount)
-        assert!(credit_limit > 0, "credit_limit must be greater than zero");
-        if interest_rate_bps > MAX_INTEREST_RATE_BPS {
-            env.panic_with_error(ContractError::RateTooHigh);
-        }
-        if risk_score > MAX_RISK_SCORE {
-            env.panic_with_error(ContractError::ScoreTooHigh);
-        }
-
-        if let Some(existing) = env
-            .storage()
-            .persistent()
-            .get::<Address, CreditLineData>(&borrower)
-        {
-            assert!(
-                existing.status != CreditStatus::Active,
-                "borrower already has an active credit line"
-            );
-        }
-
-        let credit_line = CreditLineData {
-            borrower: borrower.clone(),
-            credit_limit,
-            utilized_amount: 0,
-            interest_rate_bps,
-            risk_score,
-            status: CreditStatus::Active,
-            last_rate_update_ts: 0,
-            accrued_interest: 0,
-            last_accrual_ts: env.ledger().timestamp(),
-        };
-        env.storage().persistent().set(&borrower, &credit_line);
-
-        publish_credit_line_event(
-            &env,
-            (symbol_short!("credit"), symbol_short!("opened")),
-            CreditLineEvent {
-                event_type: symbol_short!("opened"),
-                borrower: borrower.clone(),
-                status: CreditStatus::Active,
-                credit_limit,
-                interest_rate_bps,
-                risk_score,
-            },
-        );
-    }
-
     /// Draws credit by transferring liquidity tokens to the borrower.
     ///
     /// Enforces status, limit, and liquidity checks before executing the transfer.
@@ -220,7 +171,7 @@ impl Credit {
     /// - [`ContractError::CreditLineClosed`] — credit line is closed.
     /// - [`ContractError::Overflow`] — utilized amount would overflow.
     /// - [`ContractError::DrawExceedsMaxAmount`] — amount exceeds per-tx draw cap.
-    pub fn draw_credit(env: Env, borrower: Address, amount: i128) -> () {
+    pub fn draw_credit(env: Env, borrower: Address, amount: i128) {
         assert_not_paused(&env);
         set_reentrancy_guard(&env);
 
@@ -230,12 +181,6 @@ impl Credit {
         if amount <= 0 {
             clear_reentrancy_guard(&env);
             panic!("amount must be positive");
-        }
-
-        // Global emergency freeze: block all draws during liquidity reserve operations.
-        if freeze::is_draws_frozen(&env) {
-            clear_reentrancy_guard(&env);
-            env.panic_with_error(ContractError::DrawsFrozen);
         }
 
         // Global emergency freeze: block all draws during liquidity reserve operations.
@@ -347,7 +292,6 @@ impl Credit {
     }
 
     pub fn repay_credit(env: Env, borrower: Address, amount: i128) {
-        borrow::repay_credit(env, borrower, amount)
         // --- Reentrancy guard (defense-in-depth) ---
         set_reentrancy_guard(&env);
         borrower.require_auth();
@@ -631,9 +575,12 @@ impl Credit {
 
     // duplicate wrapper removed
 
+    /// Return the credit line for `borrower`, or `None` if no line exists.
+    ///
+    /// No authentication required — this is a pure read with no side effects.
+    /// Accrual is lazy; pending interest since the last checkpoint is not applied here.
     pub fn get_credit_line(env: Env, borrower: Address) -> Option<CreditLineData> {
         query::get_credit_line(env, borrower)
-        env.storage().persistent().get(&borrower)
     }
 
     // ── Global draw-freeze switch ─────────────────────────────────────────────

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+//! Read-only query helpers for the Credit contract.
+
+use crate::types::CreditLineData;
+use soroban_sdk::{Address, Env};
+
+/// Return the credit line for `borrower`, or `None` if no line exists.
+///
+/// # Authentication
+/// No authentication required. This is a pure read — it does not mutate
+/// any storage and carries no trust boundary. Any caller (indexer, client,
+/// or another contract) may invoke it freely.
+///
+/// # Stability
+/// The returned [`CreditLineData`] struct is stable for integrators.
+/// All fields — including `last_rate_update_ts`, `accrued_interest`, and
+/// `last_accrual_ts` — are serialized in the order declared in `types.rs`.
+/// New fields will only be appended; existing field positions will not change.
+///
+/// # Note on accrual
+/// Interest accrual is lazy: `accrued_interest` and `utilized_amount` reflect
+/// the last mutating call (draw, repay, suspend, etc.). Pending interest since
+/// the last checkpoint is **not** applied by this query.
+pub fn get_credit_line(env: Env, borrower: Address) -> Option<CreditLineData> {
+    env.storage().persistent().get(&borrower)
+}

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -15,6 +15,8 @@ pub enum DataKey {
     MaxDrawAmount,
     /// Per-borrower block flag; when `true`, draw_credit is rejected.
     BlockedBorrower(Address),
+    /// Storage schema version marker. Set to `1` on init.
+    SchemaVersion,
 }
 
 pub fn admin_key(env: &Env) -> Symbol {
@@ -137,4 +139,9 @@ pub fn assert_not_paused(env: &Env) {
     if is_paused(env) {
         env.panic_with_error(crate::types::ContractError::Paused);
     }
+}
+
+/// Instance storage key for the grace period policy.
+pub fn grace_period_key(env: &Env) -> Symbol {
+    Symbol::new(env, "grace_cfg")
 }

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -160,6 +160,39 @@ pub struct RateChangeConfig {
     /// Minimum elapsed seconds between two consecutive rate changes.
     pub rate_change_min_interval: u64,
 }
+
+/// Grace period waiver mode for suspended credit lines.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GraceWaiverMode {
+    /// Zero interest during the grace window.
+    FullWaiver = 0,
+    /// Reduced interest rate during the grace window.
+    ReducedRate = 1,
+}
+
+/// Admin-configurable grace period policy for suspended credit lines.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GracePeriodConfig {
+    /// Duration of the grace window in seconds.
+    pub grace_period_seconds: u64,
+    /// How interest is waived during the grace window.
+    pub waiver_mode: GraceWaiverMode,
+    /// Rate applied during the window when `waiver_mode` is `ReducedRate` (bps).
+    pub reduced_rate_bps: u32,
+}
+
+/// Snapshot of global protocol configuration returned by `get_protocol_config`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolConfig {
+    /// Configured liquidity token address, or `None` if not yet set.
+    pub liquidity_token: Option<soroban_sdk::Address>,
+    /// Configured liquidity source address, or `None` if not yet set.
+    pub liquidity_source: Option<soroban_sdk::Address>,
+    /// Rate-change limit configuration, or `None` if not yet set.
+    pub rate_change_config: Option<RateChangeConfig>,
 }
 
 /// Admin-configurable piecewise-linear rate formula.

--- a/contracts/credit/tests/get_credit_line.rs
+++ b/contracts/credit/tests/get_credit_line.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+use creditra_credit::types::CreditStatus;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup(env: &Env) -> (CreditClient, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, admin)
+}
+
+/// No credit line opened → must return None.
+#[test]
+fn get_credit_line_returns_none_for_unknown_borrower() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    assert!(client.get_credit_line(&borrower).is_none());
+}
+
+/// After opening a credit line → must return Some with correct fields.
+#[test]
+fn get_credit_line_returns_some_after_open() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &5_000_i128, &300_u32, &50_u32);
+
+    let line = client.get_credit_line(&borrower).expect("expected Some");
+    assert_eq!(line.borrower, borrower);
+    assert_eq!(line.credit_limit, 5_000);
+    assert_eq!(line.utilized_amount, 0);
+    assert_eq!(line.interest_rate_bps, 300);
+    assert_eq!(line.risk_score, 50);
+    assert_eq!(line.last_rate_update_ts, 0);
+    assert_eq!(line.accrued_interest, 0);
+}
+
+/// After closing a credit line → still returns Some (record is preserved, status is Closed).
+#[test]
+fn get_credit_line_returns_some_after_close() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000_i128, &200_u32, &30_u32);
+    client.close_credit_line(&borrower, &admin);
+
+    let line = client.get_credit_line(&borrower).expect("expected Some after close");
+    assert_eq!(
+        line.status,
+        CreditStatus::Closed
+    );
+}

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -358,7 +358,30 @@ Reinstate a Defaulted credit line to Active. Admin only.
 Emits: `("credit", "reinstate")` event.
 
 ### `get_credit_line(env, borrower) -> Option<CreditLineData>`
-View function — returns credit line data or `None`.
+View function — returns the full [`CreditLineData`] for `borrower`, or `None` if no credit line exists.
+
+#### Authentication
+No authentication required. Any caller — indexer, client SDK, or another contract — may call this freely.
+
+#### Stable serialization
+The returned struct is stable for integrators. Fields are serialized in declaration order (see `types.rs`). New fields will only ever be appended; existing field positions will not change.
+
+#### Accrual note
+Interest accrual is lazy. `accrued_interest` and `utilized_amount` reflect the last mutating call (draw, repay, suspend, etc.). Pending interest since the last checkpoint is **not** applied by this query. To get the current accrued value, trigger a mutating call first or compute it off-chain using `last_accrual_ts` and `interest_rate_bps`.
+
+#### Key fields for indexers
+
+| Field | Description |
+|---|---|
+| `last_rate_update_ts` | Ledger timestamp of the last rate change; `0` means the rate has never been updated |
+| `last_accrual_ts` | Ledger timestamp of the last interest checkpoint; `0` means no accrual has run yet |
+| `accrued_interest` | Capitalized interest included in `utilized_amount` |
+| `status` | Current lifecycle state (`Active`, `Suspended`, `Defaulted`, `Closed`, `Restricted`) |
+
+#### Security notes
+- Pure read — no storage is mutated, no auth is checked, no events are emitted.
+- Safe to call from untrusted contexts; the worst outcome is a stale accrual snapshot (see accrual note above).
+- Returns `None` for addresses that have never had a credit line; callers must handle this case.
 
 ### `freeze_draws(env)`
 Freeze all `draw_credit` calls contract-wide (admin only).


### PR DESCRIPTION
- Add query.rs module with get_credit_line returning Option<CreditLineData>
- Fix lib.rs: remove duplicate draw_credit/repay_credit stubs that called non-existent borrow:: module, remove duplicate freeze check, fix -> () return type, clean up unused imports
- Add missing types to types.rs: GraceWaiverMode, GracePeriodConfig, ProtocolConfig, and remove stray closing brace
- Add SchemaVersion variant to DataKey enum and grace_period_key() to storage.rs
- Add integration tests: None for unknown borrower, Some with field assertions after open, Some with Closed status after close
- Document get_credit_line in docs/credit.md: no auth required, stable serialization guarantee, lazy accrual note, key fields for indexers

closes #231 