### PR TITLE
feat(credit): replace remaining panic! calls with ContractError in production paths (#640)

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -512,7 +512,7 @@ impl Credit {
             });
             if updated_utilized > cap_amount {
                 clear_reentrancy_guard(&env);
-                panic!("exceeds utilization cap");
+                env.panic_with_error(ContractError::OverLimit);
             }
         }
 
@@ -1417,10 +1417,7 @@ impl Credit {
         admin.require_auth();
         require_admin_auth(&env);
         if borrowers.len() > BULK_BLOCK_MAX {
-            panic!(
-                "bulk_block_borrowers: exceeds max batch size of {}",
-                BULK_BLOCK_MAX
-            );
+            env.panic_with_error(ContractError::InvalidAmount);
         }
         for borrower in borrowers.iter() {
             storage_set_borrower_blocked(&env, &borrower, true);
@@ -1437,10 +1434,7 @@ impl Credit {
     pub fn accrue_batch(env: Env, borrowers: Vec<Address>) {
         assert_not_paused(&env);
         if borrowers.len() as u32 > ACCRUE_BATCH_MAX {
-            panic!(
-                "accrue_batch: exceeds max batch size of {}",
-                ACCRUE_BATCH_MAX
-            );
+            env.panic_with_error(ContractError::InvalidAmount);
         }
 
         accrual::accrue_batch(&env, borrowers);
@@ -1516,7 +1510,7 @@ impl Credit {
 
         let now = env.ledger().timestamp();
         if now.saturating_sub(original_ts) > DRAW_REVERSAL_WINDOW_SECS {
-            panic!("draw reversal window expired");
+            env.panic_with_error(ContractError::DrawReversalWindowExpired);
         }
 
         let mut credit_line: CreditLineData = env
@@ -1530,7 +1524,7 @@ impl Credit {
             .storage()
             .persistent()
             .get(&DataKey::DrawAudit(borrower.clone(), original_ts))
-            .unwrap_or_else(|| panic!("original draw not found for borrower"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::OriginalDrawNotFound));
         let already_reversed: i128 = env
             .storage()
             .persistent()
@@ -1538,13 +1532,13 @@ impl Credit {
             .unwrap_or(0);
         let remaining_reversible = original_draw.saturating_sub(already_reversed);
         if amount > remaining_reversible {
-            panic!("reversal amount exceeds original draw");
+            env.panic_with_error(ContractError::OverLimit);
         }
 
         let new_utilized_amount = credit_line
             .utilized_amount
             .checked_sub(amount)
-            .unwrap_or_else(|| panic!("reversal exceeds outstanding utilization"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::OverLimit));
 
         credit_line.utilized_amount = new_utilized_amount;
         env.storage().persistent().set(&borrower, &credit_line);

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -545,11 +545,11 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
     } else if closer == borrower {
         // Borrower self-close: only allowed when fully repaid.
         if credit_line.utilized_amount != 0 {
-            panic!("cannot close: utilized amount not zero");
+            env.panic_with_error(ContractError::UtilizationNotZero);
         }
     } else {
         // Third party: unconditionally rejected.
-        panic!("unauthorized");
+        env.panic_with_error(ContractError::Unauthorized);
     }
 
     let previous_status = credit_line.status;

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -133,6 +133,8 @@ pub enum CreditStatus {
 /// | 38   | `OraclePriceDeviation`        | Oracle price deviation exceeds the configured maximum |
 /// | 39   | `InsufficientCollateralBalance` | Borrower collateral balance cannot cover withdrawal |
 /// | 40   | `BorrowerFrozen`               | Borrower's draws are temporarily frozen until expiry |
+/// | 41   | `DrawReversalWindowExpired`     | Draw reversal window has expired |
+/// | 42   | `OriginalDrawNotFound`           | Original draw record not found for borrower |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -217,6 +219,10 @@ pub enum ContractError {
     InsufficientCollateralBalance = 39,
     /// Borrower's draws are temporarily frozen until the specified expiry timestamp.
     BorrowerFrozen = 40,
+    /// Draw reversal window has expired (admin must reverse within DRAW_REVERSAL_WINDOW_SECS).
+    DrawReversalWindowExpired = 41,
+    /// Original draw audit record not found for the specified (borrower, timestamp) pair.
+    OriginalDrawNotFound = 42,
 }
 
 /// Stored credit line data for a borrower.

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -55,6 +55,8 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::OraclePriceDeviation as u32, 38);
     assert_eq!(ContractError::InsufficientCollateralBalance as u32, 39);
     assert_eq!(ContractError::BorrowerFrozen as u32, 40);
+    assert_eq!(ContractError::DrawReversalWindowExpired as u32, 41);
+    assert_eq!(ContractError::OriginalDrawNotFound as u32, 42);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -105,6 +107,8 @@ fn no_duplicate_discriminants() {
         ContractError::OraclePriceDeviation as u32,
         ContractError::InsufficientCollateralBalance as u32,
         ContractError::BorrowerFrozen as u32,
+        ContractError::DrawReversalWindowExpired as u32,
+        ContractError::OriginalDrawNotFound as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -120,7 +124,7 @@ fn no_duplicate_discriminants() {
 #[test]
 fn variant_count_is_known() {
     // 40 variants as of this writing. Update when adding new ones.
-    const EXPECTED_VARIANT_COUNT: usize = 40;
+    const EXPECTED_VARIANT_COUNT: usize = 42;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -163,6 +167,8 @@ fn variant_count_is_known() {
         ContractError::OraclePriceDeviation as u32,
         ContractError::InsufficientCollateralBalance as u32,
         ContractError::BorrowerFrozen as u32,
+        ContractError::DrawReversalWindowExpired as u32,
+        ContractError::OriginalDrawNotFound as u32,
     ];
 
     assert_eq!(


### PR DESCRIPTION
## Summary

Replaces all remaining `panic!` calls in production paths with proper `ContractError` returns.

### Changes
- **`types.rs`**: Added `DrawReversalWindowExpired = 41` and `OriginalDrawNotFound = 42` to `ContractError`
- **`lib.rs`**: Replaced 7 `panic!` calls with `env.panic_with_error(ContractError::...)`:
  - Utilization cap exceeded → `OverLimit`
  - Bulk block max batch → `InvalidAmount`
  - Accrue batch max batch → `InvalidAmount`
  - Draw reversal window expired → `DrawReversalWindowExpired`
  - Original draw not found → `OriginalDrawNotFound`
  - Reversal exceeds original draw → `OverLimit`
  - Reversal exceeds utilization → `OverLimit`
- **`lifecycle.rs`**: Replaced 2 `panic!` calls:
  - Cannot close non-zero utilization → `UtilizationNotZero`
  - Unauthorized closer → `Unauthorized`
- **`error_discriminants.rs`**: Updated all assert arrays and variant count to 42

Closes #640