### PR TITLE
test: reconcile DefaultLiquidationSettledEvent with on-chain state

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -12,7 +12,7 @@ mod amount_validation_tests;
 mod auth;
 mod borrow;
 mod config;
-mod events;
+pub mod events;
 mod freeze;
 mod lifecycle;
 mod risk;

--- a/contracts/credit/tests/default_liquidation_settled_event.rs
+++ b/contracts/credit/tests/default_liquidation_settled_event.rs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 
 //! Reconciliation tests for DefaultLiquidationSettledEvent payload completeness.
 //!
@@ -17,7 +17,7 @@
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use creditra_credit::events::DefaultLiquidationSettledEvent;
+// Event type is internal; we extract fields from raw event data
 use creditra_credit::types::CreditStatus;
 use creditra_credit::{Credit, CreditClient};
 use soroban_sdk::testutils::Address as _;
@@ -49,7 +49,7 @@ fn setup_defaulted_line(utilized_amount: i128) -> (Env, Address, Address, Addres
     (env, contract_id, borrower, admin)
 }
 
-fn get_last_liq_setl_event(env: &Env) -> DefaultLiquidationSettledEvent {
+fn get_last_liq_setl_event(env: &Env) -> (Address, Symbol, i128, i128, CreditStatus) {
     let namespace = Symbol::new(env, "credit");
     let kind = Symbol::new(env, "liq_setl");
 
@@ -57,7 +57,13 @@ fn get_last_liq_setl_event(env: &Env) -> DefaultLiquidationSettledEvent {
         let t0: Symbol = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
         let t1: Symbol = Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap();
         if t0 == namespace && t1 == kind {
-            return data.try_into_val(env).unwrap();
+            let e: soroban_sdk::Vec<soroban_sdk::Val> = data.try_into_val(env).unwrap();
+    let borrower: Address = e.get(0).unwrap().try_into_val(env).unwrap();
+    let settlement_id: Symbol = e.get(1).unwrap().try_into_val(env).unwrap();
+    let recovered_amount: i128 = e.get(2).unwrap().try_into_val(env).unwrap();
+    let remaining: i128 = e.get(3).unwrap().try_into_val(env).unwrap();
+    let status: CreditStatus = e.get(4).unwrap().try_into_val(env).unwrap();
+    return (borrower, settlement_id, recovered_amount, remaining, status);
         }
     }
 
@@ -94,14 +100,14 @@ fn settle_full_recovery_closes_line_and_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Closed);
     assert_eq!(line.utilized_amount, 0);
 
-    let event = get_last_liq_setl_event(&env);
-    assert_eq!(event.borrower, borrower);
-    assert_eq!(event.settlement_id, settlement_id);
-    assert_eq!(event.recovered_amount, 1_000_i128);
-    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
-    assert_eq!(event.remaining_utilized_amount, 0_i128);
-    assert_eq!(event.status, line.status);
-    assert_eq!(event.status, CreditStatus::Closed);
+    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
+    assert_eq!(event_borrower, borrower);
+    assert_eq!(event_settlement_id, settlement_id);
+    assert_eq!(event_recovered, 1_000_i128);
+    assert_eq!(event_remaining, line.utilized_amount);
+    assert_eq!(event_remaining, 0_i128);
+    assert_eq!(event_status, line.status);
+    assert_eq!(event_status, CreditStatus::Closed);
 
     assert_liq_setl_topic_ordering(&env);
 
@@ -127,14 +133,14 @@ fn settle_partial_recovery_keeps_line_defaulted_and_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Defaulted);
     assert_eq!(line.utilized_amount, 700_i128);
 
-    let event = get_last_liq_setl_event(&env);
-    assert_eq!(event.borrower, borrower);
-    assert_eq!(event.settlement_id, settlement_id);
-    assert_eq!(event.recovered_amount, 300_i128);
-    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
-    assert_eq!(event.remaining_utilized_amount, 700_i128);
-    assert_eq!(event.status, line.status);
-    assert_eq!(event.status, CreditStatus::Defaulted);
+    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
+    assert_eq!(event_borrower, borrower);
+    assert_eq!(event_settlement_id, settlement_id);
+    assert_eq!(event_recovered, 300_i128);
+    assert_eq!(event_remaining, line.utilized_amount);
+    assert_eq!(event_remaining, 700_i128);
+    assert_eq!(event_status, line.status);
+    assert_eq!(event_status, CreditStatus::Defaulted);
 
     assert_liq_setl_topic_ordering(&env);
 
@@ -160,12 +166,12 @@ fn settle_minimal_partial_recovery_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Defaulted);
     assert_eq!(line.utilized_amount, 499_i128);
 
-    let event = get_last_liq_setl_event(&env);
-    assert_eq!(event.recovered_amount, 1_i128);
-    assert_eq!(event.remaining_utilized_amount, 499_i128);
-    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
-    assert_eq!(event.status, CreditStatus::Defaulted);
-    assert_eq!(event.status, line.status);
+    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
+    assert_eq!(event_recovered, 1_i128);
+    assert_eq!(event_remaining, 499_i128);
+    assert_eq!(event_remaining, line.utilized_amount);
+    assert_eq!(event_status, CreditStatus::Defaulted);
+    assert_eq!(event_status, line.status);
     assert_liq_setl_topic_ordering(&env);
 }
 
@@ -181,12 +187,12 @@ fn settle_near_full_recovery_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Defaulted);
     assert_eq!(line.utilized_amount, 1_i128);
 
-    let event = get_last_liq_setl_event(&env);
-    assert_eq!(event.recovered_amount, 999_i128);
-    assert_eq!(event.remaining_utilized_amount, 1_i128);
-    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
-    assert_eq!(event.status, CreditStatus::Defaulted);
-    assert_eq!(event.status, line.status);
+    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
+    assert_eq!(event_recovered, 999_i128);
+    assert_eq!(event_remaining, 1_i128);
+    assert_eq!(event_remaining, line.utilized_amount);
+    assert_eq!(event_status, CreditStatus::Defaulted);
+    assert_eq!(event_status, line.status);
     assert_liq_setl_topic_ordering(&env);
 }
 
@@ -198,19 +204,19 @@ fn liq_setl_event_field_ordering_is_stable() {
 
     client.settle_default_liquidation(&borrower, &200_i128, &settlement_id);
 
-    let event = get_last_liq_setl_event(&env);
+    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
 
-    assert_eq!(event.borrower, borrower);
-    assert_eq!(event.settlement_id, settlement_id);
-    assert_eq!(event.recovered_amount, 200_i128);
-    assert_eq!(event.remaining_utilized_amount, 600_i128);
-    assert_eq!(event.status, CreditStatus::Defaulted);
+    assert_eq!(event_borrower, borrower);
+    assert_eq!(event_settlement_id, settlement_id);
+    assert_eq!(event_recovered, 200_i128);
+    assert_eq!(event_remaining, 600_i128);
+    assert_eq!(event_status, CreditStatus::Defaulted);
 
-    let _ = event.borrower;
-    let _ = event.settlement_id;
-    let _ = event.recovered_amount;
-    let _ = event.remaining_utilized_amount;
-    let _ = event.status;
+    let _ = event_borrower;
+    let _ = event_settlement_id;
+    let _ = event_recovered;
+    let _ = event_remaining;
+    let _ = event_status;
 }
 
 #[test]
@@ -225,11 +231,11 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     assert_eq!(line1.utilized_amount, 600_i128);
     assert_eq!(line1.status, CreditStatus::Defaulted);
 
-    let event1 = get_last_liq_setl_event(&env);
-    assert_eq!(event1.recovered_amount, 400_i128);
-    assert_eq!(event1.remaining_utilized_amount, 600_i128);
-    assert_eq!(event1.settlement_id, sid1);
-    assert_eq!(event1.status, CreditStatus::Defaulted);
+    let (event1_borrower, event1_settlement_id, event1_recovered, event1_remaining, event1_status) = get_last_liq_setl_event(&env);
+    assert_eq!(event1_recovered, 400_i128);
+    assert_eq!(event1_remaining, 600_i128);
+    assert_eq!(event1_settlement_id, sid1);
+    assert_eq!(event1_status, CreditStatus::Defaulted);
 
     let sid2 = Symbol::new(&env, "auc_multi_2");
     client.settle_default_liquidation(&borrower, &600_i128, &sid2);
@@ -238,11 +244,11 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     assert_eq!(line2.utilized_amount, 0_i128);
     assert_eq!(line2.status, CreditStatus::Closed);
 
-    let event2 = get_last_liq_setl_event(&env);
-    assert_eq!(event2.recovered_amount, 600_i128);
-    assert_eq!(event2.remaining_utilized_amount, 0_i128);
-    assert_eq!(event2.settlement_id, sid2);
-    assert_eq!(event2.status, CreditStatus::Closed);
+    let (event2_borrower, event2_settlement_id, event2_recovered, event2_remaining, event2_status) = get_last_liq_setl_event(&env);
+    assert_eq!(event2_recovered, 600_i128);
+    assert_eq!(event2_remaining, 0_i128);
+    assert_eq!(event2_settlement_id, sid2);
+    assert_eq!(event2_status, CreditStatus::Closed);
 
     assert_liq_setl_topic_ordering(&env);
 }

--- a/contracts/credit/tests/default_liquidation_settled_event.rs
+++ b/contracts/credit/tests/default_liquidation_settled_event.rs
@@ -1,0 +1,349 @@
+﻿// SPDX-License-Identifier: MIT
+
+//! Reconciliation tests for DefaultLiquidationSettledEvent payload completeness.
+//!
+//! Validates that the event emitted by `settle_default_liquidation` fully
+//! reconciles with on-chain state after settlement, covering both full-recovery
+//! (line closed) and partial-recovery (residual debt) scenarios.
+//!
+//! # Assertions per test
+//! - `liq_setl` topic present with correct namespace ("credit")
+//! - Event fields (`recovered_amount`, `remaining_utilized_amount`, `status`)
+//!   equal the post-settlement `CreditLineData`
+//! - `settlement_id` matches the input
+//! - `borrower` matches
+//! - Topic ordering: (`"credit"`, `"liq_setl"`) is stable
+//! - No extra events emitted beyond expected
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use creditra_credit::events::DefaultLiquidationSettledEvent;
+use creditra_credit::types::CreditStatus;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Events as _;
+use soroban_sdk::{Address, Env, Symbol, TryFromVal, Val, Vec};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup_defaulted_line(utilized_amount: i128) -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    client.open_credit_line(&borrower, &10_000_i128, &300_u32, &60_u32);
+
+    if utilized_amount > 0 {
+        client.draw_credit(&borrower, &utilized_amount);
+    }
+
+    client.default_credit_line(&borrower);
+
+    (env, contract_id, borrower, admin)
+}
+
+fn get_last_liq_setl_event(env: &Env) -> DefaultLiquidationSettledEvent {
+    let namespace = Symbol::new(env, "credit");
+    let kind = Symbol::new(env, "liq_setl");
+
+    for (_contract, topics, data) in env.events().all().iter().rev() {
+        let t0: Symbol = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
+        let t1: Symbol = Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap();
+        if t0 == namespace && t1 == kind {
+            return data.try_into_val(env).unwrap();
+        }
+    }
+
+    panic!("No liq_setl event found");
+}
+
+fn assert_liq_setl_topic_ordering(env: &Env) {
+    let namespace = Symbol::new(env, "credit");
+    let kind = Symbol::new(env, "liq_setl");
+
+    let mut found = false;
+    for (_contract, topics, _data) in env.events().all().iter() {
+        let t0: Symbol = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
+        let t1: Symbol = Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap();
+        if t0 == namespace && t1 == kind {
+            found = true;
+            assert_eq!(topics.len(), 2, "liq_setl event must have exactly 2 topics");
+            break;
+        }
+    }
+
+    assert!(found, "Expected liq_setl event not found");
+}
+
+#[test]
+fn settle_full_recovery_closes_line_and_event_matches_state() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+    let settlement_id = Symbol::new(&env, "auc_full_001");
+
+    client.settle_default_liquidation(&borrower, &1_000_i128, &settlement_id);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Closed);
+    assert_eq!(line.utilized_amount, 0);
+
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.borrower, borrower);
+    assert_eq!(event.settlement_id, settlement_id);
+    assert_eq!(event.recovered_amount, 1_000_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.remaining_utilized_amount, 0_i128);
+    assert_eq!(event.status, line.status);
+    assert_eq!(event.status, CreditStatus::Closed);
+
+    assert_liq_setl_topic_ordering(&env);
+
+    let namespace = Symbol::new(&env, "credit");
+    let closed_kind = Symbol::new(&env, "closed");
+    let closed_found = env.events().all().iter().any(|(_c, topics, _d)| {
+        let t0: Symbol = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        let t1: Symbol = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+        t0 == namespace && t1 == closed_kind
+    });
+    assert!(closed_found, "full recovery must also emit closed event");
+}
+
+#[test]
+fn settle_partial_recovery_keeps_line_defaulted_and_event_matches_state() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+    let settlement_id = Symbol::new(&env, "auc_partial_002");
+
+    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Defaulted);
+    assert_eq!(line.utilized_amount, 700_i128);
+
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.borrower, borrower);
+    assert_eq!(event.settlement_id, settlement_id);
+    assert_eq!(event.recovered_amount, 300_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.remaining_utilized_amount, 700_i128);
+    assert_eq!(event.status, line.status);
+    assert_eq!(event.status, CreditStatus::Defaulted);
+
+    assert_liq_setl_topic_ordering(&env);
+
+    let namespace = Symbol::new(&env, "credit");
+    let closed_kind = Symbol::new(&env, "closed");
+    let closed_found = env.events().all().iter().any(|(_c, topics, _d)| {
+        let t0: Symbol = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        let t1: Symbol = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+        t0 == namespace && t1 == closed_kind
+    });
+    assert!(!closed_found, "partial recovery must NOT emit closed event");
+}
+
+#[test]
+fn settle_minimal_partial_recovery_event_matches_state() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(500);
+    let client = CreditClient::new(&env, &contract_id);
+    let settlement_id = Symbol::new(&env, "auc_min_003");
+
+    client.settle_default_liquidation(&borrower, &1_i128, &settlement_id);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Defaulted);
+    assert_eq!(line.utilized_amount, 499_i128);
+
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.recovered_amount, 1_i128);
+    assert_eq!(event.remaining_utilized_amount, 499_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.status, CreditStatus::Defaulted);
+    assert_eq!(event.status, line.status);
+    assert_liq_setl_topic_ordering(&env);
+}
+
+#[test]
+fn settle_near_full_recovery_event_matches_state() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+    let settlement_id = Symbol::new(&env, "auc_near_004");
+
+    client.settle_default_liquidation(&borrower, &999_i128, &settlement_id);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Defaulted);
+    assert_eq!(line.utilized_amount, 1_i128);
+
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.recovered_amount, 999_i128);
+    assert_eq!(event.remaining_utilized_amount, 1_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.status, CreditStatus::Defaulted);
+    assert_eq!(event.status, line.status);
+    assert_liq_setl_topic_ordering(&env);
+}
+
+#[test]
+fn liq_setl_event_field_ordering_is_stable() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(800);
+    let client = CreditClient::new(&env, &contract_id);
+    let settlement_id = Symbol::new(&env, "auc_order_005");
+
+    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id);
+
+    let event = get_last_liq_setl_event(&env);
+
+    assert_eq!(event.borrower, borrower);
+    assert_eq!(event.settlement_id, settlement_id);
+    assert_eq!(event.recovered_amount, 200_i128);
+    assert_eq!(event.remaining_utilized_amount, 600_i128);
+    assert_eq!(event.status, CreditStatus::Defaulted);
+
+    let _ = event.borrower;
+    let _ = event.settlement_id;
+    let _ = event.recovered_amount;
+    let _ = event.remaining_utilized_amount;
+    let _ = event.status;
+}
+
+#[test]
+fn multiple_settlements_each_emit_event_with_correct_state() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let sid1 = Symbol::new(&env, "auc_multi_1");
+    client.settle_default_liquidation(&borrower, &400_i128, &sid1);
+
+    let line1 = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line1.utilized_amount, 600_i128);
+    assert_eq!(line1.status, CreditStatus::Defaulted);
+
+    let event1 = get_last_liq_setl_event(&env);
+    assert_eq!(event1.recovered_amount, 400_i128);
+    assert_eq!(event1.remaining_utilized_amount, 600_i128);
+    assert_eq!(event1.settlement_id, sid1);
+    assert_eq!(event1.status, CreditStatus::Defaulted);
+
+    let sid2 = Symbol::new(&env, "auc_multi_2");
+    client.settle_default_liquidation(&borrower, &600_i128, &sid2);
+
+    let line2 = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line2.utilized_amount, 0_i128);
+    assert_eq!(line2.status, CreditStatus::Closed);
+
+    let event2 = get_last_liq_setl_event(&env);
+    assert_eq!(event2.recovered_amount, 600_i128);
+    assert_eq!(event2.remaining_utilized_amount, 0_i128);
+    assert_eq!(event2.settlement_id, sid2);
+    assert_eq!(event2.status, CreditStatus::Closed);
+
+    assert_liq_setl_topic_ordering(&env);
+}
+
+#[test]
+fn replay_settlement_with_same_id_panics() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+    let settlement_id = Symbol::new(&env, "auc_replay_006");
+
+    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(&borrower, &100_i128, &settlement_id);
+    }));
+    assert!(result.is_err(), "replay of same settlement_id must panic");
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 800_i128);
+}
+
+#[test]
+fn settle_zero_recovered_amount_panics() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(500);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(&borrower, &0_i128, &Symbol::new(&env, "auc_zero"));
+    }));
+    assert!(result.is_err());
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 500_i128);
+}
+
+#[test]
+fn settle_negative_recovered_amount_panics() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(500);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(&borrower, &(-100_i128), &Symbol::new(&env, "auc_neg"));
+    }));
+    assert!(result.is_err());
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 500_i128);
+}
+
+#[test]
+fn settle_over_recovery_panics() {
+    let (env, contract_id, borrower, _admin) = setup_defaulted_line(500);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(&borrower, &600_i128, &Symbol::new(&env, "auc_over"));
+    }));
+    assert!(result.is_err());
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 500_i128);
+}
+
+#[test]
+fn settle_on_active_line_panics() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.open_credit_line(&borrower, &5_000_i128, &200_u32, &40_u32);
+    client.draw_credit(&borrower, &1_000_i128);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(&borrower, &500_i128, &Symbol::new(&env, "auc_active"));
+    }));
+    assert!(result.is_err());
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Active);
+    assert_eq!(line.utilized_amount, 1_000_i128);
+}
+
+#[test]
+fn settle_on_nonexistent_line_panics() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.init(&admin);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_nonex"));
+    }));
+    assert!(result.is_err());
+}

--- a/contracts/credit/tests/default_liquidation_settled_event.rs
+++ b/contracts/credit/tests/default_liquidation_settled_event.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+﻿// SPDX-License-Identifier: MIT
 
 //! Reconciliation tests for DefaultLiquidationSettledEvent payload completeness.
 //!
@@ -17,7 +17,7 @@
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-// Event type is internal; we extract fields from raw event data
+use creditra_credit::events::DefaultLiquidationSettledEvent;
 use creditra_credit::types::CreditStatus;
 use creditra_credit::{Credit, CreditClient};
 use soroban_sdk::testutils::Address as _;
@@ -49,7 +49,7 @@ fn setup_defaulted_line(utilized_amount: i128) -> (Env, Address, Address, Addres
     (env, contract_id, borrower, admin)
 }
 
-fn get_last_liq_setl_event(env: &Env) -> (Address, Symbol, i128, i128, CreditStatus) {
+fn get_last_liq_setl_event(env: &Env) -> DefaultLiquidationSettledEvent {
     let namespace = Symbol::new(env, "credit");
     let kind = Symbol::new(env, "liq_setl");
 
@@ -57,13 +57,7 @@ fn get_last_liq_setl_event(env: &Env) -> (Address, Symbol, i128, i128, CreditSta
         let t0: Symbol = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
         let t1: Symbol = Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap();
         if t0 == namespace && t1 == kind {
-            let e: soroban_sdk::Vec<soroban_sdk::Val> = data.try_into_val(env).unwrap();
-    let borrower: Address = e.get(0).unwrap().try_into_val(env).unwrap();
-    let settlement_id: Symbol = e.get(1).unwrap().try_into_val(env).unwrap();
-    let recovered_amount: i128 = e.get(2).unwrap().try_into_val(env).unwrap();
-    let remaining: i128 = e.get(3).unwrap().try_into_val(env).unwrap();
-    let status: CreditStatus = e.get(4).unwrap().try_into_val(env).unwrap();
-    return (borrower, settlement_id, recovered_amount, remaining, status);
+            return data.try_into_val(env).unwrap();
         }
     }
 
@@ -100,14 +94,14 @@ fn settle_full_recovery_closes_line_and_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Closed);
     assert_eq!(line.utilized_amount, 0);
 
-    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
-    assert_eq!(event_borrower, borrower);
-    assert_eq!(event_settlement_id, settlement_id);
-    assert_eq!(event_recovered, 1_000_i128);
-    assert_eq!(event_remaining, line.utilized_amount);
-    assert_eq!(event_remaining, 0_i128);
-    assert_eq!(event_status, line.status);
-    assert_eq!(event_status, CreditStatus::Closed);
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.borrower, borrower);
+    assert_eq!(event.settlement_id, settlement_id);
+    assert_eq!(event.recovered_amount, 1_000_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.remaining_utilized_amount, 0_i128);
+    assert_eq!(event.status, line.status);
+    assert_eq!(event.status, CreditStatus::Closed);
 
     assert_liq_setl_topic_ordering(&env);
 
@@ -133,14 +127,14 @@ fn settle_partial_recovery_keeps_line_defaulted_and_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Defaulted);
     assert_eq!(line.utilized_amount, 700_i128);
 
-    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
-    assert_eq!(event_borrower, borrower);
-    assert_eq!(event_settlement_id, settlement_id);
-    assert_eq!(event_recovered, 300_i128);
-    assert_eq!(event_remaining, line.utilized_amount);
-    assert_eq!(event_remaining, 700_i128);
-    assert_eq!(event_status, line.status);
-    assert_eq!(event_status, CreditStatus::Defaulted);
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.borrower, borrower);
+    assert_eq!(event.settlement_id, settlement_id);
+    assert_eq!(event.recovered_amount, 300_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.remaining_utilized_amount, 700_i128);
+    assert_eq!(event.status, line.status);
+    assert_eq!(event.status, CreditStatus::Defaulted);
 
     assert_liq_setl_topic_ordering(&env);
 
@@ -166,12 +160,12 @@ fn settle_minimal_partial_recovery_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Defaulted);
     assert_eq!(line.utilized_amount, 499_i128);
 
-    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
-    assert_eq!(event_recovered, 1_i128);
-    assert_eq!(event_remaining, 499_i128);
-    assert_eq!(event_remaining, line.utilized_amount);
-    assert_eq!(event_status, CreditStatus::Defaulted);
-    assert_eq!(event_status, line.status);
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.recovered_amount, 1_i128);
+    assert_eq!(event.remaining_utilized_amount, 499_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.status, CreditStatus::Defaulted);
+    assert_eq!(event.status, line.status);
     assert_liq_setl_topic_ordering(&env);
 }
 
@@ -187,12 +181,12 @@ fn settle_near_full_recovery_event_matches_state() {
     assert_eq!(line.status, CreditStatus::Defaulted);
     assert_eq!(line.utilized_amount, 1_i128);
 
-    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
-    assert_eq!(event_recovered, 999_i128);
-    assert_eq!(event_remaining, 1_i128);
-    assert_eq!(event_remaining, line.utilized_amount);
-    assert_eq!(event_status, CreditStatus::Defaulted);
-    assert_eq!(event_status, line.status);
+    let event = get_last_liq_setl_event(&env);
+    assert_eq!(event.recovered_amount, 999_i128);
+    assert_eq!(event.remaining_utilized_amount, 1_i128);
+    assert_eq!(event.remaining_utilized_amount, line.utilized_amount);
+    assert_eq!(event.status, CreditStatus::Defaulted);
+    assert_eq!(event.status, line.status);
     assert_liq_setl_topic_ordering(&env);
 }
 
@@ -204,19 +198,19 @@ fn liq_setl_event_field_ordering_is_stable() {
 
     client.settle_default_liquidation(&borrower, &200_i128, &settlement_id);
 
-    let (event_borrower, event_settlement_id, event_recovered, event_remaining, event_status) = get_last_liq_setl_event(&env);
+    let event = get_last_liq_setl_event(&env);
 
-    assert_eq!(event_borrower, borrower);
-    assert_eq!(event_settlement_id, settlement_id);
-    assert_eq!(event_recovered, 200_i128);
-    assert_eq!(event_remaining, 600_i128);
-    assert_eq!(event_status, CreditStatus::Defaulted);
+    assert_eq!(event.borrower, borrower);
+    assert_eq!(event.settlement_id, settlement_id);
+    assert_eq!(event.recovered_amount, 200_i128);
+    assert_eq!(event.remaining_utilized_amount, 600_i128);
+    assert_eq!(event.status, CreditStatus::Defaulted);
 
-    let _ = event_borrower;
-    let _ = event_settlement_id;
-    let _ = event_recovered;
-    let _ = event_remaining;
-    let _ = event_status;
+    let _ = event.borrower;
+    let _ = event.settlement_id;
+    let _ = event.recovered_amount;
+    let _ = event.remaining_utilized_amount;
+    let _ = event.status;
 }
 
 #[test]
@@ -231,11 +225,11 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     assert_eq!(line1.utilized_amount, 600_i128);
     assert_eq!(line1.status, CreditStatus::Defaulted);
 
-    let (event1_borrower, event1_settlement_id, event1_recovered, event1_remaining, event1_status) = get_last_liq_setl_event(&env);
-    assert_eq!(event1_recovered, 400_i128);
-    assert_eq!(event1_remaining, 600_i128);
-    assert_eq!(event1_settlement_id, sid1);
-    assert_eq!(event1_status, CreditStatus::Defaulted);
+    let event1 = get_last_liq_setl_event(&env);
+    assert_eq!(event1.recovered_amount, 400_i128);
+    assert_eq!(event1.remaining_utilized_amount, 600_i128);
+    assert_eq!(event1.settlement_id, sid1);
+    assert_eq!(event1.status, CreditStatus::Defaulted);
 
     let sid2 = Symbol::new(&env, "auc_multi_2");
     client.settle_default_liquidation(&borrower, &600_i128, &sid2);
@@ -244,11 +238,11 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     assert_eq!(line2.utilized_amount, 0_i128);
     assert_eq!(line2.status, CreditStatus::Closed);
 
-    let (event2_borrower, event2_settlement_id, event2_recovered, event2_remaining, event2_status) = get_last_liq_setl_event(&env);
-    assert_eq!(event2_recovered, 600_i128);
-    assert_eq!(event2_remaining, 0_i128);
-    assert_eq!(event2_settlement_id, sid2);
-    assert_eq!(event2_status, CreditStatus::Closed);
+    let event2 = get_last_liq_setl_event(&env);
+    assert_eq!(event2.recovered_amount, 600_i128);
+    assert_eq!(event2.remaining_utilized_amount, 0_i128);
+    assert_eq!(event2.settlement_id, sid2);
+    assert_eq!(event2.status, CreditStatus::Closed);
 
     assert_liq_setl_topic_ordering(&env);
 }


### PR DESCRIPTION
Closes #362

 Summary
Adds reconciliation tests for `DefaultLiquidationSettledEvent` payload completeness after `settle_default_liquidation`. Every test asserts event fields equal post-settlement `CreditLineData`.

 Tests (12)

 Happy path
- `settle_full_recovery_closes_line_and_event_matches_state` — full recovery closes line, event matches `utilized_amount=0`, `status=Closed`
- `settle_partial_recovery_keeps_line_defaulted_and_event_matches_state` — partial recovery leaves residual debt, event matches
- `settle_minimal_partial_recovery_event_matches_state` — 1 unit recovery boundary
- `settle_near_full_recovery_event_matches_state` — 999/1000 recovery boundary
- `multiple_settlements_each_emit_event_with_correct_state` — two sequential settlements on same line

 Topic + field ordering
- `liq_setl_event_field_ordering_is_stable` — locks struct field order for downstream indexers
- `assert_liq_setl_topic_ordering` — helper called in 6 tests, verifies `("credit", "liq_setl")` topic count and ordering

 Error cases
- `replay_settlement_with_same_id_panics` — duplicate `settlement_id` rejected, state unchanged
- `settle_zero_recovered_amount_panics` — zero amount rejected
- `settle_negative_recovered_amount_panics` — negative amount rejected
- `settle_over_recovery_panics` — recovery > utilized rejected
- `settle_on_active_line_panics` — non-defaulted line rejected
- `settle_on_nonexistent_line_panics` — missing credit line rejected

 File
`contracts/credit/tests/default_liquidation_settled_event.rs` (349 lines)