### PR TITLE
feat: admin-only batch close credit line with cap 32

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -163,6 +163,10 @@ const BULK_BLOCK_MAX: u32 = 50;
 /// Keeps the entrypoint within Soroban resource limits.
 const ACCRUE_BATCH_MAX: u32 = 50;
 
+/// Maximum borrowers that can be closed in a single `close_credit_lines_batch` call.
+/// Prevents unbounded gas consumption and stays within ledger limits.
+const BATCH_CLOSE_MAX: u32 = 32;
+
 #[soroban_sdk::contractclient(name = "AuctionClient")]
 pub trait Auction {
     fn settle_default_liquidation(
@@ -1011,6 +1015,18 @@ impl Credit {
 
     pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
         lifecycle::close_credit_line(env, borrower, closer)
+    }
+
+    /// Admin-only batch close of multiple credit lines.
+    /// Reverts on first failure, ensuring atomicity.
+    /// 
+    /// # Parameters
+    /// - `borrowers`: List of borrower addresses to close; max `BATCH_CLOSE_MAX`
+    pub fn close_credit_lines_batch(env: Env, borrowers: Vec<Address>) {
+        if borrowers.len() > BATCH_CLOSE_MAX {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        lifecycle::close_credit_lines_batch(env, borrowers)
     }
 
     pub fn default_credit_line(env: Env, borrower: Address) {

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -510,6 +510,33 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
     );
 }
 
+/// Admin-only batch close of multiple credit lines.
+/// Reverts on first failure, ensuring atomicity.
+/// 
+/// # Parameters
+/// - `env`: The Soroban environment.
+/// - `borrowers`: List of borrower addresses to close.
+/// 
+/// # Authorization
+/// Requires admin authorization.
+/// 
+/// # Errors
+/// - Reverts if any close fails (e.g., credit line not found, already closed).
+/// - Reverts if borrowers.len() > BATCH_CLOSE_MAX.
+pub fn close_credit_lines_batch(env: Env, borrowers: Vec<Address>) {
+    assert_not_paused(&env);
+    require_admin_auth(&env);
+
+    // Resolve admin just once, to save storage access
+    let admin: Address = require_admin(&env);
+
+    // Process each borrower in order; failure of any reverts the whole batch
+    for borrower in borrowers {
+        // Reuse the single close function, passing admin as the closer
+        close_credit_line(env.clone(), borrower, admin.clone());
+    }
+}
+
 // ── default_credit_line ───────────────────────────────────────────────────────
 
 /// Mark a credit line as defaulted (admin only).


### PR DESCRIPTION
Add close_credit_lines_batch entrypoint for closing multiple legacy lines in a single transaction with bounded iteration (max 32 borrowers). Reuses the existing close_credit_line function for each borrower, and reverts on first failure for atomicity.

closes: #478