### PR TITLE
feat(credit): escape-hatch admin pause with structured reason (#650)

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -124,7 +124,7 @@ use crate::events::{
     publish_borrower_blocked_event, publish_borrower_frozen_event, publish_contract_upgraded_event,
     publish_credit_line_event, publish_draw_reversed_event, publish_drawn_event,
     publish_interest_accrued_event, publish_oracle_config_set_event,
-    publish_oracle_price_accepted_event, publish_rate_formula_config_event,
+    publish_oracle_price_accepted_event, publish_paused_event, publish_rate_formula_config_event,
     publish_repayment_event, publish_token_rescued_event, ContractUpgradedEvent, CreditLineEvent,
     DrawReversedEvent, DrawnEvent, InterestAccruedEvent, RepaymentEvent,
 };
@@ -1566,6 +1566,78 @@ impl Credit {
                 accounting_only: true,
             },
         );
+    }
+
+    /// Emergency pause the protocol (admin only).
+    ///
+    /// When paused, all mutating entrypoints except `repay_credit` are blocked
+    /// with [`ContractError::Paused`] (code 18). Repayments are always allowed
+    /// so borrowers can deleverage even during an emergency.
+    ///
+    /// # Parameters
+    /// - `paused`: `true` to pause, `false` to unpause.
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Events
+    /// Emits `("credit", "paused")` with `true` or `("credit", "unpaused")` with `false`.
+    pub fn set_protocol_paused(env: Env, paused: bool) {
+        require_admin_auth(&env);
+        crate::storage::set_paused(&env, paused);
+        publish_paused_event(&env, paused);
+    }
+
+    /// Query whether the protocol is currently paused.
+    ///
+    /// No auth required — pure read.
+    pub fn is_protocol_paused(env: Env) -> bool {
+        crate::storage::is_paused(&env)
+    }
+
+    /// Get the structured pause reason, if one was recorded during the last pause.
+    ///
+    /// Returns `None` before any pause or when the admin used the reason-less
+    /// `set_protocol_paused(bool)`. The reason is cleared on unpause.
+    ///
+    /// No auth required — pure read.
+    pub fn get_protocol_pause_reason(env: Env) -> Option<crate::types::PauseReason> {
+        crate::storage::get_pause_reason(&env)
+    }
+
+    /// Emergency pause the protocol with a structured reason (admin only).
+    ///
+    /// Same as `set_protocol_paused` but records a human-readable reason for
+    /// governance transparency and off-chain monitoring. The reason is stored
+    /// alongside the pause flag and cleared on unpause.
+    ///
+    /// # Parameters
+    /// - `paused`: `true` to pause, `false` to unpause.
+    /// - `reason`: A human-readable reason symbol (e.g., "oracle-outage").
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Events
+    /// Emits `("credit", "paused")` or `("credit", "unpaused")`.
+    pub fn set_protocol_paused_with_reason(
+        env: Env,
+        paused: bool,
+        reason: soroban_sdk::Symbol,
+    ) {
+        let admin = require_admin_auth(&env);
+
+        if paused {
+            let pause_reason = crate::types::PauseReason {
+                reason,
+                timestamp: env.ledger().timestamp(),
+                actor: admin,
+            };
+            crate::storage::set_pause_reason(&env, &pause_reason);
+        }
+
+        crate::storage::set_paused(&env, paused);
+        publish_paused_event(&env, paused);
     }
 
     pub fn freeze_draws(env: Env) {

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -171,6 +171,9 @@ pub enum DataKey {
     OracleLastPriceTs,
     /// Global sum of every borrower's collateral balance.
     TotalCollateral,
+    /// Structured reason for the most recent protocol pause (escape-hatch audit trail).
+    /// Stored when admin invokes pause with a reason; cleared on unpause.
+    PauseReason,
 }
 
 /// Maximum number of credit lines returned per page.
@@ -795,6 +798,28 @@ pub fn is_paused(env: &Env) -> bool {
 /// - **TTL Note**: Shares instance TTL — extend alongside other instance keys.
 pub fn set_paused(env: &Env, paused: bool) {
     env.storage().instance().set(&paused_key(env), &paused);
+    if !paused {
+        // Clear the pause reason when unpausing.
+        env.storage().instance().remove(&DataKey::PauseReason);
+    }
+}
+
+/// Get the structured pause reason, if one was recorded during the last pause.
+///
+/// Returns `None` when no pause reason was set (e.g., before any pause or
+/// if the admin used the reason-less `set_protocol_paused(bool)`).
+pub fn get_pause_reason(env: &Env) -> Option<crate::types::PauseReason> {
+    env.storage().instance().get(&DataKey::PauseReason)
+}
+
+/// Store a structured pause reason alongside the pause flag.
+///
+/// Should be called by the entrypoint that sets the pause flag, so the reason
+/// and the flag are written atomically within the same host transaction.
+pub fn set_pause_reason(env: &Env, reason: &crate::types::PauseReason) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PauseReason, reason);
 }
 
 /// Assert the protocol is not paused. Reverts with ContractError::Paused if paused.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -398,3 +398,20 @@ pub struct ProtocolSummaryView {
     /// Count of currently Active credit lines.
     pub active_line_count: u32,
 }
+
+/// Reason for protocol pause (escape-hatch audit trail).
+///
+/// Stored alongside the pause flag in instance storage when the admin invokes
+/// `set_protocol_paused`. Intended for governance transparency and off-chain
+/// monitoring — the reason is a human-readable symbol that indexers and
+/// dashboards can display to explain why the protocol is paused.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseReason {
+    /// Human-readable reason for pausing (e.g., "oracle-outage", "token-migration").
+    pub reason: soroban_sdk::Symbol,
+    /// Ledger timestamp when the pause was activated.
+    pub timestamp: u64,
+    /// Admin address that invoked the pause.
+    pub actor: soroban_sdk::Address,
+}

--- a/contracts/credit/tests/circuit_breaker.rs
+++ b/contracts/credit/tests/circuit_breaker.rs
@@ -479,3 +479,93 @@ fn operations_resume_after_unpause() {
     let line = client.get_credit_line(&borrower).unwrap();
     assert_eq!(line.credit_limit, 1_000);
 }
+
+// ── pause with reason (escape-hatch audit trail) ─────────────────────────
+
+#[test]
+fn pause_with_reason_stores_reason() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    assert!(!client.is_protocol_paused());
+
+    let reason = soroban_sdk::Symbol::new(&env, "oracle-outage");
+    client.set_protocol_paused_with_reason(&true, &reason);
+
+    assert!(client.is_protocol_paused());
+
+    let stored = client.get_protocol_pause_reason();
+    assert!(stored.is_some(), "pause reason must be stored");
+    let pause_reason = stored.unwrap();
+    assert_eq!(pause_reason.reason, reason);
+}
+
+#[test]
+fn pause_with_reason_unpause_clears_reason() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let reason = soroban_sdk::Symbol::new(&env, "token-migration");
+    client.set_protocol_paused_with_reason(&true, &reason);
+    assert!(client.get_protocol_pause_reason().is_some());
+
+    // Unpause — reason should be cleared
+    client.set_protocol_paused_with_reason(&false, &reason);
+    assert!(!client.is_protocol_paused());
+    assert!(client.get_protocol_pause_reason().is_none(), "reason must be cleared on unpause");
+}
+
+#[test]
+fn pause_without_reason_has_no_stored_reason() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Use the reason-less pause
+    client.set_protocol_paused(&true);
+    assert!(client.is_protocol_paused());
+
+    // No reason should be stored
+    let stored = client.get_protocol_pause_reason();
+    assert!(stored.is_none(), "reason-less pause must not store a reason");
+}
+
+#[test]
+fn pause_with_reason_records_timestamp_and_actor() {
+    let (env, admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let reason = soroban_sdk::Symbol::new(&env, "maintenance");
+    client.set_protocol_paused_with_reason(&true, &reason);
+
+    let stored = client.get_protocol_pause_reason().unwrap();
+    assert!(stored.timestamp > 0, "timestamp must be recorded");
+    assert_eq!(stored.actor, admin, "actor must be the admin");
+}
+
+#[test]
+fn get_protocol_pause_reason_works_when_paused() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    // No reason before pause
+    assert!(client.get_protocol_pause_reason().is_none());
+
+    let reason = soroban_sdk::Symbol::new(&env, "emergency");
+    client.set_protocol_paused_with_reason(&true, &reason);
+
+    // Reason available after pause-with-reason
+    assert!(client.get_protocol_pause_reason().is_some());
+}
+
+#[test]
+#[should_panic]
+fn pause_with_reason_requires_admin() {
+    let (env, _admin, contract_id) = setup();
+    env.mock_all_auths_allowing_non_root_auth();
+    let non_admin = Address::generate(&env);
+    let client = CreditClient::new(&env, &contract_id);
+
+    non_admin.require_auth();
+    let reason = soroban_sdk::Symbol::new(&env, "bad-actor");
+    client.set_protocol_paused_with_reason(&true, &reason);
+}

--- a/contracts/credit/tests/unauthorized_matrix.rs
+++ b/contracts/credit/tests/unauthorized_matrix.rs
@@ -346,6 +346,15 @@ fn set_protocol_paused_unauthorized() {
     client.set_protocol_paused(&true);
 }
 
+#[test]
+#[should_panic]
+fn set_protocol_paused_with_reason_unauthorized() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let reason = soroban_sdk::Symbol::new(&env, "test");
+    client.set_protocol_paused_with_reason(&true, &reason);
+}
+
 // ── Borrower role-gated functions: wrong signer ─────────────────────────────
 
 #[test]
@@ -721,6 +730,15 @@ fn set_protocol_paused_unauthorized() {
     let env = Env::default();
     let (client, _, _, _) = setup(&env);
     client.set_protocol_paused(&true);
+}
+
+#[test]
+#[should_panic]
+fn set_protocol_paused_with_reason_unauthorized() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let reason = soroban_sdk::Symbol::new(&env, "test");
+    client.set_protocol_paused_with_reason(&true, &reason);
 }
 
 // ── Borrower role-gated functions: wrong signer ─────────────────────────────


### PR DESCRIPTION
## Summary

Adds escape-hatch admin pause functionality with a structured reason field for governance transparency and off-chain monitoring.

### Changes
- **`types.rs`**: Added `PauseReason` struct (reason, timestamp, actor)
- **`storage.rs`**: Added `DataKey::PauseReason`, `get_pause_reason`/`set_pause_reason` helpers, modified `set_paused` to clear reason on unpause
- **`lib.rs`**: Added entrypoints:
  - `set_protocol_paused(env, paused)` — admin-only pause/unpause
  - `is_protocol_paused(env)` — read-only query
  - `get_protocol_pause_reason(env)` — view the stored pause reason
  - `set_protocol_paused_with_reason(env, paused, reason)` — pause with structured audit trail
- **`circuit_breaker.rs`**: Added 5 tests for pause-with-reason
- **`unauthorized_matrix.rs`**: Added unauthorized test for new entrypoint

Closes #650