### PR TITLE
PR: test: pin BorrowerBlockedEvent.ledger to env.ledger().sequence()

### DIFF
--- a/contracts/credit/tests/event_block_ledger_seq.rs
+++ b/contracts/credit/tests/event_block_ledger_seq.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+
+//! Pin `BorrowerBlockedEvent.ledger` to `env.ledger().sequence()` at emission.
+//!
+//! These tests advance the ledger sequence between calls and assert the
+//! `ledger` field of every emitted `BorrowerBlockedEvent` matches the
+//! sequence number that was live when the event was published. This guards
+//! against off-by-one regressions and ensures off-chain indexers can rely
+//! on the field for chronological ordering.
+
+use creditra_credit::events::BorrowerBlockedEvent;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{Address, Env, Symbol};
+
+fn setup(env: &Env) -> (CreditClient<'_>, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, admin)
+}
+
+/// Advance the ledger sequence by `delta` ticks.
+fn advance_ledger(env: &Env, delta: u32) {
+    env.ledger().with_mut(|li| {
+        li.sequence_number = li.sequence_number.saturating_add(delta);
+    });
+}
+
+/// Return the last emitted `BorrowerBlockedEvent` (data only).
+fn last_blocked_event(env: &Env) -> BorrowerBlockedEvent {
+    let kind = Symbol::new(env, "blk_chg");
+    for (_contract, topics, data) in env.events().all().iter().rev() {
+        let t0 = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
+        if t0 == kind {
+            return BorrowerBlockedEvent::try_from_val(env, &data).unwrap();
+        }
+    }
+    panic!("No blk_chg event found");
+}
+
+// ── block_borrower ────────────────────────────────────────────────────────────
+
+#[test]
+fn block_emits_ledger_matching_sequence() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    advance_ledger(&env, 5);
+    let seq = env.ledger().sequence();
+    client.block_borrower(&_admin, &borrower);
+
+    let event = last_blocked_event(&env);
+    assert_eq!(event.ledger, seq, "block ledger must equal env sequence");
+    assert!(event.blocked);
+    assert_eq!(event.borrower, borrower);
+}
+
+#[test]
+fn block_after_advancing_twice_matches_newer_sequence() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    advance_ledger(&env, 3);
+    let seq1 = env.ledger().sequence();
+    client.block_borrower(&_admin, &borrower);
+
+    let ev1 = last_blocked_event(&env);
+    assert_eq!(ev1.ledger, seq1);
+
+    advance_ledger(&env, 10);
+    let borrower2 = Address::generate(&env);
+    let seq2 = env.ledger().sequence();
+    client.block_borrower(&_admin, &borrower2);
+
+    let ev2 = last_blocked_event(&env);
+    assert_eq!(ev2.ledger, seq2, "second block must reflect later sequence");
+    assert!(
+        ev2.ledger > ev1.ledger,
+        "ledger must be strictly increasing"
+    );
+}
+
+// ── unblock_borrower ──────────────────────────────────────────────────────────
+
+#[test]
+fn unblock_emits_ledger_matching_sequence() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.block_borrower(&_admin, &borrower);
+
+    advance_ledger(&env, 7);
+    let seq = env.ledger().sequence();
+    client.unblock_borrower(&_admin, &borrower);
+
+    let event = last_blocked_event(&env);
+    assert_eq!(event.ledger, seq, "unblock ledger must equal env sequence");
+    assert!(!event.blocked, "unblock event must have blocked = false");
+}
+
+// ── block → unblock round-trip ────────────────────────────────────────────────
+
+#[test]
+fn block_then_unblock_ledger_values_differ() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    let seq_block = env.ledger().sequence();
+    client.block_borrower(&_admin, &borrower);
+    let ev_block = last_blocked_event(&env);
+    assert_eq!(ev_block.ledger, seq_block);
+
+    advance_ledger(&env, 1);
+    let seq_unblock = env.ledger().sequence();
+    client.unblock_borrower(&_admin, &borrower);
+    let ev_unblock = last_blocked_event(&env);
+    assert_eq!(ev_unblock.ledger, seq_unblock);
+    assert!(ev_unblock.ledger > ev_block.ledger);
+}
+
+// ── bulk_block_borrowers ──────────────────────────────────────────────────────
+
+#[test]
+fn bulk_block_emits_one_event_per_borrower_all_with_same_ledger() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+
+    advance_ledger(&env, 4);
+    let seq = env.ledger().sequence();
+
+    client.bulk_block_borrowers(
+        &_admin,
+        &soroban_sdk::vec![&env, b1.clone(), b2.clone(), b3.clone()],
+    );
+
+    // Collect all blk_chg events emitted after the clear point
+    let kind = Symbol::new(&env, "blk_chg");
+    let mut blocked_events: Vec<BorrowerBlockedEvent> = Vec::new();
+    for (_contract, topics, data) in env.events().all().iter() {
+        let t0 = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        if t0 == kind {
+            blocked_events.push(BorrowerBlockedEvent::try_from_val(&env, &data).unwrap());
+        }
+    }
+
+    assert_eq!(
+        blocked_events.len(),
+        3,
+        "bulk block must emit exactly 3 events"
+    );
+
+    for ev in blocked_events.iter() {
+        assert_eq!(
+            ev.ledger, seq,
+            "every bulk event must share the same ledger"
+        );
+        assert!(ev.blocked);
+    }
+}
+
+#[test]
+fn bulk_block_ledger_matches_at_emission_not_call_time() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    // Advance ledger before calling bulk_block
+    advance_ledger(&env, 20);
+    let seq = env.ledger().sequence();
+
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+
+    client.bulk_block_borrowers(&_admin, &soroban_sdk::vec![&env, b1.clone(), b2.clone()]);
+
+    let kind = Symbol::new(&env, "blk_chg");
+    let mut events = Vec::new();
+    for (_contract, topics, data) in env.events().all().iter() {
+        let t0 = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        if t0 == kind {
+            events.push(BorrowerBlockedEvent::try_from_val(&env, &data).unwrap());
+        }
+    }
+
+    assert_eq!(events.len(), 2);
+    for ev in events.iter() {
+        assert_eq!(
+            ev.ledger, seq,
+            "ledger must reflect the sequence at emission, not some earlier default"
+        );
+    }
+}
+
+// ── edge case: no advancement (default sequence) ──────────────────────────────
+
+#[test]
+fn block_at_default_sequence_matches() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    let seq = env.ledger().sequence();
+    client.block_borrower(&_admin, &borrower);
+
+    let event = last_blocked_event(&env);
+    assert_eq!(
+        event.ledger, seq,
+        "must match even at the default ledger sequence"
+    );
+}


### PR DESCRIPTION

Summary
BorrowerBlockedEvent carries a ledger: u32 field for off-chain chronological reordering. This PR adds integration tests that advance the ledger sequence between calls and assert the emitted ledger value equals env.ledger().sequence() at the exact moment of emission.
What changed
New file: contracts/credit/tests/event_block_ledger_seq.rs (220 lines, 7 tests)
Test	Scenario
block_emits_ledger_matching_sequence	block_borrower after advancing ledger by 5 ticks
block_after_advancing_twice_matches_newer_sequence	Two blocks at different sequences, asserts strictly increasing
unblock_emits_ledger_matching_sequence	unblock_borrower after advancing ledger by 7 ticks
block_then_unblock_ledger_values_differ	Round-trip with 1-tick advance between block and unblock
bulk_block_emits_one_event_per_borrower_all_with_same_ledger	3 borrowers blocked in a single call, all share the same ledger
bulk_block_ledger_matches_at_emission_not_call_time	Advances ledger by 20 before bulk call, confirms it's not the default
block_at_default_sequence_matches	No advancement — matches the initial default sequence
Why
- 
Off-chain indexers use BorrowerBlockedEvent.ledger for chronological ordering and reorg detection.
- 
A future refactor could accidentally change env.ledger().sequence() to a cached value or introduce an off-by-one. These tests pin the current correct behavior.
- 
No dedicated happy-path tests existed for block_borrower / unblock_borrower / bulk_block_borrowers — this fills that gap.
How it works
1. 
advance_ledger(env, delta) bumps env.ledger().sequence_number via saturating_add.
2. 
last_blocked_event(env) scans env.events().all() in reverse for the ("blk_chg",) topic and deserializes the BorrowerBlockedEvent payload.
3. 
Each test captures seq = env.ledger().sequence() right before the client call and asserts event.ledger == seq.
Acceptance criteria
- 
Ledger sequence matches at emission time
- 
Multiple toggles tested (block, unblock, bulk, round-trip)
- 
No off-by-one (advanced by 1, 3, 4, 5, 7, 10, 20 ticks)
- 
Follows existing test patterns (setup, mock_all_auths, event iteration)
- 
Formatted with rustfmt
/agents      
Switch agent
/compact     
To verify
Compact session
/connect     
Connect provider
/copy        
cargo test -p creditra-credit --test event_block_ledger_seq
Copy session transcript
/editor      
Open editor
/exit        
Note: cargo test could not run in this environment (missing MSVC linker). The code has been rustfmt-cleaned and verified against existing patterns in event_topic_stability.rs and default_liquidation_settled_event.rs.
Exit the app
/export      
Export session transcript
/fork        
Fork session
/help        
▣  Build · MiMo V2.5 Free · 32.3s
Help
/init        
guided AGENTS.md setup

closes #507 