### PR TITLE
task: add cargo-deny CI gate for licence and dup-version safety

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,14 @@
+name: Cargo Deny
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+# Cargo-deny configuration for licence and dependency safety
+# https://embarkstudios.github.io/cargo-deny/
+
+[licenses]
+# Allow only these licences for dependencies
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+]
+# Warn on duplicate licences (will become error later)
+confidence-threshold = 0.8
+
+[advisories]
+# Deny yanked crates - prevents merge-time build breakages
+deny = []
+
+[bans]
+# Warn on duplicate crate versions (will become error later)
+multiple-versions = "warn"
+# Deny yanked crates
+yanked = "deny"
+# Allow common exceptions
+skip = [
+    # Windows-specific crates that appear in dev-dependencies
+    { name = "windows_aarch64_msvc", version = "*" },
+    { name = "windows_i686_gnu", version = "*" },
+    { name = "windows_x86_64_gnu", version = "*" },
+    { name = "windows_x86_64_msvc", version = "*" },
+]

--- a/test_cargo_deny.sh
+++ b/test_cargo_deny.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Test script for cargo-deny configuration
+
+echo "=== Testing Cargo Deny Configuration ==="
+echo ""
+
+# Check if cargo-deny is installed
+if ! command -v cargo-deny &> /dev/null; then
+    echo "cargo-deny not found. Installing..."
+    cargo install cargo-deny
+fi
+
+echo "Running cargo deny check..."
+echo ""
+
+# Run cargo deny check
+cargo deny check
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ cargo deny check PASSED"
+else
+    echo ""
+    echo "❌ cargo deny check FAILED"
+    echo ""
+    echo "Common fixes:"
+    echo "1. Update deny.toml to allow additional licenses if needed"
+    echo "2. Add duplicate versions to skip list"
+    echo "3. Check for yanked dependencies in Cargo.lock"
+fi


### PR DESCRIPTION
- Add deny.toml with MIT/Apache-2.0/BSD-3-Clause allowlist
- Deny yanked crates to prevent merge-time build breakages
- Warn on duplicate versions (error later)
- Add GitHub Actions CI workflow
- Include test script for local validation

closes #464