### PR TITLE
audit(accrual): replace panics with ContractError::Overflow; add over…

### DIFF
--- a/contracts/credit/src/accrual.rs
+++ b/contracts/credit/src/accrual.rs
@@ -1,19 +1,30 @@
 // SPDX-License-Identifier: MIT
 
 use crate::events::{publish_interest_accrued_event, InterestAccruedEvent};
-use crate::types::CreditLineData;
-use soroban_sdk::{Address, Env};
+use crate::types::{ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode};
+use soroban_sdk::Env;
 
 pub(crate) const SECONDS_PER_YEAR: u64 = 31_536_000;
 
-fn compute_interest(utilized: i128, rate_bps: i128, seconds: i128) -> i128 {
+/// Compute simple interest: `utilized * rate_bps * seconds / (10_000 * SECONDS_PER_YEAR)`.
+///
+/// # Overflow behavior — **revert with `ContractError::Overflow`**
+/// All intermediate multiplications use `checked_mul`. If any step would exceed
+/// `i128::MAX` the function returns `Err(ContractError::Overflow)` so the caller
+/// can propagate it via `env.panic_with_error`. No silent wrapping or saturation
+/// occurs; the contract reverts deterministically.
+fn compute_interest(
+    utilized: i128,
+    rate_bps: i128,
+    seconds: i128,
+) -> Result<i128, ContractError> {
     let denominator: i128 = 10_000 * (SECONDS_PER_YEAR as i128);
     let intermediate = utilized
         .checked_mul(rate_bps)
         .and_then(|v| v.checked_mul(seconds));
     match intermediate {
-        Some(val) => val / denominator,
-        None => panic!("interest calculation overflow"),
+        Some(val) => Ok(val / denominator),
+        None => Err(ContractError::Overflow),
     }
 }
 
@@ -31,6 +42,14 @@ fn compute_interest(utilized: i128, rate_bps: i128, seconds: i128) -> i128 {
 ///   the full rate.
 /// - If no policy is configured, or the line is not Suspended, normal accrual
 ///   applies unchanged.
+///
+/// # Overflow behavior — **revert with `ContractError::Overflow`**
+/// Every arithmetic step that could overflow uses checked arithmetic. If any
+/// intermediate multiplication in `compute_interest` overflows `i128`, or if
+/// adding the newly accrued amount to `utilized_amount` / `accrued_interest`
+/// would overflow, the function reverts deterministically via
+/// `env.panic_with_error(ContractError::Overflow)`. No silent wrapping or
+/// saturation occurs anywhere in this function.
 pub fn apply_accrual(env: &Env, mut line: CreditLineData) -> CreditLineData {
     let now = env.ledger().timestamp();
 
@@ -64,12 +83,14 @@ pub fn apply_accrual(env: &Env, mut line: CreditLineData) -> CreditLineData {
                         GraceWaiverMode::FullWaiver => 0,
                         GraceWaiverMode::ReducedRate => {
                             compute_interest(utilized, cfg.reduced_rate_bps as i128, seconds)
+                                .unwrap_or_else(|e| env.panic_with_error(e))
                         }
                     }
                 } else if accrual_start >= grace_end {
                     // Entire period is after grace window
                     let seconds = (now - accrual_start) as i128;
                     compute_interest(utilized, full_rate, seconds)
+                        .unwrap_or_else(|e| env.panic_with_error(e))
                 } else {
                     // Period straddles the grace boundary
                     let in_window_secs = (grace_end - accrual_start) as i128;
@@ -79,32 +100,41 @@ pub fn apply_accrual(env: &Env, mut line: CreditLineData) -> CreditLineData {
                         GraceWaiverMode::FullWaiver => 0,
                         GraceWaiverMode::ReducedRate => {
                             compute_interest(utilized, cfg.reduced_rate_bps as i128, in_window_secs)
+                                .unwrap_or_else(|e| env.panic_with_error(e))
                         }
                     };
                     let post_window_interest =
-                        compute_interest(utilized, full_rate, post_window_secs);
-                    in_window_interest + post_window_interest
+                        compute_interest(utilized, full_rate, post_window_secs)
+                            .unwrap_or_else(|e| env.panic_with_error(e));
+                    // Checked addition of the two sub-period interests — revert on overflow.
+                    in_window_interest
+                        .checked_add(post_window_interest)
+                        .unwrap_or_else(|| env.panic_with_error(ContractError::Overflow))
                 }
             }
             _ => {
                 let seconds = (now - accrual_start) as i128;
                 compute_interest(utilized, full_rate, seconds)
+                    .unwrap_or_else(|e| env.panic_with_error(e))
             }
         }
     } else {
         let seconds = (now - accrual_start) as i128;
         compute_interest(utilized, full_rate, seconds)
+            .unwrap_or_else(|e| env.panic_with_error(e))
     };
 
     if accrued > 0 {
+        // Accumulate accrued interest into utilized_amount — revert on overflow.
         line.utilized_amount = line
             .utilized_amount
             .checked_add(accrued)
-            .expect("utilized_amount overflow");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::Overflow));
+        // Accumulate running accrued_interest total — revert on overflow.
         line.accrued_interest = line
             .accrued_interest
             .checked_add(accrued)
-            .expect("accrued_interest overflow");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::Overflow));
 
         publish_interest_accrued_event(
             env,

--- a/contracts/credit/tests/accrual_overflow_audit.rs
+++ b/contracts/credit/tests/accrual_overflow_audit.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+
+//! Overflow audit tests for `apply_accrual` and `compute_interest`.
+//!
+//! # Coverage
+//! - Max principal + max rate (10 000 bps) + long elapsed time does not panic
+//!   or silently wrap — it either produces a valid result or reverts with
+//!   `ContractError::Overflow` (discriminant 12).
+//! - The overflow path is deterministic: the same inputs always produce
+//!   `ContractError::Overflow`, never a wrong numeric result.
+
+use creditra_credit::types::ContractError;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Deploy the contract, init admin, configure a SAC token as liquidity source,
+/// and mint `reserve_amount` tokens into the contract address (the reserve).
+fn setup_with_token(reserve_amount: i128) -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    // Register a Stellar Asset Contract to act as the liquidity token.
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+
+    client.set_liquidity_token(&token_address);
+    client.set_liquidity_source(&contract_id);
+
+    // Mint reserve tokens into the contract so draws can succeed.
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &reserve_amount);
+
+    (env, contract_id, admin, token_address)
+}
+
+// ── Test 1: max principal + max rate + long elapsed time ─────────────────────
+
+/// With a very large principal (1e18) and the maximum rate (10 000 bps = 100%),
+/// advancing 1 000 years must not panic or silently wrap.
+///
+/// `1e18 * 10_000 * (1_000 * 31_536_000)` = `3.15e29`, which is well within
+/// `i128::MAX` (~1.7e38), so this case must succeed and return a positive
+/// accrued amount.
+#[test]
+fn max_rate_large_principal_long_elapsed_does_not_panic() {
+    let principal: i128 = 1_000_000_000_000_000_000; // 1e18
+    let (env, contract_id, _admin, _token) = setup_with_token(principal);
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    // Open line at max rate (10 000 bps).
+    client.open_credit_line(&borrower, &principal, &10_000_u32, &50_u32);
+
+    // Draw at t = 1 to establish the accrual checkpoint.
+    env.ledger().set_timestamp(1);
+    client.draw_credit(&borrower, &principal);
+
+    // Advance 1 000 years.
+    let one_thousand_years: u64 = 1_000 * 31_536_000;
+    env.ledger().set_timestamp(1 + one_thousand_years);
+
+    // Trigger accrual — must not panic.
+    client.update_risk_parameters(&borrower, &i128::MAX, &10_000_u32, &50_u32);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+
+    // Accrued interest must be positive and the line must still be readable.
+    assert!(
+        line.accrued_interest > 0,
+        "expected positive accrued interest, got {}",
+        line.accrued_interest
+    );
+    assert!(
+        line.utilized_amount > principal,
+        "utilized_amount must have grown from accrual"
+    );
+}
+
+// ── Test 2: overflow path returns ContractError::Overflow deterministically ───
+
+/// When `utilized * rate_bps` already overflows `i128`, `compute_interest`
+/// must return `ContractError::Overflow` (discriminant 12) — never a wrong
+/// numeric result and never a bare panic.
+///
+/// `i128::MAX / 2 * 10_000` overflows `i128`, so any positive elapsed time
+/// triggers the overflow path.
+#[test]
+fn overflow_path_returns_contract_error_overflow_deterministically() {
+    // i128::MAX / 2 overflows when multiplied by 10_000.
+    let huge_principal: i128 = i128::MAX / 2;
+    let (env, contract_id, _admin, _token) = setup_with_token(huge_principal);
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &huge_principal, &10_000_u32, &50_u32);
+
+    // Draw at t = 1.
+    env.ledger().set_timestamp(1);
+    client.draw_credit(&borrower, &huge_principal);
+
+    // Advance time so accrual is triggered.
+    env.ledger().set_timestamp(2);
+
+    // Trigger accrual — must revert with ContractError::Overflow (code 12).
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.update_risk_parameters(&borrower, &i128::MAX, &10_000_u32, &50_u32);
+    }));
+
+    assert!(
+        result.is_err(),
+        "expected a revert on overflow, but the call succeeded"
+    );
+
+    // The panic payload from Soroban encodes the contract error discriminant.
+    // ContractError::Overflow = 12, encoded as "Error(Contract, #12)".
+    // We verify the error string contains the discriminant to confirm it is
+    // ContractError::Overflow and not some other panic.
+    let err = result.unwrap_err();
+    let err_str = if let Some(s) = err.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = err.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        String::new()
+    };
+
+    assert!(
+        err_str.contains("#12"),
+        "expected ContractError::Overflow (#12) but got: {:?}",
+        err_str
+    );
+}
+
+/// Same overflow scenario repeated a second time with identical inputs must
+/// produce the same `ContractError::Overflow` — confirming determinism.
+#[test]
+fn overflow_path_is_deterministic_same_inputs_same_error() {
+    let huge_principal: i128 = i128::MAX / 2;
+
+    for _ in 0..2 {
+        let (env, contract_id, _admin, _token) = setup_with_token(huge_principal);
+        let client = CreditClient::new(&env, &contract_id);
+        let borrower = Address::generate(&env);
+
+        client.open_credit_line(&borrower, &huge_principal, &10_000_u32, &50_u32);
+
+        env.ledger().set_timestamp(1);
+        client.draw_credit(&borrower, &huge_principal);
+        env.ledger().set_timestamp(2);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.update_risk_parameters(&borrower, &i128::MAX, &10_000_u32, &50_u32);
+        }));
+
+        assert!(result.is_err(), "must revert on overflow (run {})", _ + 1);
+
+        let err = result.unwrap_err();
+        let err_str = if let Some(s) = err.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(s) = err.downcast_ref::<&str>() {
+            s.to_string()
+        } else {
+            String::new()
+        };
+
+        assert!(
+            err_str.contains("#12"),
+            "run {}: expected #12 but got: {:?}",
+            _ + 1,
+            err_str
+        );
+    }
+}


### PR DESCRIPTION
…flow tests

- compute_interest: return Result<i128, ContractError> instead of bare panic; add doc comment documenting overflow-revert behavior
- apply_accrual: propagate compute_interest errors via env.panic_with_error; fix plain + in straddle branch with checked_add; replace .expect() calls on utilized_amount and accrued_interest with checked_add + panic_with_error; add doc comment on overflow policy; fix missing type imports
- Add tests/accrual_overflow_audit.rs: large principal + max rate + long elapsed does not panic; i128::MAX/2 at 10000 bps reverts with Overflow #12; determinism check confirms same inputs always produce same error.



Closes #359