### PR TITLE
feat(credit): add protocol-level close_factor_bps cap for partial liquidation

### DIFF
--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -403,6 +403,13 @@ pub fn publish_contract_upgraded_event(env: &Env, event: ContractUpgradedEvent) 
     );
 }
 
+pub fn publish_close_factor_bps_set_event(env: &Env, close_factor_bps: u32) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "clsfctr")),
+        close_factor_bps,
+    );
+}
+
 pub fn publish_oracle_config_set_event(env: &Env, max_deviation_bps: u32, max_age_seconds: u64) {
     env.events().publish(
         (symbol_short!("credit"), Symbol::new(env, "orc_cfg")),

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -117,12 +117,12 @@ mod risk_formula_tests;
 use crate::auth::require_admin_auth;
 use crate::events::{
     publish_admin_rotation_accepted, publish_admin_rotation_proposed,
-    publish_borrower_blocked_event, publish_contract_upgraded_event, publish_credit_line_event,
-    publish_draw_reversed_event, publish_drawn_event, publish_interest_accrued_event,
-    publish_oracle_config_set_event, publish_oracle_price_accepted_event,
-    publish_rate_formula_config_event, publish_repayment_event, publish_token_rescued_event,
-    ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent, InterestAccruedEvent,
-    RepaymentEvent,
+    publish_borrower_blocked_event, publish_close_factor_bps_set_event,
+    publish_contract_upgraded_event, publish_credit_line_event, publish_draw_reversed_event,
+    publish_drawn_event, publish_interest_accrued_event, publish_oracle_config_set_event,
+    publish_oracle_price_accepted_event, publish_rate_formula_config_event,
+    publish_repayment_event, publish_token_rescued_event, ContractUpgradedEvent, CreditLineEvent,
+    DrawReversedEvent, DrawnEvent, InterestAccruedEvent, RepaymentEvent,
 };
 use crate::math_utils::{compute_deviation_bps, mul_div, Rounding};
 use crate::storage::{
@@ -1259,6 +1259,40 @@ impl Credit {
     /// Return the configured auction contract address, if set.
     pub fn get_auction_contract(env: Env) -> Option<Address> {
         crate::storage::get_auction_contract(&env)
+    }
+
+    // ── Close factor (partial liquidation cap) ────────────────────────────────
+
+    /// Set the protocol-level max close factor in basis points (admin only).
+    ///
+    /// This caps the `close_factor_bps` parameter accepted by
+    /// `settle_default_liquidation`. When set to e.g. `5_000`, no single
+    /// settlement can recover more than 50% of the outstanding debt, even
+    /// if the caller supplies a higher value. Defaults to `10_000` (full
+    /// liquidation) when never configured.
+    ///
+    /// # Validation
+    /// - `close_factor_bps` must be in `1..=10_000`.
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Events
+    /// Emits a `clsfctr` event with the new value.
+    pub fn set_close_factor_bps(env: Env, close_factor_bps: u32) {
+        require_admin_auth(&env);
+        if close_factor_bps == 0 || close_factor_bps > 10_000 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        crate::storage::set_close_factor_bps(&env, close_factor_bps);
+        publish_close_factor_bps_set_event(&env, close_factor_bps);
+    }
+
+    /// Return the current protocol-level max close factor in basis points.
+    ///
+    /// Returns `10_000` if never configured by the admin.
+    pub fn get_close_factor_bps(env: Env) -> u32 {
+        crate::storage::get_close_factor_bps(&env)
     }
 
     // ── Oracle circuit-breaker admin ──────────────────────────────────────────

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -703,6 +703,11 @@ pub fn settle_default_liquidation(
         env.panic_with_error(ContractError::InvalidAmount);
     }
 
+    let max_close_factor = crate::storage::get_close_factor_bps(&env);
+    if close_factor_bps > max_close_factor {
+        env.panic_with_error(ContractError::CloseFactorAboveMax);
+    }
+
     let settlement_key = liquidation_settlement_key(&borrower, &settlement_id);
     if env.storage().persistent().has(&settlement_key) {
         env.panic_with_error(ContractError::AlreadyInitialized);

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -126,9 +126,9 @@ pub fn get_health_factor(env: Env, borrower: Address) -> u32 {
     let min_ratio_bps = crate::storage::get_min_collateral_ratio_bps(&env).unwrap_or(15_000);
 
     // Convert to u128 for overflow-safe multiplication.
-    let collateral_u128 = u128::from(collateral.max(0));
-    let utilized_u128 = u128::from(utilized.max(0));
-    let min_ratio_u128 = u128::from(min_ratio_bps);
+    let collateral_u128 = collateral.max(0) as u128;
+    let utilized_u128 = utilized.max(0) as u128;
+    let min_ratio_u128 = min_ratio_bps as u128;
 
     // health_bps = collateral * 100_000_000 / (utilized * min_ratio)
     //

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -162,6 +162,11 @@ pub enum DataKey {
     OracleLastPriceTs,
     /// Global sum of every borrower's collateral balance.
     TotalCollateral,
+    /// Max close factor in basis points for default-liquidation settlement.
+    /// When set, `settle_default_liquidation` caps the caller-supplied
+    /// `close_factor_bps` to this value. Defaults to 10_000 (full recovery)
+    /// when absent.
+    CloseFactorBps,
 }
 
 /// Maximum number of credit lines returned per page.
@@ -655,6 +660,26 @@ pub fn set_auction_contract(env: &Env, addr: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::AuctionContract, addr);
+}
+
+// ── Close factor (partial liquidation cap) ─────────────────────────────────────
+
+/// Return the protocol-level max close factor in basis points.
+/// Defaults to 10_000 (full liquidation allowed) when not set.
+pub fn get_close_factor_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CloseFactorBps)
+        .unwrap_or(10_000)
+}
+
+/// Set the protocol-level max close factor in basis points (admin only).
+/// Supply `10_000` for full-liquidation-only (no partial), or any value
+/// `1..=10_000` to cap partial settlements.
+pub fn set_close_factor_bps(env: &Env, bps: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CloseFactorBps, &bps);
 }
 
 /// Return the installment schedule for a borrower, if configured.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -214,6 +214,8 @@ pub enum ContractError {
     OraclePriceDeviation = 38,
     /// Borrower's collateral balance is below the requested withdrawal amount.
     InsufficientCollateralBalance = 39,
+    /// The supplied close_factor_bps exceeds the protocol-configured maximum.
+    CloseFactorAboveMax = 40,
 }
 
 /// Stored credit line data for a borrower.

--- a/contracts/credit/tests/close_factor_bps.rs
+++ b/contracts/credit/tests/close_factor_bps.rs
@@ -1,0 +1,241 @@
+use creditra_credit::types::CreditStatus;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{token, Address, Env, Symbol, TryFromVal};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+fn setup_defaulted_line(utilized_amount: i128) -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+    client.set_liquidity_token(&token_address);
+    token::StellarAssetClient::new(&env, &token_address).mint(&contract_id, &1_000_000_i128);
+    token::StellarAssetClient::new(&env, &token_address).mint(&borrower, &1_000_000_i128);
+    token::Client::new(&env, &token_address).approve(
+        &borrower,
+        &contract_id,
+        &1_000_000_i128,
+        &1_000_000_u32,
+    );
+
+    client.open_credit_line(&borrower, &10_000, &300_u32, &60_u32);
+
+    if utilized_amount > 0 {
+        // Deposit ample collateral (3x utilized) to satisfy min ratio of 150%
+        client.deposit_collateral(&borrower, &(utilized_amount.saturating_mul(3).max(1)));
+        client.draw_credit(&borrower, &utilized_amount);
+    }
+
+    client.default_credit_line(&borrower);
+
+    (env, contract_id, borrower)
+}
+
+fn has_event_topic(env: &Env, event_kind: &str) -> bool {
+    let namespace = Symbol::new(env, "credit");
+    let kind = Symbol::new(env, event_kind);
+
+    for (_contract, topics, _data) in env.events().all().iter() {
+        let t0: Symbol = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
+        let t1: Symbol = Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap();
+        if t0 == namespace && t1 == kind {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[test]
+fn default_close_factor_is_10k() {
+    let (env, contract_id, _borrower) = setup_defaulted_line(500);
+    let client = CreditClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_close_factor_bps(), 10_000);
+}
+
+#[test]
+fn set_close_factor_bps_stores_value() {
+    let (env, contract_id, _borrower) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&5_000_u32);
+
+    assert_eq!(client.get_close_factor_bps(), 5_000);
+}
+
+#[test]
+fn set_close_factor_bps_updates_value() {
+    let (env, contract_id, _borrower) = setup_defaulted_line(0);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&2_500_u32);
+    assert_eq!(client.get_close_factor_bps(), 2_500);
+
+    client.set_close_factor_bps(&7_500_u32);
+    assert_eq!(client.get_close_factor_bps(), 7_500);
+}
+
+#[test]
+fn settle_within_capped_close_factor_succeeds() {
+    let (env, contract_id, borrower) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&5_000_u32);
+
+    client.settle_default_liquidation(
+        &borrower,
+        &300_i128,
+        &Symbol::new(&env, "s1"),
+        &5_000_u32,
+        &None,
+    );
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Defaulted);
+    assert_eq!(line.utilized_amount, 700);
+}
+
+#[test]
+fn settle_exceeding_capped_close_factor_fails() {
+    let (env, contract_id, borrower) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&5_000_u32);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.settle_default_liquidation(
+            &borrower,
+            &300_i128,
+            &Symbol::new(&env, "s1"),
+            &6_000_u32,
+            &None,
+        );
+    }));
+    assert!(result.is_err(), "settlement with over-cap close_factor should panic");
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Defaulted);
+    assert_eq!(line.utilized_amount, 1_000);
+}
+
+#[test]
+fn full_close_factor_default_10k_allows_full_settlement() {
+    let (env, contract_id, borrower) = setup_defaulted_line(450);
+    let client = CreditClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_close_factor_bps(), 10_000);
+
+    client.settle_default_liquidation(
+        &borrower,
+        &450_i128,
+        &Symbol::new(&env, "s_full"),
+        &10_000_u32,
+        &None,
+    );
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.status, CreditStatus::Closed);
+    assert_eq!(line.utilized_amount, 0);
+}
+
+#[test]
+fn capped_at_50_percent_enforced_across_settlements() {
+    let (env, contract_id, borrower) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&5_000_u32);
+
+    // First settlement at exactly 50% — allowed
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &Symbol::new(&env, "s1"),
+        &5_000_u32,
+        &None,
+    );
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 500);
+
+    // Second settlement also at 50% of remaining — allowed
+    client.settle_default_liquidation(
+        &borrower,
+        &250_i128,
+        &Symbol::new(&env, "s2"),
+        &5_000_u32,
+        &None,
+    );
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 250);
+}
+
+#[test]
+fn set_close_factor_bps_to_1_allows_minimal_settlement() {
+    let (env, contract_id, borrower) = setup_defaulted_line(10_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&1_u32);
+
+    // 1 bps of 10000 = 1, so recovering 1 is within target
+    client.settle_default_liquidation(
+        &borrower,
+        &1_i128,
+        &Symbol::new(&env, "s_tiny"),
+        &1_u32,
+        &None,
+    );
+
+    let line = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(line.utilized_amount, 9_999);
+}
+
+#[test]
+fn set_close_factor_bps_to_0_panics() {
+    let (env, contract_id, _borrower) = setup_defaulted_line(0);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_close_factor_bps(&0_u32);
+    }));
+    assert!(result.is_err(), "close_factor_bps of 0 should panic");
+}
+
+#[test]
+fn set_close_factor_bps_above_10k_panics() {
+    let (env, contract_id, _borrower) = setup_defaulted_line(0);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_close_factor_bps(&10_001_u32);
+    }));
+    assert!(result.is_err(), "close_factor_bps > 10000 should panic");
+}
+
+#[test]
+fn capped_settlement_still_emits_liquidation_event() {
+    let (env, contract_id, borrower) = setup_defaulted_line(1_000);
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_close_factor_bps(&3_000_u32);
+
+    client.settle_default_liquidation(
+        &borrower,
+        &200_i128,
+        &Symbol::new(&env, "s_evt"),
+        &3_000_u32,
+        &None,
+    );
+
+    assert!(has_event_topic(&env, "liq_setl"));
+}


### PR DESCRIPTION
Closes #652

Add a new admin-configurable `CloseFactorBps` storage value that limits the maximum `close_factor_bps` accepted by `settle_default_liquidation`. When the caller-supplied value exceeds the stored cap, the call fails with `ContractError::CloseFactorAboveMax` (discriminant 40).

### Changes
- Add `CloseFactorBps` variant to `DataKey` enum (storage.rs)
- Add `get_close_factor_bps` / `set_close_factor_bps` storage helpers
- Add `ContractError::CloseFactorAboveMax` error variant (types.rs)
- Add `publish_close_factor_bps_set_event` event publisher (events.rs)
- Add `set_close_factor_bps` / `get_close_factor_bps` entrypoints (lib.rs)
- Add cap enforcement in lifecycle.rs settle_default_liquidation
- Fix pre-existing query.rs compilation error (i128→u128 cast)
- Add 11 focused tests in tests/close_factor_bps.rs

### API
- `set_close_factor_bps(close_factor_bps: u32)` — admin-only, emits `clsfctr` event
- `get_close_factor_bps() -> u32` — returns stored value or 10_000 default

### Testing
All 11 new tests pass. Cargo check and clippy clean.