### PR TITLE
test: settle_default_liquidation Unauthorized reverts for non-factory invoker

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -375,6 +375,7 @@ impl Auction {
     ) -> i128 {
         let factory = get_factory_contract(&env)
             .unwrap_or_else(|| env.panic_with_error(AuctionError::NoFactoryContract));
+        factory.require_auth();
         if credit_contract != factory {
             env.panic_with_error(AuctionError::Unauthorized);
         }

--- a/gateway-contract/contracts/auction_contract/tests/auth_settle.rs
+++ b/gateway-contract/contracts/auction_contract/tests/auth_settle.rs
@@ -1,0 +1,167 @@
+//! Tests for `require_auth` coverage on `settle_default_liquidation` factory caller.
+//!
+//! The auction-side [`settle_default_liquidation`] checks the caller against the
+//! registered factory address but must also cryptographically verify the factory's
+//! authorization via [`Address::require_auth`]. These tests prove that a forged
+//! invoker with mocked auth entries cannot bypass the check.
+//!
+//! # Tests
+//!
+//! | Test | Auth mock | `credit_contract` | Expected |
+//! |------|-----------|-------------------|----------|
+//! | `non_factory_invoker_reverts` | intruder only | factory address | revert |
+//! | `factory_invoker_succeeds` | factory only | factory address | `Ok(420)` |
+//! | `replay_settle_reverts` | factory (twice) | factory address | `Err(AlreadySettled)` |
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo test -p gateway-auction --test auth_settle
+//! ```
+//!
+//! [`settle_default_liquidation`]: ../src/lib.rs
+
+use gateway_auction::{Auction, AuctionClient, AuctionMode};
+use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::{Address, Env, IntoVal, Symbol};
+
+/// Deploy the auction contract, register the factory, create and close an
+/// auction so that `settle_default_liquidation` can be exercised.
+///
+/// Returns `(env, contract_id, auction_id, factory, borrower, expected_recovered)`.
+/// Callers create the `AuctionClient` locally to keep borrow lifetimes simple.
+fn setup_auction() -> (Env, Address, Symbol, Address, Address, i128) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let contract_id = env.register(Auction, ());
+    let client = AuctionClient::new(&env, &contract_id);
+
+    let factory = Address::generate(&env);
+    let bidder = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let auction_id = Symbol::new(&env, "auth_stl");
+
+    client.set_factory_contract(&factory);
+    client.init_auction(
+        &auction_id,
+        &AuctionMode::English,
+        &0_u64,
+        &u64::MAX,
+        &50_i128,
+        &0_u32,
+        &None,
+        &None,
+    );
+    client.place_bid(&auction_id, &bidder, &420_i128);
+    client.close_auction(&auction_id);
+
+    (env, contract_id, auction_id, factory, borrower, 420_i128)
+}
+
+// ── Negative ────────────────────────────────────────────────────────────────
+
+#[test]
+fn non_factory_invoker_reverts() {
+    let (env, contract_id, auction_id, factory, borrower, _expected) = setup_auction();
+    let client = AuctionClient::new(&env, &contract_id);
+
+    let intruder = Address::generate(&env);
+
+    let result = client
+        .mock_auths(&[MockAuth {
+            address: &intruder,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "settle_default_liquidation",
+                args: (
+                    auction_id.clone(),
+                    factory.clone(),
+                    borrower.clone(),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_settle_default_liquidation(&auction_id, &factory, &borrower);
+
+    assert!(
+        result.is_err(),
+        "non-factory invoker must be rejected (require_auth prevents bypass)"
+    );
+}
+
+// ── Positive ────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_invoker_succeeds() {
+    let (env, contract_id, auction_id, factory, borrower, expected) = setup_auction();
+    let client = AuctionClient::new(&env, &contract_id);
+
+    let result = client
+        .mock_auths(&[MockAuth {
+            address: &factory,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "settle_default_liquidation",
+                args: (
+                    auction_id.clone(),
+                    factory.clone(),
+                    borrower.clone(),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_settle_default_liquidation(&auction_id, &factory, &borrower);
+
+    let recovered = result
+        .expect("factory-authorized call must not encounter host error")
+        .expect("factory-authorized call must not encounter contract error");
+    assert_eq!(recovered, expected, "must return the highest bid");
+}
+
+// ── Replay ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn replay_settle_reverts() {
+    let (env, contract_id, auction_id, factory, borrower, _expected) = setup_auction();
+    let client = AuctionClient::new(&env, &contract_id);
+    // First settlement — succeeds
+    let first = client
+        .mock_auths(&[MockAuth {
+            address: &factory,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "settle_default_liquidation",
+                args: (
+                    auction_id.clone(),
+                    factory.clone(),
+                    borrower.clone(),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_settle_default_liquidation(&auction_id, &factory, &borrower);
+    assert!(first.is_ok(), "first settlement must succeed");
+
+    // Second settlement — must revert with AlreadySettled
+    let second = client
+        .mock_auths(&[MockAuth {
+            address: &factory,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "settle_default_liquidation",
+                args: (
+                    auction_id.clone(),
+                    factory.clone(),
+                    borrower.clone(),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_settle_default_liquidation(&auction_id, &factory, &borrower);
+    assert!(second.is_err(), "second settlement must revert");
+}


### PR DESCRIPTION
## Summary

Closes #485 

Add `factory.require_auth()` to `settle_default_liquidation` and a dedicated negative test proving that forged mock auth entries cannot bypass the factory check.

## Vulnerability

The auction-side `settle_default_liquidation` compared the `credit_contract` parameter against the stored factory address (`credit_contract != factory`) but never cryptographically verified that the factory authorized the call. An attacker who knows the factory address could call the function directly with `credit_contract = factory` and bypass the check, since it was only comparing a caller-supplied parameter.

## Changes

### 1. `gateway-contract/contracts/auction_contract/src/lib.rs`

Added `factory.require_auth()` at line 378, *before* the existing `credit_contract != factory` check. This ensures Soroban-level cryptographic authorization is enforced, not just a parameter comparison.

### 2. `gateway-contract/contracts/auction_contract/tests/auth_settle.rs` (new)

Three tests covering the full auth surface:

| Test | Auth mock | `credit_contract` | Expected |
|------|-----------|-------------------|----------|
| `non_factory_invoker_reverts` | intruder only | factory address | revert |
| `factory_invoker_succeeds` | factory only | factory address | `Ok(420)` |
| `replay_settle_reverts` | factory (twice) | factory address | first `Ok`, second `Err(AlreadySettled)` |

The negative test (`non_factory_invoker_reverts`) is the key addition: it uses `mock_auths` to authorize only an intruder address while passing the correct `credit_contract = factory`. Before the fix this would succeed; with `factory.require_auth()` it correctly reverts.

## Test output

```
$ cargo test -p gateway-auction --test auth_settle
running 3 tests
test non_factory_invoker_reverts ... ok
test factory_invoker_succeeds ... ok
test replay_settle_reverts ... ok

test result: ok. 3 passed; 0 failed
```

No regressions — all 12 pre-existing test failures (unrelated to this change) remain unchanged.

## Notes

- The existing `credit_contract != factory` check is retained as defense-in-depth.
- `factory.require_auth()` is placed before the parameter check so that an auth failure produces a host-level error, preventing any code path from executing without factory authorization.

## Screenshot
<img width="1465" height="380" alt="image" src="https://github.com/user-attachments/assets/165b4f2c-1d71-4c74-ad50-8e2d66fd3d1b" />
