### PR TITLE
fix: collateral release missing-entry

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -5547,7 +5547,7 @@ mod test_mock_liquidity_token {
             let env = Env::default();
             let (client, _admin, _borrower, _token) = setup_with_token(&env);
 
-        client.set_max_repay_amount(&0_i128);
+            client.set_max_repay_amount(&0_i128);
         }
     }
 
@@ -5555,9 +5555,9 @@ mod test_mock_liquidity_token {
     #[cfg(test)]
     mod test_health_factor {
         use super::*;
+        use crate::collateral;
         use soroban_sdk::testutils::Address as _;
         use soroban_sdk::token::StellarAssetClient;
-        use crate::collateral;
 
         /// Setup: contract + admin + borrower + token (used for both liquidity
         /// and collateral — the contract shares one token).  `reserve` tokens
@@ -5689,10 +5689,7 @@ mod test_mock_liquidity_token {
 
             assert_eq!(hf_again, hf_before);
             assert_eq!(line_before.utilized_amount, line_after.utilized_amount);
-            assert_eq!(
-                line_before.accrued_interest,
-                line_after.accrued_interest
-            );
+            assert_eq!(line_before.accrued_interest, line_after.accrued_interest);
             assert_eq!(collateral_before, collateral_after);
         }
 

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -126,9 +126,9 @@ pub fn get_health_factor(env: Env, borrower: Address) -> u32 {
     let min_ratio_bps = crate::storage::get_min_collateral_ratio_bps(&env).unwrap_or(15_000);
 
     // Convert to u128 for overflow-safe multiplication.
-    let collateral_u128 = u128::from(collateral.max(0));
-    let utilized_u128 = u128::from(utilized.max(0));
-    let min_ratio_u128 = u128::from(min_ratio_bps);
+    let collateral_u128 = collateral.max(0) as u128;
+    let utilized_u128 = utilized.max(0) as u128;
+    let min_ratio_u128 = min_ratio_bps as u128;
 
     // health_bps = collateral * 100_000_000 / (utilized * min_ratio)
     //
@@ -142,7 +142,9 @@ pub fn get_health_factor(env: Env, borrower: Address) -> u32 {
         .checked_mul(100_000_000)
         .unwrap_or(u128::MAX);
 
-    let denominator = utilized_u128.checked_mul(min_ratio_u128).unwrap_or(u128::MAX);
+    let denominator = utilized_u128
+        .checked_mul(min_ratio_u128)
+        .unwrap_or(u128::MAX);
 
     // If the denominator overflowed to u128::MAX, the result will be small.
     // We guard against division-by-zero: `utilized > 0` and `min_ratio_bps`

--- a/contracts/credit/tests/collateral.rs
+++ b/contracts/credit/tests/collateral.rs
@@ -76,3 +76,47 @@ fn test_draw_credit_succeeds_with_sufficient_collateral() {
     client.draw_credit(&borrower, &1000);
     assert_eq!(client.get_collateral(&borrower), 1500);
 }
+
+#[test]
+fn test_withdraw_with_open_credit_line_zero_utilized() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10000, &0, &0);
+    client.deposit_collateral(&borrower, &5000);
+    assert_eq!(client.get_collateral(&borrower), 5000);
+
+    // Credit line exists but utilized_amount = 0 → no ratio check → can withdraw all.
+    client.withdraw_collateral(&borrower, &5000);
+    assert_eq!(client.get_collateral(&borrower), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")] // MissingLiquidityToken
+fn test_deposit_without_collateral_token_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    // No liquidity token set → deposit should fail with MissingLiquidityToken.
+    client.deposit_collateral(&borrower, &1000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")] // MissingLiquidityToken
+fn test_withdraw_without_collateral_token_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    // No liquidity token set → withdraw should fail with MissingLiquidityToken.
+    client.withdraw_collateral(&borrower, &1000);
+}

--- a/contracts/credit/tests/conservation_cross_contract.rs
+++ b/contracts/credit/tests/conservation_cross_contract.rs
@@ -145,7 +145,13 @@ fn run_conservation_test(env: &Env, draw_amount: i128, highest_bid: i128) {
     assert_eq!(auction_state.highest_bid, highest_bid);
 
     // Settle default liquidation (credit contract calls auction contract)
-    credit.settle_default_liquidation(&deployment.borrower, &highest_bid, &settlement_id, &10_000_u32, &None);
+    credit.settle_default_liquidation(
+        &deployment.borrower,
+        &highest_bid,
+        &settlement_id,
+        &10_000_u32,
+        &None,
+    );
 
     // Check conservation
     let post_line = credit.get_credit_line(&deployment.borrower).unwrap();

--- a/contracts/credit/tests/default_liquidation_auction_hook.rs
+++ b/contracts/credit/tests/default_liquidation_auction_hook.rs
@@ -106,7 +106,13 @@ fn settle_full_default_liquidation_closes_credit_line() {
     let (env, contract_id, borrower) = setup_defaulted_line(450);
     let client = CreditClient::new(&env, &contract_id);
 
-    client.settle_default_liquidation(&borrower, &450_i128, &Symbol::new(&env, "auc_fin"), &10_000_u32, &None);
+    client.settle_default_liquidation(
+        &borrower,
+        &450_i128,
+        &Symbol::new(&env, "auc_fin"),
+        &10_000_u32,
+        &None,
+    );
     assert!(has_event_topic(&env, "closed"));
     assert!(has_event_topic(&env, "liq_setl"));
 

--- a/contracts/credit/tests/event_liq_req_payload.rs
+++ b/contracts/credit/tests/event_liq_req_payload.rs
@@ -24,7 +24,7 @@ fn setup_defaulted_line(env: &Env, utilized_amount: i128) -> (Address, Address, 
     let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
     let token_address = token_id.address();
     client.set_liquidity_token(&token_address);
-    
+
     // Mint liquidity tokens to fund credit lines and draws
     token::StellarAssetClient::new(env, &token_address).mint(&contract_id, &1_000_000_i128);
     token::StellarAssetClient::new(env, &token_address).mint(&borrower, &1_000_000_i128);
@@ -71,10 +71,15 @@ fn test_event_liq_req_payload_tuple_pin() {
         }
     }
 
-    let (topics, data) = found_event.expect("Expected a ('credit', 'liq_req') event to be published");
+    let (topics, data) =
+        found_event.expect("Expected a ('credit', 'liq_req') event to be published");
 
     // 1. Assert topic symbols
-    assert_eq!(topics.len(), 2, "Topic list must contain exactly 2 elements");
+    assert_eq!(
+        topics.len(),
+        2,
+        "Topic list must contain exactly 2 elements"
+    );
     assert_eq!(
         Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
         symbol_short!("credit"),

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -185,11 +185,8 @@ pub fn auction_set_status(env: &Env, id: u32, status: crate::types::AuctionStatu
     );
 }
 
-pub fn auction_get_seller(env: &Env, id: u32) -> Address {
-    env.storage()
-        .persistent()
-        .get(&AuctionKey::Seller(id))
-        .unwrap()
+pub fn auction_get_seller(env: &Env, id: u32) -> Option<Address> {
+    env.storage().persistent().get(&AuctionKey::Seller(id))
 }
 
 pub fn auction_set_seller(env: &Env, id: u32, seller: &Address) {
@@ -202,11 +199,8 @@ pub fn auction_set_seller(env: &Env, id: u32, seller: &Address) {
     );
 }
 
-pub fn auction_get_asset(env: &Env, id: u32) -> Address {
-    env.storage()
-        .persistent()
-        .get(&AuctionKey::Asset(id))
-        .unwrap()
+pub fn auction_get_asset(env: &Env, id: u32) -> Option<Address> {
+    env.storage().persistent().get(&AuctionKey::Asset(id))
 }
 
 pub fn auction_set_asset(env: &Env, id: u32, asset: &Address) {


### PR DESCRIPTION
Closes #654

Replaces unsafe `unwrap()` production paths with proper error handling:

- `contracts/credit/src/query.rs`: Fixed `u128::from(i128)` compilation error — `i128` → `u128` is fallible, replaced with safe `as u128` cast (value guaranteed non-negative via `.max(0)`).
- `gateway-contract/contracts/auction_contract/src/storage.rs`: Changed `auction_get_seller` / `auction_get_asset` return type from `Address` to `Option<Address>` so callers must handle the missing-entry case instead of panicking.

New tests in `contracts/credit/tests/collateral.rs`:
- `test_withdraw_with_open_credit_line_zero_utilized` — credit line exists, 0 utilized, ratio check skipped
- `test_deposit_without_collateral_token_fails` — missing token → `MissingLiquidityToken`
- `test_withdraw_without_collateral_token_fails` — missing token → `MissingLiquidityToken`

The `withdraw_collateral` function itself already uses `unwrap_or_else` / `unwrap_or` for all storage reads; no further changes needed there.