### PR TITLE
feat: added Auction Contract Storage TTL Extension

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod events;
+mod storage;
 mod types;
 
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env, Symbol};
@@ -9,6 +10,7 @@ use crate::types::*;
 use events::{
     publish_auction_closed_event, publish_bid_refunded_event, publish_default_liquidation_settlement_event,
 };
+use storage::{bump_auction_state_ttl, bump_settlement_marker_ttl};
 
 #[contract]
 pub struct Auction;
@@ -39,6 +41,7 @@ impl Auction {
             highest_bid: 0,
         };
         env.storage().persistent().set(&auction_id, &state);
+        bump_auction_state_ttl(&env, &auction_id);
     }
 
     pub fn close_auction(env: Env, auction_id: Symbol) {
@@ -47,11 +50,13 @@ impl Auction {
             .persistent()
             .get(&auction_id)
             .unwrap_or_else(|| panic!("auction not found"));
+        bump_auction_state_ttl(&env, &auction_id);
         if state.status == AuctionStatus::Closed {
             panic!("already closed");
         }
         state.status = AuctionStatus::Closed;
         env.storage().persistent().set(&auction_id, &state);
+        bump_auction_state_ttl(&env, &auction_id);
         publish_auction_closed_event(&env, auction_id, state.highest_bidder, state.highest_bid);
     }
 
@@ -70,6 +75,7 @@ impl Auction {
             .persistent()
             .get(&auction_id)
             .unwrap_or_else(|| panic!("auction not initialized"));
+        bump_auction_state_ttl(&env, &auction_id);
 
         if state.status != AuctionStatus::Open {
             panic!("auction not open");
@@ -89,7 +95,7 @@ impl Auction {
             }
 
             // Emit refund event before performing token transfer
-            publish_bid_refunded_event(&env, prev_bidder, state.highest_bid);
+            publish_bid_refunded_event(&env, prev_bidder.clone(), state.highest_bid);
 
             // Attempt refund token transfer if token address configured in instance storage
             let token_addr: Option<Address> = env
@@ -107,6 +113,7 @@ impl Auction {
         state.highest_bidder = Some(bidder);
         state.highest_bid = amount;
         env.storage().persistent().set(&auction_id, &state);
+        bump_auction_state_ttl(&env, &auction_id);
     }
 
     /// Emit an auction settlement signal for credit default liquidation orchestration.
@@ -125,12 +132,14 @@ impl Auction {
             .persistent()
             .get(&auction_id)
             .unwrap_or_else(|| panic!("auction state not found"));
+        bump_auction_state_ttl(&env, &auction_id);
 
         if state.status != AuctionStatus::Closed {
             panic!("auction not closed");
         }
 
         let settlement_key = AuctionKey::LiquidationSettled(auction_id.clone());
+        bump_settlement_marker_ttl(&env, &settlement_key);
         let already_settled = env
             .storage()
             .persistent()
@@ -141,8 +150,9 @@ impl Auction {
         }
 
         env.storage().persistent().set(&settlement_key, &true);
+        bump_settlement_marker_ttl(&env, &settlement_key);
 
-        let winner = state.highest_bidder.unwrap_or(borrower);
+        let winner = state.highest_bidder.unwrap_or(borrower.clone());
         publish_default_liquidation_settlement_event(
             &env,
             auction_id,
@@ -164,12 +174,16 @@ impl Auction {
             .persistent()
             .get(&auction_id)
             .unwrap_or_else(|| panic!("auction state not found"));
+        bump_auction_state_ttl(&env, &auction_id);
 
         if state.status != AuctionStatus::Closed {
             panic!("auction not closed");
         }
 
-        let winner = state.highest_bidder.unwrap_or_else(|| panic!("no winner"));
+        let winner = state
+            .highest_bidder
+            .clone()
+            .unwrap_or_else(|| panic!("no winner"));
         winner.require_auth();
 
         if state.status == AuctionStatus::Claimed {
@@ -180,8 +194,12 @@ impl Auction {
         let mut updated_state = state;
         updated_state.status = AuctionStatus::Claimed;
         env.storage().persistent().set(&auction_id, &updated_state);
+        bump_auction_state_ttl(&env, &auction_id);
     }
 }
+
+#[cfg(test)]
+extern crate std;
 
 #[cfg(test)]
 mod test;

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -1,11 +1,38 @@
 use crate::types::{AuctionStatus, DataKey};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Symbol};
 
 /// TTL constants for persistent storage entries.
 /// Bump amount: ~30 days (at ~5s per ledger close).
 pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
 /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+
+/// Extend TTL for an `AuctionState` entry stored under `auction_id`.
+///
+/// Called on every read/write path that may be followed by `claim_auction` so
+/// in-flight auctions are not archived mid-lifecycle. Uses `PERSISTENT_BUMP_AMOUNT`
+/// as the threshold so freshly created entries (short default TTL) are extended
+/// on first touch.
+pub(crate) fn bump_auction_state_ttl(env: &Env, auction_id: &Symbol) {
+    if env.storage().persistent().has(auction_id) {
+        env.storage().persistent().extend_ttl(
+            auction_id,
+            PERSISTENT_BUMP_AMOUNT,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+}
+
+/// Extend TTL for settlement replay-protection markers (only when the key exists).
+pub(crate) fn bump_settlement_marker_ttl(env: &Env, key: &crate::AuctionKey) {
+    if env.storage().persistent().has(key) {
+        env.storage().persistent().extend_ttl(
+            key,
+            PERSISTENT_BUMP_AMOUNT,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+}
 
 pub fn get_status(env: &Env) -> AuctionStatus {
     env.storage()

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -4,8 +4,9 @@ mod tests {
     use core::convert::TryFrom;
     use core::ops::Range;
     use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::vec::Vec;
 
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::testutils::Events as _;
     use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
     use soroban_sdk::{Address, Env, Symbol, TryFromVal, TryIntoVal};
@@ -15,6 +16,13 @@ mod tests {
     const AUCTION_ID: &str = "inv_auc";
     const FUZZ_STEPS: usize = 64;
     const MAX_INCREMENT: u64 = 500;
+
+    fn advance_ledgers(env: &Env, ledgers: u32) {
+        env.ledger().with_mut(|li| {
+            li.sequence_number += ledgers;
+            li.timestamp += (ledgers as u64) * 5;
+        });
+    }
 
     fn next_u64(state: &mut u64) -> u64 {
         let mut x = *state;
@@ -251,7 +259,7 @@ mod tests {
 
         client.init_auction(&auction_id, &0, &u64::MAX, &1_i128);
 
-        let mut seed: u64 = 0xa11ce_f00d_cafe_beef;
+        let mut seed: u64 = 0xa11ced00cafebabe;
         let mut highest = 0_i128;
         for _ in 0..8 {
             let idx = pick_index(&mut seed, 0..bidders.len());
@@ -408,5 +416,75 @@ mod tests {
             t0 == Symbol::new(&env, "AUC_CLOSE")
         }).collect::<Vec<_>>();
         assert_eq!(close_events.len(), 1);
+    }
+
+    #[test]
+    fn auction_state_survives_large_ledger_advance_until_claim() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        // Ensure we have a non-zero starting ledger sequence/timestamp.
+        env.ledger().with_mut(|li| {
+            li.sequence_number = 1;
+            li.timestamp = 1;
+        });
+
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+
+        let bidder = Address::generate(&env);
+        let auction_id = Symbol::new(&env, "ttl_claim");
+
+        client.init_auction(&auction_id, &0, &u64::MAX, &1_i128);
+        client.place_bid(&auction_id, &bidder, &100_i128);
+
+        // Jump far past the threshold window. If we fail to bump TTL, the state
+        // risks being archived and subsequent reads will fail.
+        advance_ledgers(
+            &env,
+            crate::storage::PERSISTENT_LIFETIME_THRESHOLD.saturating_add(10),
+        );
+
+        client.close_auction(&auction_id);
+        client.claim_auction(&auction_id);
+
+        let stored: crate::types::AuctionState = env
+            .as_contract(&contract_id, || env.storage().persistent().get(&auction_id))
+            .unwrap();
+        assert_eq!(stored.status, AuctionStatus::Claimed);
+    }
+
+    #[test]
+    fn settlement_marker_survives_large_ledger_advance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|li| {
+            li.sequence_number = 1;
+            li.timestamp = 1;
+        });
+
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+
+        let auction_id = Symbol::new(&env, "ttl_settle");
+        let bidder = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let credit_contract = Address::generate(&env);
+
+        client.init_auction(&auction_id, &0, &u64::MAX, &1_i128);
+        client.place_bid(&auction_id, &bidder, &100_i128);
+        client.close_auction(&auction_id);
+        client.settle_default_liquidation(&auction_id, &credit_contract, &borrower);
+
+        advance_ledgers(
+            &env,
+            crate::storage::PERSISTENT_LIFETIME_THRESHOLD.saturating_add(10),
+        );
+
+        // If the marker was archived, this would incorrectly succeed (replay).
+        let replay = catch_unwind(AssertUnwindSafe(|| {
+            client.settle_default_liquidation(&auction_id, &credit_contract, &borrower);
+        }));
+        assert!(replay.is_err(), "settlement replay should remain rejected");
     }
 }


### PR DESCRIPTION
# Issue #348 — Auction Contract Storage TTL Extension

**Status:** 🚧 In Progress (Not Merge Ready)

TTL extension logic has been added to prevent active auctions and settlement markers from being archived prematurely. However, 4 tests are still failing, so the branch is not yet ready for PR or merge.

## Summary

Added persistent storage TTL extension across the auction lifecycle to keep `AuctionState` and liquidation settlement markers alive during long ledger gaps.

TTL is now refreshed on all major flows:

- `init_auction`
- `place_bid`
- `close_auction`
- `claim_auction`
- `settle_default_liquidation`

Centralized helpers were introduced in `storage.rs`:

- `bump_auction_state_ttl`
- `bump_settlement_marker_ttl`

These safely extend TTL only when the underlying key exists and use a unified bump policy (~30 days).

## What’s Done

- TTL extension wired into all auction lifecycle functions
- Settlement replay marker TTL protection added
- Storage helpers centralized in `storage.rs`
- Ledger advance test utilities added
- New tests for long-lived auction and settlement marker survival

Closes: #348 