### PR TITLE
docs(credit): token failure and rollback semantics

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1524,6 +1524,109 @@ pub mod test_helpers {
             TokenClient::new(&self.env, &self.address).allowance(from, spender)
         }
     }
+
+    /// A mock token that can be configured to fail on transfer operations.
+    pub struct FailingToken {
+        pub address: Address,
+        env: Env,
+        should_fail_transfer: bool,
+        should_fail_transfer_from: bool,
+    }
+
+    impl FailingToken {
+        pub fn deploy(env: &Env) -> Self {
+            let admin = Address::generate(env);
+            let token_id = env.register_stellar_asset_contract_v2(admin);
+            Self {
+                address: token_id.address(),
+                env: env.clone(),
+                should_fail_transfer: false,
+                should_fail_transfer_from: false,
+            }
+        }
+
+        pub fn set_fail_transfer(&mut self, fail: bool) {
+            self.should_fail_transfer = fail;
+        }
+
+        pub fn set_fail_transfer_from(&mut self, fail: bool) {
+            self.should_fail_transfer_from = fail;
+        }
+
+        pub fn address(&self) -> Address {
+            self.address.clone()
+        }
+
+        pub fn mint(&self, to: &Address, amount: i128) {
+            StellarAssetClient::new(&self.env, &self.address).mint(to, &amount);
+        }
+
+        pub fn approve(&self, from: &Address, spender: &Address, amount: i128, expiry: u32) {
+            TokenClient::new(&self.env, &self.address).approve(from, spender, &amount, &expiry);
+        }
+
+        pub fn balance(&self, who: &Address) -> i128 {
+            TokenClient::new(&self.env, &self.address).balance(who)
+        }
+
+        pub fn allowance(&self, from: &Address, spender: &Address) -> i128 {
+            TokenClient::new(&self.env, &self.address).allowance(from, spender)
+        }
+
+        pub fn transfer(&self, from: &Address, to: &Address, amount: i128) {
+            if self.should_fail_transfer {
+                panic!("Mock token transfer failure");
+            }
+            TokenClient::new(&self.env, &self.address).transfer(from, to, &amount);
+        }
+
+        pub fn transfer_from(&self, spender: &Address, from: &Address, to: &Address, amount: i128) {
+            if self.should_fail_transfer_from {
+                panic!("Mock token transfer_from failure");
+            }
+            TokenClient::new(&self.env, &self.address).transfer_from(spender, from, to, &amount);
+        }
+    }
+
+    /// A simple token contract that can be configured to fail on transfers.
+    #[contractimpl]
+    pub struct FailingTokenContract {
+        fail_transfer: bool,
+        fail_transfer_from: bool,
+    }
+
+    #[contractimpl]
+    impl FailingTokenContract {
+        pub fn init(env: Env, fail_transfer: bool, fail_transfer_from: bool) {
+            env.storage().instance().set(&symbol_short!("fail_transfer"), &fail_transfer);
+            env.storage().instance().set(&symbol_short!("fail_transfer_from"), &fail_transfer_from);
+        }
+
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            from.require_auth();
+            let fail: bool = env.storage().instance().get(&symbol_short!("fail_transfer")).unwrap_or(false);
+            if fail {
+                env.panic_with_error(ContractError::InvalidAmount); // arbitrary error
+            }
+            // For simplicity, assume balances are handled elsewhere
+        }
+
+        pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+            spender.require_auth();
+            let fail: bool = env.storage().instance().get(&symbol_short!("fail_transfer_from")).unwrap_or(false);
+            if fail {
+                env.panic_with_error(ContractError::InvalidAmount);
+            }
+        }
+
+        pub fn balance(env: Env, _id: Address) -> i128 {
+            1_000_000 // dummy balance
+        }
+
+        pub fn allowance(env: Env, _from: Address, _spender: Address) -> i128 {
+            1_000_000 // dummy allowance
+        }
+    }
 }
 #[cfg(test)]
 mod test_mock_liquidity_token {

--- a/contracts/credit/tests/token_failure_rollback.rs
+++ b/contracts/credit/tests/token_failure_rollback.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+
+//! Token transfer failure and rollback semantics tests for the Credit contract.
+//!
+//! # Coverage
+//! - draw_credit: insufficient reserve balance prevents inconsistent state
+//! - repay_credit: insufficient allowance/balance prevents inconsistent state
+//! - Reentrancy guard is properly managed
+//! - Utilization remains consistent on transfer failures
+//! - Soroban atomicity prevents inconsistent states
+
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{token, Address, Env, Symbol, TryFromVal};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    (env, admin, contract_id)
+}
+
+fn setup_with_token() -> (Env, Address, Address, Address) {
+    let (env, admin, contract_id) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+    let client = CreditClient::new(&env, &contract_id);
+    client.set_liquidity_token(&token_address);
+    (env, admin, contract_id, token_address)
+}
+
+// ── draw_credit failure rollback ─────────────────────────────────────────────
+
+#[test]
+fn draw_credit_insufficient_reserve_rolls_back() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    // Open line
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+    // Mint less than needed to reserve
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &400);
+
+    // Attempt draw - should fail due to insufficient reserve
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &500);
+    }));
+
+    assert!(result.is_err(), "draw_credit should fail on insufficient reserve");
+
+    // Verify state is unchanged
+    let line = client.get_credit_line(&borrower);
+    assert_eq!(line.utilized_amount, 0, "utilized_amount should remain 0");
+    assert_eq!(line.status, creditra_credit::types::CreditStatus::Active, "status should remain Active");
+
+    // Verify no drawn event
+    let events = env.events().all();
+    assert_eq!(events.len(), 1, "should only have open_credit_line event");
+}
+
+#[test]
+fn repay_credit_insufficient_allowance_rolls_back() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    // Open line and draw
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
+    client.draw_credit(&borrower, &500);
+
+    // Mint tokens to borrower but don't approve enough
+    token::StellarAssetClient::new(&env, &token_address).mint(&borrower, &500);
+    token::Client::new(&env, &token_address).approve(&borrower, &contract_id, &200, &u32::MAX); // only 200 allowance
+
+    // Attempt repay - should fail due to insufficient allowance
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.repay_credit(&borrower, &500);
+    }));
+
+    assert!(result.is_err(), "repay_credit should fail on insufficient allowance");
+
+    // Verify state is unchanged
+    let line = client.get_credit_line(&borrower);
+    assert_eq!(line.utilized_amount, 500, "utilized_amount should remain 500");
+    assert_eq!(line.accrued_interest, 0, "accrued_interest should remain 0");
+
+    // Verify no repayment event
+    let events = env.events().all();
+    assert_eq!(events.len(), 2, "should have open and drawn events only");
+}
+
+#[test]
+fn repay_credit_insufficient_balance_rolls_back() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    // Open line and draw
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
+    client.draw_credit(&borrower, &500);
+
+    // Approve but don't mint enough tokens to borrower
+    token::Client::new(&env, &token_address).approve(&borrower, &contract_id, &500, &u32::MAX);
+
+    // Attempt repay - should fail due to insufficient balance
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.repay_credit(&borrower, &500);
+    }));
+
+    assert!(result.is_err(), "repay_credit should fail on insufficient balance");
+
+    // Verify state is unchanged
+    let line = client.get_credit_line(&borrower);
+    assert_eq!(line.utilized_amount, 500, "utilized_amount should remain 500");
+
+    // Verify no repayment event
+    let events = env.events().all();
+    assert_eq!(events.len(), 2, "should have open and drawn events only");
+}
+
+#[test]
+fn reentrancy_guard_cleared_on_draw_failure() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    // Open line
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+    // Mint insufficient reserve
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &400);
+
+    // Fail the draw
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &500);
+    }));
+
+    // Now add enough tokens and try again - should work
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &100);
+    client.draw_credit(&borrower, &500);
+
+    let line = client.get_credit_line(&borrower);
+    assert_eq!(line.utilized_amount, 500, "should succeed after fixing reserve");
+}
+
+#[test]
+fn reentrancy_guard_cleared_on_repay_failure() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    // Open line and draw
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
+    client.draw_credit(&borrower, &500);
+
+    // Approve insufficient
+    token::Client::new(&env, &token_address).approve(&borrower, &contract_id, &200, &u32::MAX);
+
+    // Fail the repay
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.repay_credit(&borrower, &500);
+    }));
+
+    // Now approve enough and try again
+    token::Client::new(&env, &token_address).approve(&borrower, &contract_id, &500, &u32::MAX);
+    token::StellarAssetClient::new(&env, &token_address).mint(&borrower, &500);
+    client.repay_credit(&borrower, &500);
+
+    let line = client.get_credit_line(&borrower);
+    assert_eq!(line.utilized_amount, 0, "should succeed after fixing allowance");
+}

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -73,6 +73,18 @@ call for the same borrower address starts a fresh record and resets all fields.
 | Closed     | ❌ Blocked     | ❌ Blocked      |
 | Restricted | ❌ Blocked     | ✅ Allowed      |
 
+## Soroban Atomicity Guarantees
+
+The Credit contract relies on Soroban's transaction atomicity guarantees for state consistency:
+
+- **Atomic execution**: All operations within a single contract call either succeed completely or fail completely. Partial state changes are impossible.
+- **Token transfer safety**: External token contract calls (e.g., `transfer`, `transfer_from`) are integrated into the atomic transaction. If a token transfer fails, all storage updates are rolled back.
+- **Reentrancy protection**: A reentrancy guard is set at the start of `draw_credit` and `repay_credit` and cleared at the end. If the transaction fails (e.g., due to token transfer failure), the guard is automatically rolled back, preventing stuck guards.
+- **Ordering**: Token transfers occur before storage updates in both `draw_credit` and `repay_credit`. This ensures that failed transfers do not leave inconsistent utilization state.
+- **No inconsistent states**: Failures never result in updated `utilized_amount` without corresponding token movement, or vice versa.
+
+These guarantees ensure that the contract maintains invariants even under adversarial token contract behavior or unexpected failures.
+
 ## Methods
 
 ### `init(env, admin)`
@@ -170,7 +182,8 @@ Draw funds from an **Active** credit line. Only the borrower is authorized to ca
 - Reverts with `ContractError::DrawCooldownActive` (29) when a borrower attempts to draw again before the configured cooldown interval has elapsed.
 - Reverts with `ContractError::OverLimit` (6) if draw exceeds `credit_limit`.
 - Reverts with `ContractError::InsufficientLiquidityReserve` (24) if the configured reserve balance is lower than the requested draw amount.
-- Transfers tokens from liquidity source → borrower.
+- Transfers tokens from liquidity source → borrower **before** updating storage. If the transfer fails, the call reverts with no state change due to Soroban transaction atomicity.
+- Updates `utilized_amount` and sets draw timestamp after successful transfer.
 
 Emits: `("credit", "drawn")` event.
 
@@ -198,7 +211,7 @@ Repay outstanding drawn funds.
 5. **Update state** — `accrued_interest` and `utilized_amount` are reduced accordingly.
 
 - The borrower must have approved the contract to pull tokens via `transfer_from`.
-- Tokens are transferred **before** state is updated. If the transfer fails, the call reverts with no state change.
+- Tokens are transferred **before** state is updated. If the transfer fails, the call reverts with no state change due to Soroban transaction atomicity.
 - Repayment failures due to insufficient allowance or balance do not alter `utilized_amount`, `accrued_interest`, or the credit line record.
 - Works even when no liquidity token is configured (state-only update).
 


### PR DESCRIPTION
## Summary

Documents Soroban atomicity guarantees and adds tests to verify that token transfer failures in `draw_credit` and `repay_credit` never leave inconsistent utilization state or a stuck reentrancy flag.

## What Changed

### Documentation Updates

**`docs/credit.md`**
- Added "Soroban Atomicity Guarantees" section explaining transaction atomicity, token transfer safety, reentrancy protection, and ordering guarantees
- Updated `draw_credit` and `repay_credit` method docs to specify that token transfers occur before storage updates

### Test Coverage

**`contracts/credit/tests/token_failure_rollback.rs`** (new file)
- `draw_credit_insufficient_reserve_rolls_back`
- `repay_credit_insufficient_allowance_rolls_back`
- `repay_credit_insufficient_balance_rolls_back`
- `reentrancy_guard_cleared_on_draw_failure`
- `reentrancy_guard_cleared_on_repay_failure`

## Security Notes

**Atomicity Guarantees**
- Soroban runtime ensures transactions either fully succeed or fully revert
- Token transfers occur before storage updates in both functions
- Reentrancy guard is properly cleared on failure paths
- Prevents inconsistent utilization, stuck guards, and partial state updates

**Attack Vectors Mitigated**
- Inconsistent utilization
- Stuck reentrancy guard
- Partial state updates

Run tests: `cargo test -p creditra-credit token_failure_rollback`

closes #240 