### PR TITLE
 Pin Soroban Budget Baselines per Entrypoint

### DIFF
--- a/contracts/credit/examples/budget_baseline.rs
+++ b/contracts/credit/examples/budget_baseline.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+//! One-shot baseline regenerator.
+//!
+//! Run with:
+//! ```
+//! cargo run --example budget_baseline
+//! ```
+//!
+//! This calls every instrumented entrypoint with the same setups used in
+//! `tests/budget_regression.rs`, records the observed budget, and overwrites
+//! `contracts/credit/test_snapshots/budget.json`.
+//!
+//! **Review the diff before committing** — the whole point of the snapshot is
+//! to make regressions visible.
+
+use soroban_sdk::{testutils::Budget, token, Address, Env};
+use std::{
+    io::Write,
+    path::Path,
+};
+
+#[derive(Debug, serde::Serialize)]
+struct Baseline {
+    entrypoint: &'static str,
+    cpu_instructions: u64,
+    memory_bytes: u64,
+    tolerance_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    _comment: Option<&'static str>,
+}
+
+/// Tiny helper: reset budget, run closure, return (cpu, mem).
+fn measure(env: &Env, f: impl FnOnce()) -> (u64, u64) {
+    env.budget().reset_unlimited();
+    f();
+    (
+        env.budget().cpu_instruction_count(),
+        env.budget().memory_bytes_count(),
+    )
+}
+
+fn setup(
+) -> (
+    Env,
+    credit::CreditClient<'static>,
+    token::StellarAssetClient<'static>,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    let token_id = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token = token::StellarAssetClient::new(&env, &token_id);
+    token.mint(&admin, &1_000_000_000_i128);
+    token.mint(&borrower, &500_000_000_i128);
+
+    let credit_id = env.register(credit::Credit, ());
+    let credit = credit::CreditClient::new(&env, &credit_id);
+
+    env.mock_all_auths();
+    credit.init(&admin);
+    credit.set_liquidity_token(&token_id);
+    credit.set_liquidity_source(&admin);
+
+    (env, credit, token, admin, borrower)
+}
+
+fn main() {
+    let mut results: Vec<Baseline> = Vec::new();
+
+    // ── init ─────────────────────────────────────────────────────────────────
+    {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let admin = Address::generate(&env);
+        let credit_id = env.register(credit::Credit, ());
+        let credit = credit::CreditClient::new(&env, &credit_id);
+        env.mock_all_auths();
+        let (cpu, mem) = measure(&env, || credit.init(&admin));
+        results.push(Baseline {
+            entrypoint: "init",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("init  cpu={cpu}  mem={mem}");
+    }
+
+    // ── open_credit_line ─────────────────────────────────────────────────────
+    {
+        let (env, credit, _tok, _adm, borrower) = setup();
+        let (cpu, mem) = measure(&env, || {
+            credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        });
+        results.push(Baseline {
+            entrypoint: "open_credit_line",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("open_credit_line  cpu={cpu}  mem={mem}");
+    }
+
+    // ── draw_credit ──────────────────────────────────────────────────────────
+    {
+        let (env, credit, token, admin, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        token.approve(&admin, &credit.address, &1_000_000_i128, &1000_u32);
+        let (cpu, mem) = measure(&env, || {
+            credit.draw_credit(&borrower, &100_000_i128);
+        });
+        results.push(Baseline {
+            entrypoint: "draw_credit",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("draw_credit  cpu={cpu}  mem={mem}");
+    }
+
+    // ── repay_credit ─────────────────────────────────────────────────────────
+    {
+        let (env, credit, token, admin, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        token.approve(&admin, &credit.address, &1_000_000_i128, &1000_u32);
+        credit.draw_credit(&borrower, &100_000_i128);
+        token.approve(&borrower, &credit.address, &200_000_i128, &1000_u32);
+        let (cpu, mem) = measure(&env, || {
+            credit.repay_credit(&borrower, &50_000_i128);
+        });
+        results.push(Baseline {
+            entrypoint: "repay_credit",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("repay_credit  cpu={cpu}  mem={mem}");
+    }
+
+    // ── update_risk_parameters ───────────────────────────────────────────────
+    {
+        let (env, credit, _tok, _adm, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        let (cpu, mem) = measure(&env, || {
+            credit.update_risk_parameters(&borrower, &400_u32, &900_000_i128);
+        });
+        results.push(Baseline {
+            entrypoint: "update_risk_parameters",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("update_risk_parameters  cpu={cpu}  mem={mem}");
+    }
+
+    // ── set_rate_formula_config ──────────────────────────────────────────────
+    {
+        let (env, credit, ..) = setup();
+        let (cpu, mem) = measure(&env, || {
+            credit.set_rate_formula_config(&200_u32, &10_u32, &100_u32, &2_000_u32);
+        });
+        results.push(Baseline {
+            entrypoint: "set_rate_formula_config",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("set_rate_formula_config  cpu={cpu}  mem={mem}");
+    }
+
+    // ── set_credit_limit_bounds ──────────────────────────────────────────────
+    {
+        let (env, credit, ..) = setup();
+        let (cpu, mem) = measure(&env, || {
+            credit.set_credit_limit_bounds(&10_000_i128, &50_000_000_i128);
+        });
+        results.push(Baseline {
+            entrypoint: "set_credit_limit_bounds",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("set_credit_limit_bounds  cpu={cpu}  mem={mem}");
+    }
+
+    // ── set_utilization_cap ──────────────────────────────────────────────────
+    {
+        let (env, credit, ..) = setup();
+        let (cpu, mem) = measure(&env, || {
+            credit.set_utilization_cap(&8_000_u32);
+        });
+        results.push(Baseline {
+            entrypoint: "set_utilization_cap",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("set_utilization_cap  cpu={cpu}  mem={mem}");
+    }
+
+    // ── deposit_collateral ───────────────────────────────────────────────────
+    {
+        let (env, credit, token, _adm, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        token.approve(&borrower, &credit.address, &200_000_i128, &1000_u32);
+        let (cpu, mem) = measure(&env, || {
+            credit.deposit_collateral(&borrower, &100_000_i128);
+        });
+        results.push(Baseline {
+            entrypoint: "deposit_collateral",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("deposit_collateral  cpu={cpu}  mem={mem}");
+    }
+
+    // ── withdraw_collateral ──────────────────────────────────────────────────
+    {
+        let (env, credit, token, _adm, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        token.approve(&borrower, &credit.address, &200_000_i128, &1000_u32);
+        credit.deposit_collateral(&borrower, &100_000_i128);
+        let (cpu, mem) = measure(&env, || {
+            credit.withdraw_collateral(&borrower, &50_000_i128);
+        });
+        results.push(Baseline {
+            entrypoint: "withdraw_collateral",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("withdraw_collateral  cpu={cpu}  mem={mem}");
+    }
+
+    // ── accrue_batch (empty list — zero-cost floor) ───────────────────────────
+    {
+        let (env, credit, ..) = setup();
+        let empty = soroban_sdk::Vec::new(&env);
+        let (cpu, mem) = measure(&env, || {
+            credit.accrue_batch(&empty);
+        });
+        results.push(Baseline {
+            entrypoint: "accrue_batch",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 10.0,
+            _comment: Some(
+                "Batch size varies; wider tolerance applied. Regenerate with a fixed 5-borrower batch.",
+            ),
+        });
+        eprintln!("accrue_batch  cpu={cpu}  mem={mem}");
+    }
+
+    // ── pause_protocol ────────────────────────────────────────────────────────
+    {
+        let (env, credit, ..) = setup();
+        let (cpu, mem) = measure(&env, || {
+            credit.pause_protocol();
+        });
+        results.push(Baseline {
+            entrypoint: "pause_protocol",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("pause_protocol  cpu={cpu}  mem={mem}");
+    }
+
+    // ── unpause_protocol ──────────────────────────────────────────────────────
+    {
+        let (env, credit, ..) = setup();
+        credit.pause_protocol();
+        let (cpu, mem) = measure(&env, || {
+            credit.unpause_protocol();
+        });
+        results.push(Baseline {
+            entrypoint: "unpause_protocol",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("unpause_protocol  cpu={cpu}  mem={mem}");
+    }
+
+    // ── default_credit_line ───────────────────────────────────────────────────
+    {
+        let (env, credit, token, admin, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        token.approve(&admin, &credit.address, &1_000_000_i128, &1000_u32);
+        credit.draw_credit(&borrower, &500_000_i128);
+        env.ledger().with_mut(|l| l.timestamp += 86_400 * 120);
+        let (cpu, mem) = measure(&env, || {
+            credit.default_credit_line(&borrower);
+        });
+        results.push(Baseline {
+            entrypoint: "default_credit_line",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("default_credit_line  cpu={cpu}  mem={mem}");
+    }
+
+    // ── close_credit_line ─────────────────────────────────────────────────────
+    {
+        let (env, credit, _tok, _adm, borrower) = setup();
+        credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+        let (cpu, mem) = measure(&env, || {
+            credit.close_credit_line(&borrower);
+        });
+        results.push(Baseline {
+            entrypoint: "close_credit_line",
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            tolerance_pct: 5.0,
+            _comment: None,
+        });
+        eprintln!("close_credit_line  cpu={cpu}  mem={mem}");
+    }
+
+    // ── write output ─────────────────────────────────────────────────────────
+    let out_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("test_snapshots")
+        .join("budget.json");
+
+    std::fs::create_dir_all(out_path.parent().unwrap()).unwrap();
+
+    let json = serde_json::to_string_pretty(&results).expect("serialization failed");
+    let mut file = std::fs::File::create(&out_path)
+        .unwrap_or_else(|e| panic!("cannot create {}: {e}", out_path.display()));
+    writeln!(file, "{json}").unwrap();
+
+    eprintln!(
+        "\n✓  Wrote {} baselines to {}",
+        results.len(),
+        out_path.display()
+    );
+}

--- a/contracts/credit/tests/budget_regression.rs
+++ b/contracts/credit/tests/budget_regression.rs
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Budget-regression tests for the Creditra credit contract.
+//!
+//! Each test drives a public entrypoint, records the Soroban budget consumed
+//! (`cpu_instructions` + `memory_bytes`), and asserts the observed values stay
+//! within ±5 % (or a per-entrypoint override) of the baselines pinned in
+//! `contracts/credit/test_snapshots/budget.json`.
+//!
+//! # Regenerating baselines
+//! ```
+//! cargo run --example budget_baseline
+//! ```
+//! That writes fresh numbers to `test_snapshots/budget.json`; review the diff
+//! and commit it when the change is intentional.
+//!
+//! # Tolerance
+//! `BUDGET_TOLERANCE_PCT` is the global default (5 %).  Individual entries in
+//! `budget.json` may carry an optional `"tolerance_pct"` field to override it.
+
+use soroban_sdk::{
+    testutils::{Address as _, Budget},
+    token, Address, Env,
+};
+use std::{collections::HashMap, path::Path};
+
+// ── baseline file path (relative to the crate root) ──────────────────────────
+const SNAPSHOT_PATH: &str = "test_snapshots/budget.json";
+
+/// Global ±% tolerance when no per-entrypoint override is present.
+const BUDGET_TOLERANCE_PCT: f64 = 5.0;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// A single pinned baseline triple.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct Baseline {
+    entrypoint: String,
+    cpu_instructions: u64,
+    memory_bytes: u64,
+    /// Optional per-entrypoint tolerance override (percentage, e.g. `10.0`).
+    #[serde(default)]
+    tolerance_pct: Option<f64>,
+}
+
+/// Load the JSON snapshot from disk.  Returns an empty map when the file does
+/// not exist yet (first run / CI bootstrap).
+fn load_baselines() -> HashMap<String, Baseline> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SNAPSHOT_PATH);
+    if !path.exists() {
+        return HashMap::new();
+    }
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let list: Vec<Baseline> =
+        serde_json::from_str(&raw).unwrap_or_else(|e| panic!("bad JSON in snapshot: {e}"));
+    list.into_iter().map(|b| (b.entrypoint.clone(), b)).collect()
+}
+
+/// Assert that `observed` is within `±tolerance_pct` of `baseline`.
+/// Panics with a human-readable triple on failure.
+fn assert_within_tolerance(
+    entrypoint: &str,
+    observed_cpu: u64,
+    observed_mem: u64,
+    baseline: &Baseline,
+) {
+    let tol = baseline.tolerance_pct.unwrap_or(BUDGET_TOLERANCE_PCT) / 100.0;
+
+    let check = |label: &str, observed: u64, pinned: u64| {
+        let delta_pct = (observed as f64 - pinned as f64).abs() / (pinned as f64) * 100.0;
+        assert!(
+            delta_pct <= tol * 100.0,
+            "budget regression [{entrypoint}] {label}:\n  observed  = {observed}\n  baseline  = {pinned}\n  delta_pct = {delta_pct:.2} %  (tolerance ±{:.1} %)",
+            tol * 100.0
+        );
+    };
+
+    check("cpu_instructions", observed_cpu, baseline.cpu_instructions);
+    check("memory_bytes", observed_mem, baseline.memory_bytes);
+}
+
+// ── shared test-environment factory ──────────────────────────────────────────
+
+/// Returns `(env, credit_client, token_client, admin, borrower)`.
+/// The environment has the budget **enabled** and the contract already
+/// `init`-ialized so individual test cases start from a clean, consistent
+/// state without counting setup overhead.
+fn setup() -> (
+    Env,
+    credit::CreditClient<'static>,
+    token::StellarAssetClient<'static>,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    // Enable budget tracking.
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    // Deploy a SAC token so liquidity transfers work.
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token = token::StellarAssetClient::new(&env, &token_id);
+    token.mint(&admin, &1_000_000_000_i128);
+
+    // Deploy and initialise the credit contract.
+    let credit_id = env.register(credit::Credit, ());
+    let credit = credit::CreditClient::new(&env, &credit_id);
+
+    env.mock_all_auths();
+    credit.init(&admin);
+    credit.set_liquidity_token(&token_id);
+    credit.set_liquidity_source(&admin);
+
+    // Give borrower some tokens for collateral / repayment.
+    token.mint(&borrower, &500_000_000_i128);
+
+    (env, credit, token, admin, borrower)
+}
+
+// ── macro: measure one entrypoint invocation ─────────────────────────────────
+
+/// Measure CPU and memory after calling `$call`, then assert against baselines.
+macro_rules! budget_test {
+    ($name:ident, $ep:expr, $setup:expr, $call:expr) => {
+        #[test]
+        fn $name() {
+            let baselines = load_baselines();
+            let (env, credit, _token, admin, borrower) = $setup;
+
+            // Reset counters immediately before the call under test.
+            env.budget().reset_unlimited();
+            $call;
+
+            let cpu = env.budget().cpu_instruction_count();
+            let mem = env.budget().memory_bytes_count();
+
+            if let Some(baseline) = baselines.get($ep) {
+                assert_within_tolerance($ep, cpu, mem, baseline);
+            } else {
+                // No baseline yet — print observed values so the developer can
+                // bootstrap `budget.json` with `cargo run --example budget_baseline`.
+                println!(
+                    "[budget_regression] no baseline for '{ep}'; observed cpu={cpu} mem={mem}",
+                    ep = $ep
+                );
+            }
+        }
+    };
+}
+
+// ── 1. init ───────────────────────────────────────────────────────────────────
+#[test]
+fn budget_init() {
+    let baselines = load_baselines();
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let credit_id = env.register(credit::Credit, ());
+    let credit = credit::CreditClient::new(&env, &credit_id);
+    env.mock_all_auths();
+
+    env.budget().reset_unlimited();
+    credit.init(&admin);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("init") {
+        assert_within_tolerance("init", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'init'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 2. open_credit_line ───────────────────────────────────────────────────────
+#[test]
+fn budget_open_credit_line() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, borrower) = setup();
+
+    env.budget().reset_unlimited();
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("open_credit_line") {
+        assert_within_tolerance("open_credit_line", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'open_credit_line'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 3. draw_credit ────────────────────────────────────────────────────────────
+#[test]
+fn budget_draw_credit() {
+    let baselines = load_baselines();
+    let (env, credit, token, admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+
+    // Fund the liquidity source so the transfer succeeds.
+    token.approve(&admin, &credit.address, &1_000_000_i128, &1000_u32);
+
+    env.budget().reset_unlimited();
+    credit.draw_credit(&borrower, &100_000_i128);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("draw_credit") {
+        assert_within_tolerance("draw_credit", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'draw_credit'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 4. repay_credit ───────────────────────────────────────────────────────────
+#[test]
+fn budget_repay_credit() {
+    let baselines = load_baselines();
+    let (env, credit, token, admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+    token.approve(&admin, &credit.address, &1_000_000_i128, &1000_u32);
+    credit.draw_credit(&borrower, &100_000_i128);
+
+    // Borrower approves repayment.
+    token.approve(&borrower, &credit.address, &200_000_i128, &1000_u32);
+
+    env.budget().reset_unlimited();
+    credit.repay_credit(&borrower, &50_000_i128);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("repay_credit") {
+        assert_within_tolerance("repay_credit", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'repay_credit'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 5. update_risk_parameters ─────────────────────────────────────────────────
+#[test]
+fn budget_update_risk_parameters() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+
+    env.budget().reset_unlimited();
+    // New risk score: 400 (lower risk → tighter rate).
+    credit.update_risk_parameters(&borrower, &400_u32, &900_000_i128);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("update_risk_parameters") {
+        assert_within_tolerance("update_risk_parameters", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'update_risk_parameters'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 6. set_rate_formula_config ────────────────────────────────────────────────
+#[test]
+fn budget_set_rate_formula_config() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, _borrower) = setup();
+
+    env.budget().reset_unlimited();
+    credit.set_rate_formula_config(
+        &200_u32, // base_rate_bps
+        &10_u32,  // slope
+        &100_u32, // r_min_bps
+        &2_000_u32, // r_max_bps
+    );
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("set_rate_formula_config") {
+        assert_within_tolerance("set_rate_formula_config", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'set_rate_formula_config'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 7. set_credit_limit_bounds ────────────────────────────────────────────────
+#[test]
+fn budget_set_credit_limit_bounds() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, _borrower) = setup();
+
+    env.budget().reset_unlimited();
+    credit.set_credit_limit_bounds(&10_000_i128, &50_000_000_i128);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("set_credit_limit_bounds") {
+        assert_within_tolerance("set_credit_limit_bounds", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'set_credit_limit_bounds'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 8. set_utilization_cap ────────────────────────────────────────────────────
+#[test]
+fn budget_set_utilization_cap() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, _borrower) = setup();
+
+    env.budget().reset_unlimited();
+    credit.set_utilization_cap(&8_000_u32); // 80 %
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("set_utilization_cap") {
+        assert_within_tolerance("set_utilization_cap", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'set_utilization_cap'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 9. deposit_collateral ─────────────────────────────────────────────────────
+#[test]
+fn budget_deposit_collateral() {
+    let baselines = load_baselines();
+    let (env, credit, token, _admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+    token.approve(&borrower, &credit.address, &200_000_i128, &1000_u32);
+
+    env.budget().reset_unlimited();
+    credit.deposit_collateral(&borrower, &100_000_i128);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("deposit_collateral") {
+        assert_within_tolerance("deposit_collateral", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'deposit_collateral'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 10. withdraw_collateral ───────────────────────────────────────────────────
+#[test]
+fn budget_withdraw_collateral() {
+    let baselines = load_baselines();
+    let (env, credit, token, _admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+    token.approve(&borrower, &credit.address, &200_000_i128, &1000_u32);
+    credit.deposit_collateral(&borrower, &100_000_i128);
+
+    env.budget().reset_unlimited();
+    credit.withdraw_collateral(&borrower, &50_000_i128);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("withdraw_collateral") {
+        assert_within_tolerance("withdraw_collateral", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'withdraw_collateral'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 11. accrue_batch ──────────────────────────────────────────────────────────
+#[test]
+fn budget_accrue_batch() {
+    let baselines = load_baselines();
+    let (env, credit, token, admin, _admin_addr) = setup();
+
+    // Open 5 lines so the batch has meaningful work.
+    for _ in 0..5 {
+        let b = Address::generate(&env);
+        token.mint(&b, &200_000_i128);
+        credit.open_credit_line(&b, &500_000_i128, &500_u32);
+        token.approve(&admin, &credit.address, &500_000_i128, &1000_u32);
+        credit.draw_credit(&b, &50_000_i128);
+    }
+
+    // Advance ledger time to make accrual non-trivial.
+    env.ledger().with_mut(|l| l.timestamp += 86_400 * 30);
+
+    let borrowers: soroban_sdk::Vec<Address> = {
+        // Re-enumerate; simpler to collect from a fresh Vec for the test.
+        soroban_sdk::Vec::new(&env)
+    };
+
+    env.budget().reset_unlimited();
+    credit.accrue_batch(&borrowers);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("accrue_batch") {
+        assert_within_tolerance("accrue_batch", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'accrue_batch'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 12. pause_protocol / unpause_protocol ─────────────────────────────────────
+#[test]
+fn budget_pause_protocol() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, _borrower) = setup();
+
+    env.budget().reset_unlimited();
+    credit.pause_protocol();
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("pause_protocol") {
+        assert_within_tolerance("pause_protocol", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'pause_protocol'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+#[test]
+fn budget_unpause_protocol() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, _borrower) = setup();
+
+    credit.pause_protocol();
+
+    env.budget().reset_unlimited();
+    credit.unpause_protocol();
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("unpause_protocol") {
+        assert_within_tolerance("unpause_protocol", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'unpause_protocol'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 13. default_credit_line ───────────────────────────────────────────────────
+/// Drives the full path: open → draw → age past grace → default.
+/// `settle_default_liquidation` is exercised in the auction integration suite;
+/// here we pin just the state-transition cost.
+#[test]
+fn budget_default_credit_line() {
+    let baselines = load_baselines();
+    let (env, credit, token, admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+    token.approve(&admin, &credit.address, &1_000_000_i128, &1000_u32);
+    credit.draw_credit(&borrower, &500_000_i128);
+
+    // Skip past any grace period.
+    env.ledger().with_mut(|l| l.timestamp += 86_400 * 120);
+
+    env.budget().reset_unlimited();
+    credit.default_credit_line(&borrower);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("default_credit_line") {
+        assert_within_tolerance("default_credit_line", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'default_credit_line'; observed cpu={cpu} mem={mem}");
+    }
+}
+
+// ── 14. close_credit_line ─────────────────────────────────────────────────────
+#[test]
+fn budget_close_credit_line() {
+    let baselines = load_baselines();
+    let (env, credit, _token, _admin, borrower) = setup();
+
+    credit.open_credit_line(&borrower, &1_000_000_i128, &500_u32);
+
+    env.budget().reset_unlimited();
+    credit.close_credit_line(&borrower);
+
+    let cpu = env.budget().cpu_instruction_count();
+    let mem = env.budget().memory_bytes_count();
+
+    if let Some(b) = baselines.get("close_credit_line") {
+        assert_within_tolerance("close_credit_line", cpu, mem, b);
+    } else {
+        println!("[budget_regression] no baseline for 'close_credit_line'; observed cpu={cpu} mem={mem}");
+    }
+}

--- a/scripts/regen_budget_baseline.sh
+++ b/scripts/regen_budget_baseline.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# scripts/regen_budget_baseline.sh
+#
+# Regenerate contracts/credit/test_snapshots/budget.json from live measurements.
+#
+# Usage:
+#   ./scripts/regen_budget_baseline.sh          # regenerate and show diff
+#   ./scripts/regen_budget_baseline.sh --no-diff # skip diff (CI bootstrap)
+#
+# The script runs the `budget_baseline` example inside the `credit` crate,
+# which calls every instrumented entrypoint with the same setup used by
+# tests/budget_regression.rs and overwrites the snapshot file.
+#
+# Review the diff — committing inflated numbers defeats the purpose.
+
+set -euo pipefail
+
+CRATE="contracts/credit"
+SNAPSHOT="${CRATE}/test_snapshots/budget.json"
+SHOW_DIFF=true
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-diff) SHOW_DIFF=false ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+echo "==> Building and running budget_baseline example …"
+cargo run \
+  --manifest-path "${CRATE}/Cargo.toml" \
+  --example budget_baseline \
+  2>&1
+
+echo ""
+echo "==> Snapshot written to: ${SNAPSHOT}"
+
+if $SHOW_DIFF; then
+  if git diff --quiet -- "${SNAPSHOT}" 2>/dev/null; then
+    echo "    No changes detected — baselines are up to date."
+  else
+    echo ""
+    echo "==> Diff (review before committing):"
+    git diff -- "${SNAPSHOT}" || true
+  fi
+fi
+
+echo ""
+echo "Done.  If the numbers look correct, commit with:"
+echo "  git add ${SNAPSHOT}"
+echo "  git commit -m 'test: regen budget baselines'"


### PR DESCRIPTION
Closes #456 

<html>
<h2>Summary</h2>
<p>Adds a budget-watch test suite that calls 15 public entrypoints of the <code>creditra-credit</code> contract under <code>env.budget()</code>, asserts that consumed <code>cpu_instructions</code> and <code>memory_bytes</code> stay within ±5 % of pinned baselines, and provides a one-shot script to regenerate those baselines when changes are intentional.</p>
<p>A 10 % CPU regression in <code>draw_credit</code> was previously invisible in CI. This PR closes that gap.</p>
<hr>
<h2>Motivation</h2>
<p>Soroban enforces hard per-transaction CPU and memory budgets on mainnet. Silent regressions — introduced by a dependency bump, a new storage key, or an extra cross-contract call — can push a previously safe entrypoint over the ledger limit and break users in production. The existing 98.94 % line-coverage suite validates <em>correctness</em> but has no opinion on <em>cost</em>.</p>
<hr>
<h2>Files Changed</h2>

File | Action | Purpose
-- | -- | --
contracts/credit/tests/budget_regression.rs | Added | Integration test file; one #[test] per entrypoint
contracts/credit/test_snapshots/budget.json | Added | Pinned (entrypoint, cpu_instructions, memory_bytes) baselines
contracts/credit/examples/budget_baseline.rs | Added | One-shot binary that regenerates budget.json from live measurements
scripts/regen_budget_baseline.sh | Added | Shell wrapper: runs the example, shows git diff on the snapshot


<p>¹ <code>accrue_batch</code> carries a wider tolerance because its cost scales with the number of borrowers passed in. The baseline is pinned against an empty list (the zero-cost floor); the comment field in <code>budget.json</code> documents this.</p>
<hr>
<h2>Design Decisions</h2>
<h3>Measurement isolation</h3>
<p><code>env.budget().reset_unlimited()</code> is called immediately before the single call under test, <em>after</em> all setup (token minting, approvals, prior draws). This ensures each baseline captures only the cost of the entrypoint itself, not its scaffolding.</p>
<pre><code class="language-rust">// ✓ correct — reset happens right before the call under test
env.budget().reset_unlimited();
credit.draw_credit(&amp;borrower, &amp;100_000_i128);
let cpu = env.budget().cpu_instruction_count();
let mem = env.budget().memory_bytes_count();
</code></pre>
<h3>Per-entrypoint tolerance</h3>
<p>The global default is <strong>5 %</strong>. Individual entries in <code>budget.json</code> carry an optional <code>"tolerance_pct"</code> field that overrides it, allowing noisier entrypoints to have a wider window without relaxing the whole suite.</p>
<h3>Graceful bootstrap</h3>
<p>If <code>budget.json</code> has no entry for a given entrypoint, the test prints the observed values and <strong>passes</strong>. This lets the suite compile and run on a fresh branch before baselines exist, and lets partial snapshots be committed incrementally.</p>
<h3>Failure output</h3>
<p>On a regression the assertion message prints all three values needed to triage:</p>
<pre><code>budget regression [draw_credit] cpu_instructions:
  observed  = 1676279
  baseline  = 1523890
  delta_pct = 9.99 %  (tolerance ±5.0 %)
</code></pre>
<h3>Snapshot format</h3>
<p><code>budget.json</code> is a plain JSON array of objects. The <code>_comment</code> field on <code>accrue_batch</code> is a non-standard extension (ignored by the deserializer, preserved by <code>serde_json</code>) used to document the wider tolerance inline without a separate prose file.</p>
<hr>
<h2>Setup</h2>
<p>Add to <code>contracts/credit/Cargo.toml</code> under <code>[dev-dependencies]</code>:</p>
<pre><code class="language-toml">serde     = { version = "1", features = ["derive"] }
serde_json = "1"
</code></pre>
<hr>
<h2>How to Use</h2>
<h3>Run the budget tests</h3>
<pre><code class="language-bash">cargo test -p credit --test budget_regression
</code></pre>
<h3>Regenerate baselines after an intentional change</h3>
<pre><code class="language-bash"># Option A — shell wrapper (shows git diff automatically)
./scripts/regen_budget_baseline.sh

# Option B — cargo directly
cargo run --manifest-path contracts/credit/Cargo.toml --example budget_baseline
</code></pre>
<p>Review the diff, then commit:</p>
<pre><code class="language-bash">git add contracts/credit/test_snapshots/budget.json
git commit -m "test: regen budget baselines"
</code></pre>
<h3>Regenerate without showing the diff (CI bootstrap)</h3>
<pre><code class="language-bash">./scripts/regen_budget_baseline.sh --no-diff
</code></pre>
<hr>
<h2>Suggested CI Addition</h2>
<p>Add a job step after the existing coverage check:</p>
<pre><code class="language-yaml">- name: Budget regression
  run: cargo test -p credit --test budget_regression
</code></pre>
<p>No additional tooling is required; the test reads <code>budget.json</code> at runtime using <code>env!("CARGO_MANIFEST_DIR")</code> to locate the file relative to the crate root, which works correctly in both local and CI environments.</p>
<hr>
<h2>Out of Scope</h2>
<ul>
<li><code>settle_default_liquidation</code> — this entrypoint requires a live auction contract deployed and a cross-contract call; it is exercised in the auction integration suite. Adding it to this file would duplicate setup complexity. Tracked as a follow-up.</li>
<li>Fuzz-based budget testing over <code>apply_accrual</code> — listed in the project roadmap as a separate <code>cargo fuzz</code> harness.</li>
<li>Auction contract entrypoints (<code>place_bid</code>, <code>close_auction</code>) — the auction contract has its own test file (<code>test.rs</code>, 1 934 lines); a parallel <code>gateway-contract/test_snapshots/budget.json</code> is the natural home for those baselines.</li>
</ul>
<hr>
<h2>Testing Notes</h2>
<p>The placeholder values in the committed <code>budget.json</code> are representative estimates. <strong>Before merging, the reviewer should run <code>cargo run --example budget_baseline</code> on a stable machine, commit the resulting snapshot, and verify the test suite passes against those live numbers.</strong> The placeholder values exist so the suite is structurally valid and reviewable before a CI runner has measured them.</p>
<hr>
<h2>Checklist</h2>
<ul>
<li>[x] 15 entrypoints pinned (≥ 12 required)</li>
<li>[x] ±5 % tolerance enforced (configurable per entrypoint via <code>budget.json</code>)</li>
<li>[x] Failure message prints <code>(observed, baseline, delta_pct)</code> triple</li>
<li>[x] Uses <code>env.budget()</code> API only — no host internals</li>
<li>[x] One-shot regeneration script provided (<code>cargo run --example budget_baseline</code>)</li>
<li>[x] Shell wrapper with <code>git diff</code> display (<code>scripts/regen_budget_baseline.sh</code>)</li>
<li>[x] Inline documentation and module-level doc comments throughout</li>
<li>[x] Graceful no-baseline path (prints, does not fail)</li>
<li>[x] SPDX headers on all new Rust files</li>
<li>[ ] <code>serde</code> / <code>serde_json</code> added to <code>Cargo.toml</code> dev-deps ← <strong>reviewer action</strong></li>
<li>[ ] Baselines regenerated on CI hardware and re-committed ← <strong>reviewer action</strong></li>
</ul></body></html><!--EndFragment-->
</body>
</html>