### PR TITLE
feat: add InsufficientCollateralBalance = 39 and migrate withdraw_collateral

### DIFF
--- a/contracts/credit/src/collateral.rs
+++ b/contracts/credit/src/collateral.rs
@@ -38,12 +38,9 @@
 //!
 //! # Error reuse note
 //!
-//! Over-withdraw reverts with [`ContractError::InsufficientRepaymentBalance`]
-//! (`= 27`). This reuses the repay-side error variant rather than
-//! introducing a fourth balance-related error. SDK consumers must
-//! disambiguate by entrypoint context. See
-//! [`docs/contract-errors.md`](../../../docs/contract-errors.md) for the
-//! full error table.
+//! Over-withdraw reverts with [`ContractError::InsufficientCollateralBalance`]
+//! (`= 39`). See [`docs/contract-errors.md`](../../../docs/contract-errors.md)
+//! for the full error table.
 
 use crate::storage::{
     get_collateral_balance, set_collateral_balance, get_min_collateral_ratio_bps,
@@ -102,11 +99,7 @@ pub fn withdraw_collateral(env: &Env, borrower: &Address, amount: i128) {
     // Get current collateral balance
     let cur_balance = get_collateral_balance(env, borrower);
     if amount > cur_balance {
-        // We reuse `InsufficientRepaymentBalance` here to avoid expanding the
-        // error enum for this niche case; the semantics ("the caller asked to
-        // move more tokens than they have available") are close enough that
-        // SDK consumers can interpret the code without ambiguity.
-        env.panic_with_error(ContractError::InsufficientRepaymentBalance);
+        env.panic_with_error(ContractError::InsufficientCollateralBalance);
     }
 
     let post_balance = cur_balance - amount;

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -131,6 +131,7 @@ pub enum CreditStatus {
 /// | 36   | `OraclePriceInvalid`          | Oracle price is invalid (zero, negative, or malformed) |
 /// | 37   | `OraclePriceStale`            | Oracle price is stale (exceeds max_age_seconds) |
 /// | 38   | `OraclePriceDeviation`        | Oracle price deviation exceeds the configured maximum |
+/// | 39   | `InsufficientCollateralBalance` | Borrower collateral balance cannot cover withdrawal |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -211,6 +212,8 @@ pub enum ContractError {
     OraclePriceStale = 37,
     /// Oracle price deviation exceeds the configured maximum.
     OraclePriceDeviation = 38,
+    /// Borrower's collateral balance is below the requested withdrawal amount.
+    InsufficientCollateralBalance = 39,
 }
 
 /// Stored credit line data for a borrower.

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -49,6 +49,11 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::AdminNotInitialized as u32, 32);
     assert_eq!(ContractError::TimestampRegression as u32, 33);
     assert_eq!(ContractError::LimitOutOfBounds as u32, 34);
+    assert_eq!(ContractError::CollateralRatioBelowMinimum as u32, 35);
+    assert_eq!(ContractError::OraclePriceInvalid as u32, 36);
+    assert_eq!(ContractError::OraclePriceStale as u32, 37);
+    assert_eq!(ContractError::OraclePriceDeviation as u32, 38);
+    assert_eq!(ContractError::InsufficientCollateralBalance as u32, 39);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -93,6 +98,11 @@ fn no_duplicate_discriminants() {
         ContractError::AdminNotInitialized as u32,
         ContractError::TimestampRegression as u32,
         ContractError::LimitOutOfBounds as u32,
+        ContractError::CollateralRatioBelowMinimum as u32,
+        ContractError::OraclePriceInvalid as u32,
+        ContractError::OraclePriceStale as u32,
+        ContractError::OraclePriceDeviation as u32,
+        ContractError::InsufficientCollateralBalance as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -107,8 +117,8 @@ fn no_duplicate_discriminants() {
 /// Update this number when adding new variants (and add the assertion above).
 #[test]
 fn variant_count_is_known() {
-    // 34 variants as of this writing. Update when adding new ones.
-    const EXPECTED_VARIANT_COUNT: usize = 34;
+    // 39 variants as of this writing. Update when adding new ones.
+    const EXPECTED_VARIANT_COUNT: usize = 39;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -145,6 +155,11 @@ fn variant_count_is_known() {
         ContractError::AdminNotInitialized as u32,
         ContractError::TimestampRegression as u32,
         ContractError::LimitOutOfBounds as u32,
+        ContractError::CollateralRatioBelowMinimum as u32,
+        ContractError::OraclePriceInvalid as u32,
+        ContractError::OraclePriceStale as u32,
+        ContractError::OraclePriceDeviation as u32,
+        ContractError::InsufficientCollateralBalance as u32,
     ];
 
     assert_eq!(

--- a/docs/contract-errors.md
+++ b/docs/contract-errors.md
@@ -56,10 +56,11 @@ be reordered or renumbered; new variants must be appended.
 | 36 | `OraclePriceInvalid` | Oracle price is zero, negative, or malformed. |
 | 37 | `OraclePriceStale` | Oracle price exceeds `max_age_seconds`. |
 | 38 | `OraclePriceDeviation` | Oracle price deviation exceeds configured maximum. |
+| 39 | `InsufficientCollateralBalance` | Borrower collateral balance below withdrawal amount. |
 
 ## Taxonomy
 
 See [`docs/error-taxonomy.md`](./error-taxonomy.md) for the authoritative
-grouping of all 38 variants into **named categories** (Auth, Lifecycle,
+grouping of all 39 variants into **named categories** (Auth, Lifecycle,
 Numeric, Limit, Liquidity, Risk, Oracle, Collateral, Block, Reentrancy, Misc)
 with **SDK-side recovery actions** per category.

--- a/docs/error-taxonomy.md
+++ b/docs/error-taxonomy.md
@@ -166,16 +166,18 @@ where the contract can observe it. |
 
 ---
 
-## Collateral (code 35)
+## Collateral (codes 35, 39)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
 | 35   | `CollateralRatioBelowMinimum` | Collateral withdraw would leave the ratio below `MinCollateralRatioBps`. |
+| 39   | `InsufficientCollateralBalance` | Withdrawal amount exceeds the borrower's deposited collateral balance. |
 
-**Recovery action:** Reduce the withdrawal amount so that
+**Recovery action:** For code 35, reduce the withdrawal amount so that
 `(post_collateral * MinCollateralRatioBps) / 10_000 >= utilized`. Query the
 minimum collateral ratio via `get_protocol_config()` and compute the maximum
-safe withdrawal client-side.
+safe withdrawal client-side. For code 39, query `get_collateral_balance` and
+ensure the requested amount does not exceed it.
 
 ---
 
@@ -235,8 +237,8 @@ ensure it does not re-enter the credit contract during `transfer` /
 | Liquidity | 22, 23, 24, 25, 26, 27, 30, 31 | 8 | Replenish allowance / wait for reserve |
 | Risk | 8, 9, 18, 29 | 4 | Clamp inputs / wait for cooldown or unpause |
 | Oracle | 36, 37, 38 | 3 | Await valid price feed |
-| Collateral | 35 | 1 | Reduce withdrawal amount |
+| Collateral | 35, 39 | 2 | Reduce withdrawal amount |
 | Block | 16, 19 | 2 | Contact admin or wait for unfreeze |
 | Reentrancy | 11 | 1 | Do not retry; inspect on-chain state |
 | Misc | 3, 15 | 2 | Create line first / wait for delay |
-| **Total** | 1–38 | **38** | — |
+| **Total** | 1–39 | **39** | — |


### PR DESCRIPTION
## Summary

Resolves the error-reuse noted in `collateral.rs` — `withdraw_collateral` previously returned `InsufficientRepaymentBalance = 27` for over-withdraw, forcing SDK consumers to disambiguate by entrypoint context.

## Changes

| File | Change |
|---|---|
| `contracts/credit/src/types.rs` | Append `InsufficientCollateralBalance = 39` to `ContractError`; add row to doc-comment table |
| `contracts/credit/src/collateral.rs` | `withdraw_collateral` now panics with the dedicated error; update module doc |
| `contracts/credit/tests/error_discriminants.rs` | Pin discriminant 39; add to `no_duplicate_discriminants` vec; bump `variant_count_is_known` to 39 |
| `docs/contract-errors.md` | Add row 39 to table; add 39 to Collateral categorization |

## Acceptance criteria

- [x] Discriminant 39 pinned in the stability test
- [x] `withdraw_collateral` over-withdraw path uses new error code (= 39)
- [x] Docs table updated

Closes #458