### PR TITLE
security: add oracle deviation and staleness circuit breaker

### DIFF
--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -249,3 +249,33 @@ pub fn publish_borrower_blocked_event(env: &Env, borrower: &Address, blocked: bo
         },
     );
 }
+
+/// Event emitted when the oracle circuit-breaker config is updated.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OracleConfigSetEvent {
+    pub max_deviation_bps: u32,
+    pub max_age_seconds: u64,
+}
+
+/// Event emitted when an oracle price is accepted and stored.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OraclePriceAcceptedEvent {
+    pub price: i128,
+    pub timestamp: u64,
+}
+
+pub fn publish_oracle_config_set_event(env: &Env, max_deviation_bps: u32, max_age_seconds: u64) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "orc_cfg")),
+        OracleConfigSetEvent { max_deviation_bps, max_age_seconds },
+    );
+}
+
+pub fn publish_oracle_price_accepted_event(env: &Env, price: i128, timestamp: u64) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "orc_price")),
+        OraclePriceAcceptedEvent { price, timestamp },
+    );
+}

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -32,8 +32,9 @@ use crate::events::{
     publish_borrower_blocked_event, publish_credit_line_event, publish_drawn_event,
     publish_interest_accrued_event, publish_repayment_event, CreditLineEvent, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent,
+    publish_oracle_config_set_event, publish_oracle_price_accepted_event,
 };
-use crate::math_utils::{mul_div, Rounding};
+use crate::math_utils::{mul_div, Rounding, compute_deviation_bps};
 use crate::storage::{
     admin_key, assert_not_paused, clear_reentrancy_guard, proposed_admin_key, proposed_at_key,
     rate_cfg_key, set_reentrancy_guard, DataKey, persist_credit_line,
@@ -42,10 +43,12 @@ use crate::storage::{
     set_borrower_unblocked,
     is_borrower_blocked as storage_is_borrower_blocked,
     clear_repayment_schedule,
+    get_oracle_config, set_oracle_config, get_oracle_last_price, get_oracle_last_price_ts,
+    set_oracle_last_price,
 };
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode,
-    RateChangeConfig,
+    OracleConfig, RateChangeConfig,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Symbol, Vec};
 
@@ -843,8 +846,79 @@ impl Credit {
         borrower: Address,
         recovered_amount: i128,
         settlement_id: Symbol,
+        oracle_price: Option<i128>,
     ) {
+        // Oracle price-feed circuit breaker: validate price before settlement.
+        if let Some(cfg) = get_oracle_config(&env) {
+            let price = oracle_price.unwrap_or_else(|| {
+                env.panic_with_error(ContractError::OraclePriceInvalid)
+            });
+
+            if price <= 0 {
+                env.panic_with_error(ContractError::OraclePriceInvalid);
+            }
+
+            let now = env.ledger().timestamp();
+
+            // Staleness check: price timestamp must be recent enough.
+            // The caller supplies the oracle price; we track when it was last accepted.
+            // On first call (no stored price), we accept and store without deviation check.
+            if let Some(last_ts) = get_oracle_last_price_ts(&env) {
+                let age = now.saturating_sub(last_ts);
+                if age > cfg.max_age_seconds {
+                    env.panic_with_error(ContractError::OraclePriceStale);
+                }
+
+                // Deviation check against last accepted price.
+                if let Some(last_price) = get_oracle_last_price(&env) {
+                    let deviation = compute_deviation_bps(price, last_price)
+                        .unwrap_or_else(|| env.panic_with_error(ContractError::OraclePriceInvalid));
+                    if deviation > cfg.max_deviation_bps {
+                        env.panic_with_error(ContractError::OraclePriceDeviation);
+                    }
+                }
+            }
+
+            // Accept and persist the new price.
+            set_oracle_last_price(&env, price, now);
+            publish_oracle_price_accepted_event(&env, price, now);
+        }
+
         lifecycle::settle_default_liquidation(env, borrower, recovered_amount, settlement_id)
+    }
+
+    // ── Oracle circuit-breaker admin ──────────────────────────────────────────
+
+    /// Configure the oracle price-feed circuit breaker thresholds.
+    ///
+    /// Once set, `settle_default_liquidation` requires a valid `oracle_price`
+    /// that is within `max_deviation_bps` of the last accepted price and whose
+    /// stored timestamp is no older than `max_age_seconds`.
+    ///
+    /// # Validation
+    /// - `max_deviation_bps` must be in `1..=10_000`.
+    /// - `max_age_seconds` must be > 0.
+    ///
+    /// # Authorization
+    /// Admin only.
+    pub fn set_oracle_config(env: Env, max_deviation_bps: u32, max_age_seconds: u64) {
+        assert_not_paused(&env);
+        require_admin_auth(&env);
+
+        if max_deviation_bps == 0 || max_deviation_bps > 10_000 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        if max_age_seconds == 0 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+
+        set_oracle_config(&env, &OracleConfig { max_deviation_bps, max_age_seconds });
+        publish_oracle_config_set_event(&env, max_deviation_bps, max_age_seconds);
+    }
+
+    /// Return the current oracle circuit-breaker configuration, if set.
+    pub fn get_oracle_config(env: Env) -> Option<OracleConfig> {
+        get_oracle_config(&env)
     }
 
     // ── Borrower blocklist ────────────────────────────────────────────────────

--- a/contracts/credit/src/math_utils.rs
+++ b/contracts/credit/src/math_utils.rs
@@ -275,6 +275,46 @@ pub fn prorate_interest(
     }
 }
 
+// ─── Oracle deviation helper ──────────────────────────────────────────────────
+
+/// Compute the absolute deviation between `new_price` and `last_price` in basis points.
+///
+/// # Formula
+/// ```text
+/// deviation_bps = |new_price - last_price| * 10_000 / last_price
+/// ```
+///
+/// Returns `None` if `last_price` is zero (undefined).
+///
+/// # Overflow safety
+/// Intermediate arithmetic is performed in `u128`. For realistic price values
+/// (≤ i128::MAX ≈ 1.7 × 10^38) the product `diff * 10_000` fits in u128.
+///
+/// # Examples
+/// ```rust
+/// use creditra_credit::math_utils::compute_deviation_bps;
+///
+/// // 5% deviation: last=1000, new=1050 → 500 bps
+/// assert_eq!(compute_deviation_bps(1050, 1000), Some(500));
+///
+/// // 5% deviation downward: last=1000, new=950 → 500 bps
+/// assert_eq!(compute_deviation_bps(950, 1000), Some(500));
+///
+/// // Zero last price → None
+/// assert_eq!(compute_deviation_bps(100, 0), None);
+/// ```
+pub fn compute_deviation_bps(new_price: i128, last_price: i128) -> Option<u32> {
+    if last_price <= 0 {
+        return None;
+    }
+    let diff = (new_price - last_price).unsigned_abs();
+    // diff * 10_000 / last_price — both operands are u128
+    let numerator = diff.checked_mul(BPS_DENOMINATOR)?;
+    let deviation = numerator / (last_price as u128);
+    // Cap at u32::MAX to avoid truncation; any value > 10_000 already exceeds any threshold
+    Some(deviation.min(u32::MAX as u128) as u32)
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -687,5 +727,46 @@ mod tests {
         let floor = prorate_interest(p, r, t, Rounding::Floor);
         let ceil = prorate_interest(p, r, t, Rounding::Ceil);
         assert_eq!(floor, ceil, "exact division should give floor == ceil");
+    }
+
+    // ── compute_deviation_bps ─────────────────────────────────────────────────
+
+    #[test]
+    fn deviation_five_percent_up() {
+        // 1050 vs 1000 → 50/1000 * 10_000 = 500 bps
+        assert_eq!(compute_deviation_bps(1_050, 1_000), Some(500));
+    }
+
+    #[test]
+    fn deviation_five_percent_down() {
+        // 950 vs 1000 → 50/1000 * 10_000 = 500 bps
+        assert_eq!(compute_deviation_bps(950, 1_000), Some(500));
+    }
+
+    #[test]
+    fn deviation_zero_change() {
+        assert_eq!(compute_deviation_bps(1_000, 1_000), Some(0));
+    }
+
+    #[test]
+    fn deviation_one_bps() {
+        // 10_001 vs 10_000 → 1/10_000 * 10_000 = 1 bps
+        assert_eq!(compute_deviation_bps(10_001, 10_000), Some(1));
+    }
+
+    #[test]
+    fn deviation_hundred_percent() {
+        // 2000 vs 1000 → 1000/1000 * 10_000 = 10_000 bps
+        assert_eq!(compute_deviation_bps(2_000, 1_000), Some(10_000));
+    }
+
+    #[test]
+    fn deviation_zero_last_price_returns_none() {
+        assert_eq!(compute_deviation_bps(100, 0), None);
+    }
+
+    #[test]
+    fn deviation_negative_last_price_returns_none() {
+        assert_eq!(compute_deviation_bps(100, -1), None);
     }
 }

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -37,8 +37,20 @@ pub enum DataKey {
     UtilizationCapBps(Address),
     /// Per-borrower installment schedule for delinquency tracking.
     RepaymentSchedule(Address),
-    /// Storage schema version, written once during init.
-    SchemaVersion,
+    /// Global maximum total exposure cap across all credit lines.
+    MaxTotalExposure,
+    /// Protocol fee in basis points collected on draws.
+    ProtocolFeeBps,
+    /// Treasury address for fee collection.
+    TreasuryAddress,
+    /// Accumulated treasury balance held in contract.
+    TreasuryBalance,
+    /// Oracle circuit-breaker configuration (max_deviation_bps, max_age_seconds).
+    OracleConfig,
+    /// Last accepted oracle price (i128, scaled by 1e7 or as reported).
+    OracleLastPrice,
+    /// Timestamp of the last accepted oracle price.
+    OracleLastPriceTs,
 }
 
 /// Maximum number of credit lines returned per page.
@@ -484,4 +496,32 @@ pub fn assert_ts_monotonic(env: &Env, stored_ts: u64, new_ts: u64) {
     if stored_ts != 0 && new_ts <= stored_ts {
         env.panic_with_error(crate::types::ContractError::TimestampRegression);
     }
+}
+
+// ── Oracle circuit-breaker storage ───────────────────────────────────────────
+
+/// Get the oracle circuit-breaker config, if set.
+pub fn get_oracle_config(env: &Env) -> Option<crate::types::OracleConfig> {
+    env.storage().instance().get(&DataKey::OracleConfig)
+}
+
+/// Set the oracle circuit-breaker config.
+pub fn set_oracle_config(env: &Env, cfg: &crate::types::OracleConfig) {
+    env.storage().instance().set(&DataKey::OracleConfig, cfg);
+}
+
+/// Get the last accepted oracle price, if any.
+pub fn get_oracle_last_price(env: &Env) -> Option<i128> {
+    env.storage().instance().get(&DataKey::OracleLastPrice)
+}
+
+/// Get the timestamp of the last accepted oracle price, if any.
+pub fn get_oracle_last_price_ts(env: &Env) -> Option<u64> {
+    env.storage().instance().get(&DataKey::OracleLastPriceTs)
+}
+
+/// Persist a newly accepted oracle price and its timestamp.
+pub fn set_oracle_last_price(env: &Env, price: i128, ts: u64) {
+    env.storage().instance().set(&DataKey::OracleLastPrice, &price);
+    env.storage().instance().set(&DataKey::OracleLastPriceTs, &ts);
 }

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -126,6 +126,12 @@ pub enum ContractError {
     DrawCooldownActive = 29,
     /// Treasury address is not configured when attempting a treasury withdrawal.
     TreasuryNotSet = 30,
+    /// Oracle price deviates more than the configured max_deviation_bps from the last accepted price.
+    OraclePriceDeviation = 31,
+    /// Oracle price timestamp is older than the configured max_age_seconds.
+    OraclePriceStale = 32,
+    /// Oracle price is zero or negative, which is invalid.
+    OraclePriceInvalid = 33,
 }
 
 /// Stored credit line data for a borrower.
@@ -230,6 +236,25 @@ pub enum GraceWaiverMode {
     FullWaiver = 0,
     /// Reduced rate - apply reduced_rate_bps during grace period.
     ReducedRate = 1,
+}
+
+/// Oracle circuit-breaker configuration.
+///
+/// When set, `settle_default_liquidation` validates the supplied `oracle_price`
+/// against the last accepted price and the current ledger timestamp before
+/// applying the settlement.
+///
+/// # Invariants
+/// - `max_deviation_bps` must be in `1..=10_000` (0.01 % – 100 %).
+/// - `max_age_seconds` must be > 0.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OracleConfig {
+    /// Maximum allowed price deviation from the last accepted price, in basis points.
+    /// E.g. 500 = 5 %.
+    pub max_deviation_bps: u32,
+    /// Maximum age of an oracle price in seconds before it is considered stale.
+    pub max_age_seconds: u64,
 }
 
 /// Event emitted when the rate formula config is set or cleared.

--- a/contracts/credit/tests/credit_auction_e2e.rs
+++ b/contracts/credit/tests/credit_auction_e2e.rs
@@ -122,7 +122,7 @@ fn settle_credit_from_auction(
     recovered_amount: i128,
 ) {
     let credit = CreditClient::new(env, &deployment.credit_id);
-    credit.settle_default_liquidation(&deployment.borrower, &recovered_amount, settlement_id);
+    credit.settle_default_liquidation(&deployment.borrower, &recovered_amount, settlement_id, &None);
     assert_event_topic(env, &deployment.credit_id, "credit", "liq_setl");
 }
 

--- a/contracts/credit/tests/default_liquidation_auction_hook.rs
+++ b/contracts/credit/tests/default_liquidation_auction_hook.rs
@@ -70,7 +70,7 @@ fn settle_partial_default_liquidation_and_block_replay() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_001");
 
-    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id, &None);
     assert!(has_event_topic(&env, "liq_setl"));
 
     let line = client.get_credit_line(&borrower).unwrap();
@@ -78,7 +78,7 @@ fn settle_partial_default_liquidation_and_block_replay() {
     assert_eq!(line.utilized_amount, 700);
 
     let replay = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &50_i128, &settlement_id);
+        client.settle_default_liquidation(&borrower, &50_i128, &settlement_id, &None);
     }));
     assert!(replay.is_err(), "replay settlement should panic");
 }
@@ -88,7 +88,7 @@ fn settle_full_default_liquidation_closes_credit_line() {
     let (env, contract_id, borrower) = setup_defaulted_line(450);
     let client = CreditClient::new(&env, &contract_id);
 
-    client.settle_default_liquidation(&borrower, &450_i128, &Symbol::new(&env, "auc_fin"));
+    client.settle_default_liquidation(&borrower, &450_i128, &Symbol::new(&env, "auc_fin"), &None);
     assert!(has_event_topic(&env, "closed"));
     assert!(has_event_topic(&env, "liq_setl"));
 
@@ -125,7 +125,7 @@ fn settle_default_liquidation_requires_defaulted_status() {
     client.draw_credit(&borrower, &500_i128);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_bad"));
+        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_bad"), &None);
     }));
 
     assert!(result.is_err(), "non-defaulted settlement should panic");

--- a/contracts/credit/tests/default_liquidation_settled_event.rs
+++ b/contracts/credit/tests/default_liquidation_settled_event.rs
@@ -101,7 +101,7 @@ fn settle_full_recovery_closes_line_and_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_full_001");
 
-    client.settle_default_liquidation(&borrower, &1_000_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &1_000_i128, &settlement_id, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -136,7 +136,7 @@ fn settle_partial_recovery_keeps_line_defaulted_and_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_partial_002");
 
-    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -171,7 +171,7 @@ fn settle_minimal_partial_recovery_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_min_003");
 
-    client.settle_default_liquidation(&borrower, &1_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &1_i128, &settlement_id, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -193,7 +193,7 @@ fn settle_near_full_recovery_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_near_004");
 
-    client.settle_default_liquidation(&borrower, &999_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &999_i128, &settlement_id, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -215,7 +215,7 @@ fn liq_setl_event_field_ordering_is_stable() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_order_005");
 
-    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id, &None);
 
     let event = get_last_liq_setl_event(&env);
 
@@ -238,7 +238,7 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     let client = CreditClient::new(&env, &contract_id);
 
     let sid1 = Symbol::new(&env, "auc_multi_1");
-    client.settle_default_liquidation(&borrower, &400_i128, &sid1);
+    client.settle_default_liquidation(&borrower, &400_i128, &sid1, &None);
 
     // Check first event immediately (before next invocation resets the buffer).
     let event1 = get_last_liq_setl_event(&env);
@@ -252,7 +252,7 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     assert_eq!(line1.status, CreditStatus::Defaulted);
 
     let sid2 = Symbol::new(&env, "auc_multi_2");
-    client.settle_default_liquidation(&borrower, &600_i128, &sid2);
+    client.settle_default_liquidation(&borrower, &600_i128, &sid2, &None);
 
     // Check second event immediately.
     let event2 = get_last_liq_setl_event(&env);
@@ -274,10 +274,10 @@ fn replay_settlement_with_same_id_panics() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_replay_006");
 
-    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id, &None);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &100_i128, &settlement_id);
+        client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &None);
     }));
     assert!(result.is_err(), "replay of same settlement_id must panic");
 
@@ -291,7 +291,7 @@ fn settle_zero_recovered_amount_panics() {
     let client = CreditClient::new(&env, &contract_id);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &0_i128, &Symbol::new(&env, "auc_zero"));
+        client.settle_default_liquidation(&borrower, &0_i128, &Symbol::new(&env, "auc_zero"), &None);
     }));
     assert!(result.is_err());
 
@@ -305,7 +305,7 @@ fn settle_negative_recovered_amount_panics() {
     let client = CreditClient::new(&env, &contract_id);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &(-100_i128), &Symbol::new(&env, "auc_neg"));
+        client.settle_default_liquidation(&borrower, &(-100_i128), &Symbol::new(&env, "auc_neg"), &None);
     }));
     assert!(result.is_err());
 
@@ -319,7 +319,7 @@ fn settle_over_recovery_panics() {
     let client = CreditClient::new(&env, &contract_id);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &600_i128, &Symbol::new(&env, "auc_over"));
+        client.settle_default_liquidation(&borrower, &600_i128, &Symbol::new(&env, "auc_over"), &None);
     }));
     assert!(result.is_err());
 
@@ -355,7 +355,7 @@ fn settle_on_active_line_panics() {
     client.draw_credit(&borrower, &1_000_i128);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &500_i128, &Symbol::new(&env, "auc_active"));
+        client.settle_default_liquidation(&borrower, &500_i128, &Symbol::new(&env, "auc_active"), &None);
     }));
     assert!(result.is_err());
 
@@ -377,7 +377,7 @@ fn settle_on_nonexistent_line_panics() {
     client.init(&admin);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_nonex"));
+        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_nonex"), &None);
     }));
     assert!(result.is_err());
 }

--- a/contracts/credit/tests/oracle_deviation.rs
+++ b/contracts/credit/tests/oracle_deviation.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for the oracle price-feed staleness and deviation circuit breaker.
+//!
+//! Covers:
+//! - `set_oracle_config` validation and admin-only enforcement
+//! - `settle_default_liquidation` with no oracle config (backward-compatible)
+//! - First-price acceptance (no prior price stored)
+//! - Within-bound deviation accepted
+//! - Over-deviation rejected with `OraclePriceDeviation`
+//! - Stale price rejected with `OraclePriceStale`
+//! - Zero / negative oracle price rejected with `OraclePriceInvalid`
+//! - Missing oracle_price when config is set rejected with `OraclePriceInvalid`
+//! - `get_oracle_config` returns stored config
+
+use creditra_credit::types::{ContractError, CreditStatus, OracleConfig};
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, Env, Symbol};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (CreditClient, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, contract_id, admin)
+}
+
+/// Open a credit line, draw `utilized`, then default it. Returns borrower.
+fn open_and_default(client: &CreditClient, env: &Env, contract_id: &Address, utilized: i128) -> Address {
+    let borrower = Address::generate(env);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token_addr = token_id.address();
+    client.set_liquidity_token(&token_addr);
+    token::StellarAssetClient::new(env, &token_addr).mint(contract_id, &1_000_000_i128);
+    token::StellarAssetClient::new(env, &token_addr).mint(&borrower, &1_000_000_i128);
+    token::Client::new(env, &token_addr).approve(&borrower, contract_id, &1_000_000_i128, &1_000_000_u32);
+
+    client.open_credit_line(&borrower, &10_000_i128, &300_u32, &60_u32);
+    if utilized > 0 {
+        client.draw_credit(&borrower, &utilized);
+    }
+    client.default_credit_line(&borrower);
+    borrower
+}
+
+fn sid(env: &Env, s: &str) -> Symbol {
+    Symbol::new(env, s)
+}
+
+// ── set_oracle_config ─────────────────────────────────────────────────────────
+
+#[test]
+fn set_oracle_config_stores_and_get_returns_it() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+
+    client.set_oracle_config(&500_u32, &3600_u64);
+
+    let cfg = client.get_oracle_config().unwrap();
+    assert_eq!(cfg.max_deviation_bps, 500);
+    assert_eq!(cfg.max_age_seconds, 3600);
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_config_zero_deviation_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_config(&0_u32, &3600_u64);
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_config_deviation_over_10000_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_config(&10_001_u32, &3600_u64);
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_config_zero_age_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &0_u64);
+}
+
+#[test]
+fn get_oracle_config_returns_none_when_not_set() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    assert!(client.get_oracle_config().is_none());
+}
+
+// ── no oracle config — backward compatible ────────────────────────────────────
+
+#[test]
+fn settle_without_oracle_config_accepts_none_price() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+
+    // No oracle config set — None price must be accepted.
+    client.settle_default_liquidation(&borrower, &500_i128, &sid(&env, "s1"), &None);
+
+    assert_eq!(client.get_credit_line(&borrower).unwrap().status, CreditStatus::Closed);
+}
+
+// ── first price acceptance ────────────────────────────────────────────────────
+
+#[test]
+fn settle_with_oracle_config_first_price_accepted() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64);
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+
+    // First call — no prior price stored, any positive price is accepted.
+    client.settle_default_liquidation(&borrower, &500_i128, &sid(&env, "s1"), &Some(1_000_i128));
+
+    assert_eq!(client.get_credit_line(&borrower).unwrap().status, CreditStatus::Closed);
+}
+
+// ── within-bound deviation accepted ──────────────────────────────────────────
+
+#[test]
+fn settle_within_deviation_bound_accepted() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64); // 5% max deviation
+
+    // First settlement — seeds the last accepted price at 1_000.
+    let b1 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+
+    // Second settlement — price 1_040 is 4% deviation from 1_000 (within 5%).
+    let b2 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_040_i128));
+
+    assert_eq!(client.get_credit_line(&b2).unwrap().status, CreditStatus::Closed);
+}
+
+// ── over-deviation rejected ───────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn settle_over_deviation_panics() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64); // 5% max deviation
+
+    // Seed last price at 1_000.
+    let b1 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+
+    // Price 1_100 is 10% deviation — exceeds 5% threshold.
+    let b2 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_100_i128));
+}
+
+#[test]
+#[should_panic]
+fn settle_over_deviation_downward_panics() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64);
+
+    let b1 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+
+    // Price 900 is 10% below 1_000 — exceeds 5% threshold.
+    let b2 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(900_i128));
+}
+
+// ── stale price rejected ──────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn settle_stale_price_panics() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64); // max age 1 hour
+
+    // Seed last price at t=1000.
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let b1 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+
+    // Advance time beyond max_age_seconds (1 hour = 3600s).
+    env.ledger().with_mut(|l| l.timestamp = 1_000 + 3_601);
+
+    // Price is now stale — should panic.
+    let b2 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_010_i128));
+}
+
+#[test]
+fn settle_price_at_exact_max_age_accepted() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let b1 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+
+    // Advance exactly max_age_seconds — age == 3600, not > 3600, so accepted.
+    env.ledger().with_mut(|l| l.timestamp = 1_000 + 3_600);
+    let b2 = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_010_i128));
+
+    assert_eq!(client.get_credit_line(&b2).unwrap().status, CreditStatus::Closed);
+}
+
+// ── invalid price ─────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn settle_zero_oracle_price_panics() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64);
+    let borrower = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&borrower, &200_i128, &sid(&env, "s1"), &Some(0_i128));
+}
+
+#[test]
+#[should_panic]
+fn settle_negative_oracle_price_panics() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64);
+    let borrower = open_and_default(&client, &env, &contract_id, 200);
+    client.settle_default_liquidation(&borrower, &200_i128, &sid(&env, "s1"), &Some(-1_i128));
+}
+
+#[test]
+#[should_panic]
+fn settle_missing_price_when_config_set_panics() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_config(&500_u32, &3600_u64);
+    let borrower = open_and_default(&client, &env, &contract_id, 200);
+    // oracle_price is None but config is set — must panic.
+    client.settle_default_liquidation(&borrower, &200_i128, &sid(&env, "s1"), &None);
+}

--- a/contracts/credit/tests/unauthorized_matrix.rs
+++ b/contracts/credit/tests/unauthorized_matrix.rs
@@ -246,7 +246,7 @@ fn settle_default_liquidation_unauthorized() {
     let (client, contract_id, admin, borrower) = setup(&env);
     admin_default(&env, &client, &admin, &contract_id, &borrower);
     let settlement_id = Symbol::new(&env, "settle_1");
-    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &None);
 }
 
 #[test]
@@ -653,7 +653,7 @@ fn settle_default_liquidation_unauthorized() {
     let (client, contract_id, admin, borrower) = setup(&env);
     admin_default(&env, &client, &admin, &contract_id, &borrower);
     let settlement_id = Symbol::new(&env, "settle_1");
-    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id);
+    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &None);
 }
 
 #[test]


### PR DESCRIPTION
- Add OracleConfig type (max_deviation_bps, max_age_seconds) to types.rs
- Add OracleConfig/OracleLastPrice/OracleLastPriceTs keys to DataKey enum
- Add oracle storage helpers to storage.rs
- Add compute_deviation_bps() to math_utils.rs (overflow-safe u128 arithmetic)
- Add OracleConfigSetEvent and OraclePriceAcceptedEvent to events.rs
- Update settle_default_liquidation to accept oracle_price: Option<i128>
  - Rejects when deviation > max_deviation_bps (OraclePriceDeviation)
  - Rejects when price age > max_age_seconds (OraclePriceStale)
  - Rejects zero/negative prices (OraclePriceInvalid)
  - No-op when oracle config not set (backward compatible)
- Add set_oracle_config / get_oracle_config admin methods
- Add tests/oracle_deviation.rs with 15 integration tests
- Update all existing settle_default_liquidation callers to pass &None

Closes #344