### PR TITLE
feat: get_draw_audit + paginated enumerate_draw_audit

### DIFF
--- a/contracts/credit/src/draw_audit_tests.rs
+++ b/contracts/credit/src/draw_audit_tests.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{token::StellarAssetClient, Vec};
+
+fn setup_default() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+    client.set_liquidity_token(&token_address);
+    client.set_liquidity_source(&contract_id);
+
+    StellarAssetClient::new(&env, &token_address).mint(&contract_id, &100_000_i128);
+
+    client.open_credit_line(&borrower, &100_000_i128, &300_u32, &50_u32);
+
+    (env, borrower, contract_id)
+}
+
+#[test]
+fn get_draw_audit_returns_recorded_amount() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.draw_credit(&borrower, &5_000_i128);
+    let ts = env.ledger().timestamp();
+
+    let audit = client.get_draw_audit(&borrower, &ts);
+    assert_eq!(audit, Some(5_000_i128));
+}
+
+#[test]
+fn get_draw_audit_unknown_timestamp_returns_none() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let audit = client.get_draw_audit(&borrower, &0_u64);
+    assert_eq!(audit, None);
+}
+
+#[test]
+fn get_draw_audit_nonexistent_borrower_returns_none() {
+    let (env, _borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let stranger = Address::generate(&env);
+    let audit = client.get_draw_audit(&stranger, &100_u64);
+    assert_eq!(audit, None);
+}
+
+#[test]
+fn enumerate_draw_audit_returns_multiple_draws() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.draw_credit(&borrower, &2_000_i128);
+    let ts1 = env.ledger().timestamp();
+
+    env.ledger().with_mut(|li| li.timestamp = 2000);
+    client.draw_credit(&borrower, &3_000_i128);
+    let ts2 = env.ledger().timestamp();
+
+    env.ledger().with_mut(|li| li.timestamp = 3000);
+    client.draw_credit(&borrower, &4_000_i128);
+    let ts3 = env.ledger().timestamp();
+
+    let audit = client.enumerate_draw_audit(&borrower, &None, &10_u32);
+    let mut expected = Vec::new(&env);
+    expected.push_back((ts3, 4_000_i128));
+    expected.push_back((ts2, 3_000_i128));
+    expected.push_back((ts1, 2_000_i128));
+    assert_eq!(audit, expected);
+}
+
+#[test]
+fn enumerate_draw_audit_cursor_excludes_upper_bound() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.draw_credit(&borrower, &2_000_i128);
+    let ts1 = env.ledger().timestamp();
+
+    env.ledger().with_mut(|li| li.timestamp = 2000);
+    client.draw_credit(&borrower, &3_000_i128);
+    let ts2 = env.ledger().timestamp();
+
+    env.ledger().with_mut(|li| li.timestamp = 3000);
+    client.draw_credit(&borrower, &4_000_i128);
+    let ts3 = env.ledger().timestamp();
+
+    // cursor = ts3 means we exclude entries >= ts3, so only ts2, ts1
+    let audit = client.enumerate_draw_audit(&borrower, &Some(ts3), &10_u32);
+    let mut expected = Vec::new(&env);
+    expected.push_back((ts2, 3_000_i128));
+    expected.push_back((ts1, 2_000_i128));
+    assert_eq!(audit, expected);
+}
+
+#[test]
+fn enumerate_draw_audit_respects_limit() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.draw_credit(&borrower, &2_000_i128);
+
+    env.ledger().with_mut(|li| li.timestamp = 2000);
+    client.draw_credit(&borrower, &3_000_i128);
+
+    env.ledger().with_mut(|li| li.timestamp = 3000);
+    client.draw_credit(&borrower, &4_000_i128);
+
+    let audit = client.enumerate_draw_audit(&borrower, &None, &2_u32);
+    assert_eq!(audit.len(), 2);
+}
+
+#[test]
+fn enumerate_draw_audit_zero_limit_returns_empty() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.draw_credit(&borrower, &2_000_i128);
+
+    let audit = client.enumerate_draw_audit(&borrower, &None, &0_u32);
+    assert_eq!(audit.len(), 0);
+}
+
+#[test]
+fn enumerate_draw_audit_no_draws_returns_empty() {
+    let (env, borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let audit = client.enumerate_draw_audit(&borrower, &None, &10_u32);
+    assert_eq!(audit.len(), 0);
+}
+
+#[test]
+fn enumerate_draw_audit_nonexistent_borrower_returns_empty() {
+    let (env, _borrower, contract_id) = setup_default();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let stranger = Address::generate(&env);
+    let audit = client.enumerate_draw_audit(&stranger, &None, &10_u32);
+    assert_eq!(audit.len(), 0);
+}

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -97,10 +97,10 @@ mod accrual_tests;
 mod amount_validation_tests;
 mod auth;
 mod borrow;
+mod collateral;
 mod config;
 pub mod events;
 mod freeze;
-mod collateral;
 mod lifecycle;
 mod query;
 pub mod math_utils;
@@ -111,36 +111,32 @@ pub mod types;
 #[cfg(test)]
 mod boundary_tests;
 #[cfg(test)]
+mod draw_audit_tests;
+#[cfg(test)]
 mod risk_formula_tests;
 
 use crate::auth::require_admin_auth;
 use crate::events::{
     publish_admin_rotation_accepted, publish_admin_rotation_proposed,
-    publish_borrower_blocked_event, publish_credit_line_event, publish_drawn_event,
-    publish_interest_accrued_event, publish_repayment_event, CreditLineEvent, DrawnEvent,
-    InterestAccruedEvent, RepaymentEvent,
-    publish_oracle_config_set_event, publish_oracle_price_accepted_event,
-    publish_contract_upgraded_event, ContractUpgradedEvent,
-    publish_token_rescued_event,
+    publish_borrower_blocked_event, publish_contract_upgraded_event, publish_credit_line_event,
+    publish_drawn_event, publish_interest_accrued_event, publish_oracle_config_set_event,
+    publish_oracle_price_accepted_event, publish_repayment_event, publish_token_rescued_event,
+    ContractUpgradedEvent, CreditLineEvent, DrawnEvent, InterestAccruedEvent, RepaymentEvent,
 };
-use crate::math_utils::{mul_div, Rounding, compute_deviation_bps};
+use crate::math_utils::{compute_deviation_bps, mul_div, Rounding};
 use crate::storage::{
-    admin_key, assert_not_paused, clear_reentrancy_guard, proposed_admin_key, proposed_at_key,
-    rate_cfg_key, set_reentrancy_guard, DataKey, persist_credit_line,
-    get_borrower_by_credit_line_id, MAX_ENUMERATION_LIMIT,
-    set_borrower_blocked as storage_set_borrower_blocked,
-    set_borrower_unblocked,
-    is_borrower_blocked as storage_is_borrower_blocked,
-    clear_repayment_schedule,
-    get_credit_line as storage_get_credit_line,
+    admin_key, assert_not_paused, clear_reentrancy_guard, clear_repayment_schedule,
+    get_borrower_by_credit_line_id, get_credit_line as storage_get_credit_line,
     get_last_draw_ts as storage_get_last_draw_ts,
-    set_last_draw_ts as storage_set_last_draw_ts,
     get_utilization_cap_bps as storage_get_utilization_cap_bps,
-    set_utilization_cap_bps as storage_set_utilization_cap_bps,
+    is_borrower_blocked as storage_is_borrower_blocked, persist_credit_line, proposed_admin_key,
+    proposed_at_key, rate_cfg_key, set_borrower_blocked as storage_set_borrower_blocked,
+    set_borrower_unblocked, set_last_draw_ts as storage_set_last_draw_ts, set_reentrancy_guard,
+    set_utilization_cap_bps as storage_set_utilization_cap_bps, DataKey, MAX_ENUMERATION_LIMIT,
 };
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode,
-    OracleConfig, ProtocolConfig, ProtocolSummary, RateChangeConfig, RateFormulaConfig,
+    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
+    ProtocolConfig, ProtocolSummary, RateChangeConfig, RateFormulaConfig,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -148,7 +144,6 @@ pub const CONTRACT_API_VERSION: (u32, u32, u32) = (1, 0, 0);
 
 /// Maximum allowed protocol fee in basis points (1000 = 10%). Adjust if needed.
 const MAX_PROTOCOL_FEE_BPS: u32 = 1_000;
-
 
 #[allow(dead_code)]
 const SECONDS_PER_YEAR: u64 = 31_536_000;
@@ -413,10 +408,11 @@ impl Credit {
             }
         }
 
-        let stored_line: CreditLineData = storage_get_credit_line(&env, &borrower).unwrap_or_else(|| {
-            clear_reentrancy_guard(&env);
-            env.panic_with_error(ContractError::CreditLineNotFound)
-        });
+        let stored_line: CreditLineData =
+            storage_get_credit_line(&env, &borrower).unwrap_or_else(|| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::CreditLineNotFound)
+            });
         let previous_utilized = stored_line.utilized_amount;
 
         let mut credit_line = accrual::apply_accrual(&env, stored_line);
@@ -539,6 +535,10 @@ impl Credit {
 
         let timestamp = env.ledger().timestamp();
         storage_set_last_draw_ts(&env, &borrower, timestamp);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DrawAudit(borrower.clone(), timestamp), &amount);
+        crate::storage::push_draw_audit_timestamp(&env, &borrower, timestamp);
         publish_drawn_event(
             &env,
             DrawnEvent {
@@ -582,10 +582,11 @@ impl Credit {
             }
         }
 
-        let stored_line: CreditLineData = storage_get_credit_line(&env, &borrower).unwrap_or_else(|| {
-            clear_reentrancy_guard(&env);
-            env.panic_with_error(ContractError::CreditLineNotFound)
-        });
+        let stored_line: CreditLineData =
+            storage_get_credit_line(&env, &borrower).unwrap_or_else(|| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::CreditLineNotFound)
+            });
         let previous_utilized = stored_line.utilized_amount;
 
         let mut credit_line = accrual::apply_accrual(&env, stored_line);
@@ -631,18 +632,31 @@ impl Credit {
                 // Transfer fee portion into contract (treasury accumulator), then
                 // transfer remaining amount into the reserve.
                 if fee > 0 {
-                    token_client.transfer_from(&contract_address, &borrower, &contract_address, &fee);
+                    token_client.transfer_from(
+                        &contract_address,
+                        &borrower,
+                        &contract_address,
+                        &fee,
+                    );
                     crate::storage::add_treasury_balance(&env, fee);
-                    crate::events::publish_fee_accrued_event(&env, crate::events::FeeAccruedEvent {
-                        borrower: borrower.clone(),
-                        fee_amount: fee,
-                        new_treasury_balance: crate::storage::get_treasury_balance(&env),
-                    });
+                    crate::events::publish_fee_accrued_event(
+                        &env,
+                        crate::events::FeeAccruedEvent {
+                            borrower: borrower.clone(),
+                            fee_amount: fee,
+                            new_treasury_balance: crate::storage::get_treasury_balance(&env),
+                        },
+                    );
                 }
 
                 let reserve_amount = effective_repay.saturating_sub(fee);
                 if reserve_amount > 0 {
-                    token_client.transfer_from(&contract_address, &borrower, &reserve_address, &reserve_amount);
+                    token_client.transfer_from(
+                        &contract_address,
+                        &borrower,
+                        &reserve_address,
+                        &reserve_amount,
+                    );
                 }
             }
         }
@@ -931,7 +945,9 @@ impl Credit {
             .storage()
             .instance()
             .get(&DataKey::LiquidityToken)
-            .unwrap_or_else(|| env.panic_with_error(crate::types::ContractError::MissingLiquidityToken));
+            .unwrap_or_else(|| {
+                env.panic_with_error(crate::types::ContractError::MissingLiquidityToken)
+            });
 
         let token_client = token::Client::new(&env, &token_address);
         let contract_address = env.current_contract_address();
@@ -1070,7 +1086,6 @@ impl Credit {
         out
     }
 
-    
     pub fn suspend_credit_line(env: Env, borrower: Address) {
         lifecycle::suspend_credit_line(env, borrower)
     }
@@ -1103,7 +1118,7 @@ impl Credit {
         lifecycle::reinstate_credit_line(env, borrower)
     }
 
-// duplicate wrapper removed
+    // duplicate wrapper removed
 
     pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditStatus) {
         lifecycle::reinstate_credit_line(env, borrower, target_status)
@@ -1151,11 +1166,10 @@ impl Credit {
                 }
 
                 if let Some(last_price) = crate::storage::get_oracle_last_price(&env) {
-                    let deviation = compute_deviation_bps(price, last_price)
-                        .unwrap_or_else(|| {
-                            clear_reentrancy_guard(&env);
-                            env.panic_with_error(ContractError::OraclePriceInvalid)
-                        });
+                    let deviation = compute_deviation_bps(price, last_price).unwrap_or_else(|| {
+                        clear_reentrancy_guard(&env);
+                        env.panic_with_error(ContractError::OraclePriceInvalid)
+                    });
                     if deviation > cfg.max_deviation_bps {
                         clear_reentrancy_guard(&env);
                         env.panic_with_error(ContractError::OraclePriceDeviation);
@@ -1181,7 +1195,12 @@ impl Credit {
             }
         }
 
-        lifecycle::settle_default_liquidation(env.clone(), borrower, recovered_amount, settlement_id);
+        lifecycle::settle_default_liquidation(
+            env.clone(),
+            borrower,
+            recovered_amount,
+            settlement_id,
+        );
         clear_reentrancy_guard(&env);
     }
 
@@ -1231,7 +1250,13 @@ impl Credit {
             env.panic_with_error(ContractError::InvalidAmount);
         }
 
-        set_oracle_config(&env, &OracleConfig { max_deviation_bps, max_age_seconds });
+        set_oracle_config(
+            &env,
+            &OracleConfig {
+                max_deviation_bps,
+                max_age_seconds,
+            },
+        );
         publish_oracle_config_set_event(&env, max_deviation_bps, max_age_seconds);
     }
 
@@ -1301,7 +1326,10 @@ impl Credit {
     pub fn accrue_batch(env: Env, borrowers: Vec<Address>) {
         assert_not_paused(&env);
         if borrowers.len() as u32 > ACCRUE_BATCH_MAX {
-            panic!("accrue_batch: exceeds max batch size of {}", ACCRUE_BATCH_MAX);
+            panic!(
+                "accrue_batch: exceeds max batch size of {}",
+                ACCRUE_BATCH_MAX
+            );
         }
 
         accrual::accrue_batch(&env, borrowers);
@@ -1318,6 +1346,31 @@ impl Credit {
     /// Backward-compatible alias for older tests and SDK callers.
     pub fn get_credit_line_summary(env: Env, borrower: Address) -> Option<CreditLineData> {
         Self::get_credit_line(env, borrower)
+    }
+
+    /// Return the draw amount recorded for `borrower` at `timestamp`, or `None`
+    /// if no draw occurred at that timestamp.
+    ///
+    /// No authentication required — read-only.
+    pub fn get_draw_audit(env: Env, borrower: Address, timestamp: u64) -> Option<i128> {
+        query::get_draw_audit(env, borrower, timestamp)
+    }
+
+    /// Enumerate draw audit entries for `borrower` in reverse chronological order
+    /// (most recent first).
+    ///
+    /// `cursor` is an exclusive upper bound: the scan starts from
+    /// `cursor.saturating_sub(1)` when provided, or from the borrower's most recent
+    /// draw timestamp otherwise. Results are capped by `MAX_ENUMERATION_LIMIT`.
+    ///
+    /// No authentication required — read-only.
+    pub fn enumerate_draw_audit(
+        env: Env,
+        borrower: Address,
+        cursor: Option<u64>,
+        limit: u32,
+    ) -> Vec<(u64, i128)> {
+        query::enumerate_draw_audit(env, borrower, cursor, limit)
     }
 
     pub fn get_rate_formula_config(env: Env) -> Option<RateFormulaConfig> {
@@ -1491,14 +1544,14 @@ impl Credit {
     /// ```ignore
     /// // Deploy new WASM and get its hash
     /// let new_wasm_hash = env.deployer().upload_contract_wasm(new_wasm);
-    /// 
+    ///
     /// // Upgrade the contract
     /// client.upgrade(&new_wasm_hash);
     /// ```
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
         // Enforce pause check: upgrades are blocked during emergency circuit breaker.
         assert_not_paused(&env);
-        
+
         // Enforce admin authentication: only the configured admin can upgrade.
         require_admin_auth(&env);
 
@@ -1510,7 +1563,8 @@ impl Credit {
         crate::storage::set_schema_version(&env, current_version.saturating_add(1));
 
         // Perform the atomic WASM upgrade.
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         // Emit upgrade event for off-chain indexers and audit trails.
         publish_contract_upgraded_event(
@@ -2707,8 +2761,8 @@ mod test_mock_liquidity_token {
     #[test]
     fn test_event_lifecycle_sequence() {
         use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::TryIntoVal;
         use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+        use soroban_sdk::TryIntoVal;
 
         /// Setup helper: creates contract with token, mints `reserve` to contract,
         /// opens credit line for borrower with `credit_limit`, draws `draw_amount`.
@@ -2933,7 +2987,8 @@ mod test_mock_liquidity_token {
             assert!(checkpoint > 0);
 
             // Advance ledger timestamp by exactly one year
-            env.ledger().set_timestamp(checkpoint + crate::accrual::SECONDS_PER_YEAR);
+            env.ledger()
+                .set_timestamp(checkpoint + crate::accrual::SECONDS_PER_YEAR);
 
             // At 300 bps (3%) on 900 principal, expected interest = floor(900 * 300 / 10000) = 27
             StellarAssetClient::new(&env, &token).mint(&borrower, &200);
@@ -3105,22 +3160,23 @@ mod test_mock_liquidity_token {
                     .transfer_from(spender, from, to, &amount);
             }
         }
-
     }
     #[cfg(test)]
     mod test_mock_liquidity_token {
         use super::*;
-        use crate::test_coverage::test_helpers::MockLiquidityToken;
         use crate::events::CreditLineEvent;
+        use crate::test_coverage::test_helpers::MockLiquidityToken;
         use soroban_sdk::testutils::Events as _;
         use soroban_sdk::testutils::Ledger;
-        use soroban_sdk::token::StellarAssetClient;
         use soroban_sdk::token::Client as TokenClient;
-        use soroban_sdk::{symbol_short, Symbol, TryFromVal, TryIntoVal, Env};
+        use soroban_sdk::token::StellarAssetClient;
+        use soroban_sdk::{symbol_short, Env, Symbol, TryFromVal, TryIntoVal};
         use std::boxed::Box;
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
-        fn setup_mock<'a>(env: &'a Env) -> (CreditClient<'a>, Address, Address, MockLiquidityToken) {
+        fn setup_mock<'a>(
+            env: &'a Env,
+        ) -> (CreditClient<'a>, Address, Address, MockLiquidityToken) {
             env.mock_all_auths();
             let admin = Address::generate(env);
             let borrower = Address::generate(env);
@@ -3373,7 +3429,10 @@ mod test_mock_liquidity_token {
             StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_000_i128);
             StellarAssetClient::new(&env, &token).mint(&borrower, &1_000_000_i128);
             soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower, &contract_id, &1_000_000_i128, &1_000_000_u32,
+                &borrower,
+                &contract_id,
+                &1_000_000_i128,
+                &1_000_000_u32,
             );
             client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
             client.draw_credit(&borrower, &200_i128);
@@ -3877,7 +3936,10 @@ mod test_mock_liquidity_token {
             StellarAssetClient::new(&env, &token).mint(&contract_id, &10_000_i128);
             StellarAssetClient::new(&env, &token).mint(&borrower, &10_000_i128);
             soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower, &contract_id, &10_000_i128, &1_000_000_u32,
+                &borrower,
+                &contract_id,
+                &10_000_i128,
+                &1_000_000_u32,
             );
             client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
             client.draw_credit(&borrower, &500_i128);
@@ -4178,7 +4240,8 @@ mod test_mock_liquidity_token {
             let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
             let token = token_id.address();
             client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(env, &token).mint(&contract_id, &1_000_000_i128);
+            soroban_sdk::token::StellarAssetClient::new(env, &token)
+                .mint(&contract_id, &1_000_000_i128);
             client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
             (client, admin, borrower)
         }
@@ -4633,13 +4696,17 @@ mod test_mock_liquidity_token {
             let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
             let token = token_id.address();
             client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_i128);
+            soroban_sdk::token::StellarAssetClient::new(&env, &token)
+                .mint(&contract_id, &1_000_i128);
             client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
 
             client.set_draw_min_interval(&60_u64);
             client.draw_credit(&borrower, &200_i128);
             soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower, &contract_id, &1_000_i128, &1_000_000_u32,
+                &borrower,
+                &contract_id,
+                &1_000_i128,
+                &1_000_000_u32,
             );
             client.repay_credit(&borrower, &100_i128);
 
@@ -4687,7 +4754,8 @@ mod test_mock_liquidity_token {
             let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
             let token = token_id.address();
             client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &i128::MAX);
+            soroban_sdk::token::StellarAssetClient::new(&env, &token)
+                .mint(&contract_id, &i128::MAX);
 
             // Set credit limit to a large value near i128::MAX
             let large_limit = i128::MAX / 2;
@@ -4744,7 +4812,8 @@ mod test_mock_liquidity_token {
             let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
             let token = token_id.address();
             client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &i128::MAX);
+            soroban_sdk::token::StellarAssetClient::new(&env, &token)
+                .mint(&contract_id, &i128::MAX);
             env.ledger().set_timestamp(1);
             client.open_credit_line(&borrower, &(i128::MAX / 2), &300_u32, &70_u32);
 
@@ -4758,7 +4827,10 @@ mod test_mock_liquidity_token {
             // Approve and repay a large amount (saturating_sub should handle safely)
             let repay_amount = draw_amount / 2;
             soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower, &contract_id, &repay_amount, &1_000_000_u32,
+                &borrower,
+                &contract_id,
+                &repay_amount,
+                &1_000_000_u32,
             );
             client.repay_credit(&borrower, &repay_amount);
 
@@ -4798,7 +4870,8 @@ mod test_mock_liquidity_token {
             let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
             let token = token_id.address();
             client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_i128);
+            soroban_sdk::token::StellarAssetClient::new(&env, &token)
+                .mint(&contract_id, &1_000_i128);
             env.ledger().set_timestamp(1);
             client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
 
@@ -4806,7 +4879,10 @@ mod test_mock_liquidity_token {
 
             // Approve borrower to repay (borrower received 500 tokens from draw)
             soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower, &contract_id, &1_000_i128, &1_000_000_u32,
+                &borrower,
+                &contract_id,
+                &1_000_i128,
+                &1_000_000_u32,
             );
 
             // Repay more than owed (1000 > 500) — effective_repay = 500
@@ -5393,7 +5469,10 @@ mod test_mock_liquidity_token {
             // Mint to borrower so they have funds to repay
             StellarAssetClient::new(env, &token).mint(&borrower, &5_000_i128);
             soroban_sdk::token::Client::new(env, &token).approve(
-                &borrower, &contract_id, &10_000_i128, &1_000_000_u32,
+                &borrower,
+                &contract_id,
+                &10_000_i128,
+                &1_000_000_u32,
             );
 
             (client, admin, borrower, token)

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -10,11 +10,11 @@
 //! structs are designed for stable serialization order (see
 //! [`crate::types::CreditLineData`] field ordering note).
 
-use crate::storage::grace_period_key;
+use crate::storage::{grace_period_key, MAX_ENUMERATION_LIMIT};
 use crate::types::{
     CreditLineData, CreditStatus, GracePeriodConfig, ProtocolSummary, RepaymentSchedule,
 };
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Vec};
 
 /// Return the credit line for `borrower`, or `None` if no line exists.
 ///
@@ -82,9 +82,99 @@ pub fn is_delinquent(env: Env, borrower: Address) -> bool {
         return false;
     };
 
-    let grace_cfg: Option<GracePeriodConfig> = env.storage().instance().get(&grace_period_key(&env));
+    let grace_cfg: Option<GracePeriodConfig> =
+        env.storage().instance().get(&grace_period_key(&env));
     let grace_seconds = grace_cfg.map(|cfg| cfg.grace_period_seconds).unwrap_or(0);
     let delinquent_after = schedule.next_due_ts.saturating_add(grace_seconds);
 
     env.ledger().timestamp() > delinquent_after
+}
+
+/// Return the draw amount recorded for `borrower` at `timestamp`, or `None`
+/// if no draw occurred at that timestamp.
+///
+/// # Authentication
+/// No authentication required. Read-only — does not mutate storage.
+pub fn get_draw_audit(env: Env, borrower: Address, timestamp: u64) -> Option<i128> {
+    env.storage()
+        .persistent()
+        .get(&crate::storage::DataKey::DrawAudit(borrower, timestamp))
+}
+
+/// Enumerate draw audit entries for `borrower` in reverse chronological order
+/// (most recent first).
+///
+/// `cursor` is an exclusive upper bound: only entries with timestamp strictly
+/// less than `cursor` are returned. Pass `None` to start from the most recent
+/// draw. Results are capped by `MAX_ENUMERATION_LIMIT`.
+///
+/// # CPU complexity
+///
+/// O(log N + limit) — a binary search locates the first qualifying entry in the
+/// timestamp index, then walks backward collecting at most `limit` results.
+///
+/// # Authentication
+/// No authentication required. Read-only — does not mutate storage.
+pub fn enumerate_draw_audit(
+    env: Env,
+    borrower: Address,
+    cursor: Option<u64>,
+    limit: u32,
+) -> Vec<(u64, i128)> {
+    let capped = limit.min(MAX_ENUMERATION_LIMIT);
+    let mut out: Vec<(u64, i128)> = Vec::new(&env);
+    if capped == 0 {
+        return out;
+    }
+
+    let timestamps = crate::storage::get_draw_audit_timestamps(&env, &borrower);
+    let len = timestamps.len();
+    if len == 0 {
+        return out;
+    }
+
+    // Binary search: find the rightmost index with timestamp < cursor.
+    // When cursor is None, start from the newest entry (last index).
+    let start_idx: i64 = match cursor {
+        Some(cursor_ts) => {
+            let mut lo: i64 = 0;
+            let mut hi: i64 = len as i64 - 1;
+            let mut result: i64 = -1;
+            while lo <= hi {
+                let mid = lo + (hi - lo) / 2;
+                let ts = timestamps.get(mid as u32).unwrap();
+                if ts < cursor_ts {
+                    result = mid;
+                    lo = mid + 1;
+                } else {
+                    hi = mid - 1;
+                }
+            }
+            if result < 0 {
+                return out;
+            }
+            result
+        }
+        None => len as i64 - 1,
+    };
+
+    // Walk backward from start_idx, collecting at most `capped` entries.
+    let mut idx = start_idx;
+    let mut collected = 0u32;
+    while idx >= 0 {
+        let ts = timestamps.get(idx as u32).unwrap();
+        let amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&crate::storage::DataKey::DrawAudit(borrower.clone(), ts))
+            .unwrap_or(0);
+        out.push_back((ts, amount));
+        collected += 1;
+        if collected >= capped {
+            break;
+        }
+        idx -= 1;
+    }
+
+    out
 }

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -59,7 +59,7 @@
 //! full per-variant tier table.
 
 use crate::types::{ContractError, CreditLineData, RepaymentSchedule};
-use soroban_sdk::{contracttype, Address, Env, Symbol};
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 /// Storage keys used in instance and persistent storage.
 ///
@@ -149,6 +149,8 @@ pub enum DataKey {
     MinCollateralRatioBps,
     /// Per-borrower draw audit trail: (borrower, timestamp) → original draw amount.
     DrawAudit(Address, u64),
+    /// Per-borrower list of draw timestamps (ascending), used for O(limit) enumeration.
+    DrawAuditTimestamps(Address),
     /// Per-borrower draw reversal tracking: (borrower, timestamp) → total reversed amount.
     DrawReversedAmount(Address, u64),
     /// Oracle circuit-breaker configuration.
@@ -512,7 +514,10 @@ pub fn clear_reentrancy_guard(env: &Env) {
 /// Set a per-borrower interest rate floor (admin only, enforced by caller).
 pub fn set_borrower_rate_floor(env: &Env, borrower: &Address, floor_bps: Option<u32>) {
     if let Some(floor) = floor_bps {
-        assert!(floor <= crate::risk::MAX_INTEREST_RATE_BPS, "floor exceeds max rate");
+        assert!(
+            floor <= crate::risk::MAX_INTEREST_RATE_BPS,
+            "floor exceeds max rate"
+        );
     }
     if let Some(floor) = floor_bps {
         env.storage()
@@ -639,7 +644,9 @@ pub fn get_collateral_token(env: &Env) -> Option<Address> {
 
 /// Persist the auction contract address (admin only, enforced by caller).
 pub fn set_auction_contract(env: &Env, addr: &Address) {
-    env.storage().instance().set(&DataKey::AuctionContract, addr);
+    env.storage()
+        .instance()
+        .set(&DataKey::AuctionContract, addr);
 }
 
 /// Return the installment schedule for a borrower, if configured.
@@ -670,6 +677,23 @@ pub fn set_last_draw_ts(env: &Env, borrower: &Address, ts: u64) {
         .set(&DataKey::LastDrawTs(borrower.clone()), &ts);
 }
 
+/// Return the list of draw timestamps for a borrower (ascending), or empty.
+pub fn get_draw_audit_timestamps(env: &Env, borrower: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DrawAuditTimestamps(borrower.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Append a timestamp to the borrower's draw audit timestamp list.
+pub fn push_draw_audit_timestamp(env: &Env, borrower: &Address, ts: u64) {
+    let mut timestamps = get_draw_audit_timestamps(env, borrower);
+    timestamps.push_back(ts);
+    env.storage()
+        .persistent()
+        .set(&DataKey::DrawAuditTimestamps(borrower.clone()), &timestamps);
+}
+
 /// Get the configured max draw amount, if set.
 pub fn get_max_draw_amount(env: &Env) -> Option<i128> {
     env.storage().instance().get(&DataKey::MaxDrawAmount)
@@ -677,7 +701,9 @@ pub fn get_max_draw_amount(env: &Env) -> Option<i128> {
 
 /// Set the max draw amount (admin only, enforced by caller).
 pub fn set_max_draw_amount(env: &Env, amount: i128) {
-    env.storage().instance().set(&DataKey::MaxDrawAmount, &amount);
+    env.storage()
+        .instance()
+        .set(&DataKey::MaxDrawAmount, &amount);
 }
 
 /// Get the configured max repay amount, if set.
@@ -687,12 +713,16 @@ pub fn get_max_repay_amount(env: &Env) -> Option<i128> {
 
 /// Set the max repay amount (admin only, enforced by caller).
 pub fn set_max_repay_amount(env: &Env, amount: i128) {
-    env.storage().instance().set(&DataKey::MaxRepayAmount, &amount);
+    env.storage()
+        .instance()
+        .set(&DataKey::MaxRepayAmount, &amount);
 }
 
 /// Get the configured draw min interval, if set.
 pub fn get_draw_min_interval(env: &Env) -> Option<u64> {
-    env.storage().instance().get(&DataKey::DrawMinIntervalSeconds)
+    env.storage()
+        .instance()
+        .get(&DataKey::DrawMinIntervalSeconds)
 }
 
 /// Set the draw min interval (admin only, enforced by caller).
@@ -709,12 +739,18 @@ pub fn set_draws_frozen(env: &Env, frozen: bool) {
 
 /// Check if draws are globally frozen.
 pub fn is_draws_frozen(env: &Env) -> bool {
-    env.storage().instance().get(&DataKey::DrawsFrozen).unwrap_or(false)
+    env.storage()
+        .instance()
+        .get(&DataKey::DrawsFrozen)
+        .unwrap_or(false)
 }
 
 /// Check if the protocol is paused.
 pub fn is_paused(env: &Env) -> bool {
-    env.storage().instance().get(&paused_key(env)).unwrap_or(false)
+    env.storage()
+        .instance()
+        .get(&paused_key(env))
+        .unwrap_or(false)
 }
 
 /// Set the protocol pause state (admin only, enforced by caller).
@@ -792,8 +828,12 @@ pub fn get_oracle_last_price_ts(env: &Env) -> Option<u64> {
 /// The two `instance().set(..)` calls are part of the same host transaction,
 /// so observers cannot see a half-updated price/timestamp pair.
 pub fn set_oracle_last_price(env: &Env, price: i128, ts: u64) {
-    env.storage().instance().set(&DataKey::OracleLastPrice, &price);
-    env.storage().instance().set(&DataKey::OracleLastPriceTs, &ts);
+    env.storage()
+        .instance()
+        .set(&DataKey::OracleLastPrice, &price);
+    env.storage()
+        .instance()
+        .set(&DataKey::OracleLastPriceTs, &ts);
 }
 
 // ── Penalty surcharge for delinquent lines ───────────────────────────────────
@@ -808,7 +848,10 @@ pub fn set_oracle_last_price(env: &Env, price: i128, ts: u64) {
 /// - **Type**: Instance storage
 /// - **Key**: [`DataKey::PenaltySurchargeBps`]
 pub fn get_penalty_surcharge_bps(env: &Env) -> u32 {
-    env.storage().instance().get(&DataKey::PenaltySurchargeBps).unwrap_or(0)
+    env.storage()
+        .instance()
+        .get(&DataKey::PenaltySurchargeBps)
+        .unwrap_or(0)
 }
 
 /// Set the penalty surcharge in basis points.
@@ -821,5 +864,7 @@ pub fn get_penalty_surcharge_bps(env: &Env) -> u32 {
 /// - **Type**: Instance storage
 /// - **Key**: [`DataKey::PenaltySurchargeBps`]
 pub fn set_penalty_surcharge_bps(env: &Env, bps: u32) {
-    env.storage().instance().set(&DataKey::PenaltySurchargeBps, &bps);
+    env.storage()
+        .instance()
+        .set(&DataKey::PenaltySurchargeBps, &bps);
 }

--- a/docs/indexer-integration.md
+++ b/docs/indexer-integration.md
@@ -246,3 +246,69 @@ Before ingesting events from a deployed credit contract, indexers should call th
 - Store raw XDR alongside normalized records for audit/replay.
 - Make ingestion idempotent and checkpointed.
 - Support versioned topic suffixes (`*_v2`, etc.) for future migrations.
+
+---
+
+## 8) Draw audit queries (contract read)
+
+Indexers can also obtain per-draw records directly via contract queries instead of parsing events. This is useful for backfill, reconciliation, or building historical draw timelines without event storage.
+
+### `get_draw_audit`
+
+Returns the draw amount for a specific borrower at a specific ledger timestamp, or `None` if no draw occurred at that timestamp.
+
+**Signature:**
+```rust,ignore
+fn get_draw_audit(env: Env, borrower: Address, timestamp: u64) -> Option<i128>
+```
+
+**Arguments:**
+| Name | Type | Description |
+|------|------|-------------|
+| `borrower` | `Address` | Borrower address |
+| `timestamp` | `u64` | Ledger timestamp of the draw |
+
+**Example:** `get_draw_audit(borrower, 1717171200)` returns `Some(5_000_0000000)` if drawn at that timestamp.
+
+### `enumerate_draw_audit`
+
+Returns a reverse-chronological list of `(timestamp, amount)` pairs for a borrower, with optional cursor-based pagination.
+
+**Signature:**
+```rust,ignore
+fn enumerate_draw_audit(
+    env: Env,
+    borrower: Address,
+    cursor: Option<u64>,
+    limit: u32,
+) -> Vec<(u64, i128)>
+```
+
+**Arguments:**
+| Name | Type | Description |
+|------|------|-------------|
+| `borrower` | `Address` | Borrower address |
+| `cursor` | `Option<u64>` | Exclusive upper bound timestamp (start before this). Pass `None` for most recent first. |
+| `limit` | `u32` | Maximum results (capped at 100 internally). |
+
+**Pagination pattern:**
+
+1. Call with `cursor = None, limit = 100` to get the first page (newest draws).
+2. If the result is full, use the last entry's timestamp as `cursor` for the next call.
+3. Cursor is exclusive, so set `cursor = last_timestamp` (not `last_timestamp - 1`).
+
+**Example (first page):**
+```
+enumerate_draw_audit(borrower, None, 10)
+-> [(1717248000, 3000000000), (1717171200, 2000000000)]
+```
+
+**Example (second page, paginating past ts=1717171200):**
+```
+enumerate_draw_audit(borrower, Some(1717171200), 10)
+-> [(1717084800, 1000000000)]
+```
+
+### Storage key
+
+Draw audit entries are stored under `DataKey::DrawAudit(Address, u64)` keyed by borrower and timestamp, storing an `i128` draw amount. No authentication is required for any read query.


### PR DESCRIPTION
Closes #508
Adds get_draw_audit(borrower, timestamp) for point lookups and enumerate_draw_audit(borrower, cursor, limit) for paginated reverse-chronological enumeration of the DrawAudit storage.
DrawAuditTimestamps(Address) index enables O(log N + limit) enumeration
Entries written atomically in draw_credit
8 tests covering point queries, pagination, cursors, limits, empty states