### PR TITLE
test: cover per-borrower utilization cap interactions

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -15,6 +15,7 @@ mod config;
 mod events;
 mod freeze;
 mod lifecycle;
+pub mod math_utils;
 mod risk;
 mod storage;
 pub mod types;
@@ -32,6 +33,7 @@ use crate::events::{
     AdminRotationAcceptedEvent, AdminRotationProposedEvent, CreditLineEvent, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent,
 };
+use crate::math_utils::{mul_div, Rounding};
 use crate::storage::{
     admin_key, assert_not_paused, clear_reentrancy_guard, proposed_admin_key, proposed_at_key,
     rate_cfg_key, set_reentrancy_guard, DataKey,
@@ -308,14 +310,20 @@ impl Credit {
             .instance()
             .get::<_, u32>(&DataKey::UtilizationCapBps(borrower.clone()))
         {
-            let cap_amount = credit_line
-                .credit_limit
-                .checked_mul(cap_bps as i128)
-                .and_then(|v| v.checked_div(10_000))
-                .unwrap_or_else(|| {
-                    clear_reentrancy_guard(&env);
-                    env.panic_with_error(ContractError::Overflow)
-                });
+            let credit_limit_u128 = u128::try_from(credit_line.credit_limit).unwrap_or_else(|_| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::Overflow)
+            });
+            let cap_amount = i128::try_from(mul_div(
+                credit_limit_u128,
+                cap_bps as u128,
+                10_000,
+                Rounding::Floor,
+            ))
+            .unwrap_or_else(|_| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::Overflow)
+            });
             if updated_utilized > cap_amount {
                 clear_reentrancy_guard(&env);
                 panic!("exceeds utilization cap");
@@ -3884,22 +3892,22 @@ mod test_max_repay_amount {
         let contract_id = env.register(Credit, ());
         let client = CreditClient::new(env, &contract_id);
         client.init(&admin);
-        
+
         let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
         let token = token_id.address();
         client.set_liquidity_token(&token);
-        
+
         // Mint to contract to allow draw
         StellarAssetClient::new(env, &token).mint(&contract_id, &5_000_i128);
-        
+
         client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-        
+
         // Draw some credit to repay later
         client.draw_credit(&borrower, &500_i128);
-        
+
         // Mint to borrower so they have funds to repay
         StellarAssetClient::new(env, &token).mint(&borrower, &5_000_i128);
-        
+
         (client, admin, borrower, token)
     }
 
@@ -3907,9 +3915,9 @@ mod test_max_repay_amount {
     fn test_unset_max_repay_amount_allows_any() {
         let env = Env::default();
         let (client, _admin, borrower, _token) = setup_with_token(&env);
-        
+
         assert_eq!(client.get_max_repay_amount(), None);
-        
+
         client.repay_credit(&borrower, &400_i128);
         let line = client.get_credit_line(&borrower).unwrap();
         assert_eq!(line.utilized_amount, 100);
@@ -3919,7 +3927,7 @@ mod test_max_repay_amount {
     fn test_set_and_get_max_repay_amount() {
         let env = Env::default();
         let (client, _admin, _borrower, _token) = setup_with_token(&env);
-        
+
         client.set_max_repay_amount(&300_i128);
         assert_eq!(client.get_max_repay_amount(), Some(300_i128));
     }
@@ -3929,7 +3937,7 @@ mod test_max_repay_amount {
     fn test_repay_exceeds_max_cap_reverts() {
         let env = Env::default();
         let (client, _admin, borrower, _token) = setup_with_token(&env);
-        
+
         client.set_max_repay_amount(&300_i128);
         client.repay_credit(&borrower, &400_i128);
     }
@@ -3938,7 +3946,7 @@ mod test_max_repay_amount {
     fn test_repay_within_max_cap_succeeds() {
         let env = Env::default();
         let (client, _admin, borrower, _token) = setup_with_token(&env);
-        
+
         client.set_max_repay_amount(&300_i128);
         client.repay_credit(&borrower, &300_i128);
         let line = client.get_credit_line(&borrower).unwrap();
@@ -3950,7 +3958,7 @@ mod test_max_repay_amount {
     fn test_set_max_repay_amount_zero_or_negative() {
         let env = Env::default();
         let (client, _admin, _borrower, _token) = setup_with_token(&env);
-        
+
         client.set_max_repay_amount(&0_i128);
     }
 }

--- a/contracts/credit/tests/utilization_cap_interaction.rs
+++ b/contracts/credit/tests/utilization_cap_interaction.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+
+use creditra_credit::math_utils::{mul_div, Rounding};
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, Env};
+
+fn setup_with_credit_line(env: &Env, credit_limit: i128) -> (CreditClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token_address = token_id.address();
+    client.set_liquidity_token(&token_address);
+    token::StellarAssetClient::new(env, &token_address).mint(&contract_id, &(credit_limit * 10));
+
+    client.open_credit_line(&borrower, &credit_limit, &300_u32, &50_u32);
+    (client, borrower, contract_id)
+}
+
+fn effective_ceiling(credit_limit: i128, cap_bps: u32) -> i128 {
+    let cap_amount = i128::try_from(mul_div(
+        credit_limit as u128,
+        cap_bps as u128,
+        10_000,
+        Rounding::Floor,
+    ))
+    .unwrap();
+    credit_limit.min(cap_amount)
+}
+
+#[test]
+fn cap_10000_is_no_op_effective_ceiling_equals_credit_limit() {
+    let env = Env::default();
+    let credit_limit = 1_000_i128;
+    let (client, borrower, _) = setup_with_credit_line(&env, credit_limit);
+
+    client.set_utilization_cap(&borrower, &10_000_u32);
+
+    let ceiling = effective_ceiling(credit_limit, 10_000);
+    assert_eq!(ceiling, credit_limit);
+
+    client.draw_credit(&borrower, &ceiling);
+    assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, ceiling);
+}
+
+#[test]
+fn draws_are_capped_at_min_credit_limit_and_cap_amount() {
+    let env = Env::default();
+    let credit_limit = 1_000_i128;
+    let (client, borrower, _) = setup_with_credit_line(&env, credit_limit);
+
+    client.set_utilization_cap(&borrower, &6_000_u32);
+
+    let ceiling = effective_ceiling(credit_limit, 6_000);
+    assert_eq!(ceiling, 600);
+
+    client.draw_credit(&borrower, &ceiling);
+    assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, 600);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &1_i128);
+    }));
+    assert!(result.is_err());
+    let panic_msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        panic_msg.contains("exceeds utilization cap"),
+        "unexpected panic: {panic_msg}"
+    );
+}
+
+#[test]
+fn cap_below_current_utilization_blocks_new_draws_until_cap_removed() {
+    let env = Env::default();
+    let credit_limit = 1_000_i128;
+    let (client, borrower, _) = setup_with_credit_line(&env, credit_limit);
+
+    client.draw_credit(&borrower, &700_i128);
+    client.set_utilization_cap(&borrower, &6_000_u32);
+    assert_eq!(effective_ceiling(credit_limit, 6_000), 600);
+
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &1_i128);
+    }));
+    assert!(blocked.is_err());
+    let panic_msg = format!("{:?}", blocked.unwrap_err());
+    assert!(panic_msg.contains("exceeds utilization cap"));
+
+    client.set_utilization_cap(&borrower, &0_u32);
+    assert!(client.get_utilization_cap(&borrower).is_none());
+
+    client.draw_credit(&borrower, &300_i128);
+    assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, 1_000_i128);
+}
+
+#[test]
+fn cap_composes_with_credit_limit_updates_documented_in_docs() {
+    let env = Env::default();
+    let (client, borrower, _) = setup_with_credit_line(&env, 1_000_i128);
+
+    client.set_utilization_cap(&borrower, &8_000_u32);
+    client.draw_credit(&borrower, &800_i128);
+
+    client.update_risk_parameters(&borrower, &2_000_i128, &300_u32, &50_u32);
+    let raised_limit_ceiling = effective_ceiling(2_000, 8_000);
+    assert_eq!(raised_limit_ceiling, 1_600);
+
+    client.draw_credit(&borrower, &800_i128);
+    assert_eq!(client.get_credit_line(&borrower).unwrap().utilized_amount, 1_600_i128);
+
+    let over_new_cap = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &1_i128);
+    }));
+    assert!(over_new_cap.is_err());
+    let panic_msg = format!("{:?}", over_new_cap.unwrap_err());
+    assert!(panic_msg.contains("exceeds utilization cap"));
+
+    client.update_risk_parameters(&borrower, &1_500_i128, &300_u32, &50_u32);
+    let lowered_limit_ceiling = effective_ceiling(1_500, 8_000);
+    assert_eq!(lowered_limit_ceiling, 1_200);
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.credit_limit, 1_500_i128);
+    assert!(line.utilized_amount > lowered_limit_ceiling);
+
+    let blocked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &1_i128);
+    }));
+    assert!(blocked.is_err());
+    let panic_msg = format!("{:?}", blocked.unwrap_err());
+    assert!(
+        panic_msg.contains("Error(Contract, #22)") || panic_msg.contains("Error(Contract, #6)"),
+        "unexpected panic: {panic_msg}"
+    );
+}
+
+#[test]
+fn effective_ceiling_math_matches_overflow_safe_mul_div() {
+    let huge_limit = i128::MAX;
+    let cap_bps = 10_000_u32;
+
+    let ceiling = effective_ceiling(huge_limit, cap_bps);
+    let via_mul_div = i128::try_from(mul_div(
+        huge_limit as u128,
+        cap_bps as u128,
+        10_000,
+        Rounding::Floor,
+    ))
+    .unwrap();
+
+    assert_eq!(ceiling, huge_limit.min(via_mul_div));
+    assert_eq!(ceiling, huge_limit);
+}

--- a/docs/utilization-cap.md
+++ b/docs/utilization-cap.md
@@ -6,7 +6,8 @@ The utilization cap allows an admin to restrict how much of a borrower's nominal
 
 ## Semantics
 
-- **Cap formula:** `cap_amount = credit_limit * cap_bps / 10_000`
+- **Cap formula:** `cap_amount = floor(credit_limit * cap_bps / 10_000)`, computed with overflow-safe `mul_div` math.
+- **Effective ceiling:** Because `draw_credit` already enforces `utilized_amount + draw_amount <= credit_limit`, the real draw ceiling is always `min(credit_limit, cap_amount)`. For valid configured caps (`cap_bps <= 10_000`), this reduces to `cap_amount`, while `cap_bps = 10_000` is a no-op.
 - **Enforcement:** In `draw_credit`, after the credit-limit check, if a cap is configured the contract verifies: `utilized_amount + draw_amount <= cap_amount`. If not, the transaction reverts with `"exceeds utilization cap"`.
 - **No cap set:** If no cap is configured for a borrower, the full credit limit applies (existing behavior is unchanged).
 
@@ -28,7 +29,7 @@ The utilization cap allows an admin to restrict how much of a borrower's nominal
 
 ## Interaction with credit limit updates
 
-When `update_risk_parameters` changes `credit_limit`, the cap ratio (bps) is unchanged. The effective cap amount recalculates automatically on the next draw because it is derived from the current `credit_limit` at draw time.
+When `update_risk_parameters` changes `credit_limit`, the cap ratio (bps) is unchanged. The effective cap amount recalculates automatically on the next draw because it is derived from the current `credit_limit` at draw time. This composes with the underlying credit-limit rule: after an update, the borrower may draw only up to `min(new_credit_limit, floor(new_credit_limit * cap_bps / 10_000))`.
 
 **Example:** borrower has `credit_limit=1_000`, `cap_bps=8_000` (cap_amount=800). Admin raises limit to 2_000. On the next draw, cap_amount becomes 1_600 automatically — no cap reconfiguration needed.
 


### PR DESCRIPTION
## Summary
Add focused coverage for per-borrower utilization cap interactions.

## What changed
- added `contracts/credit/tests/utilization_cap_interaction.rs`
- covered effective draw ceiling behavior:
  - `min(credit_limit, floor(credit_limit * cap_bps / 10_000))`
- covered `cap_bps = 10_000` as a no-op
- covered cap below current utilization
- covered cap removal
- verified draws above the effective ceiling revert
- updated utilization-cap math in `draw_credit` to use overflow-safe `mul_div`
- clarified the documented behavior in `docs/utilization-cap.md`

Closes #376 