### PR TITLE
feat: protocol summary view

### DIFF
--- a/contracts/credit/src/accrual.rs
+++ b/contracts/credit/src/accrual.rs
@@ -341,12 +341,13 @@ pub fn accrue_batch(env: &Env, borrowers: Vec<Address>) {
             if stored_line.status == CreditStatus::Active && stored_line.utilized_amount > 0 {
                 let previous_utilized = stored_line.utilized_amount;
                 let previous_ts = stored_line.last_accrual_ts;
+                let previous_status = stored_line.status;
                 let updated = apply_accrual(env, stored_line);
                 // Only persist if accrual actually changed the line
                 if updated.utilized_amount != previous_utilized
                     || updated.last_accrual_ts != previous_ts
                 {
-                    persist_credit_line(env, &borrower, &updated, previous_utilized);
+                    persist_credit_line(env, &borrower, &updated, previous_utilized, Some(previous_status));
                 }
             }
         }

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -108,11 +108,14 @@ mod risk;
 pub use crate::risk::compute_rate_from_score;
 mod storage;
 pub mod types;
+mod views;
 
 #[cfg(test)]
 mod boundary_tests;
 #[cfg(test)]
 mod risk_formula_tests;
+#[cfg(test)]
+mod views_tests;
 
 use crate::auth::require_admin_auth;
 use crate::events::{
@@ -139,7 +142,7 @@ use crate::storage::{
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, RateChangeConfig, RateFormulaConfig, RateFormulaConfigEvent,
+    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig, RateFormulaConfigEvent,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -359,7 +362,7 @@ impl Credit {
             suspension_ts: 0,
         };
 
-        persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+        persist_credit_line(&env, &borrower, &credit_line, previous_utilized, None);
         clear_repayment_schedule(&env, &borrower);
 
         publish_credit_line_event(
@@ -543,8 +546,9 @@ impl Credit {
         }
         token_client.transfer(&reserve_address, &borrower, &amount);
 
+        let previous_status = credit_line.status;
         credit_line.utilized_amount = updated_utilized;
-        persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+        persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
 
         let timestamp = env.ledger().timestamp();
         storage_set_last_draw_ts(&env, &borrower, timestamp);
@@ -679,9 +683,10 @@ impl Credit {
             .utilized_amount
             .saturating_sub(effective_repay)
             .max(0);
+        let previous_status = credit_line.status;
         credit_line.utilized_amount = new_utilized;
 
-        persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+        persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
         lifecycle::advance_repayment_schedule_after_repay(&env, &borrower, effective_repay);
 
         let _timestamp = env.ledger().timestamp();
@@ -1012,6 +1017,11 @@ impl Credit {
     /// entries are extended.
     pub fn get_protocol_summary(env: Env) -> ProtocolSummary {
         query::get_protocol_summary(env)
+    }
+
+    /// Get protocol-level dashboard totals requested for GrantFox campaign.
+    pub fn get_protocol_summary_view(env: Env) -> ProtocolSummaryView {
+        views::get_protocol_summary_view(env)
     }
 
     pub fn deposit_collateral(env: Env, borrower: Address, amount: i128) {

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -225,6 +225,8 @@ fn suspend_credit_line_internal(env: &Env, borrower: Address) {
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
 
+    let previous_status = stored_line.status;
+
     // Apply interest accrual before any mutation.
     let mut credit_line = crate::accrual::apply_accrual(env, stored_line);
 
@@ -236,7 +238,7 @@ fn suspend_credit_line_internal(env: &Env, borrower: Address) {
     let new_ts = env.ledger().timestamp();
     assert_ts_monotonic(env, credit_line.suspension_ts, new_ts);
     credit_line.suspension_ts = new_ts;
-    persist_credit_line(env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(env, &borrower, &credit_line, previous_utilized, Some(previous_status));
 
     publish_credit_line_event(
         env,
@@ -421,7 +423,7 @@ pub fn open_credit_line(
         last_accrual_ts: env.ledger().timestamp(),
         suspension_ts: 0,
     };
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, None);
     clear_repayment_schedule(&env, &borrower);
 
     publish_credit_line_event(
@@ -544,8 +546,9 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
         panic!("unauthorized");
     }
 
+    let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Closed;
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
     clear_repayment_schedule(&env, &borrower);
 
     publish_credit_line_event(
@@ -623,8 +626,9 @@ pub fn default_credit_line(env: Env, borrower: Address) {
         return;
     }
 
+    let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Defaulted;
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
 
     publish_credit_line_event(
         &env,
@@ -678,7 +682,8 @@ pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
         .checked_sub(effective_forgive)
         .unwrap_or(0);
 
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    let previous_status = credit_line.status;
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
 }
 
 /// Apply auction liquidation proceeds to a defaulted credit line (admin only).
@@ -738,11 +743,12 @@ pub fn settle_default_liquidation(
         .checked_sub(recovered_amount)
         .unwrap_or_else(|| env.panic_with_error(ContractError::Overflow));
 
+    let previous_status = credit_line.status;
     if credit_line.utilized_amount == 0 {
         credit_line.status = CreditStatus::Closed;
     }
 
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
     if credit_line.status == CreditStatus::Closed {
         clear_repayment_schedule(&env, &borrower);
     }
@@ -812,9 +818,10 @@ pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditS
         env.panic_with_error(ContractError::CreditLineDefaulted);
     }
 
+    let previous_status = credit_line.status;
     credit_line.status = target_status;
     credit_line.suspension_ts = 0;
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
 
     publish_credit_line_event(
         &env,

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -126,9 +126,9 @@ pub fn get_health_factor(env: Env, borrower: Address) -> u32 {
     let min_ratio_bps = crate::storage::get_min_collateral_ratio_bps(&env).unwrap_or(15_000);
 
     // Convert to u128 for overflow-safe multiplication.
-    let collateral_u128 = u128::from(collateral.max(0));
-    let utilized_u128 = u128::from(utilized.max(0));
-    let min_ratio_u128 = u128::from(min_ratio_bps);
+    let collateral_u128 = collateral.max(0) as u128;
+    let utilized_u128 = utilized.max(0) as u128;
+    let min_ratio_u128 = min_ratio_bps as u128;
 
     // health_bps = collateral * 100_000_000 / (utilized * min_ratio)
     //

--- a/contracts/credit/src/risk.rs
+++ b/contracts/credit/src/risk.rs
@@ -59,9 +59,9 @@
 #![warn(missing_docs)]
 
 use crate::auth::require_admin_auth;
-use crate::events::{publish_risk_parameters_updated, RiskParametersUpdatedEvent};
+use crate::events::publish_risk_parameters_updated;
 use crate::storage::{
-    assert_not_paused, assert_ts_monotonic, persist_credit_line, rate_cfg_key, rate_formula_key,
+    assert_not_paused, assert_ts_monotonic, get_credit_line, persist_credit_line, rate_cfg_key, rate_formula_key,
 };
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, RateChangeConfig, RateFormulaConfig,
@@ -354,6 +354,7 @@ pub fn update_risk_parameters(
     credit_line.interest_rate_bps = final_rate;
     credit_line.risk_score = risk_score;
 
+    let previous_status = credit_line.status;
     // Handle limit decrease: transition to Restricted if utilization exceeds new limit
     if credit_line.utilized_amount > credit_limit {
         credit_line.status = CreditStatus::Restricted;
@@ -361,7 +362,7 @@ pub fn update_risk_parameters(
 
     credit_line.credit_limit = credit_limit;
 
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, Some(previous_status));
 
     publish_risk_parameters_updated(
         &env,

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -58,7 +58,7 @@
 //! [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) §3 for the
 //! full per-variant tier table.
 
-use crate::types::{ContractError, CreditLineData, RepaymentSchedule};
+use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
 use soroban_sdk::{contracttype, Address, Env, Symbol};
 
 /// Storage keys used in instance and persistent storage.
@@ -99,6 +99,8 @@ pub enum DataKey {
     SchemaVersion,
     /// Monotonic count of unique borrowers that have had a credit line recorded.
     CreditLineCount,
+    /// Count of currently Active credit lines.
+    ActiveLineCount,
     /// Borrower → stable numeric id used for deterministic enumeration.
     CreditLineIdByBorrower(Address),
     /// Stable numeric id → borrower address.
@@ -261,6 +263,30 @@ pub fn get_credit_line_count(env: &Env) -> u32 {
         .unwrap_or(0)
 }
 
+/// Return the count of currently Active credit lines.
+pub fn get_active_line_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ActiveLineCount)
+        .unwrap_or(0)
+}
+
+/// Increment the count of currently Active credit lines.
+pub fn increment_active_line_count(env: &Env) {
+    let count = get_active_line_count(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::ActiveLineCount, &count.saturating_add(1));
+}
+
+/// Decrement the count of currently Active credit lines.
+pub fn decrement_active_line_count(env: &Env) {
+    let count = get_active_line_count(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::ActiveLineCount, &count.saturating_sub(1));
+}
+
 /// Return the configured global exposure cap, if set.
 pub fn get_max_total_exposure(env: &Env) -> Option<i128> {
     env.storage().instance().get(&DataKey::MaxTotalExposure)
@@ -351,11 +377,21 @@ pub fn persist_credit_line(
     borrower: &Address,
     line: &CreditLineData,
     previous_utilized: i128,
+    previous_status: Option<CreditStatus>,
 ) {
     ensure_credit_line_id(env, borrower);
     env.storage().persistent().set(borrower, line);
     bump_credit_line_ttl(env, borrower);
     adjust_total_utilized(env, previous_utilized, line.utilized_amount);
+    
+    let is_now_active = line.status == CreditStatus::Active;
+    let was_active = previous_status == Some(CreditStatus::Active);
+    
+    if is_now_active && !was_active {
+        increment_active_line_count(env);
+    } else if !is_now_active && was_active {
+        decrement_active_line_count(env);
+    }
 }
 
 /// Return a borrower's collateral balance without bumping unrelated TTL.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -383,3 +383,15 @@ pub struct ProtocolSummary {
     /// Accumulated protocol fees awaiting treasury withdrawal.
     pub treasury_balance: i128,
 }
+
+/// Protocol summary returned by the specific query view for GrantFox campaign.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolSummaryView {
+    /// Global utilized principal accumulator.
+    pub total_utilized: i128,
+    /// Global collateral balance accumulator.
+    pub total_collateral: i128,
+    /// Count of currently Active credit lines.
+    pub active_line_count: u32,
+}

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+//! Read-only query views for specialized campaign indexing.
+//!
+//! Provides the protocol summary view requested for the GrantFox campaign.
+
+use crate::types::ProtocolSummaryView;
+use soroban_sdk::Env;
+
+/// Return protocol-level dashboard aggregates including ActiveLineCount.
+///
+/// This reads aggregate storage slots to return TotalUtilized, TotalCollateral,
+/// and ActiveLineCount without iterating through individual borrower records.
+pub fn get_protocol_summary_view(env: Env) -> ProtocolSummaryView {
+    ProtocolSummaryView {
+        total_utilized: crate::storage::get_total_utilized(&env),
+        total_collateral: crate::storage::get_total_collateral(&env),
+        active_line_count: crate::storage::get_active_line_count(&env),
+    }
+}

--- a/contracts/credit/src/views_tests.rs
+++ b/contracts/credit/src/views_tests.rs
@@ -1,0 +1,57 @@
+#![cfg(test)]
+
+use crate::{Credit, CreditClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+#[test]
+fn test_protocol_summary_view_active_lines() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Initialize with dummy token/source
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Initial summary
+    let summary = client.get_protocol_summary_view();
+    assert_eq!(summary.active_line_count, 0);
+
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+
+    // Open b1 -> count 1
+    client.open_credit_line(&b1, &1000, &500, &10);
+    assert_eq!(client.get_protocol_summary_view().active_line_count, 1);
+
+    // Open b2 -> count 2
+    client.open_credit_line(&b2, &1000, &500, &10);
+    assert_eq!(client.get_protocol_summary_view().active_line_count, 2);
+
+    // Open b3 -> count 3
+    client.open_credit_line(&b3, &1000, &500, &10);
+    assert_eq!(client.get_protocol_summary_view().active_line_count, 3);
+
+    // Suspend b2 -> count 2
+    client.suspend_credit_line(&b2);
+    assert_eq!(client.get_protocol_summary_view().active_line_count, 2);
+
+    // Default b1 -> count 1
+    client.default_credit_line(&b1);
+    assert_eq!(client.get_protocol_summary_view().active_line_count, 1);
+
+    // Close b3 -> count 0
+    client.close_credit_line(&b3, &admin);
+    assert_eq!(client.get_protocol_summary_view().active_line_count, 0);
+}


### PR DESCRIPTION
Closes #612 

## Description
This PR implements the `protocol_summary` view for the GrantFox campaign. It introduces the ability for the dashboard to receive protocol-level aggregates directly via the API without iterating through individual borrower records, reducing gas constraints and improving API efficiency.

## Changes Included
- **State Tracking (`ActiveLineCount`)**: 
  - Added `ActiveLineCount` inside the `DataKey` enum for persistent tracking.
  - Implemented the active line count mutation directly inside the central `persist_credit_line` method, ensuring it's robust and secure across all credit state transitions (e.g. `None` to `Active`, `Active` to `Suspended`). All parent callers of `persist_credit_line` were updated to properly pass `previous_status`.
- **Protocol View Layer**: 
  - Added the `ProtocolSummaryView` struct inside `types.rs`.
  - Added the `get_protocol_summary_view` method in the new `views.rs` module, which exposes `TotalUtilized`, `TotalCollateral`, and `ActiveLineCount`.
- **Unit Testing**: 
  - Developed focused unit tests inside `views_tests.rs` verifying accurate `ActiveLineCount` additions and deductions.

## Validation
- Executed `cargo test --lib views_tests` and confirmed the `ActiveLineCount` increments and decrements correctly.
- Code compiles via `cargo check --workspace` and enforces strict linting rules without new warnings.
- API changes documented using standard NatSpec comments.
