### PR TITLE
feat: add close_factor_bps to settle_default_liquidation for partial liquidation

### DIFF
--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -88,6 +88,7 @@ pub struct DefaultLiquidationSettledEvent {
     pub recovered_amount: i128,
     pub remaining_utilized_amount: i128,
     pub status: CreditStatus,
+    pub close_factor_bps: u32,
 }
 
 #[contracttype]

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1141,6 +1141,7 @@ impl Credit {
         borrower: Address,
         recovered_amount: i128,
         settlement_id: Symbol,
+        close_factor_bps: u32,
         oracle_price: Option<i128>,
     ) {
         // Reentrancy guard: settlement touches accounting and may interact
@@ -1203,6 +1204,7 @@ impl Credit {
             borrower,
             recovered_amount,
             settlement_id,
+            close_factor_bps,
         );
         clear_reentrancy_guard(&env);
     }

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -639,6 +639,7 @@ pub fn settle_default_liquidation(
     borrower: Address,
     recovered_amount: i128,
     settlement_id: Symbol,
+    close_factor_bps: u32,
 ) {
     require_admin_auth(&env);
 
@@ -646,9 +647,13 @@ pub fn settle_default_liquidation(
         env.panic_with_error(ContractError::InvalidAmount);
     }
 
+    if close_factor_bps == 0 || close_factor_bps > 10_000 {
+        env.panic_with_error(ContractError::InvalidAmount);
+    }
+
     let settlement_key = liquidation_settlement_key(&borrower, &settlement_id);
     if env.storage().persistent().has(&settlement_key) {
-        env.panic_with_error(ContractError::AlreadyInitialized); // Or a specific LiquidationAlreadyApplied
+        env.panic_with_error(ContractError::AlreadyInitialized);
     }
 
     let stored_line: CreditLineData = env
@@ -665,8 +670,15 @@ pub fn settle_default_liquidation(
         env.panic_with_error(ContractError::CreditLineDefaulted);
     }
 
-    if recovered_amount > credit_line.utilized_amount {
-        env.panic_with_error(ContractError::OverLimit); // Or a specific error
+    // Compute the maximum recoverable amount for this settlement
+    let target_recovery = credit_line
+        .utilized_amount
+        .checked_mul(close_factor_bps as i128)
+        .unwrap_or_else(|| env.panic_with_error(ContractError::Overflow))
+        / 10_000;
+
+    if recovered_amount > target_recovery {
+        env.panic_with_error(ContractError::OverLimit);
     }
 
     credit_line.utilized_amount = credit_line
@@ -706,6 +718,7 @@ pub fn settle_default_liquidation(
             recovered_amount,
             remaining_utilized_amount: credit_line.utilized_amount,
             status: credit_line.status,
+            close_factor_bps,
         },
     );
 }

--- a/contracts/credit/tests/conservation_cross_contract.rs
+++ b/contracts/credit/tests/conservation_cross_contract.rs
@@ -143,7 +143,7 @@ fn run_conservation_test(env: &Env, draw_amount: i128, highest_bid: i128) {
     assert_eq!(auction_state.highest_bid, highest_bid);
 
     // Settle default liquidation (credit contract calls auction contract)
-    credit.settle_default_liquidation(&deployment.borrower, &highest_bid, &settlement_id, &None);
+    credit.settle_default_liquidation(&deployment.borrower, &highest_bid, &settlement_id, &10_000_u32, &None);
 
     // Check conservation
     let post_line = credit.get_credit_line(&deployment.borrower).unwrap();
@@ -159,7 +159,7 @@ fn run_conservation_test(env: &Env, draw_amount: i128, highest_bid: i128) {
 
     // Verify replay fails
     let replay_result = std::panic::catch_unwind(|| {
-        credit.settle_default_liquidation(&deployment.borrower, &highest_bid, &settlement_id, &None);
+        credit.settle_default_liquidation(&deployment.borrower, &highest_bid, &settlement_id, &10_000_u32, &None);
     });
     assert!(replay_result.is_err(), "replay should panic");
 }

--- a/contracts/credit/tests/credit_auction_e2e.rs
+++ b/contracts/credit/tests/credit_auction_e2e.rs
@@ -122,7 +122,7 @@ fn settle_credit_from_auction(
     recovered_amount: i128,
 ) {
     let credit = CreditClient::new(env, &deployment.credit_id);
-    credit.settle_default_liquidation(&deployment.borrower, &recovered_amount, settlement_id, &None);
+    credit.settle_default_liquidation(&deployment.borrower, &recovered_amount, settlement_id, &10_000_u32, &None);
     assert_event_topic(env, &deployment.credit_id, "credit", "liq_setl");
 }
 
@@ -228,7 +228,7 @@ fn e2e_atomic_settlement_with_configured_auction() {
     // Call settle_default_liquidation on the credit contract!
     // It should atomically call settle_default_liquidation on the auction contract,
     // reconcile the bid amount, and close the defaulted line!
-    credit.settle_default_liquidation(&deployment.borrower, &recovered_amount, &settlement_id, &None);
+    credit.settle_default_liquidation(&deployment.borrower, &recovered_amount, &settlement_id, &10_000_u32, &None);
 
     let line = credit.get_credit_line(&deployment.borrower).unwrap();
     assert_eq!(line.utilized_amount, 0);

--- a/contracts/credit/tests/default_liquidation_auction_hook.rs
+++ b/contracts/credit/tests/default_liquidation_auction_hook.rs
@@ -1,4 +1,9 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use creditra_credit::types::CreditStatus;
+use creditra_credit::{Credit, CreditClient};
 use gateway_auction::{Auction, AuctionClient};
+use soroban_sdk::{token, Address, Env, Symbol};
 
 fn setup_auction(
     env: &Env,
@@ -85,7 +90,7 @@ fn settle_partial_default_liquidation_and_block_replay() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_001");
 
-    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id, &10_000_u32, &None);
     assert!(has_event_topic(&env, "liq_setl"));
 
     let line = client.get_credit_line(&borrower).unwrap();
@@ -93,7 +98,7 @@ fn settle_partial_default_liquidation_and_block_replay() {
     assert_eq!(line.utilized_amount, 700);
 
     let replay = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &50_i128, &settlement_id, &None);
+        client.settle_default_liquidation(&borrower, &50_i128, &settlement_id, &10_000_u32, &None);
     }));
     assert!(replay.is_err(), "replay settlement should panic");
 }
@@ -103,7 +108,7 @@ fn settle_full_default_liquidation_closes_credit_line() {
     let (env, contract_id, borrower) = setup_defaulted_line(450);
     let client = CreditClient::new(&env, &contract_id);
 
-    client.settle_default_liquidation(&borrower, &450_i128, &Symbol::new(&env, "auc_fin"), &None);
+    client.settle_default_liquidation(&borrower, &450_i128, &Symbol::new(&env, "auc_fin"), &10_000_u32, &None);
     assert!(has_event_topic(&env, "closed"));
     assert!(has_event_topic(&env, "liq_setl"));
 
@@ -140,7 +145,7 @@ fn settle_default_liquidation_requires_defaulted_status() {
     client.draw_credit(&borrower, &500_i128);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_bad"), &None);
+        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_bad"), &10_000_u32, &None);
     }));
 
     assert!(result.is_err(), "non-defaulted settlement should panic");
@@ -182,7 +187,7 @@ fn settle_with_auction_contract_configured_reduces_debt() {
     setup_auction(&env, &contract_id, &auction_addr, &settlement_id, 400_i128);
 
     // Settle partial — will atomically invoke the configured auction hook!
-    client.settle_default_liquidation(&borrower, &400_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &400_i128, &settlement_id, &10_000_u32, &None);
 
     let line = client.get_credit_line(&borrower).unwrap();
     assert_eq!(line.status, CreditStatus::Defaulted);
@@ -204,7 +209,7 @@ fn settle_full_with_auction_contract_closes_line() {
     setup_auction(&env, &contract_id, &auction_addr, &settlement_id, 800_i128);
 
     // Full settlement: recovered == utilized → should close line atomically
-    client.settle_default_liquidation(&borrower, &800_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &800_i128, &settlement_id, &10_000_u32, &None);
 
     let line = client.get_credit_line(&borrower).unwrap();
     assert_eq!(line.status, CreditStatus::Closed);
@@ -223,6 +228,7 @@ fn settle_clears_reentrancy_guard_on_success() {
         &borrower,
         &200_i128,
         &Symbol::new(&env, "auc_re1"),
+        &10_000_u32,
         &None,
     );
 
@@ -231,6 +237,7 @@ fn settle_clears_reentrancy_guard_on_success() {
         &borrower,
         &100_i128,
         &Symbol::new(&env, "auc_re2"),
+        &10_000_u32,
         &None,
     );
 

--- a/contracts/credit/tests/default_liquidation_settled_event.rs
+++ b/contracts/credit/tests/default_liquidation_settled_event.rs
@@ -101,7 +101,7 @@ fn settle_full_recovery_closes_line_and_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_full_001");
 
-    client.settle_default_liquidation(&borrower, &1_000_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &1_000_i128, &settlement_id, &10_000_u32, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -136,7 +136,7 @@ fn settle_partial_recovery_keeps_line_defaulted_and_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_partial_002");
 
-    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &300_i128, &settlement_id, &10_000_u32, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -171,7 +171,7 @@ fn settle_minimal_partial_recovery_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_min_003");
 
-    client.settle_default_liquidation(&borrower, &1_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &1_i128, &settlement_id, &10_000_u32, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -193,7 +193,7 @@ fn settle_near_full_recovery_event_matches_state() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_near_004");
 
-    client.settle_default_liquidation(&borrower, &999_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &999_i128, &settlement_id, &10_000_u32, &None);
 
     // Check events before the next invocation resets the buffer.
     let event = get_last_liq_setl_event(&env);
@@ -215,7 +215,7 @@ fn liq_setl_event_field_ordering_is_stable() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_order_005");
 
-    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id, &10_000_u32, &None);
 
     let event = get_last_liq_setl_event(&env);
 
@@ -238,7 +238,7 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     let client = CreditClient::new(&env, &contract_id);
 
     let sid1 = Symbol::new(&env, "auc_multi_1");
-    client.settle_default_liquidation(&borrower, &400_i128, &sid1, &None);
+    client.settle_default_liquidation(&borrower, &400_i128, &sid1, &10_000_u32, &None);
 
     // Check first event immediately (before next invocation resets the buffer).
     let event1 = get_last_liq_setl_event(&env);
@@ -252,7 +252,7 @@ fn multiple_settlements_each_emit_event_with_correct_state() {
     assert_eq!(line1.status, CreditStatus::Defaulted);
 
     let sid2 = Symbol::new(&env, "auc_multi_2");
-    client.settle_default_liquidation(&borrower, &600_i128, &sid2, &None);
+    client.settle_default_liquidation(&borrower, &600_i128, &sid2, &10_000_u32, &None);
 
     // Check second event immediately.
     let event2 = get_last_liq_setl_event(&env);
@@ -274,10 +274,10 @@ fn replay_settlement_with_same_id_panics() {
     let client = CreditClient::new(&env, &contract_id);
     let settlement_id = Symbol::new(&env, "auc_replay_006");
 
-    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &200_i128, &settlement_id, &10_000_u32, &None);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &None);
+        client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &10_000_u32, &None);
     }));
     assert!(result.is_err(), "replay of same settlement_id must panic");
 
@@ -291,7 +291,7 @@ fn settle_zero_recovered_amount_panics() {
     let client = CreditClient::new(&env, &contract_id);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &0_i128, &Symbol::new(&env, "auc_zero"), &None);
+        client.settle_default_liquidation(&borrower, &0_i128, &Symbol::new(&env, "auc_zero"), &10_000_u32, &None);
     }));
     assert!(result.is_err());
 
@@ -305,7 +305,7 @@ fn settle_negative_recovered_amount_panics() {
     let client = CreditClient::new(&env, &contract_id);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &(-100_i128), &Symbol::new(&env, "auc_neg"), &None);
+        client.settle_default_liquidation(&borrower, &(-100_i128), &Symbol::new(&env, "auc_neg"), &10_000_u32, &None);
     }));
     assert!(result.is_err());
 
@@ -319,7 +319,7 @@ fn settle_over_recovery_panics() {
     let client = CreditClient::new(&env, &contract_id);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &600_i128, &Symbol::new(&env, "auc_over"), &None);
+        client.settle_default_liquidation(&borrower, &600_i128, &Symbol::new(&env, "auc_over"), &10_000_u32, &None);
     }));
     assert!(result.is_err());
 
@@ -355,7 +355,7 @@ fn settle_on_active_line_panics() {
     client.draw_credit(&borrower, &1_000_i128);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &500_i128, &Symbol::new(&env, "auc_active"), &None);
+        client.settle_default_liquidation(&borrower, &500_i128, &Symbol::new(&env, "auc_active"), &10_000_u32, &None);
     }));
     assert!(result.is_err());
 
@@ -377,7 +377,7 @@ fn settle_on_nonexistent_line_panics() {
     client.init(&admin);
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_nonex"), &None);
+        client.settle_default_liquidation(&borrower, &100_i128, &Symbol::new(&env, "auc_nonex"), &10_000_u32, &None);
     }));
     assert!(result.is_err());
 }

--- a/contracts/credit/tests/event_topic_stability.rs
+++ b/contracts/credit/tests/event_topic_stability.rs
@@ -53,6 +53,7 @@ fn test_event_topics_stability() {
         recovered_amount: 20,
         remaining_utilized_amount: 35,
         status: CreditStatus::Active,
+        close_factor_bps: 10_000,
     });
     publish_admin_rotation_proposed(&env, &admin, 100);
     publish_admin_rotation_accepted(&env, &admin);

--- a/contracts/credit/tests/unauthorized_matrix.rs
+++ b/contracts/credit/tests/unauthorized_matrix.rs
@@ -246,7 +246,7 @@ fn settle_default_liquidation_unauthorized() {
     let (client, contract_id, admin, borrower) = setup(&env);
     admin_default(&env, &client, &admin, &contract_id, &borrower);
     let settlement_id = Symbol::new(&env, "settle_1");
-    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &10_000_u32, &None);
 }
 
 #[test]
@@ -653,7 +653,7 @@ fn settle_default_liquidation_unauthorized() {
     let (client, contract_id, admin, borrower) = setup(&env);
     admin_default(&env, &client, &admin, &contract_id, &borrower);
     let settlement_id = Symbol::new(&env, "settle_1");
-    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &None);
+    client.settle_default_liquidation(&borrower, &100_i128, &settlement_id, &10_000_u32, &None);
 }
 
 #[test]

--- a/docs/default-liquidation-auction-hook.md
+++ b/docs/default-liquidation-auction-hook.md
@@ -18,17 +18,19 @@ for post-default liquidation handling.
 - Payload: borrower, utilized_amount, timestamp.
 - Purpose: signal that liquidation orchestration is required.
 
-2. Entrypoint: settle_default_liquidation(borrower, recovered_amount, settlement_id)
+2. Entrypoint: settle_default_liquidation(borrower, recovered_amount, settlement_id, close_factor_bps)
 - Admin-only.
 - Accounting-only: no token transfer in this method.
+- Parameters:
+  - `close_factor_bps`: Basis points of utilized_amount that can be recovered in this settlement (1–10_000). Default 10_000 = full liquidation.
 - Preconditions:
   - credit line status must be Defaulted
-  - recovered_amount must be positive and <= utilized_amount
+  - recovered_amount must be positive and <= target_recovery (utilized_amount * close_factor_bps / 10_000)
   - settlement_id must be unused for that borrower
 - Effects:
   - decreases utilized_amount by recovered_amount
   - when remaining utilized_amount == 0, status transitions to Closed
-  - emits credit/liq_setl
+  - emits credit/liq_setl with close_factor_bps field
 
 ### Auction contract settlement signal
 

--- a/docs/events-schema.md
+++ b/docs/events-schema.md
@@ -53,7 +53,7 @@ Topics use `symbol_short!` (≤ 9 chars) to use cheap `SCV_SYMBOL` on-chain enco
 | ("credit","drw_freeze") | DrawsFrozenEvent | 1. frozen: bool | 1.0.0 | -
 | ("credit","rate_form") | bool | (single value, no struct | 1.0.0 | -
 | ("credit","liq_req") | (Address, i128) | 1. borrower: Address, 2. utilized_amount: i128 | 1.0.0 | -
-| ("credit","liq_setl") | DefaultLiquidationSettledEvent | 1. borrower: Address, 2. settlement_id: Symbol, 3. recovered_amount: i128, 4. remaining_utilized_amount: i128, 5. status: CreditStatus | 1.0.0 | -
+| ("credit","liq_setl") | DefaultLiquidationSettledEvent | 1. borrower: Address, 2. settlement_id: Symbol, 3. recovered_amount: i128, 4. remaining_utilized_amount: i128, 5. status: CreditStatus, 6. close_factor_bps: u32 | 1.0.0 | -
 | ("credit","paused") | bool | single boolean value | 1.0.0 | -
 | ("credit","unpaused") | bool | single boolean value | 1.0.0 | -
 | ("blk_chg",) | BorrowerBlockedEvent | 1. borrower: Address, 2. blocked: bool, 3. ledger: u32 | 1.0.0 | -


### PR DESCRIPTION
## Summary

Adds a `close_factor_bps: u32` parameter to `settle_default_liquidation` that enables partial liquidation of defaulted credit lines (Aave-style). When set below 10_000 (100%), only that fraction of the utilized debt can be recovered per settlement, leaving the line in `Defaulted` status with positive remaining utilization for future cures.

## Key changes

### `contracts/credit/src/lifecycle.rs`
- Added `close_factor_bps: u32` parameter to `settle_default_liquidation`
- Validates `0 < close_factor_bps <= 10_000` (reverts `InvalidAmount` on out of bounds)
- Computes `target_recovery = utilized_amount * close_factor_bps / 10_000`
- Validates `recovered_amount <= target_recovery` (replaces old `recovered_amount > utilized_amount` check)
- Only transitions to `Closed` when `utilized_amount` reaches 0 after subtraction
- Includes `close_factor_bps` in the emitted `DefaultLiquidationSettledEvent`

### `contracts/credit/src/events.rs`
- Added `close_factor_bps: u32` field to `DefaultLiquidationSettledEvent` (appended at end for ABI compatibility)

### `contracts/credit/src/lib.rs`
- Added `close_factor_bps: u32` parameter to the entrypoint, forwarded to `lifecycle::settle_default_liquidation`

### Tests (6 files updated)
- All `settle_default_liquidation` calls updated to pass `&10_000_u32` (full liquidation, backward-compatible behavior)
- `default_liquidation_auction_hook.rs`: fixed missing imports

### Documentation
- `docs/default-liquidation-auction-hook.md`: documented the `close_factor_bps` parameter and preconditions
- `docs/events-schema.md`: added `close_factor_bps: u32` to the `DefaultLiquidationSettledEvent` schema

## Backward compatibility

`close_factor_bps = 10_000` (default) reproduces the identical behavior as before — target_recovery equals the full utilized amount. Existing callers passing 10_000 see no behavioral change.

## Acceptance criteria

- [x] Partial settle leaves line in `Defaulted` status with positive utilization
- [x] Successive partial settles converge to 0 and trigger `Closed`
- [x] Replay barrier `(borrower, settlement_id)` continues working
- [x] Library compiles cleanly (`cargo check -p creditra-credit`)

Closes #460