### PR TITLE
feat: freeze with reason enum

### DIFF
--- a/contracts/.gas-baseline.json
+++ b/contracts/.gas-baseline.json
@@ -73,7 +73,7 @@
   },
   {
     "entrypoint": "unfreeze_draws",
-    "cpu_instructions": 97541,
+    "cpu_instructions": 109835,
     "memory_bytes": 17481,
     "tolerance_pct": 5.0
   },

--- a/contracts/.gas-baseline.json
+++ b/contracts/.gas-baseline.json
@@ -74,7 +74,7 @@
   {
     "entrypoint": "unfreeze_draws",
     "cpu_instructions": 109835,
-    "memory_bytes": 17481,
+    "memory_bytes": 19160,
     "tolerance_pct": 5.0
   },
   {

--- a/contracts/credit/docs/errors.md
+++ b/contracts/credit/docs/errors.md
@@ -215,6 +215,17 @@ All errors are represented as `ContractError` enum variants with stable discrimi
 
 ---
 
+### 41. CreditLineFrozen (Code: 41)
+**Description:** The borrower's credit line has an admin freeze with a structured [`FreezeReason`]; draws are blocked without changing `CreditStatus`.
+
+**Trigger Conditions:**
+- Attempting to draw while `DataKey::CreditLineFreeze` is set for the borrower
+- Per-line compliance, investigation, or operational holds
+
+**Recovery:** Admin calls `unfreeze_credit_line`. Repayments remain available.
+
+---
+
 ### 20. CreditLineSuspended (Code: 20)
 **Description:** Action cannot be performed because the credit line is suspended.
 

--- a/contracts/credit/examples/budget_baseline.rs
+++ b/contracts/credit/examples/budget_baseline.rs
@@ -263,7 +263,7 @@ fn main() {
     {
         let (env, credit, ..) = setup();
         let (cpu, mem) = measure(&env, || {
-            credit.freeze_draws();
+            credit.freeze_draws(&creditra_credit::FreezeReason::LiquidityReserve);
         });
         results.push(Baseline {
             entrypoint: "freeze_draws",
@@ -278,7 +278,7 @@ fn main() {
     // ── unfreeze_draws ────────────────────────────────────────────────────
     {
         let (env, credit, ..) = setup();
-        credit.freeze_draws();
+        credit.freeze_draws(&creditra_credit::FreezeReason::LiquidityReserve);
         let (cpu, mem) = measure(&env, || {
             credit.unfreeze_draws();
         });

--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -130,6 +130,19 @@ pub struct DrawReversedEvent {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DrawsFrozenEvent {
     pub frozen: bool,
+    pub reason: crate::types::FreezeReason,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineFreezeEvent {
+    pub borrower: soroban_sdk::Address,
+    /// Structured reason for the freeze action.
+    pub reason: crate::types::FreezeReason,
+    /// `true` when frozen; `false` when unfrozen.
+    pub frozen: bool,
+    /// Ledger sequence at time of change (for off-chain indexers).
+    pub ledger: u32,
 }
 
 #[contracttype]
@@ -270,10 +283,28 @@ pub fn publish_interest_accrued_event(env: &Env, event: InterestAccruedEvent) {
         .publish((symbol_short!("credit"), symbol_short!("accrue")), event);
 }
 
-pub fn publish_draws_frozen_event(env: &Env, frozen: bool) {
+pub fn publish_draws_frozen_event(env: &Env, frozen: bool, reason: crate::types::FreezeReason) {
     env.events().publish(
         (symbol_short!("credit"), Symbol::new(env, "drw_freeze")),
-        DrawsFrozenEvent { frozen },
+        DrawsFrozenEvent { frozen, reason },
+    );
+}
+
+/// Publish a per-credit-line freeze/unfreeze event.
+pub fn publish_credit_line_freeze_event(
+    env: &Env,
+    borrower: &soroban_sdk::Address,
+    reason: crate::types::FreezeReason,
+    frozen: bool,
+) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "line_frz")),
+        CreditLineFreezeEvent {
+            borrower: borrower.clone(),
+            reason,
+            frozen,
+            ledger: env.ledger().sequence(),
+        },
     );
 }
 

--- a/contracts/credit/src/freeze.rs
+++ b/contracts/credit/src/freeze.rs
@@ -1,91 +1,150 @@
 // SPDX-License-Identifier: MIT
 
-//! Global draw-freeze switch.
+//! Credit-line and global draw-freeze controls with structured reason taxonomy.
 //!
-//! Provides an admin-only emergency control that blocks **all** `draw_credit`
-//! calls contract-wide while liquidity reserve operations are underway.
+//! Provides admin-only emergency controls that block `draw_credit` while
+//! preserving repayment access. Two complementary mechanisms live here:
 //!
-//! # Comparison with the protocol pause flag
+//! | Mechanism | Scope | Storage | Lifecycle impact |
+//! | --------- | ----- | ------- | ---------------- |
+//! | Global draw freeze | all borrowers | instance [`DataKey::DrawsFrozen`] | none |
+//! | Credit-line freeze | one borrower | persistent [`DataKey::CreditLineFreeze`] | none |
 //!
-//! The credit contract also exposes a broader **pause** flag
-//! ([`crate::storage::is_paused`]) controlled through a separate admin path.
-//! The two switches differ in scope and intent:
+//! Both paths record a [`FreezeReason`] so indexers and governance tooling can
+//! classify operational actions without relying on off-chain metadata.
+//!
+//! # Comparison with other draw blocks
 //!
 //! | Switch | Scope | Affects repayments | Intended use |
 //! | ------ | ----- | ------------------ | ------------ |
 //! | `DrawsFrozen` | only `draw_credit` | no | scheduled reserve operations |
+//! | `CreditLineFreeze` | one borrower's draws | no | compliance / investigation holds |
 //! | `Paused` | every mutating entrypoint except `repay_credit` | no | emergency stop |
-//!
-//! A protocol pause subsumes a draws freeze; admins should prefer the more
-//! targeted `freeze_draws` flag whenever the situation does not warrant a
-//! full circuit-breaker halt.
-//!
-//! # Design
-//! - Stored as a single `bool` under [`DataKey::DrawsFrozen`] in instance storage.
-//! - Defaults to `false` (draws allowed) when the key is absent.
-//! - Distinct from per-line [`CreditStatus::Suspended`]: this flag does not
-//!   mutate any borrower's credit line and can be toggled in O(1) regardless
-//!   of the number of open lines.
-//! - Repayments are **never** blocked by this flag.
+//! | `CreditStatus::Suspended` | one line's draws + status | no | lifecycle suspension |
 //!
 //! # Threat model
-//! An attacker who gains admin credentials could freeze draws to disrupt
-//! borrowers. This is mitigated by the same admin-key security requirements
-//! that protect all other admin operations. The flag is intentionally
-//! transparent: the current state is readable by anyone via `is_draws_frozen`.
+//! An attacker with admin credentials could freeze draws to disrupt borrowers.
+//! This is mitigated by the same admin-key security requirements that protect
+//! all other admin operations. Freeze reasons are emitted on-chain for audit.
 
 use crate::auth::require_admin_auth;
-use crate::events::publish_draws_frozen_event;
-use crate::storage::DataKey;
-use soroban_sdk::Env;
+use crate::events::{publish_credit_line_freeze_event, publish_draws_frozen_event};
+use crate::storage::{get_credit_line, DataKey};
+use crate::types::{ContractError, DrawsFreezeState, FreezeReason};
+use soroban_sdk::{Address, Env};
 
 /// Freeze all draws globally (admin only).
 ///
-/// Sets [`DataKey::DrawsFrozen`] to `true`. Idempotent: calling when already
-/// frozen is a no-op (no event emitted for the redundant call).
+/// Sets [`DataKey::DrawsFrozen`] with `frozen = true` and records `reason`.
 ///
 /// # Storage
 /// - **Type**: Instance storage (shared TTL with all instance keys)
 /// - **Key**: `DataKey::DrawsFrozen`
-/// - **TTL Note**: Shares instance TTL — extend alongside other instance keys.
-///   If instance is archived, this flag is lost and draws become allowed.
+/// - **Value**: [`DrawsFreezeState`]
 ///
 /// # Events
-/// Emits [`DrawsFrozenEvent`] with `frozen = true`.
-pub fn freeze_draws(env: Env) {
+/// Emits [`DrawsFrozenEvent`] with `frozen = true` and the supplied `reason`.
+pub fn freeze_draws(env: Env, reason: FreezeReason) {
     require_admin_auth(&env);
-    env.storage().instance().set(&DataKey::DrawsFrozen, &true);
-    publish_draws_frozen_event(&env, true);
+    env.storage().instance().set(
+        &DataKey::DrawsFrozen,
+        &DrawsFreezeState {
+            frozen: true,
+            reason,
+        },
+    );
+    publish_draws_frozen_event(&env, true, reason);
 }
 
 /// Unfreeze draws globally (admin only).
 ///
-/// Sets [`DataKey::DrawsFrozen`] to `false`. Idempotent: calling when already
-/// unfrozen is a no-op (no event emitted for the redundant call).
-///
-/// # Storage
-/// - **Type**: Instance storage (shared TTL with all instance keys)
-/// - **Key**: `DataKey::DrawsFrozen`
-/// - **TTL Note**: Shares instance TTL — extend alongside other instance keys.
+/// Sets `frozen = false` while preserving the last recorded reason for audit reads.
 ///
 /// # Events
-/// Emits [`DrawsFrozenEvent`] with `frozen = false`.
+/// Emits [`DrawsFrozenEvent`] with `frozen = false` and the last stored reason
+/// (defaults to [`FreezeReason::LiquidityReserve`] when never frozen before).
 pub fn unfreeze_draws(env: Env) {
     require_admin_auth(&env);
-    env.storage().instance().set(&DataKey::DrawsFrozen, &false);
-    publish_draws_frozen_event(&env, false);
+    let reason = get_draws_freeze_state(&env)
+        .map(|state| state.reason)
+        .unwrap_or(FreezeReason::LiquidityReserve);
+    env.storage().instance().set(
+        &DataKey::DrawsFrozen,
+        &DrawsFreezeState {
+            frozen: false,
+            reason,
+        },
+    );
+    publish_draws_frozen_event(&env, false, reason);
 }
 
 /// Returns `true` when draws are globally frozen.
 ///
 /// Defaults to `false` (draws allowed) if the key has never been set.
-///
-/// # Storage
-/// - **Type**: Instance storage (shared TTL with all instance keys)
-/// - **Key**: `DataKey::DrawsFrozen`
 pub fn is_draws_frozen(env: &Env) -> bool {
+    get_draws_freeze_state(env).map_or(false, |state| state.frozen)
+}
+
+/// Returns the active global freeze reason, if draws are currently frozen.
+pub fn get_draws_freeze_reason(env: &Env) -> Option<FreezeReason> {
+    get_draws_freeze_state(env)
+        .filter(|state| state.frozen)
+        .map(|state| state.reason)
+}
+
+/// Freeze a single credit line's draws (admin only).
+///
+/// Records `reason` under [`DataKey::CreditLineFreeze`] without mutating
+/// [`crate::types::CreditStatus`]. Repayments remain available.
+///
+/// # Errors
+/// - [`ContractError::CreditLineNotFound`] when no credit line exists for `borrower`.
+///
+/// # Events
+/// Emits [`CreditLineFreezeEvent`] on `("credit", "line_frz")` with `frozen = true`.
+pub fn freeze_credit_line(env: Env, borrower: Address, reason: FreezeReason) {
+    require_admin_auth(&env);
+    if get_credit_line(&env, &borrower).is_none() {
+        env.panic_with_error(ContractError::CreditLineNotFound);
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::CreditLineFreeze(borrower.clone()), &reason);
+    publish_credit_line_freeze_event(&env, &borrower, reason, true);
+}
+
+/// Lift a per-credit-line draw freeze (admin only).
+///
+/// No-op when the borrower was not frozen. Repayments were never blocked.
+///
+/// # Events
+/// Emits [`CreditLineFreezeEvent`] with `frozen = false` when a freeze record existed.
+pub fn unfreeze_credit_line(env: Env, borrower: Address) {
+    require_admin_auth(&env);
+    let key = DataKey::CreditLineFreeze(borrower.clone());
+    let Some(reason) = env.storage().persistent().get::<DataKey, FreezeReason>(&key) else {
+        return;
+    };
+    env.storage().persistent().remove(&key);
+    publish_credit_line_freeze_event(&env, &borrower, reason, false);
+}
+
+/// Returns `true` when a credit line has an active admin freeze.
+pub fn is_credit_line_frozen(env: &Env, borrower: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::CreditLineFreeze(borrower.clone()))
+}
+
+/// Returns the structured freeze reason for a credit line, if frozen.
+pub fn get_credit_line_freeze_reason(env: &Env, borrower: &Address) -> Option<FreezeReason> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreditLineFreeze(borrower.clone()))
+}
+
+fn get_draws_freeze_state(env: &Env) -> Option<DrawsFreezeState> {
     env.storage()
         .instance()
-        .get(&DataKey::DrawsFrozen)
-        .unwrap_or(false)
+        .get::<DataKey, DrawsFreezeState>(&DataKey::DrawsFrozen)
 }

--- a/contracts/credit/src/freeze.rs
+++ b/contracts/credit/src/freeze.rs
@@ -122,7 +122,11 @@ pub fn freeze_credit_line(env: Env, borrower: Address, reason: FreezeReason) {
 pub fn unfreeze_credit_line(env: Env, borrower: Address) {
     require_admin_auth(&env);
     let key = DataKey::CreditLineFreeze(borrower.clone());
-    let Some(reason) = env.storage().persistent().get::<DataKey, FreezeReason>(&key) else {
+    let Some(reason) = env
+        .storage()
+        .persistent()
+        .get::<DataKey, FreezeReason>(&key)
+    else {
         return;
     };
     env.storage().persistent().remove(&key);

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -106,6 +106,7 @@ pub mod math_utils;
 mod query;
 mod risk;
 pub use crate::risk::compute_rate_from_score;
+pub use crate::types::FreezeReason;
 mod scoring;
 mod storage;
 pub mod types;
@@ -143,9 +144,9 @@ use crate::storage::{
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
-    RateFormulaConfigEvent,
+    ContractError, CreditLineData, CreditStatus, FreezeReason, GracePeriodConfig,
+    GraceWaiverMode, OracleConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView,
+    RateChangeConfig, RateFormulaConfig, RateFormulaConfigEvent,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -419,6 +420,12 @@ impl Credit {
         if storage_is_borrower_frozen(&env, &borrower) {
             clear_reentrancy_guard(&env);
             env.panic_with_error(ContractError::BorrowerFrozen);
+        }
+
+        // Per-credit-line admin freeze with structured reason taxonomy.
+        if freeze::is_credit_line_frozen(&env, &borrower) {
+            clear_reentrancy_guard(&env);
+            env.panic_with_error(ContractError::CreditLineFrozen);
         }
 
         // Enforce per-transaction draw cap when configured.
@@ -1568,8 +1575,8 @@ impl Credit {
         );
     }
 
-    pub fn freeze_draws(env: Env) {
-        freeze::freeze_draws(env)
+    pub fn freeze_draws(env: Env, reason: FreezeReason) {
+        freeze::freeze_draws(env, reason)
     }
 
     pub fn unfreeze_draws(env: Env) {
@@ -1578,6 +1585,43 @@ impl Credit {
 
     pub fn is_draws_frozen(env: Env) -> bool {
         freeze::is_draws_frozen(&env)
+    }
+
+    /// Returns the structured reason for the active global draw freeze.
+    ///
+    /// Returns `None` when draws are not currently frozen.
+    pub fn get_draws_freeze_reason(env: Env) -> Option<FreezeReason> {
+        freeze::get_draws_freeze_reason(&env)
+    }
+
+    /// Freeze a single credit line's draws with a structured reason (admin only).
+    ///
+    /// Does not mutate [`CreditStatus`]. Repayments remain available.
+    ///
+    /// # Errors
+    /// - [`ContractError::CreditLineNotFound`] when no credit line exists.
+    ///
+    /// # Events
+    /// Emits `CreditLineFreezeEvent` on `("credit", "line_frz")`.
+    pub fn freeze_credit_line(env: Env, borrower: Address, reason: FreezeReason) {
+        freeze::freeze_credit_line(env, borrower, reason)
+    }
+
+    /// Lift a per-credit-line draw freeze (admin only).
+    ///
+    /// No-op when the borrower was not frozen.
+    pub fn unfreeze_credit_line(env: Env, borrower: Address) {
+        freeze::unfreeze_credit_line(env, borrower)
+    }
+
+    /// Returns `true` when the borrower's credit line has an active admin freeze.
+    pub fn is_credit_line_frozen(env: Env, borrower: Address) -> bool {
+        freeze::is_credit_line_frozen(&env, &borrower)
+    }
+
+    /// Returns the structured freeze reason for a credit line, if frozen.
+    pub fn get_credit_line_freeze_reason(env: Env, borrower: Address) -> Option<FreezeReason> {
+        freeze::get_credit_line_freeze_reason(&env, &borrower)
     }
 
     /// Temporarily freeze a borrower's draws until the given expiry timestamp (admin only).
@@ -4387,6 +4431,7 @@ mod test_mock_liquidity_token {
     #[cfg(test)]
     mod test_draw_freeze {
         use super::*;
+        use crate::types::FreezeReason;
         use soroban_sdk::testutils::Events as _;
         use soroban_sdk::Symbol;
 
@@ -4424,7 +4469,7 @@ mod test_mock_liquidity_token {
         fn freeze_draws_sets_flag() {
             let env = Env::default();
             let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
             assert!(client.is_draws_frozen());
         }
 
@@ -4434,7 +4479,7 @@ mod test_mock_liquidity_token {
         fn draw_credit_reverts_when_frozen() {
             let env = Env::default();
             let (client, _admin, borrower) = setup(&env);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.draw_credit(&borrower, &100_i128);
         }
 
@@ -4458,7 +4503,7 @@ mod test_mock_liquidity_token {
             // Draw before freeze
             client.draw_credit(&borrower, &500_i128);
             // Freeze draws
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
             // Fund borrower and approve for repayment
             sac.mint(&borrower, &200_i128);
             soroban_sdk::token::Client::new(&env, &token_address).approve(
@@ -4480,7 +4525,7 @@ mod test_mock_liquidity_token {
         fn unfreeze_draws_clears_flag() {
             let env = Env::default();
             let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
             assert!(client.is_draws_frozen());
             client.unfreeze_draws();
             assert!(!client.is_draws_frozen());
@@ -4491,7 +4536,7 @@ mod test_mock_liquidity_token {
         fn draw_credit_succeeds_after_unfreeze() {
             let env = Env::default();
             let (client, _admin, borrower) = setup(&env);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.unfreeze_draws();
             client.draw_credit(&borrower, &100_i128);
             assert_eq!(
@@ -4513,7 +4558,7 @@ mod test_mock_liquidity_token {
             let client = CreditClient::new(&env, &contract_id);
             client.init(&admin);
             // No auth mocked → should panic
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
         }
 
         /// Non-admin cannot unfreeze draws.
@@ -4539,7 +4584,7 @@ mod test_mock_liquidity_token {
 
             let env = Env::default();
             let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
 
             let events = env.events().all();
             let (_contract, topics, data) = events.last().unwrap();
@@ -4547,6 +4592,7 @@ mod test_mock_liquidity_token {
             assert_eq!(topic_sym, Symbol::new(&env, "drw_freeze"));
             let event: DrawsFrozenEvent = data.try_into_val(&env).unwrap();
             assert!(event.frozen);
+            assert_eq!(event.reason, FreezeReason::LiquidityReserve);
         }
 
         /// unfreeze_draws emits a DrawsFrozenEvent with frozen=false.
@@ -4558,7 +4604,7 @@ mod test_mock_liquidity_token {
 
             let env = Env::default();
             let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.unfreeze_draws();
 
             let events = env.events().all();
@@ -4584,7 +4630,7 @@ mod test_mock_liquidity_token {
             client.init(&admin);
             client.open_credit_line(&borrower_a, &1_000_i128, &300_u32, &70_u32);
             client.open_credit_line(&borrower_b, &2_000_i128, &300_u32, &70_u32);
-            client.freeze_draws();
+            client.freeze_draws(&FreezeReason::LiquidityReserve);
 
             // Verify the flag is set — both borrowers are blocked by the same flag
             assert!(client.is_draws_frozen());
@@ -4608,7 +4654,7 @@ mod test_mock_liquidity_token {
             client_a.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
             client_b.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
 
-            client_a.freeze_draws();
+            client_a.freeze_draws(&FreezeReason::LiquidityReserve);
 
             assert!(client_a.is_draws_frozen());
             assert!(!client_b.is_draws_frozen());

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -144,9 +144,9 @@ use crate::storage::{
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode,
-    OracleConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
-    RateFormulaConfig, RateFormulaConfigEvent,
+    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
+    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
+    RateFormulaConfigEvent,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -4478,7 +4478,7 @@ mod test_mock_liquidity_token {
         #[should_panic(expected = "Error(Contract, #19)")]
         fn draw_credit_reverts_when_frozen() {
             let env = Env::default();
-            let (client, _admin, borrower, _contract_id) = setup(&env);
+            let (client, _admin, borrower) = setup(&env);
             client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.draw_credit(&borrower, &100_i128);
         }
@@ -4535,7 +4535,7 @@ mod test_mock_liquidity_token {
         #[test]
         fn draw_credit_succeeds_after_unfreeze() {
             let env = Env::default();
-            let (client, _admin, borrower, _contract_id) = setup(&env);
+            let (client, _admin, borrower) = setup(&env);
             client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.unfreeze_draws();
             client.draw_credit(&borrower, &100_i128);
@@ -4687,7 +4687,7 @@ mod test_mock_liquidity_token {
             let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
-            env.ledger().with_mut(|li| li.timestamp = now);
+            env.ledger().set_timestamp(now);
 
             client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
 
@@ -4706,7 +4706,7 @@ mod test_mock_liquidity_token {
             let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
-            env.ledger().with_mut(|li| li.timestamp = now);
+            env.ledger().set_timestamp(now);
             client.freeze_borrower_until(&admin, &borrower, &now);
         }
 
@@ -4717,12 +4717,12 @@ mod test_mock_liquidity_token {
             let (client, admin, borrower, _contract_id) = setup(&env);
 
             let start = 1_700_000_000u64;
-            env.ledger().with_mut(|li| li.timestamp = start);
+            env.ledger().set_timestamp(start);
 
             client.freeze_borrower_until(&admin, &borrower, &(start + 3600));
             assert!(client.is_borrower_frozen(&borrower));
 
-            env.ledger().with_mut(|li| li.timestamp = start + 3600);
+            env.ledger().set_timestamp(start + 3600);
             assert!(!client.is_borrower_frozen(&borrower));
         }
 
@@ -4735,7 +4735,7 @@ mod test_mock_liquidity_token {
             let non_admin = Address::generate(&env);
 
             let now = 1_700_000_000u64;
-            env.ledger().with_mut(|li| li.timestamp = now);
+            env.ledger().set_timestamp(now);
             client.freeze_borrower_until(&non_admin, &borrower, &(now + 3600));
         }
 
@@ -4746,7 +4746,7 @@ mod test_mock_liquidity_token {
             let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
-            env.ledger().with_mut(|li| li.timestamp = now);
+            env.ledger().set_timestamp(now);
 
             client.freeze_borrower_until(&admin, &borrower, &(now + 7200));
             assert!(client.is_borrower_frozen(&borrower));
@@ -4774,7 +4774,7 @@ mod test_mock_liquidity_token {
 
             let now = 1_700_000_000u64;
             let expiry = now + 3600;
-            env.ledger().with_mut(|li| li.timestamp = now);
+            env.ledger().set_timestamp(now);
 
             client.freeze_borrower_until(&admin, &borrower, &expiry);
 
@@ -4796,12 +4796,13 @@ mod test_mock_liquidity_token {
             let (client, admin, borrower, contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
-            env.ledger().with_mut(|li| li.timestamp = now);
+            env.ledger().set_timestamp(now);
 
             let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
             let token = token_id.address();
             client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_i128);
+            soroban_sdk::token::StellarAssetClient::new(&env, &token)
+                .mint(&contract_id, &1_000_i128);
 
             client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
             client.draw_credit(&borrower, &100_i128);

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -146,7 +146,6 @@ use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
     ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
-    RateFormulaConfigEvent,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -144,9 +144,9 @@ use crate::storage::{
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, FreezeReason, GracePeriodConfig,
-    GraceWaiverMode, OracleConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView,
-    RateChangeConfig, RateFormulaConfig, RateFormulaConfigEvent,
+    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode,
+    OracleConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
+    RateFormulaConfig, RateFormulaConfigEvent,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -4478,7 +4478,7 @@ mod test_mock_liquidity_token {
         #[should_panic(expected = "Error(Contract, #19)")]
         fn draw_credit_reverts_when_frozen() {
             let env = Env::default();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, _admin, borrower, _contract_id) = setup(&env);
             client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.draw_credit(&borrower, &100_i128);
         }
@@ -4535,7 +4535,7 @@ mod test_mock_liquidity_token {
         #[test]
         fn draw_credit_succeeds_after_unfreeze() {
             let env = Env::default();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, _admin, borrower, _contract_id) = setup(&env);
             client.freeze_draws(&FreezeReason::LiquidityReserve);
             client.unfreeze_draws();
             client.draw_credit(&borrower, &100_i128);
@@ -4669,16 +4669,27 @@ mod test_mock_liquidity_token {
         use soroban_sdk::testutils::Ledger;
         use soroban_sdk::{Symbol, TryFromVal, TryIntoVal};
 
+        fn setup(env: &Env) -> (CreditClient<'_>, Address, Address, Address) {
+            env.mock_all_auths();
+            let admin = Address::generate(env);
+            let borrower = Address::generate(env);
+            let contract_id = env.register(Credit, ());
+            let client = CreditClient::new(env, &contract_id);
+            client.init(&admin);
+            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+            (client, admin, borrower, contract_id)
+        }
+
         /// freeze_borrower_until sets the freeze and stores the expiry.
         #[test]
         fn freeze_borrower_until_sets_freeze() {
             let env = Env::default();
-            env.mock_all_auths();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
+            env.ledger().with_mut(|li| li.timestamp = now);
 
-            client.freeze_borrower_until(&_admin, &borrower, &(now + 3600));
+            client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
 
             assert!(client.is_borrower_frozen(&borrower));
             assert_eq!(
@@ -4692,26 +4703,39 @@ mod test_mock_liquidity_token {
         #[should_panic(expected = "Error(Contract, #5)")]
         fn freeze_borrower_until_past_ts_reverts() {
             let env = Env::default();
-            env.mock_all_auths();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
-            // expiry_ts <= now should revert with InvalidAmount
-            client.freeze_borrower_until(&_admin, &borrower, &now);
+            env.ledger().with_mut(|li| li.timestamp = now);
+            client.freeze_borrower_until(&admin, &borrower, &now);
         }
 
         /// Freeze expires automatically when ledger timestamp passes expiry_ts.
         #[test]
+        fn freeze_auto_expires_after_ts() {
+            let env = Env::default();
+            let (client, admin, borrower, _contract_id) = setup(&env);
+
+            let start = 1_700_000_000u64;
+            env.ledger().with_mut(|li| li.timestamp = start);
+
+            client.freeze_borrower_until(&admin, &borrower, &(start + 3600));
+            assert!(client.is_borrower_frozen(&borrower));
+
+            env.ledger().with_mut(|li| li.timestamp = start + 3600);
+            assert!(!client.is_borrower_frozen(&borrower));
+        }
 
         /// freeze_borrower_until requires admin auth.
         #[test]
         #[should_panic]
         fn freeze_borrower_until_requires_auth() {
             let env = Env::default();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, _admin, borrower, _contract_id) = setup(&env);
             let non_admin = Address::generate(&env);
 
             let now = 1_700_000_000u64;
+            env.ledger().with_mut(|li| li.timestamp = now);
             client.freeze_borrower_until(&non_admin, &borrower, &(now + 3600));
         }
 
@@ -4719,15 +4743,15 @@ mod test_mock_liquidity_token {
         #[test]
         fn unfreeze_borrower_lifts_freeze() {
             let env = Env::default();
-            env.mock_all_auths();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
+            env.ledger().with_mut(|li| li.timestamp = now);
 
-            client.freeze_borrower_until(&_admin, &borrower, &(now + 7200));
+            client.freeze_borrower_until(&admin, &borrower, &(now + 7200));
             assert!(client.is_borrower_frozen(&borrower));
 
-            client.unfreeze_borrower(&_admin, &borrower);
+            client.unfreeze_borrower(&admin, &borrower);
             assert!(!client.is_borrower_frozen(&borrower));
             assert_eq!(client.get_borrower_frozen_until(&borrower), None);
         }
@@ -4736,7 +4760,7 @@ mod test_mock_liquidity_token {
         #[test]
         fn is_borrower_frozen_defaults_false() {
             let env = Env::default();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, _admin, borrower, _contract_id) = setup(&env);
 
             assert!(!client.is_borrower_frozen(&borrower));
             assert_eq!(client.get_borrower_frozen_until(&borrower), None);
@@ -4746,13 +4770,13 @@ mod test_mock_liquidity_token {
         #[test]
         fn freeze_emits_borrower_frozen_event() {
             let env = Env::default();
-            env.mock_all_auths();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, admin, borrower, _contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
             let expiry = now + 3600;
+            env.ledger().with_mut(|li| li.timestamp = now);
 
-            client.freeze_borrower_until(&_admin, &borrower, &expiry);
+            client.freeze_borrower_until(&admin, &borrower, &expiry);
 
             let events = env.events().all();
             let (_contract, topics, data) = events.last().unwrap();
@@ -4769,36 +4793,19 @@ mod test_mock_liquidity_token {
         fn draw_credit_reverts_when_borrower_frozen() {
             let env = Env::default();
             env.mock_all_auths();
-            let (client, _admin, borrower) = setup(&env);
+            let (client, admin, borrower, contract_id) = setup(&env);
 
             let now = 1_700_000_000u64;
+            env.ledger().with_mut(|li| li.timestamp = now);
 
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &50_u32);
+            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+            let token = token_id.address();
+            client.set_liquidity_token(&token);
+            soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_i128);
 
-            // Freeze the borrower
-            client.freeze_borrower_until(&_admin, &borrower, &(now + 3600));
-
-            // Draw should revert with BorrowerFrozen (#40)
+            client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
             client.draw_credit(&borrower, &100_i128);
         }
-    }
-
-    fn freeze_auto_expires_after_ts() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (client, _admin, borrower) = setup(&env);
-
-        let start = 1_700_000_000u64;
-
-        // Freeze for 1 hour
-        client.freeze_borrower_until(&_admin, &borrower, &(start + 3600));
-        assert!(client.is_borrower_frozen(&borrower));
-
-        // Advance past expiry
-        env.ledger().set_timestamp(start + 3600);
-
-        // Should now be unfrozen
-        assert!(!client.is_borrower_frozen(&borrower));
     }
 
     #[cfg(test)]

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -59,8 +59,7 @@
 //! full per-variant tier table.
 
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, DrawsFreezeState, FreezeReason,
-    RepaymentSchedule,
+    ContractError, CreditLineData, CreditStatus, DrawsFreezeState, FreezeReason, RepaymentSchedule,
 };
 use soroban_sdk::{contracttype, Address, Env, Symbol};
 
@@ -774,10 +773,9 @@ pub fn set_draw_min_interval(env: &Env, seconds: u64) {
 
 /// Set/unset the global draws frozen flag (admin only, enforced by caller).
 pub fn set_draws_frozen(env: &Env, frozen: bool, reason: FreezeReason) {
-    env.storage().instance().set(
-        &DataKey::DrawsFrozen,
-        &DrawsFreezeState { frozen, reason },
-    );
+    env.storage()
+        .instance()
+        .set(&DataKey::DrawsFrozen, &DrawsFreezeState { frozen, reason });
 }
 
 /// Check if draws are globally frozen.

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -58,7 +58,10 @@
 //! [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) §3 for the
 //! full per-variant tier table.
 
-use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
+use crate::types::{
+    ContractError, CreditLineData, CreditStatus, DrawsFreezeState, FreezeReason,
+    RepaymentSchedule,
+};
 use soroban_sdk::{contracttype, Address, Env, Symbol};
 
 /// Storage keys used in instance and persistent storage.
@@ -118,6 +121,9 @@ pub enum DataKey {
     /// Per-borrower temporary freeze expiry timestamp; draws blocked while now < expiry_ts.
     /// When key is absent or expiry_ts <= now, the borrower is not frozen.
     FrozenBorrower(Address),
+    /// Per-borrower credit-line draw freeze with structured reason taxonomy.
+    /// When absent, the line is not admin-frozen (distinct from [`CreditStatus::Suspended`]).
+    CreditLineFreeze(Address),
 
     /// Per-borrower max utilization ratio cap in basis points (e.g. 8000 = 80%).
     /// When set, draw_credit enforces: utilized_amount <= credit_limit * cap_bps / 10_000.
@@ -767,16 +773,19 @@ pub fn set_draw_min_interval(env: &Env, seconds: u64) {
 }
 
 /// Set/unset the global draws frozen flag (admin only, enforced by caller).
-pub fn set_draws_frozen(env: &Env, frozen: bool) {
-    env.storage().instance().set(&DataKey::DrawsFrozen, &frozen);
+pub fn set_draws_frozen(env: &Env, frozen: bool, reason: FreezeReason) {
+    env.storage().instance().set(
+        &DataKey::DrawsFrozen,
+        &DrawsFreezeState { frozen, reason },
+    );
 }
 
 /// Check if draws are globally frozen.
 pub fn is_draws_frozen(env: &Env) -> bool {
     env.storage()
         .instance()
-        .get(&DataKey::DrawsFrozen)
-        .unwrap_or(false)
+        .get::<DataKey, DrawsFreezeState>(&DataKey::DrawsFrozen)
+        .map_or(false, |state| state.frozen)
 }
 
 /// Check if the protocol is paused.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -8,7 +8,7 @@
 //!
 //! ABI-stable types that cross the contract boundary:
 //!
-//! - [`ContractError`] — 38-variant `#[repr(u32)]` error enum (discriminants
+//! - [`ContractError`] — 41-variant `#[repr(u32)]` error enum (discriminants
 //!   pinned by `tests/error_discriminants.rs`). See
 //!   [`docs/contract-errors.md`](../../../docs/contract-errors.md) for the
 //!   flat code table and
@@ -133,6 +133,7 @@ pub enum CreditStatus {
 /// | 38   | `OraclePriceDeviation`        | Oracle price deviation exceeds the configured maximum |
 /// | 39   | `InsufficientCollateralBalance` | Borrower collateral balance cannot cover withdrawal |
 /// | 40   | `BorrowerFrozen`               | Borrower's draws are temporarily frozen until expiry |
+/// | 41   | `CreditLineFrozen`             | Credit line draws are frozen with a structured reason |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -217,6 +218,44 @@ pub enum ContractError {
     InsufficientCollateralBalance = 39,
     /// Borrower's draws are temporarily frozen until the specified expiry timestamp.
     BorrowerFrozen = 40,
+    /// Credit line draws are frozen by admin with a structured [`FreezeReason`].
+    CreditLineFrozen = 41,
+}
+
+/// Structured taxonomy for credit-line and global draw freezes.
+///
+/// # Discriminant stability
+/// Discriminants are part of the contract ABI. New variants must be appended;
+/// existing values must never be reordered or renumbered.
+///
+/// # Usage
+/// - [`crate::freeze::freeze_draws`] records a global reason alongside the
+///   contract-wide draw kill-switch.
+/// - [`crate::freeze::freeze_credit_line`] records a per-borrower reason without
+///   mutating [`CreditStatus`], preserving lifecycle history for indexers.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FreezeReason {
+    /// Scheduled reserve or treasury operations affecting draw liquidity.
+    LiquidityReserve = 0,
+    /// Regulatory or compliance-mandated draw pause.
+    Compliance = 1,
+    /// Active risk investigation or off-chain risk signal.
+    RiskInvestigation = 2,
+    /// Planned operational maintenance window.
+    OperationalMaintenance = 3,
+    /// Borrower-initiated voluntary draw pause.
+    BorrowerRequest = 4,
+}
+
+/// Global draw-freeze state stored under [`crate::storage::DataKey::DrawsFrozen`].
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DrawsFreezeState {
+    /// Whether draws are currently frozen contract-wide.
+    pub frozen: bool,
+    /// Structured reason recorded when the freeze was last activated.
+    pub reason: FreezeReason,
 }
 
 /// Stored credit line data for a borrower.

--- a/contracts/credit/tests/budget_regression.rs
+++ b/contracts/credit/tests/budget_regression.rs
@@ -331,7 +331,7 @@ fn budget_freeze_draws() {
     let baselines = load_baselines();
     let (env, credit, _token, _admin, _borrower) = setup();
     budget(&env).reset_unlimited();
-    credit.freeze_draws();
+    credit.freeze_draws(&creditra_credit::FreezeReason::LiquidityReserve);
     let cpu = budget(&env).cpu_instruction_cost();
     let mem = budget(&env).memory_bytes_cost();
     if let Some(b) = baselines.get("freeze_draws") {
@@ -347,7 +347,7 @@ fn budget_freeze_draws() {
 fn budget_unfreeze_draws() {
     let baselines = load_baselines();
     let (env, credit, _token, _admin, _borrower) = setup();
-    credit.freeze_draws();
+    credit.freeze_draws(&creditra_credit::FreezeReason::LiquidityReserve);
     budget(&env).reset_unlimited();
     credit.unfreeze_draws();
     let cpu = budget(&env).cpu_instruction_cost();

--- a/contracts/credit/tests/coverage_edge_cases.rs
+++ b/contracts/credit/tests/coverage_edge_cases.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use creditra_credit::{Credit, CreditClient};
+use creditra_credit::{Credit, CreditClient, FreezeReason};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{token, Address, Env};
 
@@ -58,7 +58,7 @@ fn draw_credit_negative_amount_panics() {
 fn draw_credit_when_draws_frozen() {
     let (env, _admin, contract_id, borrower, _token) = setup_with_credit_line();
     let client = CreditClient::new(&env, &contract_id);
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     client.draw_credit(&borrower, &100);
 }
 

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -55,6 +55,7 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::OraclePriceDeviation as u32, 38);
     assert_eq!(ContractError::InsufficientCollateralBalance as u32, 39);
     assert_eq!(ContractError::BorrowerFrozen as u32, 40);
+    assert_eq!(ContractError::CreditLineFrozen as u32, 41);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -105,6 +106,7 @@ fn no_duplicate_discriminants() {
         ContractError::OraclePriceDeviation as u32,
         ContractError::InsufficientCollateralBalance as u32,
         ContractError::BorrowerFrozen as u32,
+        ContractError::CreditLineFrozen as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -119,8 +121,8 @@ fn no_duplicate_discriminants() {
 /// Update this number when adding new variants (and add the assertion above).
 #[test]
 fn variant_count_is_known() {
-    // 40 variants as of this writing. Update when adding new ones.
-    const EXPECTED_VARIANT_COUNT: usize = 40;
+    // 41 variants as of this writing. Update when adding new ones.
+    const EXPECTED_VARIANT_COUNT: usize = 41;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -163,6 +165,7 @@ fn variant_count_is_known() {
         ContractError::OraclePriceDeviation as u32,
         ContractError::InsufficientCollateralBalance as u32,
         ContractError::BorrowerFrozen as u32,
+        ContractError::CreditLineFrozen as u32,
     ];
 
     assert_eq!(

--- a/contracts/credit/tests/event_topic_stability.rs
+++ b/contracts/credit/tests/event_topic_stability.rs
@@ -6,8 +6,8 @@ use creditra_credit::events::{
     publish_draw_reversed_event, publish_drawn_event, publish_draws_frozen_event,
     publish_grace_waiver_applied_event, publish_interest_accrued_event, publish_paused_event,
     publish_rate_formula_config_event, publish_repayment_event, publish_risk_parameters_updated,
-    AdminRotationAcceptedEvent, AdminRotationProposedEvent, DefaultLiquidationSettledEvent, DrawReversedEvent, InterestAccruedEvent, RepaymentEvent,
-    RiskParametersUpdatedEvent,
+    AdminRotationAcceptedEvent, AdminRotationProposedEvent, DefaultLiquidationSettledEvent,
+    DrawReversedEvent, InterestAccruedEvent, RepaymentEvent, RiskParametersUpdatedEvent,
 };
 use creditra_credit::types::CreditStatus;
 use creditra_credit::{Credit, CreditClient};

--- a/contracts/credit/tests/event_topic_stability.rs
+++ b/contracts/credit/tests/event_topic_stability.rs
@@ -6,14 +6,13 @@ use creditra_credit::events::{
     publish_draw_reversed_event, publish_drawn_event, publish_draws_frozen_event,
     publish_grace_waiver_applied_event, publish_interest_accrued_event, publish_paused_event,
     publish_rate_formula_config_event, publish_repayment_event, publish_risk_parameters_updated,
-    AdminRotationAcceptedEvent, AdminRotationProposedEvent, BorrowerBlockedEvent,
-    DefaultLiquidationSettledEvent, DrawReversedEvent, InterestAccruedEvent, RepaymentEvent,
+    AdminRotationAcceptedEvent, AdminRotationProposedEvent, DefaultLiquidationSettledEvent, DrawReversedEvent, InterestAccruedEvent, RepaymentEvent,
     RiskParametersUpdatedEvent,
 };
 use creditra_credit::types::CreditStatus;
 use creditra_credit::{Credit, CreditClient};
 use soroban_sdk::testutils::{Address as _, Events};
-use soroban_sdk::{symbol_short, Address, Env, Symbol};
+use soroban_sdk::{symbol_short, Address, Env, Symbol, TryFromVal};
 
 fn setup(env: &Env) -> (CreditClient, Address) {
     env.mock_all_auths();
@@ -82,14 +81,8 @@ fn test_event_topics_stability() {
             accounting_only: false,
         },
     );
-    publish_draws_frozen_event(&env, true);
-    publish_borrower_blocked_event(
-        &env,
-        BorrowerBlockedEvent {
-            borrower: borrower.clone(),
-            blocked: true,
-        },
-    );
+    publish_draws_frozen_event(&env, true, creditra_credit::FreezeReason::LiquidityReserve);
+    publish_borrower_blocked_event(&env, &borrower, true);
     publish_rate_formula_config_event(&env, true);
     publish_grace_waiver_applied_event(
         &env,
@@ -120,7 +113,13 @@ fn test_event_topics_stability() {
     assert_topic(6, "credit", "risk_upd");
     assert_topic(7, "credit", "draw_rev");
     assert_topic(8, "credit", "drw_freeze");
-    assert_topic(9, "credit", "blk_chg");
+    let blk_event = all_events.get(9).unwrap();
+    let blk_topics = blk_event.1;
+    assert_eq!(blk_topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &blk_topics.get(0).unwrap()).unwrap(),
+        Symbol::new(&env, "blk_chg")
+    );
     assert_topic(10, "credit", "rate_form");
     assert_topic(11, "credit", "grace_wv");
 }

--- a/contracts/credit/tests/event_topic_stability.rs
+++ b/contracts/credit/tests/event_topic_stability.rs
@@ -4,7 +4,7 @@ use creditra_credit::events::{
     publish_admin_rotation_accepted, publish_admin_rotation_proposed,
     publish_borrower_blocked_event, publish_default_liquidation_settled_event,
     publish_draw_reversed_event, publish_drawn_event, publish_draws_frozen_event,
-    publish_grace_waiver_applied_event, publish_interest_accrued_event, publish_paused_event,
+    publish_grace_waiver_applied_event, publish_interest_accrued_event,
     publish_rate_formula_config_event, publish_repayment_event, publish_risk_parameters_updated,
     AdminRotationAcceptedEvent, AdminRotationProposedEvent, DefaultLiquidationSettledEvent,
     DrawReversedEvent, InterestAccruedEvent, RepaymentEvent, RiskParametersUpdatedEvent,
@@ -26,9 +26,8 @@ fn setup(env: &Env) -> (CreditClient, Address) {
 #[test]
 fn test_event_topics_stability() {
     let env = Env::default();
-    let (client, admin) = setup(&env);
+    let (_client, admin) = setup(&env);
     let borrower = Address::generate(&env);
-    let recipient = Address::generate(&env);
 
     // Trigger all events
     publish_drawn_event(
@@ -63,6 +62,7 @@ fn test_event_topics_stability() {
             recovered_amount: 20,
             remaining_utilized_amount: 35,
             status: CreditStatus::Active,
+            close_factor_bps: 0,
         },
     );
     publish_admin_rotation_proposed(&env, &admin, 100);
@@ -100,8 +100,14 @@ fn test_event_topics_stability() {
         let t0 = topics.get(0).unwrap();
         let t1 = topics.get(1).unwrap();
 
-        assert_eq!(t0, symbol_short!("credit"));
-        assert_eq!(t1, Symbol::new(&env, expected_t1));
+        assert_eq!(
+            Symbol::try_from_val(&env, &t0).unwrap(),
+            symbol_short!("credit")
+        );
+        assert_eq!(
+            Symbol::try_from_val(&env, &t1).unwrap(),
+            Symbol::new(&env, expected_t1)
+        );
     };
 
     assert_topic(0, "credit", "drawn");

--- a/contracts/credit/tests/freeze_draws.rs
+++ b/contracts/credit/tests/freeze_draws.rs
@@ -8,7 +8,7 @@
 //! - freeze_draws/unfreeze_draws toggle the flag correctly
 //! - draw_credit is blocked when draws are frozen
 
-use creditra_credit::{Credit, CreditClient};
+use creditra_credit::{Credit, CreditClient, FreezeReason};
 use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::{token, Address, Env, Symbol, TryFromVal};
 
@@ -56,7 +56,7 @@ fn freeze_draws_sets_flag_to_true() {
 
     assert!(!client.is_draws_frozen(), "should start unfrozen");
 
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     assert!(
         client.is_draws_frozen(),
         "should be frozen after freeze_draws"
@@ -68,7 +68,7 @@ fn unfreeze_draws_sets_flag_to_false() {
     let (env, _admin, contract_id) = setup();
     let client = CreditClient::new(&env, &contract_id);
 
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     assert!(client.is_draws_frozen());
 
     client.unfreeze_draws();
@@ -93,7 +93,7 @@ fn draw_credit_blocked_when_draws_frozen() {
     token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
 
     // Freeze draws
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     assert!(client.is_draws_frozen());
 
     // Draw should fail
@@ -124,7 +124,7 @@ fn repay_credit_succeeds_while_draws_frozen() {
     assert_eq!(before.utilized_amount, 500);
 
     // Freeze draws
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     assert!(client.is_draws_frozen());
 
     // Mint tokens to borrower and approve contract
@@ -154,7 +154,7 @@ fn repay_credit_full_repayment_while_draws_frozen() {
     client.draw_credit(&borrower, &800);
 
     // Freeze draws
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     assert!(client.is_draws_frozen());
 
     // Full repayment
@@ -180,7 +180,7 @@ fn freeze_draws_emits_event() {
 
     let _ = env.events().all(); // clear setup events
 
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
 
     let events = env.events().all();
     assert_eq!(events.len(), 1, "should emit exactly one event");
@@ -197,7 +197,7 @@ fn unfreeze_draws_emits_event() {
     let (env, _admin, contract_id) = setup();
     let client = CreditClient::new(&env, &contract_id);
 
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
     let _ = env.events().all(); // clear
 
     client.unfreeze_draws();

--- a/contracts/credit/tests/freeze_reason.rs
+++ b/contracts/credit/tests/freeze_reason.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+
+//! Focused tests for credit-line freeze with structured reason taxonomy (#629).
+
+use creditra_credit::{Credit, CreditClient, FreezeReason};
+use creditra_credit::events::{CreditLineFreezeEvent, DrawsFrozenEvent};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{token, Address, Env, Symbol, TryFromVal, TryIntoVal};
+
+fn setup_with_token() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+    client.set_liquidity_token(&token_address);
+    (env, admin, contract_id, token_address)
+}
+
+#[test]
+fn freeze_draws_records_and_returns_reason() {
+    let (env, _admin, contract_id, _) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+
+    assert!(client.get_draws_freeze_reason().is_none());
+
+    client.freeze_draws(&FreezeReason::Compliance);
+    assert!(client.is_draws_frozen());
+    assert_eq!(
+        client.get_draws_freeze_reason(),
+        Some(FreezeReason::Compliance)
+    );
+}
+
+#[test]
+fn unfreeze_draws_clears_active_reason() {
+    let (env, _admin, contract_id, _) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.freeze_draws(&FreezeReason::RiskInvestigation);
+    client.unfreeze_draws();
+
+    assert!(!client.is_draws_frozen());
+    assert!(client.get_draws_freeze_reason().is_none());
+}
+
+#[test]
+fn freeze_credit_line_blocks_draws_with_reason() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
+
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+    assert!(client.is_credit_line_frozen(&borrower));
+    assert_eq!(
+        client.get_credit_line_freeze_reason(&borrower),
+        Some(FreezeReason::Compliance)
+    );
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &100);
+    }));
+    assert!(result.is_err(), "draw must fail while credit line is frozen");
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #41)")]
+fn draw_credit_reverts_with_credit_line_frozen_error() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
+    client.freeze_credit_line(&borrower, &FreezeReason::RiskInvestigation);
+    client.draw_credit(&borrower, &100);
+}
+
+#[test]
+fn unfreeze_credit_line_restores_draw_access() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000);
+    client.freeze_credit_line(&borrower, &FreezeReason::OperationalMaintenance);
+    client.unfreeze_credit_line(&borrower);
+
+    assert!(!client.is_credit_line_frozen(&borrower));
+    assert!(client.get_credit_line_freeze_reason(&borrower).is_none());
+    client.draw_credit(&borrower, &100);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        100
+    );
+}
+
+#[test]
+fn repay_credit_allowed_while_credit_line_frozen() {
+    let (env, _admin, contract_id, token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    let sac = token::StellarAssetClient::new(&env, &token_address);
+    sac.mint(&contract_id, &1_000);
+    client.draw_credit(&borrower, &400);
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+
+    sac.mint(&borrower, &100);
+    token::Client::new(&env, &token_address).approve(&borrower, &contract_id, &100, &1_000);
+    client.repay_credit(&borrower, &100);
+
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        300
+    );
+}
+
+#[test]
+#[should_panic]
+fn freeze_credit_line_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn freeze_credit_line_unknown_borrower_reverts() {
+    let (env, _admin, contract_id, _) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let missing = Address::generate(&env);
+    client.freeze_credit_line(&missing, &FreezeReason::Compliance);
+}
+
+#[test]
+fn freeze_credit_line_emits_event_with_reason() {
+    let (env, _admin, contract_id, _) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+
+    let _ = env.events().all();
+    client.freeze_credit_line(&borrower, &FreezeReason::BorrowerRequest);
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_contract, topics, data) = events.last().unwrap();
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+        Symbol::new(&env, "line_frz")
+    );
+    let event: CreditLineFreezeEvent = data.try_into_val(&env).unwrap();
+    assert!(event.frozen);
+    assert_eq!(event.reason, FreezeReason::BorrowerRequest);
+    assert_eq!(event.borrower, borrower);
+}
+
+#[test]
+fn freeze_draws_emits_reason_in_event() {
+    let (env, _admin, contract_id, _) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let _ = env.events().all();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    let events = env.events().all();
+    let (_contract, topics, data) = events.last().unwrap();
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+        Symbol::new(&env, "drw_freeze")
+    );
+    let event: DrawsFrozenEvent = data.try_into_val(&env).unwrap();
+    assert!(event.frozen);
+    assert_eq!(event.reason, FreezeReason::LiquidityReserve);
+}
+
+#[test]
+fn updating_credit_line_freeze_reason_overwrites_storage() {
+    let (env, _admin, contract_id, _) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+    client.freeze_credit_line(&borrower, &FreezeReason::RiskInvestigation);
+
+    assert_eq!(
+        client.get_credit_line_freeze_reason(&borrower),
+        Some(FreezeReason::RiskInvestigation)
+    );
+}

--- a/contracts/credit/tests/freeze_reason.rs
+++ b/contracts/credit/tests/freeze_reason.rs
@@ -2,8 +2,8 @@
 
 //! Focused tests for credit-line freeze with structured reason taxonomy (#629).
 
-use creditra_credit::{Credit, CreditClient, FreezeReason};
 use creditra_credit::events::{CreditLineFreezeEvent, DrawsFrozenEvent};
+use creditra_credit::{Credit, CreditClient, FreezeReason};
 use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::{token, Address, Env, Symbol, TryFromVal, TryIntoVal};
 
@@ -66,7 +66,10 @@ fn freeze_credit_line_blocks_draws_with_reason() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         client.draw_credit(&borrower, &100);
     }));
-    assert!(result.is_err(), "draw must fail while credit line is frozen");
+    assert!(
+        result.is_err(),
+        "draw must fail while credit line is frozen"
+    );
 }
 
 #[test]

--- a/contracts/credit/tests/init_idempotency.rs
+++ b/contracts/credit/tests/init_idempotency.rs
@@ -15,7 +15,7 @@
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-use creditra_credit::{Credit, CreditClient};
+use creditra_credit::{Credit, CreditClient, FreezeReason};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -146,7 +146,7 @@ fn admin_gated_call_before_init_reverts() {
 
     // No init call — admin is not set — this must panic.
     // freeze_draws requires admin auth and will fail because no admin is stored.
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/contracts/credit/tests/unauthorized_matrix.rs
+++ b/contracts/credit/tests/unauthorized_matrix.rs
@@ -44,7 +44,7 @@
 //! | `get_*` / `is_*` / `enumerate_*` | none (read-only) |
 
 use creditra_credit::types::CreditStatus;
-use creditra_credit::{Credit, CreditClient};
+use creditra_credit::{Credit, CreditClient, FreezeReason};
 use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
 use soroban_sdk::{Address, Env, IntoVal, Symbol};
 
@@ -127,7 +127,7 @@ fn set_draw_min_interval_unauthorized() {
 fn freeze_draws_unauthorized() {
     let env = Env::default();
     let (client, _, _, _) = setup(&env);
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
 }
 
 #[test]
@@ -491,7 +491,7 @@ fn freeze_draws_non_admin_mock_auth() {
                 sub_invokes: &[],
             },
         }])
-        .freeze_draws();
+        .freeze_draws(&FreezeReason::LiquidityReserve);
 }
 
 #[test]
@@ -597,7 +597,7 @@ fn set_max_draw_amount_unauthorized() {
 fn freeze_draws_unauthorized() {
     let env = Env::default();
     let (client, _, _, _) = setup(&env);
-    client.freeze_draws();
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
 }
 
 #[test]
@@ -868,7 +868,7 @@ fn freeze_draws_non_admin_mock_auth() {
                 sub_invokes: &[],
             },
         }])
-        .freeze_draws();
+        .freeze_draws(&FreezeReason::LiquidityReserve);
 }
 
 #[test]

--- a/docs/PROTOCOL_SPEC.md
+++ b/docs/PROTOCOL_SPEC.md
@@ -325,8 +325,9 @@ emits `("credit","rate_form")` with `true`.
 
 | Entrypoint | Effect |
 |---|---|
-| `freeze_draws(env)` / `unfreeze_draws(env)` | Global flag; admin; emits `DrawsFrozenEvent` on `("credit","drw_freeze")`. |
-| `is_draws_frozen() -> bool` | Read-only. |
+| `freeze_draws(env, reason)` / `unfreeze_draws(env)` | Global flag + [`FreezeReason`]; admin; emits `DrawsFrozenEvent` on `("credit","drw_freeze")`. |
+| `freeze_credit_line(env, borrower, reason)` / `unfreeze_credit_line(env, borrower)` | Per-line draw freeze with reason taxonomy; admin; emits `CreditLineFreezeEvent` on `("credit","line_frz")`. |
+| `is_draws_frozen() -> bool` / `get_draws_freeze_reason()` / `is_credit_line_frozen(borrower)` / `get_credit_line_freeze_reason(borrower)` | Read-only freeze state. |
 | `block_borrower(admin, borrower)` / `unblock_borrower` / `bulk_block_borrowers` | Admin; `bulk_*` capped at `BULK_BLOCK_MAX=50`. Emits `BorrowerBlockedEvent` on `("blk_chg",)`. |
 | `accrue_batch(borrowers)` | No auth (pause-gated). Capped at `ACCRUE_BATCH_MAX=50`. Keeper hook. |
 | `reverse_draw(borrower, amount, original_ts, reason_code)` | Admin + pause. Time window enforced (constant `DRAW_REVERSAL_WINDOW_SECS`). Decrements utilized; emits `DrawReversedEvent` on `("credit","draw_rev")`. |

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -489,25 +489,57 @@ if let Some((last_id, _)) = page1.last() {
 - **Ordering**: Insertion order (sequential IDs assigned at creation).
 - **Gas limit**: `limit` is capped at 100 to prevent gas exhaustion.
 
-### `freeze_draws(env)`
+### `freeze_draws(env, reason)`
 Freeze all `draw_credit` calls contract-wide (admin only).
 
-- Sets `DataKey::DrawsFrozen` to `true` in instance storage.
+- Sets `DataKey::DrawsFrozen` to [`DrawsFreezeState { frozen: true, reason }`] in instance storage.
+- `reason` must be a [`FreezeReason`] variant for structured audit/indexer classification.
 - Does **not** mutate any borrower's `CreditStatus`; lines remain Active, Defaulted, etc.
 - Repayments are never blocked by this flag.
-- Idempotent: calling when already frozen still emits the event.
 
-Emits: `("credit", "drw_freeze")` with `DrawsFrozenEvent { frozen: true, timestamp, actor }`.
+Emits: `("credit", "drw_freeze")` with `DrawsFrozenEvent { frozen: true, reason }`.
 
 ### `unfreeze_draws(env)`
 Re-enable `draw_credit` after a global freeze (admin only).
 
-- Sets `DataKey::DrawsFrozen` to `false` in instance storage.
-- Idempotent: calling when already unfrozen still emits the event.
+- Sets `DrawsFreezeState.frozen` to `false` while preserving the last recorded reason.
+- Emits: `("credit", "drw_freeze")` with `DrawsFrozenEvent { frozen: false, reason }`.
 
-Emits: `("credit", "drw_freeze")` with `DrawsFrozenEvent { frozen: false, timestamp, actor }`.
+### `get_draws_freeze_reason(env) -> Option<FreezeReason>`
+Returns the structured reason for the active global draw freeze. Returns `None` when draws are not frozen. No auth required.
 
-### `set_draw_min_interval(env, seconds)`
+### `freeze_credit_line(env, borrower, reason)`
+Freeze draws for a single credit line (admin only).
+
+- Records `reason` under `DataKey::CreditLineFreeze(Address)` in persistent storage.
+- Does **not** change `CreditStatus`; distinct from `suspend_credit_line`.
+- Repayments remain available.
+- Reverts with `CreditLineNotFound` when no line exists.
+
+Emits: `("credit", "line_frz")` with `CreditLineFreezeEvent { borrower, reason, frozen: true, ledger }`.
+
+### `unfreeze_credit_line(env, borrower)`
+Lift a per-credit-line draw freeze (admin only). No-op when not frozen.
+
+Emits: `("credit", "line_frz")` with `frozen: false` when a freeze record existed.
+
+### `is_credit_line_frozen(env, borrower) -> bool`
+Returns `true` when the borrower's credit line has an active admin freeze. No auth required.
+
+### `get_credit_line_freeze_reason(env, borrower) -> Option<FreezeReason>`
+Returns the structured freeze reason for a credit line, if frozen. No auth required.
+
+#### `FreezeReason` taxonomy
+
+| Variant | Value | Intended use |
+|---------|-------|--------------|
+| `LiquidityReserve` | 0 | Scheduled reserve / treasury operations |
+| `Compliance` | 1 | Regulatory or compliance-mandated pause |
+| `RiskInvestigation` | 2 | Active risk investigation or off-chain signal |
+| `OperationalMaintenance` | 3 | Planned maintenance window |
+| `BorrowerRequest` | 4 | Borrower-initiated voluntary draw pause |
+
+### `is_draws_frozen(env) -> bool`
 Set the per-borrower draw cooldown interval in seconds (admin only).
 
 - `seconds > 0` enforces a minimum interval between successful draws for every borrower.
@@ -667,7 +699,8 @@ cargo test -p creditra-credit amount_validation
 | `("credit", "liq_setl")`   | `liq_setl` | `settle_default_liquidation`| Auction settlement applied to debt accounting |
 | `("credit", "reinstate")`  | `reinstate`| `reinstate_credit_line`     | Line reinstated |
 | `("credit", "risk_updated")`| `risk_updated` | `update_risk_parameters` | Risk parameters changed |
-| `("credit", "drw_freeze")` | `DrawsFrozenEvent` | `freeze_draws`, `unfreeze_draws` | Global draw freeze toggled |
+| `("credit", "drw_freeze")` | `DrawsFrozenEvent` | `freeze_draws`, `unfreeze_draws` | Global draw freeze toggled (`frozen`, `reason`) |
+| `("credit", "line_frz")` | `CreditLineFreezeEvent` | `freeze_credit_line`, `unfreeze_credit_line` | Per-line draw freeze toggled (`borrower`, `reason`, `frozen`, `ledger`) |
 
 The contract also emits additive v2 event topics (for indexer analytics fields
 like actor/source/timestamp identifiers) while keeping v1 payloads stable. See

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -47,6 +47,7 @@ Rules enforced by CI (`tests/error_discriminants.rs`):
 | `17` | `DrawExceedsMaxAmount`           | The requested draw amount exceeds the per-transaction cap set via `set_max_draw_amount`. | Split the draw into smaller transactions or request a cap increase from the admin. |
 | `18` | `Paused`                         | The protocol is paused via the emergency circuit breaker; operation is blocked. | Wait for the admin to unpause the protocol via `set_protocol_paused(false)`. `repay_credit` remains active during a pause. |
 | `19` | `DrawsFrozen`                    | Draws are globally frozen during liquidity reserve operations. | Wait for the admin to call `unfreeze_draws`. Repayments remain available. |
+| `41` | `CreditLineFrozen`               | The credit line has an admin freeze with structured reason; draws are blocked. | Wait for admin `unfreeze_credit_line` or resolve the underlying hold. Repayments remain available. |
 | `20` | `CreditLineSuspended`            | A draw was attempted while the credit line status is `Suspended`. | Reinstate the line or resolve the suspension before drawing. |
 | `21` | `CreditLineDefaulted`            | A draw was attempted while the credit line status is `Defaulted`. | Defaulted lines cannot draw; use repayment or liquidation workflows. |
 | `22` | `MissingLiquidityToken`          | `draw_credit` or `repay_credit` requires a liquidity token, but none is configured. | Admin must call `set_liquidity_token` before liquidity-moving operations. |

--- a/docs/events-schema.md
+++ b/docs/events-schema.md
@@ -50,7 +50,8 @@ Topics use `symbol_short!` (≤ 9 chars) to use cheap `SCV_SYMBOL` on-chain enco
 | ("credit","admin_acc") | AdminRotationAcceptedEvent | 1. new_admin: Address | 1.0.0 | -
 | ("credit","risk_upd") | RiskParametersUpdatedEvent | 1. borrower: Address, 2. credit_limit: i128, 3. interest_rate_bps: u32, 4. risk_score: u32 | 1.0.0 | -
 | ("credit","draw_rev") | DrawReversedEvent | 1. borrower: Address, 2. amount: i128, 3. original_ts: u64, 4. reason_code: u32, 5. new_utilized_amount: i128, 6. timestamp: u64, 7. admin: Address, 8. accounting_only: bool | 1.0.0 | -
-| ("credit","drw_freeze") | DrawsFrozenEvent | 1. frozen: bool | 1.0.0 | -
+| ("credit","drw_freeze") | DrawsFrozenEvent | 1. frozen: bool, 2. reason: FreezeReason | 1.0.0 | -
+| ("credit","line_frz") | CreditLineFreezeEvent | 1. borrower: Address, 2. reason: FreezeReason, 3. frozen: bool, 4. ledger: u32 | 1.0.0 | -
 | ("credit","rate_form") | bool | (single value, no struct | 1.0.0 | -
 | ("credit","liq_req") | (Address, i128) | 1. borrower: Address, 2. utilized_amount: i128 | 1.0.0 | -
 | ("credit","liq_setl") | DefaultLiquidationSettledEvent | 1. borrower: Address, 2. settlement_id: Symbol, 3. recovered_amount: i128, 4. remaining_utilized_amount: i128, 5. status: CreditStatus, 6. close_factor_bps: u32 | 1.0.0 | -

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -35,8 +35,10 @@
 | `clear_rate_formula_config` | Admin | `require_admin_auth` | Auth before storage remove. |
 | `set_grace_period_config` | Admin | `require_admin_auth` | Auth before validation and write. |
 | `set_protocol_paused` | Admin | `require_admin_auth` | Circuit-breaker control. |
-| `freeze_draws` | Admin | `require_admin_auth` | Emergency draw freeze. |
+| `freeze_draws` | Admin | `require_admin_auth` | Emergency draw freeze with [`FreezeReason`]. |
 | `unfreeze_draws` | Admin | `require_admin_auth` | Lifts emergency draw freeze. |
+| `freeze_credit_line` | Admin | `require_admin_auth` | Per-line draw freeze with [`FreezeReason`]. |
+| `unfreeze_credit_line` | Admin | `require_admin_auth` | Lifts per-line draw freeze. |
 | `suspend_credit_line` | Admin | `require_admin_auth` | Auth before state read. |
 | `self_suspend_credit_line` | Borrower | `borrower.require_auth()` | No admin path; borrower-only. |
 | `default_credit_line` | Admin | `require_admin_auth` | Auth before state read. |

--- a/gateway-contract/contracts/auction_contract/tests/auth_settle.rs
+++ b/gateway-contract/contracts/auction_contract/tests/auth_settle.rs
@@ -74,12 +74,7 @@ fn non_factory_invoker_reverts() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "settle_default_liquidation",
-                args: (
-                    auction_id.clone(),
-                    factory.clone(),
-                    borrower.clone(),
-                )
-                    .into_val(&env),
+                args: (auction_id.clone(), factory.clone(), borrower.clone()).into_val(&env),
                 sub_invokes: &[],
             },
         }])
@@ -104,12 +99,7 @@ fn factory_invoker_succeeds() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "settle_default_liquidation",
-                args: (
-                    auction_id.clone(),
-                    factory.clone(),
-                    borrower.clone(),
-                )
-                    .into_val(&env),
+                args: (auction_id.clone(), factory.clone(), borrower.clone()).into_val(&env),
                 sub_invokes: &[],
             },
         }])
@@ -134,12 +124,7 @@ fn replay_settle_reverts() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "settle_default_liquidation",
-                args: (
-                    auction_id.clone(),
-                    factory.clone(),
-                    borrower.clone(),
-                )
-                    .into_val(&env),
+                args: (auction_id.clone(), factory.clone(), borrower.clone()).into_val(&env),
                 sub_invokes: &[],
             },
         }])
@@ -153,12 +138,7 @@ fn replay_settle_reverts() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "settle_default_liquidation",
-                args: (
-                    auction_id.clone(),
-                    factory.clone(),
-                    borrower.clone(),
-                )
-                    .into_val(&env),
+                args: (auction_id.clone(), factory.clone(), borrower.clone()).into_val(&env),
                 sub_invokes: &[],
             },
         }])


### PR DESCRIPTION
## Summary
- Add structured `FreezeReason` taxonomy for global `freeze_draws` and new per-credit-line `freeze_credit_line` / `unfreeze_credit_line` admin controls
- Persist reasons on-chain, emit them in `DrawsFrozenEvent` and new `CreditLineFreezeEvent` ((credit, line_frz)), and block draws with `ContractError::CreditLineFrozen` (#41)
- Add focused integration tests in `freeze_reason.rs` and update API/docs for integrators

Closes #629

## Test plan
- [x] `cargo test -p creditra-credit freeze_reason`
- [x] `cargo test -p creditra-credit`
- [x] `cargo test -p creditra-credit --test budget_regression`
- [x] `cargo test -p creditra-credit --test error_discriminants`
- [x] `cargo test -p creditra-credit --test event_topic_stability`
- [x] `cargo clippy -p creditra-credit -- -D warnings`