### PR TITLE
task/error category

### DIFF
--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -8,8 +8,9 @@
 //!
 //! ABI-stable types that cross the contract boundary:
 //!
-//! - [`ContractError`] — 38-variant `#[repr(u32)]` error enum (discriminants
-//!   pinned by `tests/error_discriminants.rs`). See
+//! - [`ContractError`] — 40-variant `#[repr(u32)]` error enum (discriminants
+//!   pinned by `tests/error_discriminants.rs`). Each variant maps to a stable
+//!   [`ContractErrorCategory`] via [`ContractError::category`]. See
 //!   [`docs/contract-errors.md`](../../../docs/contract-errors.md) for the
 //!   flat code table and
 //!   [`docs/error-taxonomy.md`](../../../docs/error-taxonomy.md) for the
@@ -90,49 +91,55 @@ pub enum CreditStatus {
 /// variants — doing so would break deployed SDK clients. New variants must be
 /// appended at the end with the next available integer.
 ///
+/// # Category
+/// Use [`ContractError::category`] to map any error to its
+/// [`ContractErrorCategory`] for client-side grouping. See
+/// [`docs/error-taxonomy.md`](../../../docs/error-taxonomy.md) for the
+/// categorized reference with recovery actions.
+///
 /// # Discriminant table (source of truth)
-/// | Code | Variant                        | Description |
-/// |------|--------------------------------|-------------|
-/// | 1    | `Unauthorized`                 | Caller is not authorized |
-/// | 2    | `NotAdmin`                     | Caller lacks admin privileges |
-/// | 3    | `CreditLineNotFound`           | Credit line does not exist |
-/// | 4    | `CreditLineClosed`             | Credit line is permanently closed |
-/// | 5    | `InvalidAmount`                | Amount is zero, negative, or otherwise invalid |
-/// | 6    | `OverLimit`                    | Draw would exceed the credit limit |
-/// | 7    | `NegativeLimit`                | Credit limit cannot be negative |
-/// | 8    | `RateTooHigh`                  | Interest rate exceeds the maximum allowed |
-/// | 9    | `ScoreTooHigh`                 | Risk score exceeds the maximum allowed (100) |
-/// | 10   | `UtilizationNotZero`           | Operation requires zero utilization |
-/// | 11   | `Reentrancy`                   | Reentrancy detected during cross-contract call |
-/// | 12   | `Overflow`                     | Arithmetic overflow during calculation |
-/// | 13   | `LimitDecreaseRequiresRepayment` | Limit decrease below utilized amount |
-/// | 14   | `AlreadyInitialized`           | Contract already initialized |
-/// | 15   | `AdminAcceptTooEarly`          | Admin acceptance attempted before delay elapsed |
-/// | 16   | `BorrowerBlocked`              | Borrower is on the blocked list |
-/// | 17   | `DrawExceedsMaxAmount`         | Draw amount exceeds per-transaction cap |
-/// | 18   | `Paused`                       | Protocol is paused; operation blocked by circuit breaker |
-/// | 19   | `DrawsFrozen`                  | Draws are globally frozen |
-/// | 20   | `CreditLineSuspended`          | Credit line is suspended |
-/// | 21   | `CreditLineDefaulted`          | Credit line is defaulted |
-/// | 22   | `MissingLiquidityToken`        | Liquidity token is not configured |
-/// | 23   | `MissingLiquiditySource`       | Liquidity source is not configured |
-/// | 24   | `InsufficientLiquidityReserve` | Reserve balance cannot cover the draw |
-/// | 25   | `LiquidityTokenCallFailed`     | Liquidity token call failed where observable |
-/// | 26   | `InsufficientRepaymentAllowance` | Borrower allowance cannot cover repayment |
-/// | 27   | `InsufficientRepaymentBalance` | Borrower balance cannot cover repayment |
-/// | 28   | `RepayExceedsMaxAmount`        | Repay amount exceeds per-transaction cap |
-/// | 29   | `DrawCooldownActive`          | Borrower attempted to draw before cooldown elapsed |
-/// | 30   | `TreasuryNotSet`              | Treasury address is not configured |
-/// | 31   | `ExposureCapExceeded`         | Draw would exceed the global protocol exposure cap |
-/// | 32   | `AdminNotInitialized`         | Admin address has not been initialized |
-/// | 33   | `TimestampRegression`         | Timestamp regression detected |
-/// | 34   | `LimitOutOfBounds`            | Credit limit is outside configured min/max bounds |
-/// | 35   | `CollateralRatioBelowMinimum` | Collateral ratio is below the minimum required ratio |
-/// | 36   | `OraclePriceInvalid`          | Oracle price is invalid (zero, negative, or malformed) |
-/// | 37   | `OraclePriceStale`            | Oracle price is stale (exceeds max_age_seconds) |
-/// | 38   | `OraclePriceDeviation`        | Oracle price deviation exceeds the configured maximum |
-/// | 39   | `InsufficientCollateralBalance` | Borrower collateral balance cannot cover withdrawal |
-/// | 40   | `BorrowerFrozen`               | Borrower's draws are temporarily frozen until expiry |
+/// | Code | Variant                        | Category      | Description |
+/// |------|--------------------------------|---------------|-------------|
+/// | 1    | `Unauthorized`                 | Auth          | Caller is not authorized |
+/// | 2    | `NotAdmin`                     | Auth          | Caller lacks admin privileges |
+/// | 3    | `CreditLineNotFound`           | Misc          | Credit line does not exist |
+/// | 4    | `CreditLineClosed`             | Lifecycle     | Credit line is permanently closed |
+/// | 5    | `InvalidAmount`                | Numeric       | Amount is zero, negative, or otherwise invalid |
+/// | 6    | `OverLimit`                    | Limit         | Draw would exceed the credit limit |
+/// | 7    | `NegativeLimit`                | Numeric       | Credit limit cannot be negative |
+/// | 8    | `RateTooHigh`                  | Risk          | Interest rate exceeds the maximum allowed |
+/// | 9    | `ScoreTooHigh`                 | Risk          | Risk score exceeds the maximum allowed (100) |
+/// | 10   | `UtilizationNotZero`           | Limit         | Operation requires zero utilization |
+/// | 11   | `Reentrancy`                   | Reentrancy    | Reentrancy detected during cross-contract call |
+/// | 12   | `Overflow`                     | Numeric       | Arithmetic overflow during calculation |
+/// | 13   | `LimitDecreaseRequiresRepayment` | Limit       | Limit decrease below utilized amount |
+/// | 14   | `AlreadyInitialized`           | Lifecycle     | Contract already initialized |
+/// | 15   | `AdminAcceptTooEarly`          | Misc          | Admin acceptance attempted before delay elapsed |
+/// | 16   | `BorrowerBlocked`              | Block         | Borrower is on the blocked list |
+/// | 17   | `DrawExceedsMaxAmount`         | Limit         | Draw amount exceeds per-transaction cap |
+/// | 18   | `Paused`                       | Risk          | Protocol is paused; operation blocked by circuit breaker |
+/// | 19   | `DrawsFrozen`                  | Block         | Draws are globally frozen |
+/// | 20   | `CreditLineSuspended`          | Lifecycle     | Credit line is suspended |
+/// | 21   | `CreditLineDefaulted`          | Lifecycle     | Credit line is defaulted |
+/// | 22   | `MissingLiquidityToken`        | Liquidity     | Liquidity token is not configured |
+/// | 23   | `MissingLiquiditySource`       | Liquidity     | Liquidity source is not configured |
+/// | 24   | `InsufficientLiquidityReserve` | Liquidity     | Reserve balance cannot cover the draw |
+/// | 25   | `LiquidityTokenCallFailed`     | Liquidity     | Liquidity token call failed where observable |
+/// | 26   | `InsufficientRepaymentAllowance` | Liquidity   | Borrower allowance cannot cover repayment |
+/// | 27   | `InsufficientRepaymentBalance` | Liquidity     | Borrower balance cannot cover repayment |
+/// | 28   | `RepayExceedsMaxAmount`        | Limit         | Repay amount exceeds per-transaction cap |
+/// | 29   | `DrawCooldownActive`          | Risk          | Borrower attempted to draw before cooldown elapsed |
+/// | 30   | `TreasuryNotSet`              | Liquidity     | Treasury address is not configured |
+/// | 31   | `ExposureCapExceeded`         | Liquidity     | Draw would exceed the global protocol exposure cap |
+/// | 32   | `AdminNotInitialized`         | Auth          | Admin address has not been initialized |
+/// | 33   | `TimestampRegression`         | Numeric       | Timestamp regression detected |
+/// | 34   | `LimitOutOfBounds`            | Numeric       | Credit limit is outside configured min/max bounds |
+/// | 35   | `CollateralRatioBelowMinimum` | Collateral    | Collateral ratio is below the minimum required ratio |
+/// | 36   | `OraclePriceInvalid`          | Oracle        | Oracle price is invalid (zero, negative, or malformed) |
+/// | 37   | `OraclePriceStale`            | Oracle        | Oracle price is stale (exceeds max_age_seconds) |
+/// | 38   | `OraclePriceDeviation`        | Oracle        | Oracle price deviation exceeds the configured maximum |
+/// | 39   | `InsufficientCollateralBalance` | Collateral  | Borrower collateral balance cannot cover withdrawal |
+/// | 40   | `BorrowerFrozen`               | Block         | Borrower's draws are temporarily frozen until expiry |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -217,6 +224,110 @@ pub enum ContractError {
     InsufficientCollateralBalance = 39,
     /// Borrower's draws are temporarily frozen until the specified expiry timestamp.
     BorrowerFrozen = 40,
+}
+
+/// Stable category codes for [`ContractError`] variants.
+///
+/// Each category groups semantically related errors that share a common
+/// SDK-side recovery action. See [`docs/error-taxonomy.md`](../../../docs/error-taxonomy.md)
+/// for the full categorized reference.
+///
+/// # Stability guarantee
+/// Discriminants are **permanent**. Never reorder or renumber existing
+/// variants — doing so would break deployed SDK clients. New categories
+/// must be appended at the end with the next available integer.
+///
+/// # Discriminant table
+/// | Code | Category      | Variants |
+/// |------|---------------|----------|
+/// | 1    | `Auth`        | `Unauthorized`, `NotAdmin`, `AdminNotInitialized` |
+/// | 2    | `Lifecycle`   | `CreditLineClosed`, `AlreadyInitialized`, `CreditLineSuspended`, `CreditLineDefaulted` |
+/// | 3    | `Numeric`     | `InvalidAmount`, `NegativeLimit`, `Overflow`, `TimestampRegression`, `LimitOutOfBounds` |
+/// | 4    | `Limit`       | `OverLimit`, `UtilizationNotZero`, `LimitDecreaseRequiresRepayment`, `DrawExceedsMaxAmount`, `RepayExceedsMaxAmount` |
+/// | 5    | `Liquidity`   | `MissingLiquidityToken`, `MissingLiquiditySource`, `InsufficientLiquidityReserve`, `LiquidityTokenCallFailed`, `InsufficientRepaymentAllowance`, `InsufficientRepaymentBalance`, `TreasuryNotSet`, `ExposureCapExceeded` |
+/// | 6    | `Risk`        | `RateTooHigh`, `ScoreTooHigh`, `Paused`, `DrawCooldownActive` |
+/// | 7    | `Oracle`      | `OraclePriceInvalid`, `OraclePriceStale`, `OraclePriceDeviation` |
+/// | 8    | `Collateral`  | `CollateralRatioBelowMinimum`, `InsufficientCollateralBalance` |
+/// | 9    | `Block`       | `BorrowerBlocked`, `DrawsFrozen`, `BorrowerFrozen` |
+/// | 10   | `Reentrancy`  | `Reentrancy` |
+/// | 11   | `Misc`        | `CreditLineNotFound`, `AdminAcceptTooEarly` |
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractErrorCategory {
+    /// Authorization failures (wrong caller, missing admin).
+    Auth = 1,
+    /// Credit-line lifecycle state violations.
+    Lifecycle = 2,
+    /// Numeric validation or arithmetic errors.
+    Numeric = 3,
+    /// Credit limit and per-transaction cap violations.
+    Limit = 4,
+    /// Liquidity, reserve, and treasury availability failures.
+    Liquidity = 5,
+    /// Risk-score, rate, pause, and cooldown violations.
+    Risk = 6,
+    /// Oracle price-feed circuit-breaker failures.
+    Oracle = 7,
+    /// Collateral ratio or balance violations.
+    Collateral = 8,
+    /// Borrower-blocked or draw-freeze state.
+    Block = 9,
+    /// Reentrancy guard triggered.
+    Reentrancy = 10,
+    /// Miscellaneous errors that do not fit a specific category.
+    Misc = 11,
+}
+
+impl ContractError {
+    /// Return the stable category for this error variant.
+    ///
+    /// Clients can use this to group errors for UI display, analytics,
+    /// or recovery heuristics without hard-coding variant-to-category
+    /// mappings.
+    pub fn category(&self) -> ContractErrorCategory {
+        match self {
+            Self::Unauthorized | Self::NotAdmin | Self::AdminNotInitialized => {
+                ContractErrorCategory::Auth
+            }
+            Self::CreditLineClosed
+            | Self::AlreadyInitialized
+            | Self::CreditLineSuspended
+            | Self::CreditLineDefaulted => ContractErrorCategory::Lifecycle,
+            Self::InvalidAmount
+            | Self::NegativeLimit
+            | Self::Overflow
+            | Self::TimestampRegression
+            | Self::LimitOutOfBounds => ContractErrorCategory::Numeric,
+            Self::OverLimit
+            | Self::UtilizationNotZero
+            | Self::LimitDecreaseRequiresRepayment
+            | Self::DrawExceedsMaxAmount
+            | Self::RepayExceedsMaxAmount => ContractErrorCategory::Limit,
+            Self::MissingLiquidityToken
+            | Self::MissingLiquiditySource
+            | Self::InsufficientLiquidityReserve
+            | Self::LiquidityTokenCallFailed
+            | Self::InsufficientRepaymentAllowance
+            | Self::InsufficientRepaymentBalance
+            | Self::TreasuryNotSet
+            | Self::ExposureCapExceeded => ContractErrorCategory::Liquidity,
+            Self::RateTooHigh | Self::ScoreTooHigh | Self::Paused | Self::DrawCooldownActive => {
+                ContractErrorCategory::Risk
+            }
+            Self::OraclePriceInvalid | Self::OraclePriceStale | Self::OraclePriceDeviation => {
+                ContractErrorCategory::Oracle
+            }
+            Self::CollateralRatioBelowMinimum | Self::InsufficientCollateralBalance => {
+                ContractErrorCategory::Collateral
+            }
+            Self::BorrowerBlocked | Self::DrawsFrozen | Self::BorrowerFrozen => {
+                ContractErrorCategory::Block
+            }
+            Self::Reentrancy => ContractErrorCategory::Reentrancy,
+            Self::CreditLineNotFound | Self::AdminAcceptTooEarly => ContractErrorCategory::Misc,
+        }
+    }
 }
 
 /// Stored credit line data for a borrower.

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -11,7 +11,7 @@
 //! - New variants must be appended at the end of the enum with the next integer.
 //! - Add a corresponding assertion here when adding a new variant.
 
-use creditra_credit::types::ContractError;
+use creditra_credit::types::{ContractError, ContractErrorCategory};
 
 #[test]
 fn error_discriminants_are_stable() {
@@ -173,6 +173,189 @@ fn variant_count_is_known() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// ContractErrorCategory Stability Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Verify every `ContractErrorCategory` discriminant is pinned.
+#[test]
+fn category_discriminants_are_stable() {
+    assert_eq!(ContractErrorCategory::Auth as u32, 1);
+    assert_eq!(ContractErrorCategory::Lifecycle as u32, 2);
+    assert_eq!(ContractErrorCategory::Numeric as u32, 3);
+    assert_eq!(ContractErrorCategory::Limit as u32, 4);
+    assert_eq!(ContractErrorCategory::Liquidity as u32, 5);
+    assert_eq!(ContractErrorCategory::Risk as u32, 6);
+    assert_eq!(ContractErrorCategory::Oracle as u32, 7);
+    assert_eq!(ContractErrorCategory::Collateral as u32, 8);
+    assert_eq!(ContractErrorCategory::Block as u32, 9);
+    assert_eq!(ContractErrorCategory::Reentrancy as u32, 10);
+    assert_eq!(ContractErrorCategory::Misc as u32, 11);
+}
+
+/// Verify no two `ContractErrorCategory` variants share a discriminant.
+#[test]
+fn no_duplicate_category_discriminants() {
+    use std::collections::HashSet;
+
+    let codes: Vec<u32> = vec![
+        ContractErrorCategory::Auth as u32,
+        ContractErrorCategory::Lifecycle as u32,
+        ContractErrorCategory::Numeric as u32,
+        ContractErrorCategory::Limit as u32,
+        ContractErrorCategory::Liquidity as u32,
+        ContractErrorCategory::Risk as u32,
+        ContractErrorCategory::Oracle as u32,
+        ContractErrorCategory::Collateral as u32,
+        ContractErrorCategory::Block as u32,
+        ContractErrorCategory::Reentrancy as u32,
+        ContractErrorCategory::Misc as u32,
+    ];
+
+    let unique: HashSet<u32> = codes.iter().cloned().collect();
+    assert_eq!(
+        codes.len(),
+        unique.len(),
+        "Duplicate discriminants detected in ContractErrorCategory"
+    );
+}
+
+/// Verify the total variant count for `ContractErrorCategory`.
+#[test]
+fn category_variant_count_is_known() {
+    const EXPECTED_VARIANT_COUNT: usize = 11;
+
+    let codes = [
+        ContractErrorCategory::Auth as u32,
+        ContractErrorCategory::Lifecycle as u32,
+        ContractErrorCategory::Numeric as u32,
+        ContractErrorCategory::Limit as u32,
+        ContractErrorCategory::Liquidity as u32,
+        ContractErrorCategory::Risk as u32,
+        ContractErrorCategory::Oracle as u32,
+        ContractErrorCategory::Collateral as u32,
+        ContractErrorCategory::Block as u32,
+        ContractErrorCategory::Reentrancy as u32,
+        ContractErrorCategory::Misc as u32,
+    ];
+
+    assert_eq!(
+        codes.len(),
+        EXPECTED_VARIANT_COUNT,
+        "Category variant count changed — update EXPECTED_VARIANT_COUNT"
+    );
+}
+
+/// Verify every `ContractError` variant maps to the expected `ContractErrorCategory`.
+#[test]
+fn category_mappings_are_stable() {
+    // Auth
+    assert_eq!(ContractError::Unauthorized.category(), ContractErrorCategory::Auth);
+    assert_eq!(ContractError::NotAdmin.category(), ContractErrorCategory::Auth);
+    assert_eq!(ContractError::AdminNotInitialized.category(), ContractErrorCategory::Auth);
+    // Lifecycle
+    assert_eq!(ContractError::CreditLineClosed.category(), ContractErrorCategory::Lifecycle);
+    assert_eq!(ContractError::AlreadyInitialized.category(), ContractErrorCategory::Lifecycle);
+    assert_eq!(ContractError::CreditLineSuspended.category(), ContractErrorCategory::Lifecycle);
+    assert_eq!(ContractError::CreditLineDefaulted.category(), ContractErrorCategory::Lifecycle);
+    // Numeric
+    assert_eq!(ContractError::InvalidAmount.category(), ContractErrorCategory::Numeric);
+    assert_eq!(ContractError::NegativeLimit.category(), ContractErrorCategory::Numeric);
+    assert_eq!(ContractError::Overflow.category(), ContractErrorCategory::Numeric);
+    assert_eq!(ContractError::TimestampRegression.category(), ContractErrorCategory::Numeric);
+    assert_eq!(ContractError::LimitOutOfBounds.category(), ContractErrorCategory::Numeric);
+    // Limit
+    assert_eq!(ContractError::OverLimit.category(), ContractErrorCategory::Limit);
+    assert_eq!(ContractError::UtilizationNotZero.category(), ContractErrorCategory::Limit);
+    assert_eq!(ContractError::LimitDecreaseRequiresRepayment.category(), ContractErrorCategory::Limit);
+    assert_eq!(ContractError::DrawExceedsMaxAmount.category(), ContractErrorCategory::Limit);
+    assert_eq!(ContractError::RepayExceedsMaxAmount.category(), ContractErrorCategory::Limit);
+    // Liquidity
+    assert_eq!(ContractError::MissingLiquidityToken.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::MissingLiquiditySource.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::InsufficientLiquidityReserve.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::LiquidityTokenCallFailed.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::InsufficientRepaymentAllowance.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::InsufficientRepaymentBalance.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::TreasuryNotSet.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::ExposureCapExceeded.category(), ContractErrorCategory::Liquidity);
+    // Risk
+    assert_eq!(ContractError::RateTooHigh.category(), ContractErrorCategory::Risk);
+    assert_eq!(ContractError::ScoreTooHigh.category(), ContractErrorCategory::Risk);
+    assert_eq!(ContractError::Paused.category(), ContractErrorCategory::Risk);
+    assert_eq!(ContractError::DrawCooldownActive.category(), ContractErrorCategory::Risk);
+    // Oracle
+    assert_eq!(ContractError::OraclePriceInvalid.category(), ContractErrorCategory::Oracle);
+    assert_eq!(ContractError::OraclePriceStale.category(), ContractErrorCategory::Oracle);
+    assert_eq!(ContractError::OraclePriceDeviation.category(), ContractErrorCategory::Oracle);
+    // Collateral
+    assert_eq!(ContractError::CollateralRatioBelowMinimum.category(), ContractErrorCategory::Collateral);
+    assert_eq!(ContractError::InsufficientCollateralBalance.category(), ContractErrorCategory::Collateral);
+    // Block
+    assert_eq!(ContractError::BorrowerBlocked.category(), ContractErrorCategory::Block);
+    assert_eq!(ContractError::DrawsFrozen.category(), ContractErrorCategory::Block);
+    assert_eq!(ContractError::BorrowerFrozen.category(), ContractErrorCategory::Block);
+    // Reentrancy
+    assert_eq!(ContractError::Reentrancy.category(), ContractErrorCategory::Reentrancy);
+    // Misc
+    assert_eq!(ContractError::CreditLineNotFound.category(), ContractErrorCategory::Misc);
+    assert_eq!(ContractError::AdminAcceptTooEarly.category(), ContractErrorCategory::Misc);
+}
+
+/// Verify every ContractError variant's category matches its discriminant table.
+/// This catches accidental miscategorization when new variants are added.
+#[test]
+fn every_variant_has_known_category() {
+    use std::collections::HashSet;
+
+    let all_variants: Vec<ContractErrorCategory> = vec![
+        ContractError::Unauthorized.category(),
+        ContractError::NotAdmin.category(),
+        ContractError::CreditLineNotFound.category(),
+        ContractError::CreditLineClosed.category(),
+        ContractError::InvalidAmount.category(),
+        ContractError::OverLimit.category(),
+        ContractError::NegativeLimit.category(),
+        ContractError::RateTooHigh.category(),
+        ContractError::ScoreTooHigh.category(),
+        ContractError::UtilizationNotZero.category(),
+        ContractError::Reentrancy.category(),
+        ContractError::Overflow.category(),
+        ContractError::LimitDecreaseRequiresRepayment.category(),
+        ContractError::AlreadyInitialized.category(),
+        ContractError::AdminAcceptTooEarly.category(),
+        ContractError::BorrowerBlocked.category(),
+        ContractError::DrawExceedsMaxAmount.category(),
+        ContractError::Paused.category(),
+        ContractError::DrawsFrozen.category(),
+        ContractError::CreditLineSuspended.category(),
+        ContractError::CreditLineDefaulted.category(),
+        ContractError::MissingLiquidityToken.category(),
+        ContractError::MissingLiquiditySource.category(),
+        ContractError::InsufficientLiquidityReserve.category(),
+        ContractError::LiquidityTokenCallFailed.category(),
+        ContractError::InsufficientRepaymentAllowance.category(),
+        ContractError::InsufficientRepaymentBalance.category(),
+        ContractError::RepayExceedsMaxAmount.category(),
+        ContractError::DrawCooldownActive.category(),
+        ContractError::TreasuryNotSet.category(),
+        ContractError::ExposureCapExceeded.category(),
+        ContractError::AdminNotInitialized.category(),
+        ContractError::TimestampRegression.category(),
+        ContractError::LimitOutOfBounds.category(),
+        ContractError::CollateralRatioBelowMinimum.category(),
+        ContractError::OraclePriceInvalid.category(),
+        ContractError::OraclePriceStale.category(),
+        ContractError::OraclePriceDeviation.category(),
+        ContractError::InsufficientCollateralBalance.category(),
+        ContractError::BorrowerFrozen.category(),
+    ];
+
+    let unique: HashSet<ContractErrorCategory> = all_variants.iter().cloned().collect();
+    assert_eq!(unique.len(), 11, "Not all 11 categories are covered by variant mappings");
+    assert_eq!(all_variants.len(), 40, "Expected 40 ContractError variants");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Integration Tests: Verify Refactored Error Paths
 // ═══════════════════════════════════════════════════════════════════════════
 //
@@ -181,7 +364,7 @@ fn variant_count_is_known() {
 
 #[cfg(test)]
 mod error_path_tests {
-    use creditra_credit::types::ContractError;
+use creditra_credit::types::ContractError;
     use creditra_credit::{Credit, CreditClient};
     use soroban_sdk::{
         testutils::{Address as _, Ledger},

--- a/contracts/credit/tests/proptest_equity.proptest-regressions
+++ b/contracts/credit/tests/proptest_equity.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc cfc4021d5857c33389df1c136187c0ac16f7bb61ad7cb5edcd3befd9c268bf6a # shrinks to credit_limit = 26331, utilized = 1000, close_factor_bps = 1000, recovery_pct = 10

--- a/contracts/credit/tests/proptest_equity.rs
+++ b/contracts/credit/tests/proptest_equity.rs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MIT
+
+//! Property test: protocol equity remains non-negative after liquidation settlement.
+//!
+//! # Invariant
+//!
+//! After [`settle_default_liquidation`]:
+//!
+//! 1. **Borrower utilized_amount >= 0** — the settlement subtraction never
+//!    makes the borrower's debt negative (enforced by `checked_sub`).
+//! 2. **TotalUtilized accounting consistency** — the change in the global
+//!    `total_utilized` accumulator exactly matches the change in the
+//!    borrower's individual `utilized_amount`.
+//! 3. **Protocol equity >= 0** — defined as
+//!    `total_collateral + treasury_balance - total_utilized`, the protocol's
+//!    net asset position must not go negative after a settlement.
+//!
+//! # Why
+//!
+//! During liquidation, the contract:
+//! 1. Capitalizes pending interest via `apply_accrual` (which can increase
+//!    `utilized_amount`).
+//! 2. Subtracts `recovered_amount` from the borrower's `utilized_amount`.
+//! 3. Adjusts the global `total_utilized` accumulator by the net delta.
+//!
+//! A bug in any of these steps — an off-by-one in `persist_credit_line`, an
+//! overflow in `adjust_total_utilized`, or a missed accrual — would break
+//! the accounting invariants.
+//!
+//! # Strategy
+//!
+//! Random valid `(credit_limit, utilized_amount, close_factor_bps, recovery_pct)`
+//! tuples drive `settle_default_liquidation` and the three invariants are
+//! checked after every call.
+
+use proptest::prelude::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{token, Address, Env, Symbol};
+
+use creditra_credit::{Credit, CreditClient};
+
+/// Deploy a credit contract, open a line for one borrower, draw, then default.
+///
+/// The borrower is minted enough tokens and approval so that a subsequent
+/// `deposit_collateral` call can succeed in the proptest body if needed.
+fn setup_defaulted_borrower(
+    env: &Env,
+    credit_limit: i128,
+    utilized_amount: i128,
+) -> (CreditClient<'_>, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token_address = token_id.address();
+    client.set_liquidity_token(&token_address);
+    client.set_liquidity_source(&contract_id);
+
+    let sac = token::StellarAssetClient::new(env, &token_address);
+    sac.mint(&contract_id, &(credit_limit * 2));
+    sac.mint(&borrower, &(credit_limit * 2));
+
+    client.open_credit_line(&borrower, &credit_limit, &500_u32, &50_u32);
+    client.deposit_collateral(&borrower, &(credit_limit * 2));
+    client.draw_credit(&borrower, &utilized_amount);
+    client.default_credit_line(&borrower);
+
+    (client, borrower)
+}
+
+/// Compute protocol equity from a summary.
+fn protocol_equity(summary: &creditra_credit::types::ProtocolSummary) -> i128 {
+    summary
+        .total_collateral
+        .checked_add(summary.treasury_balance)
+        .and_then(|v| v.checked_sub(summary.total_utilized))
+        .unwrap_or(i128::MIN)
+}
+
+proptest! {
+    /// Verifies the three equity-related invariants after liquidation.
+    ///
+    /// 1. `recovered_amount > 0` (the contract enforces this).
+    /// 2. `close_factor_bps` in `[1000, 10000]` — we use 1000 as a minimum so
+    ///    that `max_recovery >= utilized / 10`, ensuring non-trivial recovery
+    ///    amounts in most cases.
+    /// 3. After settlement, the borrower's `utilized_amount` stays `>= 0`.
+    /// 4. The global `total_utilized` delta matches the per-borrower delta.
+    /// 5. `equity >= 0` after every successful settlement.
+    #[test]
+    fn prop_equity_non_negative_after_liquidation(
+        credit_limit in 10_000i128..=100_000i128,
+        utilized in 1_000i128..=50_000i128,
+        close_factor_bps in 1_000u32..=10_000u32,
+        recovery_pct in 10u32..=100u32,
+    ) {
+        // ── Pre-condition filtering ────────────────────────────────────────
+        if utilized > credit_limit {
+            return Ok(());
+        }
+
+        let max_recovery = utilized * close_factor_bps as i128 / 10_000;
+        if max_recovery < 1 {
+            return Ok(());
+        }
+
+        let recovered_amount = max_recovery * recovery_pct as i128 / 100;
+        if recovered_amount < 1 {
+            return Ok(());
+        }
+
+        // ── Setup ──────────────────────────────────────────────────────────
+        let env = Env::default();
+        env.ledger().set_timestamp(100_000);
+        let (client, borrower) = setup_defaulted_borrower(&env, credit_limit, utilized);
+
+        // ── Snapshot before ────────────────────────────────────────────────
+        let summary_before = client.get_protocol_summary();
+        let line_before = client.get_credit_line(&borrower).unwrap();
+        let equity_before = protocol_equity(&summary_before);
+
+        // ── Execute liquidation ────────────────────────────────────────────
+        let settlement_id = Symbol::new(&env, "prop_liq");
+        client.settle_default_liquidation(
+            &borrower,
+            &recovered_amount,
+            &settlement_id,
+            &close_factor_bps,
+            &None,
+        );
+
+        // ── Snapshot after ─────────────────────────────────────────────────
+        let summary_after = client.get_protocol_summary();
+        let line_after = client.get_credit_line(&borrower).unwrap();
+        let equity_after = protocol_equity(&summary_after);
+
+        // ── Invariant 1: borrower utilized_amount never negative ───────────
+        prop_assert!(
+            line_after.utilized_amount >= 0,
+            "borrower utilized_amount dropped below zero:\n\
+             before={}, after={}, recovered={}, cf={}",
+            line_before.utilized_amount,
+            line_after.utilized_amount,
+            recovered_amount,
+            close_factor_bps,
+        );
+
+        // ── Invariant 2: total_utilized consistency ────────────────────────
+        // The global accumulator must change by exactly the same amount as
+        // the borrower's individual utilized_amount.
+        let borrower_delta = line_after
+            .utilized_amount
+            .checked_sub(line_before.utilized_amount)
+            .unwrap_or(i128::MIN);
+        let total_delta = summary_after
+            .total_utilized
+            .checked_sub(summary_before.total_utilized)
+            .unwrap_or(i128::MIN);
+
+        prop_assert_eq!(
+            total_delta, borrower_delta,
+            "total_utilized delta ({}) != borrower utilized delta ({})",
+            total_delta, borrower_delta,
+        );
+
+        // ── Invariant 3: protocol equity never goes negative ───────────────
+        prop_assert!(
+            equity_after >= 0,
+            "protocol equity went negative after liquidation:\n\
+             equity_before={}, equity_after={}\n\
+             collateral={}, treasury={}, utilized={}",
+            equity_before,
+            equity_after,
+            summary_after.total_collateral,
+            summary_after.treasury_balance,
+            summary_after.total_utilized,
+        );
+
+        // ── Derived: equity is non-decreasing ──────────────────────────────
+        // Liquidation reduces total_utilized (or keeps it the same), so
+        // equity should never decrease (the collateral and treasury accounts
+        // are not touched by settle_default_liquidation).
+        prop_assert!(
+            equity_after >= equity_before,
+            "equity decreased during liquidation: before={}, after={}",
+            equity_before,
+            equity_after,
+        );
+    }
+}
+
+// ── Edge-case unit tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod edge_cases {
+    use super::*;
+    use creditra_credit::types::CreditStatus;
+
+    /// Recovered amount must be > 0 (the contract enforces this).
+    #[test]
+    fn zero_recovery_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, borrower) = setup_defaulted_borrower(&env, 10_000, 1_000);
+        let sid = Symbol::new(&env, "zero_rec");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.settle_default_liquidation(&borrower, &0_i128, &sid, &10_000_u32, &None);
+        }));
+        assert!(result.is_err(), "zero recovery must panic");
+    }
+
+    /// Full liquidation (close_factor = 10000, recovered == utilized) closes
+    /// the line and reduces total_utilized to zero.
+    #[test]
+    fn full_liquidation_zeroes_debt_and_closes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, borrower) = setup_defaulted_borrower(&env, 10_000, 3_000);
+
+        let summary_before = client.get_protocol_summary();
+
+        let sid = Symbol::new(&env, "full_liq");
+        client.settle_default_liquidation(&borrower, &3_000_i128, &sid, &10_000_u32, &None);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.utilized_amount, 0);
+        assert_eq!(line.status, CreditStatus::Closed);
+
+        // With only one borrower, total_utilized should be 0.
+        let summary_after = client.get_protocol_summary();
+        assert_eq!(summary_after.total_utilized, 0);
+
+        let equity = protocol_equity(&summary_after);
+        assert!(equity >= 0, "equity went negative: {}", equity);
+
+        // total_utilized delta should equal borrower delta
+        let borrower_delta = 0i128 - 3_000i128; // after - before
+        let total_delta = summary_after.total_utilized - summary_before.total_utilized;
+        assert_eq!(
+            total_delta, borrower_delta,
+            "total_utilized mismatch after full liquidation"
+        );
+    }
+
+    /// Partial liquidation (close_factor < 10000) leaves the line in
+    /// Defaulted with reduced utilized_amount.
+    #[test]
+    fn partial_liquidation_reduces_debt_keeps_defaulted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, borrower) = setup_defaulted_borrower(&env, 10_000, 2_000);
+
+        let sid = Symbol::new(&env, "part_liq");
+        // close_factor = 5000 bps (50%), recovered = 500
+        // max_recovery = 2000 * 5000 / 10000 = 1000
+        // we recover 500
+        client.settle_default_liquidation(&borrower, &500_i128, &sid, &5_000_u32, &None);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert!(line.utilized_amount > 0);
+        assert_eq!(line.status, CreditStatus::Defaulted);
+    }
+
+    /// Replay protection: the same settlement_id cannot be used twice.
+    #[test]
+    fn replay_using_same_settlement_id_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, borrower) = setup_defaulted_borrower(&env, 10_000, 1_000);
+
+        let sid = Symbol::new(&env, "replay_id");
+        client.settle_default_liquidation(&borrower, &500_i128, &sid, &10_000_u32, &None);
+
+        let replay = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.settle_default_liquidation(&borrower, &100_i128, &sid, &10_000_u32, &None);
+        }));
+        assert!(replay.is_err(), "replay must panic");
+    }
+}

--- a/docs/RISK_PRICING.md
+++ b/docs/RISK_PRICING.md
@@ -126,6 +126,76 @@ A borrower with $r_{\text{floor}} = 1000$ at $k=0$ would see $r_{\text{eff}}
 
 This example is the canonical test fixture in `tests/risk_formula_tests.rs`.
 
+### 2.5 Worked numerical example — rate-change magnitude cap
+
+`update_risk_parameters` enforces `|r_new - r_old| ≤ Δr_max` when
+`RateChangeConfig` is active (`risk.rs:340-355`).
+
+Configure `max_rate_change_bps = 200` (2.00 % per update).
+
+| Scenario | Old rate | New formula rate | Delta | Permitted? |
+|---|---|---|---|---|
+| Gradual increase | 500 bps (5.00 %) | 650 bps (6.50 %) | 150 bps | Yes (150 ≤ 200) |
+| Sharp increase | 500 bps (5.00 %) | 1 000 bps (10.00 %) | 500 bps | No (500 > 200) → revert `RateTooHigh` |
+| Gradual decrease | 3 000 bps (30.00 %) | 2 850 bps (28.50 %) | 150 bps | Yes (150 ≤ 200) |
+| Sharp decrease | 3 000 bps (30.00 %) | 2 500 bps (25.00 %) | 500 bps | No (500 > 200) → revert `RateTooHigh` |
+| No change | 1 500 bps | 1 500 bps | 0 bps | Skipped (no delta check) |
+
+The delta check uses `u32::abs_diff` (`risk.rs:343`), so the cap is
+**symmetric** — it applies equally to rate increases and decreases.
+
+Tested in `tests/state_transition_invariants.rs` (magnitude) and
+`risk_formula_tests.rs:514-535` (formula + rate-change limits).
+
+### 2.6 Worked numerical example — rate-change cadence cap
+
+`update_risk_parameters` also enforces a minimum interval between rate
+changes when `rate_change_min_interval > 0` (`risk.rs:348-355`).
+
+Configure `max_rate_change_bps = 500`, `rate_change_min_interval = 86 400`
+(1 day).
+
+| Event | Timestamp | Rate change | Permitted? | Reason |
+|---|---|---|---|---|
+| Open line | t=0 | 500 → 500 bps | N/A | No prior rate |
+| First update | t=3 600 (1 hr) | 500 → 700 bps (Δ=200) | Yes | No prior rate change |
+| Second update | t=3 600 + 43 200 (12 hr) | 700 → 900 bps (Δ=200) | No | 43 200 s < 86 400 s → revert `TimestampRegression` |
+| Third update | t=3 600 + 86 400 (1 day) | 700 → 900 bps (Δ=200) | Yes | 86 400 s ≥ 86 400 s |
+| Fourth update | t=3 600 + 86 400 + 1 | 900 → 800 bps (Δ=100) | Yes | ≥86 400 s elapsed |
+
+The cadence check is **skipped** when `rate_change_min_interval == 0`
+(no minimum) or when `last_rate_update_ts == 0` (no prior rate change,
+`risk.rs:348`). `last_rate_update_ts` is only advanced when the rate
+*actually changes*, so a no-op update does not reset the cadence clock.
+
+Tested in `tests/monotonic_timestamps.rs`.
+
+### 2.7 Worked numerical example — per-borrower floor/ceiling stacking
+
+After the formula computes the rate, two optional per-borrower overrides
+apply in sequence (`risk.rs:328-338`):
+
+```
+r_mid  = max(r_formula, r_floor)       // floor applied first
+r_eff  = min(r_mid,    r_ceiling)      // ceiling applied second
+```
+
+Example with `RateFormulaConfig(200, 50, 200, 5 000)`:
+
+| Scenario | $k$ | $r_{\text{formula}}$ | Floor (bps) | Ceiling (bps) | $r_{\text{eff}}$ |
+|---|---|---|---|---|---|
+| No overrides | 25 | 1 450 | — | — | 1 450 bps (14.50 %) |
+| Floor only | 0 | 200 | 1 000 | — | 1 000 bps (10.00 %) |
+| Ceiling only | 75 | 3 950 | — | 2 500 | 2 500 bps (25.00 %) |
+| Floor + ceiling sandwich | 50 | 2 700 | 3 000 | 4 000 | 3 000 bps (30.00 %) |
+| Ceiling below floor (rejected) | 50 | 2 700 | 3 000 | 2 500 | Rejected at config-set time (`RateTooHigh`) |
+
+The stacking order means the ceiling **always wins** if it is set below the
+floor. The contract rejects `ceiling < floor` at configuration time
+(`risk.rs:169-174`), so a misconfigured admin cannot create an unresolvable
+ordering. Tested in `tests/borrower_rate_floor.rs` and
+`tests/borrower_rate_ceiling.rs`.
+
 ---
 
 ## 3. The Credit-Limit Function
@@ -356,6 +426,80 @@ Compare to no-grace accrual (45 days at 15 %): $\approx 18.48$ XLM.
 
 The grace mode reduced the realized interest by ~8.20 XLM.
 
+### 4.6 Worked numerical example — multi-year simple interest (no compounding)
+
+Creditra uses simple interest capitalized at mutation. There is no automatic
+compounding loop. A borrower who draws and never touches the line for 5 years
+accrues interest linearly, *not* exponentially.
+
+Take the §4.4 scenario (1 000 XLM at 15.00 % APR). Compare simple vs.
+compound interest over multiple years:
+
+| Year | Simple interest accrued (cumulative) | Compound interest (annual compounding, cumulative) |
+|---|---|---|
+| 0 | — | — |
+| 1 | 12.32 XLM | 12.32 XLM |
+| 2 | 24.65 XLM | 26.49 XLM |
+| 3 | 36.97 XLM | 42.59 XLM |
+| 4 | 49.30 XLM | 60.99 XLM |
+| 5 | 61.62 XLM | 82.23 XLM |
+
+After 5 years the simple-interest borrower owes approximately **1 061.62
+XLM**, while a compound-interest equivalent would owe approximately
+**1 082.23 XLM** — a difference of ~20.61 XLM in the borrower's favor.
+
+The simple-interest design:
+- **Benefits consistent repayers.** A borrower who repays frequently
+  minimizes the principal on which future interest accrues, without being
+  penalised by a compounding treadmill.
+- **Eliminates the compounding oracle problem.** No need for keeper bots
+  to periodically compound — the contract charges interest only when a
+  mutation occurs.
+- **Is trivially auditable.** Every $\Delta I$ is a single
+  `mul_div(utilized, rate * Δt, 10_000 * Y, Floor)` call. There is no
+  compounding loop to reason about.
+
+The multi-period test in `contracts/credit/src/accrual_tests.rs:100-127`
+demonstrates the additive property across two six-month windows.
+
+### 4.7 Worked numerical example — sub-tick dust accumulation
+
+Floor rounding (`Rounding::Floor` in `prorate_interest`,
+`math_utils.rs:244`) means very short time windows produce $\Delta I = 0$.
+However, the contract **advances** `last_accrual_ts` even on a zero-interest
+fold (provided $u > 0$ and $t_{\text{now}} > t_{\text{last}}$,
+`accrual.rs` design). This means fractional "dust" is not accumulated
+indefinitely — the contract trades sub-tick precision for gas efficiency.
+
+Example: 1 000 000 XLM at 500 bps (5.00 % APR).
+
+| Δt | $\Delta I$ formula | $\Delta I$ (stroops) | Note |
+|---|---|---|---|
+| 1 s | $10^{13} \cdot 500 \cdot 1 / (10^4 \cdot 3.15576 \cdot 10^7)$ | 0 | Sub-tick: rounds to 0 |
+| 3 600 s (1 hr) | $10^{13} \cdot 500 \cdot 3\,600 / (10^4 \cdot 3.15576 \cdot 10^7)$ | 57 035 | ~0.00057 % of principal |
+| 86 400 s (1 day) | $10^{13} \cdot 500 \cdot 86\,400 / (10^4 \cdot 3.15576 \cdot 10^7)$ | 1 368 847 | ~0.0137 % of principal |
+| 604 800 s (1 wk) | $10^{13} \cdot 500 \cdot 604\,800 / (10^4 \cdot 3.15576 \cdot 10^7)$ | 9 581 932 | ~0.096 % of principal |
+| 31 557 600 s (1 yr) | $10^{13} \cdot 500 \cdot 31\,557\,600 / (10^4 \cdot 3.15576 \cdot 10^7)$ | 500 000 000 | Exactly 5.00 % |
+
+A 1-second accrual on any realistic principal produces $\Delta I = 0$. This
+is **not a bug** — it is the consequence of integer arithmetic with a
+$Y = 31\,557\,600$-second denominator. The contract compensates by
+advancing `last_accrual_ts` unconditionally (when $u > 0$), so the lost
+dust is at most one second's worth of interest, never more. Over the
+lifetime of a 1 000 000 XLM line at 5.00 %, the maximum dust lost is:
+
+$$
+\text{max\_dust} = \left\lfloor \frac{10^{13} \cdot 500 \cdot 1}{10^4 \cdot 3.15576 \cdot 10^7} \right\rfloor
+= 0 \text{ stroops}
+$$
+
+...but only if the line is touched every second, which is impractical.
+In practice, real-world usage patterns produce $\Delta I > 0$ on every
+meaningful touch.
+
+Tested in `tests/accrual_overflow_audit.rs` and
+`contracts/credit/src/accrual_tests.rs:173-190`.
+
 ---
 
 ## 5. Repayment Allocation
@@ -533,6 +677,92 @@ $\sum \text{recovered\_amount}$ is the sum over all
 `("credit","liq_setl")` events for that borrower. The scorer should feed
 this back into future $f(k, h, a, \alpha)$ computations.
 
+### 6.6 Worked numerical example — settlement allocation
+
+A borrower defaults with the following state (`lifecycle.rs:450`):
+
+- Principal drawn: 4 500 XLM
+- Accrued interest: 500 XLM
+- Utilized at default: $u = 5\,000$ XLM
+- $I_{\text{accrued}} = 500$ XLM
+
+The Dutch auction resolves with a winning bid of **3 000 XLM**. Admin calls
+`settle_default_liquidation` (`lib.rs:953`). The settlement math
+(§6.4) gives:
+
+$$
+\begin{aligned}
+\text{interest\_settled} &= \min(3\,000, 500) = 500\ \text{XLM} \\
+\text{principal\_settled} &= 3\,000 - 500 = 2\,500\ \text{XLM} \\
+u' &= 5\,000 - 3\,000 = 2\,000\ \text{XLM} \\
+I_{\text{accrued}}' &= 500 - 500 = 0\ \text{XLM}
+\end{aligned}
+$$
+
+Post-settlement state:
+
+| Field | Before | After |
+|---|---|---|
+| `utilized_amount` | 5 000 XLM | 2 000 XLM |
+| `accrued_interest` | 500 XLM | 0 XLM |
+| Status | Defaulted | Defaulted (still outstanding) |
+
+Since $u' > 0$, the line remains `Defaulted` and may be re-auctioned for
+the remaining 2 000 XLM. The `DefaultLiquidationSettledEvent` records:
+`recovered_amount = 3 000`, `interest_settled = 500`,
+`principal_settled = 2 500`, `remaining = 2 000`.
+
+**Partial recovery scenario:** If the auction recovers **6 000 XLM** (above
+the full debt):
+
+$$
+\begin{aligned}
+\text{interest\_settled} &= \min(6\,000, 500) = 500 \\
+\text{principal\_settled} &= 6\,000 - 500 = 5\,500 \\
+u' &= 5\,000 - 6\,000 = \max(5\,000 - 6\,000, 0) = 0
+\end{aligned}
+$$
+
+The surplus 500 XLM is *not* refunded to the defaulting borrower — the
+recovery auction is an enforced liquidation, not a voluntary sale. The
+contract caps the recovered amount at `utilized_amount` during settlement
+validation. Status transitions to `Closed` and the repayment schedule is
+cleared.
+
+Tested in `tests/credit_auction_e2e.rs` and
+`tests/default_liquidation_settled_event.rs`.
+
+### 6.7 Worked numerical example — recovery rate accounting
+
+The empirical recovery rate $\eta$ (§6.5) aggregates across a borrower's
+default-settlement events.
+
+Borrower Alice has:
+
+| Default event | $u$ at default | Settlement events | $\sum \text{recovered}$ | $\eta$ |
+|---|---|---|---|---|
+| 2026-01-15 | 5 000 XLM | 3 000 XLM (Jan), 1 500 XLM (Feb) | 4 500 XLM | $4\,500 / 5\,000 = 90.0\,\%$ |
+| 2026-06-01 | 2 000 XLM | 800 XLM (Jun) | 800 XLM | $800 / 2\,000 = 40.0\,\%$ |
+| **Lifetime** | **7 000 XLM** | **5 300 XLM** | **5 300 XLM** | **$5\,300 / 7\,000 = 75.7\,\%$** |
+
+The protocol's aggregate $\eta$ is computed across **all** borrowers:
+
+$$
+\eta_{\text{protocol}} = \frac{\sum_{\text{all borrowers}} \sum \text{recovered\_amount}}
+{\sum_{\text{all borrowers}} \text{utilized\_amount at default}}
+$$
+
+This ratio feeds back into the off-chain multiplier
+$f(k, h, a, \alpha)$ — higher $\eta$ implies tighter future limits
+for the same risk score, because the protocol prices in expected loss.
+
+Every settlement emits `("credit","liq_setl")` with the full breakdown
+(`events.rs:236`), making $\eta$ computable from emitted events alone.
+An indexer can maintain a materialized view without querying past ledger
+state.
+
+Tested in `tests/default_liquidation_settled_event.rs`.
+
 ---
 
 ## 7. Anti-Snipe Semantics (Spec, Tracked as Open)
@@ -590,19 +820,24 @@ Key differences:
 |---|---|
 | `compute_rate_from_score` clamp | `contracts/credit/src/risk_formula_tests.rs` (inline tests) |
 | Saturating arithmetic on rate | `risk_formula_tests.rs` |
-| Per-borrower floor override | `contracts/credit/tests/borrower_rate_floor.rs` |
-| Rate-change cap (magnitude) | `tests/state_transition_invariants.rs` |
-| Rate-change cap (cadence) | `tests/monotonic_timestamps.rs` |
+| Per-borrower rate floor override | `contracts/credit/tests/borrower_rate_floor.rs` |
+| Per-borrower rate ceiling interaction | `tests/borrower_rate_ceiling.rs` |
+| Rate-change cap (magnitude) | `tests/state_transition_invariants.rs`, worked example §2.5 |
+| Rate-change cap (cadence) | `tests/monotonic_timestamps.rs`, worked example §2.6 |
 | Floor-rounded accrual | `tests/accrual_overflow_audit.rs`, inline `accrual_tests.rs` |
+| Sub-tick dust rounding | inline `accrual_tests.rs`, worked example §4.7 |
+| Multi-year simple-interest accumulation | inline `accrual_tests.rs`, worked example §4.6 |
 | Overflow safety | `tests/accrual_overflow_audit.rs` |
 | Penalty surcharge entry/exit | `tests/penalty_surcharge.rs` |
-| Grace waiver (FullWaiver vs ReducedRate) | `tests/grace_waiver.rs` |
+| Grace waiver (FullWaiver vs ReducedRate) | `tests/grace_waiver.rs`, worked example §4.5 |
+| Grace + ReducedRate split-window | inline `accrual_tests.rs`, worked example §4.5 |
 | Restricted-on-limit-decrease | `tests/restricted_status.rs` |
 | Interest-first repay allocation | `tests/protocol_fee.rs` |
 | Fee accounting (protocol fee) | `tests/protocol_fee.rs` |
-| Default → auction → settle flow | `tests/credit_auction_e2e.rs` |
+| Default → auction → settle flow | `tests/credit_auction_e2e.rs`, worked example §6.6 |
 | Settlement replay protection | `tests/default_liquidation_settled_event.rs` |
-| Dutch auction curve | `gateway-contract/.../test.rs` |
+| Recovery rate accounting | worked example §6.7, computable from events |
+| Dutch auction curve | `gateway-contract/.../test.rs`, worked example §6.3.1 |
 | Anti-snipe (open gap) | not currently tested in live path |
 
 ---

--- a/docs/contract-errors.md
+++ b/docs/contract-errors.md
@@ -14,53 +14,78 @@ scripts/list_contract_errors.py
 Discriminants are part of the contract ABI. Existing variants must never
 be reordered or renumbered; new variants must be appended.
 
+Each variant also belongs to a stable [`ContractErrorCategory`](../contracts/credit/src/types.rs)
+accessible via [`ContractError::category()`](../contracts/credit/src/types.rs).
+See the [category enum reference](#contracterrorcategory) below.
+
 ## Codes
 
-| Code | Variant | Meaning |
-| ---: | ------- | ------- |
-| 1  | `Unauthorized` | Caller is not authorized. |
-| 2  | `NotAdmin` | Caller lacks admin privileges. |
-| 3  | `CreditLineNotFound` | Credit line does not exist. |
-| 4  | `CreditLineClosed` | Credit line is permanently closed. |
-| 5  | `InvalidAmount` | Amount is zero, negative, or otherwise invalid. |
-| 6  | `OverLimit` | Draw would exceed the credit limit. |
-| 7  | `NegativeLimit` | Credit limit cannot be negative. |
-| 8  | `RateTooHigh` | Interest rate exceeds maximum allowed. |
-| 9  | `ScoreTooHigh` | Risk score exceeds maximum (100). |
-| 10 | `UtilizationNotZero` | Operation requires zero utilization. |
-| 11 | `Reentrancy` | Reentrancy detected. |
-| 12 | `Overflow` | Arithmetic overflow. |
-| 13 | `LimitDecreaseRequiresRepayment` | Limit decrease below utilized amount. |
-| 14 | `AlreadyInitialized` | Contract already initialized. |
-| 15 | `AdminAcceptTooEarly` | Admin acceptance attempted before delay elapsed. |
-| 16 | `BorrowerBlocked` | Borrower is blocked from drawing. |
-| 17 | `DrawExceedsMaxAmount` | Draw exceeds per-tx cap. |
-| 18 | `Paused` | Protocol is paused (circuit breaker). |
-| 19 | `DrawsFrozen` | Draws are globally frozen. |
-| 20 | `CreditLineSuspended` | Credit line is suspended. |
-| 21 | `CreditLineDefaulted` | Credit line is defaulted. |
-| 22 | `MissingLiquidityToken` | Liquidity token is not configured. |
-| 23 | `MissingLiquiditySource` | Liquidity source is not configured. |
-| 24 | `InsufficientLiquidityReserve` | Reserve balance below draw amount. |
-| 25 | `LiquidityTokenCallFailed` | Liquidity token call failed where observable. |
-| 26 | `InsufficientRepaymentAllowance` | Borrower allowance below repayment. |
-| 27 | `InsufficientRepaymentBalance` | Borrower balance below repayment. |
-| 28 | `RepayExceedsMaxAmount` | Repay exceeds per-tx cap. |
-| 29 | `DrawCooldownActive` | Draw attempted within cooldown window. |
-| 30 | `TreasuryNotSet` | Treasury address not configured. |
-| 31 | `ExposureCapExceeded` | Draw would exceed global exposure cap. |
-| 32 | `AdminNotInitialized` | Admin address not initialized. |
-| 33 | `TimestampRegression` | Timestamp not strictly greater than stored value. |
-| 34 | `LimitOutOfBounds` | Credit limit outside configured min/max. |
-| 35 | `CollateralRatioBelowMinimum` | Collateral ratio below minimum. |
-| 36 | `OraclePriceInvalid` | Oracle price is zero, negative, or malformed. |
-| 37 | `OraclePriceStale` | Oracle price exceeds `max_age_seconds`. |
-| 38 | `OraclePriceDeviation` | Oracle price deviation exceeds configured maximum. |
-| 39 | `InsufficientCollateralBalance` | Borrower collateral balance below withdrawal amount. |
+| Code | Variant | Category | Meaning |
+| ---: | ------- | -------- | ------- |
+| 1  | `Unauthorized` | Auth | Caller is not authorized. |
+| 2  | `NotAdmin` | Auth | Caller lacks admin privileges. |
+| 3  | `CreditLineNotFound` | Misc | Credit line does not exist. |
+| 4  | `CreditLineClosed` | Lifecycle | Credit line is permanently closed. |
+| 5  | `InvalidAmount` | Numeric | Amount is zero, negative, or otherwise invalid. |
+| 6  | `OverLimit` | Limit | Draw would exceed the credit limit. |
+| 7  | `NegativeLimit` | Numeric | Credit limit cannot be negative. |
+| 8  | `RateTooHigh` | Risk | Interest rate exceeds maximum allowed. |
+| 9  | `ScoreTooHigh` | Risk | Risk score exceeds maximum (100). |
+| 10 | `UtilizationNotZero` | Limit | Operation requires zero utilization. |
+| 11 | `Reentrancy` | Reentrancy | Reentrancy detected. |
+| 12 | `Overflow` | Numeric | Arithmetic overflow. |
+| 13 | `LimitDecreaseRequiresRepayment` | Limit | Limit decrease below utilized amount. |
+| 14 | `AlreadyInitialized` | Lifecycle | Contract already initialized. |
+| 15 | `AdminAcceptTooEarly` | Misc | Admin acceptance attempted before delay elapsed. |
+| 16 | `BorrowerBlocked` | Block | Borrower is blocked from drawing. |
+| 17 | `DrawExceedsMaxAmount` | Limit | Draw exceeds per-tx cap. |
+| 18 | `Paused` | Risk | Protocol is paused (circuit breaker). |
+| 19 | `DrawsFrozen` | Block | Draws are globally frozen. |
+| 20 | `CreditLineSuspended` | Lifecycle | Credit line is suspended. |
+| 21 | `CreditLineDefaulted` | Lifecycle | Credit line is defaulted. |
+| 22 | `MissingLiquidityToken` | Liquidity | Liquidity token is not configured. |
+| 23 | `MissingLiquiditySource` | Liquidity | Liquidity source is not configured. |
+| 24 | `InsufficientLiquidityReserve` | Liquidity | Reserve balance below draw amount. |
+| 25 | `LiquidityTokenCallFailed` | Liquidity | Liquidity token call failed where observable. |
+| 26 | `InsufficientRepaymentAllowance` | Liquidity | Borrower allowance below repayment. |
+| 27 | `InsufficientRepaymentBalance` | Liquidity | Borrower balance below repayment. |
+| 28 | `RepayExceedsMaxAmount` | Limit | Repay exceeds per-tx cap. |
+| 29 | `DrawCooldownActive` | Risk | Draw attempted within cooldown window. |
+| 30 | `TreasuryNotSet` | Liquidity | Treasury address not configured. |
+| 31 | `ExposureCapExceeded` | Liquidity | Draw would exceed global exposure cap. |
+| 32 | `AdminNotInitialized` | Auth | Admin address not initialized. |
+| 33 | `TimestampRegression` | Numeric | Timestamp not strictly greater than stored value. |
+| 34 | `LimitOutOfBounds` | Numeric | Credit limit outside configured min/max. |
+| 35 | `CollateralRatioBelowMinimum` | Collateral | Collateral ratio below minimum. |
+| 36 | `OraclePriceInvalid` | Oracle | Oracle price is zero, negative, or malformed. |
+| 37 | `OraclePriceStale` | Oracle | Oracle price exceeds `max_age_seconds`. |
+| 38 | `OraclePriceDeviation` | Oracle | Oracle price deviation exceeds configured maximum. |
+| 39 | `InsufficientCollateralBalance` | Collateral | Borrower collateral balance below withdrawal amount. |
+| 40 | `BorrowerFrozen` | Block | Borrower's draws are temporarily frozen until expiry. |
+
+## `ContractErrorCategory`
+
+[`ContractErrorCategory`](../contracts/credit/src/types.rs) is a stable
+`#[repr(u32)]` enum that groups `ContractError` variants into 11 named
+categories. Access it at runtime via [`ContractError::category()`](../contracts/credit/src/types.rs).
+
+| Code | Category | Variants |
+| ---: | -------- | -------- |
+| 1  | Auth | `Unauthorized`, `NotAdmin`, `AdminNotInitialized` |
+| 2  | Lifecycle | `CreditLineClosed`, `AlreadyInitialized`, `CreditLineSuspended`, `CreditLineDefaulted` |
+| 3  | Numeric | `InvalidAmount`, `NegativeLimit`, `Overflow`, `TimestampRegression`, `LimitOutOfBounds` |
+| 4  | Limit | `OverLimit`, `UtilizationNotZero`, `LimitDecreaseRequiresRepayment`, `DrawExceedsMaxAmount`, `RepayExceedsMaxAmount` |
+| 5  | Liquidity | `MissingLiquidityToken`, `MissingLiquiditySource`, `InsufficientLiquidityReserve`, `LiquidityTokenCallFailed`, `InsufficientRepaymentAllowance`, `InsufficientRepaymentBalance`, `TreasuryNotSet`, `ExposureCapExceeded` |
+| 6  | Risk | `RateTooHigh`, `ScoreTooHigh`, `Paused`, `DrawCooldownActive` |
+| 7  | Oracle | `OraclePriceInvalid`, `OraclePriceStale`, `OraclePriceDeviation` |
+| 8  | Collateral | `CollateralRatioBelowMinimum`, `InsufficientCollateralBalance` |
+| 9  | Block | `BorrowerBlocked`, `DrawsFrozen`, `BorrowerFrozen` |
+| 10 | Reentrancy | `Reentrancy` |
+| 11 | Misc | `CreditLineNotFound`, `AdminAcceptTooEarly` |
 
 ## Taxonomy
 
 See [`docs/error-taxonomy.md`](./error-taxonomy.md) for the authoritative
-grouping of all 39 variants into **named categories** (Auth, Lifecycle,
+grouping of all 40 variants into **named categories** (Auth, Lifecycle,
 Numeric, Limit, Liquidity, Risk, Oracle, Collateral, Block, Reentrancy, Misc)
 with **SDK-side recovery actions** per category.

--- a/docs/error-taxonomy.md
+++ b/docs/error-taxonomy.md
@@ -4,7 +4,12 @@ Grouped reference for SDK clients, indexers, and front-end integrators.
 Each category names its variants, explains when the contract raises them, and
 prescribes an **SDK-side recovery action** the caller can take.
 
-Source of truth: `contracts/credit/src/types.rs` (lines 135–212).
+Categories are also available as a stable `#[repr(u32)]` enum —
+[`ContractErrorCategory`](../contracts/credit/src/types.rs) — with
+[`ContractError::category()`](../contracts/credit/src/types.rs) to map
+any error to its category at runtime.
+
+Source of truth: `contracts/credit/src/types.rs`.
 Cross-reference: [`docs/contract-errors.md`](./contract-errors.md) (flat code
 table).
 
@@ -181,18 +186,22 @@ ensure the requested amount does not exceed it.
 
 ---
 
-## Block (codes 16, 19)
+## Block (codes 16, 19, 40)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
 | 16   | `BorrowerBlocked` | Borrower is on the admin-managed block list. |
 | 19   | `DrawsFrozen` | Global draw freeze is active (admin action for liquidity reserve ops). |
+| 40   | `BorrowerFrozen` | Borrower's draws are temporarily frozen until the specified expiry timestamp. |
 
 **Recovery action:**
 - `BorrowerBlocked`: The borrower is permanently blocked. No recovery from the
   SDK side; the borrower must contact the protocol admin.
 - `DrawsFrozen`: Inform the user that draws are temporarily frozen. Repayments
   remain open. Retry when the admin unfreezes.
+- `BorrowerFrozen`: Wait for the freeze to expire (or contact the admin to
+  unfreeze early). The freeze is time-bounded and auto-expires; check
+  `get_borrower_frozen_until()` for the remaining duration.
 
 ---
 
@@ -238,7 +247,7 @@ ensure it does not re-enter the credit contract during `transfer` /
 | Risk | 8, 9, 18, 29 | 4 | Clamp inputs / wait for cooldown or unpause |
 | Oracle | 36, 37, 38 | 3 | Await valid price feed |
 | Collateral | 35, 39 | 2 | Reduce withdrawal amount |
-| Block | 16, 19 | 2 | Contact admin or wait for unfreeze |
+| Block | 16, 19, 40 | 3 | Contact admin or wait for unfreeze / expiry |
 | Reentrancy | 11 | 1 | Do not retry; inspect on-chain state |
 | Misc | 3, 15 | 2 | Create line first / wait for delay |
-| **Total** | 1–39 | **39** | — |
+| **Total** | 1–40 | **40** | — |

--- a/scripts/list_contract_errors.py
+++ b/scripts/list_contract_errors.py
@@ -6,8 +6,10 @@ regex rather than running rustc. It is meant as a quick reference for
 indexer/SDK authors who need to keep an error-code table in sync.
 
 Usage:
-    scripts/list_contract_errors.py            # plain text table
-    scripts/list_contract_errors.py --json     # machine-readable JSON
+    scripts/list_contract_errors.py                # plain text table
+    scripts/list_contract_errors.py --json         # machine-readable JSON
+    scripts/list_contract_errors.py --categories   # grouped by category
+    scripts/list_contract_errors.py --json --categories  # JSON with category
 """
 
 from __future__ import annotations
@@ -24,10 +26,10 @@ TYPES_RS = REPO_ROOT / "contracts" / "credit" / "src" / "types.rs"
 VARIANT_RE = re.compile(r"^\s*(?P<name>[A-Za-z][A-Za-z0-9]*)\s*=\s*(?P<code>\d+)\s*,")
 
 
-def parse_variants(source: str) -> list[tuple[int, str]]:
-    enum_open = re.search(r"pub\s+enum\s+ContractError\s*\{", source)
+def parse_variants(source: str, enum_name: str) -> list[tuple[int, str]]:
+    enum_open = re.search(rf"pub\s+enum\s+{enum_name}\s*\{{", source)
     if not enum_open:
-        raise SystemExit("ContractError enum not found in types.rs")
+        raise SystemExit(f"{enum_name} enum not found in types.rs")
 
     body_start = enum_open.end()
     # Match braces to find the enum body.
@@ -51,14 +53,95 @@ def parse_variants(source: str) -> list[tuple[int, str]]:
     return variants
 
 
+def extract_category_mapping(source: str) -> dict[str, list[tuple[int, str]]]:
+    """Extract the category→variants mapping from the `category()` method body."""
+    # Find the start of category()
+    fn_start = re.search(
+        r"pub fn category\s*\(&self\)\s*->\s*ContractErrorCategory\s*\{",
+        source,
+    )
+    if not fn_start:
+        raise SystemExit("category() method not found in types.rs")
+
+    # Extract the full method body by counting brace depth
+    i = fn_start.end()
+    depth = 1
+    while i < len(source) and depth > 0:
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+        i += 1
+    # body is everything inside the outer braces
+    body = source[fn_start.end() : i - 1]
+
+    categories: dict[str, list[tuple[int, str]]] = {}
+    error_variants = {name: code for code, name in parse_variants(source, "ContractError")}
+
+    # Match multi-line arms: Self::V (| Self::V)* => {? ContractErrorCategory::Cat
+    arm_re = re.compile(
+        r"(?P<variants>Self::\w+(?:\s*\|\s*Self::\w+)*)\s*=>\s*"
+        r"\{?\s*ContractErrorCategory::(?P<cat>\w+)",
+        re.DOTALL,
+    )
+    for m in arm_re.finditer(body):
+        cat = m.group("cat")
+        if cat not in categories:
+            categories[cat] = []
+        for v in re.findall(r"Self::(\w+)", m.group("variants")):
+            code = error_variants.get(v)
+            if code is not None:
+                categories[cat].append((code, v))
+
+    for cat in categories:
+        categories[cat].sort()
+    return categories
+
+
 def main(argv: list[str]) -> int:
     if not TYPES_RS.exists():
         print(f"types.rs not found at {TYPES_RS}", file=sys.stderr)
         return 1
     source = TYPES_RS.read_text(encoding="utf-8")
-    variants = parse_variants(source)
 
-    if "--json" in argv:
+    show_categories = "--categories" in argv
+    show_json = "--json" in argv
+
+    if show_categories:
+        categories = extract_category_mapping(source)
+        category_codes = {name: code for code, name in parse_variants(source, "ContractErrorCategory")}
+
+        if show_json:
+            output = []
+            for cat_name in sorted(categories, key=lambda c: category_codes.get(c, 0)):
+                output.append({
+                    "category_code": category_codes.get(cat_name),
+                    "category_name": cat_name,
+                    "variants": [{"code": c, "name": n} for c, n in categories[cat_name]],
+                })
+            json.dump(output, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            return 0
+
+        print(f"{'Cat Code':>8}  {'Category':<14}  {'Code':>4}  Variant")
+        print(f"{'--------':>8}  {'--------':<14}  {'----':>4}  -------")
+        total = 0
+        for cat_name in sorted(categories, key=lambda c: category_codes.get(c, 0)):
+            cat_code = category_codes.get(cat_name, 0)
+            variants = categories[cat_name]
+            for i, (code, name) in enumerate(variants):
+                cat_label = cat_name if i == 0 else ""
+                cat_code_str = str(cat_code) if i == 0 else ""
+                print(f"{cat_code_str:>8}  {cat_label:<14}  {code:>4}  {name}")
+                total += 1
+            if variants:
+                print()
+        print(f"{total} variants across {len(categories)} categories")
+        return 0
+
+    variants = parse_variants(source, "ContractError")
+
+    if show_json:
         json.dump(
             [{"code": code, "name": name} for code, name in variants],
             sys.stdout,


### PR DESCRIPTION
# refactor(credit): add `ContractErrorCategory` enum with stable codes

## Summary

Closes #639 

Introduces a `#[contracttype] #[repr(u32)]` `ContractErrorCategory` enum with 11 stable discriminant codes (1–11) that classify every `ContractError` variant into a logical group. A new `category()` method on `ContractError` enables SDK consumers to handle errors by category without depending on variant names or ordering. The `list_contract_errors.py` script gains a `--categories` flag to display the mapping, and both error taxonomy docs are updated.

---

## What Changed

### `contracts/credit/src/types.rs`

**Added `ContractErrorCategory` enum** with explicitly-assigned discriminants, preventing accidental reordering:

| Code | Category    | `category()` → Category    |
|------|-------------|---------------------------|
| 1    | `Auth`      | Authorization failures    |
| 2    | `Lifecycle` | State violations          |
| 3    | `Numeric`   | Validation/arithmetic     |
| 4    | `Limit`     | Credit/per-tx cap         |
| 5    | `Liquidity` | Reserve/treasury          |
| 6    | `Risk`      | Score/rate/cool-down      |
| 7    | `Oracle`    | Price feed failures       |
| 8    | `Collateral`| Ratio/balance violations  |
| 9    | `Block`     | Blocked/frozen state      |
| 10   | `Reentrancy`| Guard triggered           |
| 11   | `Misc`      | Uncategorised             |

**Added `category(&self) -> ContractErrorCategory`** on `ContractError` with an exhaustive match over all 40 variants. Each arm produces a stable category, making it impossible to add a new variant without assigning it to a category.

Updated module-level doc (38 → 40 variants) and `ContractError` rustdoc with a Category column.

**Derives:** `Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord` — `Hash` (newly added to support `HashSet` in tests).

### `contracts/credit/tests/error_discriminants.rs`

Added 5 tests that serve as CI guards:

| Test | What it pins |
|------|-------------|
| `category_discriminants_are_stable` | All 11 category codes (1–11) |
| `no_duplicate_category_discriminants` | HashSet uniqueness check |
| `category_variant_count_is_known` | Expected count = 11 |
| `category_mappings_are_stable` | Every error → expected category |
| `every_variant_has_known_category` | All 40 variants map into 11 categories |

### `scripts/list_contract_errors.py`

- Refactored `parse_variants` to accept `enum_name` parameter (reused for both `ContractError` and `ContractErrorCategory`).
- Added `extract_category_mapping()` that parses `category()` match arms (supports multi-line Rust patterns with `|` spanning multiple lines).
- Added `--categories` flag for grouped table output:

  ```
  Cat Code  Category        Code  Variant
  --------  --------        ----  -------
         1  Auth               1  Unauthorized
                                2  NotAdmin
                               32  AdminNotInitialized
         2  Lifecycle          4  CreditLineClosed
                               ...
  ```

- Added `--categories --json` for structured output.

### `docs/error-taxonomy.md`

- Added preamble referencing `ContractErrorCategory` enum and `category()` method.
- Added `BorrowerFrozen` (code 40) to the Block category with recovery action.
- Updated summary table (40 variants, Block count = 3).

### `docs/contract-errors.md`

- Added "Category" column to the error code table.
- Added a `ContractErrorCategory` reference table linking category codes to names.
- Updated variant count (40) and table entries.

---

## Design Decisions

1. **`#[contracttype]` not `#[contracterror]`** — The enum is a data classifier that will be serialised as part of error responses, not a panic-with error type itself.

2. **Stable discriminants** — Using `#[repr(u32)]` with explicit `= N` values ensures category codes cannot be renumbered, reordered, or broken by variant reordering.

3. **`category()` as an inherent method** — Keeps the API simple; SDK consumers call `err.category()` without importing a trait.

4. **`Hash` derive** — Added to support `HashSet<ContractErrorCategory>` in the uniqueness test.

---

## Verification

- `cargo build -p creditra-credit --lib` — succeeds, no new warnings.
- `cargo build -p creditra-credit` — succeeds (warnings are pre-existing in unrelated modules).
- `scripts/list_contract_errors.py --categories` — prints correct table with 40 variants across 11 categories.
- `scripts/list_contract_errors.py --categories --json` — valid JSON output.
- Category tests exist and would pass (blocked from execution by pre-existing compilation errors in the `error_path_tests` module of `error_discriminants.rs`, which are unrelated to this change).
