### PR TITLE
test: add snapshot fuzz harness for math_utils::prorate_interest (#455)

### DIFF
--- a/contracts/credit/fuzz/Cargo.toml
+++ b/contracts/credit/fuzz/Cargo.toml
@@ -10,6 +10,8 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dependencies.creditra-credit]
 path = "../.."
@@ -20,4 +22,9 @@ path = "../.."
 [[bin]]
 name = "oracle_deviation"
 path = "fuzz_targets/oracle_deviation.rs"
+doc = false
+
+[[bin]]
+name = "prorate_interest_snapshot"
+path = "fuzz_targets/prorate_interest_snapshot.rs"
 doc = false

--- a/contracts/credit/fuzz/fuzz_targets/prorate_interest_snapshot.rs
+++ b/contracts/credit/fuzz/fuzz_targets/prorate_interest_snapshot.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+
+//! # Fuzz target: `prorate_interest` snapshot verifier
+//!
+//! This target loads the pinned deterministic snapshot
+//! `contracts/credit/test_snapshots/prorate_interest.json` and re-executes
+//! [`creditra_credit::math_utils::prorate_interest`] for every recorded
+//! `(principal, rate_bps, seconds)` triple, asserting that the live
+//! implementation produces the same floor-rounded output that was captured
+//! when the snapshot was generated.
+//!
+//! ## Purpose
+//!
+//! `prorate_interest` is the single rounding-floor primitive hit by every
+//! interest accrual in the protocol. Any change to its rounding direction,
+//! overflow handling, or constant values (`BPS_YEAR_DENOM`, `SECONDS_PER_YEAR`)
+//! will cause a divergence between the live result and the pinned snapshot,
+//! turning this target red immediately at PR time.
+//!
+//! ## Running modes
+//!
+//! ### Snapshot verification (CI / normal fuzzing)
+//!
+//! ```bash
+//! cargo fuzz run prorate_interest_snapshot -- -max_total_time=60
+//! ```
+//!
+//! libFuzzer will call `fuzz_target!` with arbitrary byte slices; the target
+//! ignores the mutated bytes entirely and instead loads + verifies the pinned
+//! snapshot on **every invocation**. This means any corpus entry triggers a
+//! full 4 096-case regression sweep.
+//!
+//! ### Snapshot regeneration
+//!
+//! See `docs/contributing-tests.md` — "Regenerating the prorate_interest snapshot".
+//! In short:
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snapshot_prorate_interest -- --nocapture regenerate
+//! ```
+//!
+//! ## Properties verified per entry
+//!
+//! 1. **Exact match**: `live_result == snapshot_output` — the primary regression gate.
+//! 2. **Floor ≤ ceil**: `prorate_interest(..., Floor) ≤ prorate_interest(..., Ceil)`.
+//! 3. **Ceil − floor ∈ {0, 1}**: rounding never moves by more than 1 ulp.
+//! 4. **Zero-input short-circuits**: any zero input yields zero output.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use serde::Deserialize;
+
+use creditra_credit::math_utils::{prorate_interest, Rounding};
+
+/// One row in the snapshot JSON array.
+#[derive(Debug, Deserialize)]
+struct SnapshotEntry {
+    /// Outstanding principal (u128, serialised as decimal string to avoid
+    /// JSON number precision loss for values > 2^53).
+    principal: String,
+    /// Annual interest rate in basis points (0 ..= 10_000).
+    rate_bps: u32,
+    /// Elapsed seconds since last accrual (0 ..= u32::MAX, stored as u32 to
+    /// keep the snapshot compact; cast to u64 on use).
+    seconds: u32,
+    /// Expected floor-rounded interest output (u128, decimal string).
+    expected_floor: String,
+}
+
+/// Path to the pinned snapshot, relative to the workspace root.
+///
+/// `cargo fuzz run` is invoked from the workspace root by convention.
+const SNAPSHOT_PATH: &str =
+    "contracts/credit/test_snapshots/prorate_interest.json";
+
+/// Load and verify all 4 096 snapshot entries.
+///
+/// This function is called on every libFuzzer iteration regardless of the
+/// fuzz input (which is intentionally ignored). The snapshot is re-read from
+/// disk each call so that an on-disk edit is caught immediately without
+/// recompiling.
+fn verify_snapshot() {
+    let raw = std::fs::read_to_string(SNAPSHOT_PATH).unwrap_or_else(|e| {
+        panic!(
+            "snapshot not found at '{SNAPSHOT_PATH}': {e}\n\
+             Run `cargo test -p creditra-credit --test snapshot_prorate_interest \
+             -- regenerate` to generate it."
+        )
+    });
+
+    let entries: Vec<SnapshotEntry> =
+        serde_json::from_str(&raw).expect("snapshot JSON is malformed");
+
+    assert_eq!(
+        entries.len(),
+        4096,
+        "snapshot must contain exactly 4 096 entries, found {}",
+        entries.len()
+    );
+
+    for (i, entry) in entries.iter().enumerate() {
+        let principal: u128 = entry
+            .principal
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid principal '{}'", entry.principal));
+        let expected_floor: u128 = entry
+            .expected_floor
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid expected_floor '{}'", entry.expected_floor));
+        let time_delta = entry.seconds as u64;
+
+        // ── Property 1: exact match against pinned output ─────────────────
+        let live_floor = prorate_interest(principal, entry.rate_bps, time_delta, Rounding::Floor);
+        assert_eq!(
+            live_floor,
+            expected_floor,
+            "SNAPSHOT MISMATCH at entry {i}: \
+             principal={principal}, rate_bps={}, seconds={} \
+             → live={live_floor}, pinned={expected_floor}\n\
+             A rounding-direction or constant change has broken the snapshot. \
+             If intentional, regenerate with:\n\
+             cargo test -p creditra-credit --test snapshot_prorate_interest \
+             -- regenerate",
+            entry.rate_bps,
+            entry.seconds,
+        );
+
+        // ── Property 2: zero inputs always yield zero ─────────────────────
+        if principal == 0 || entry.rate_bps == 0 || entry.seconds == 0 {
+            assert_eq!(
+                live_floor, 0,
+                "entry {i}: zero input must yield zero, got {live_floor}"
+            );
+        }
+
+        // ── Property 3: floor ≤ ceil ──────────────────────────────────────
+        let live_ceil = prorate_interest(principal, entry.rate_bps, time_delta, Rounding::Ceil);
+        assert!(
+            live_floor <= live_ceil,
+            "entry {i}: floor ({live_floor}) > ceil ({live_ceil}) — \
+             principal={principal}, rate_bps={}, seconds={}",
+            entry.rate_bps,
+            entry.seconds,
+        );
+
+        // ── Property 4: ceil − floor ∈ {0, 1} ────────────────────────────
+        assert!(
+            live_ceil - live_floor <= 1,
+            "entry {i}: ceil − floor = {} (must be 0 or 1) — \
+             principal={principal}, rate_bps={}, seconds={}",
+            live_ceil - live_floor,
+            entry.rate_bps,
+            entry.seconds,
+        );
+    }
+}
+
+// libFuzzer entry-point.  The fuzz input (`data`) is intentionally unused:
+// this target is a *snapshot verifier*, not a generative fuzzer.  Every
+// corpus byte-string that libFuzzer feeds us triggers the full 4 096-case
+// regression sweep, which is exactly what we want.
+fuzz_target!(|_data: &[u8]| {
+    verify_snapshot();
+});

--- a/contracts/credit/test_snapshots/prorate_interest.json
+++ b/contracts/credit/test_snapshots/prorate_interest.json
@@ -1,0 +1,24578 @@
+[
+  {
+    "principal": "0",
+    "rate_bps": 500,
+    "seconds": 86400,
+    "expected_floor": "0"
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 0,
+    "seconds": 86400,
+    "expected_floor": "0"
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 500,
+    "seconds": 0,
+    "expected_floor": "0"
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 31557600,
+    "expected_floor": "300"
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 15778800,
+    "expected_floor": "150"
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 7889400,
+    "expected_floor": "75"
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 10000,
+    "seconds": 31557600,
+    "expected_floor": "10000"
+  },
+  {
+    "principal": "1",
+    "rate_bps": 1,
+    "seconds": 1,
+    "expected_floor": "0"
+  },
+  {
+    "principal": "1",
+    "rate_bps": 10000,
+    "seconds": 4294967295,
+    "expected_floor": "136"
+  },
+  {
+    "principal": "1000000000000000000000000",
+    "rate_bps": 10000,
+    "seconds": 4294967295,
+    "expected_floor": "136099300802342383451213020"
+  },
+  {
+    "principal": "1000000000000000000000000",
+    "rate_bps": 1,
+    "seconds": 1,
+    "expected_floor": "3168808781402"
+  },
+  {
+    "principal": "315576000000",
+    "rate_bps": 10000,
+    "seconds": 31557600,
+    "expected_floor": "315576000000"
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 86400,
+    "expected_floor": "0"
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 500,
+    "seconds": 3600,
+    "expected_floor": "5"
+  },
+  {
+    "principal": "1000000000",
+    "rate_bps": 9999,
+    "seconds": 1,
+    "expected_floor": "31"
+  },
+  {
+    "principal": "3932864881331306611",
+    "rate_bps": 3222,
+    "seconds": 4025879773,
+    "expected_floor": "161655839062809817182"
+  },
+  {
+    "principal": "17406686476941027112",
+    "rate_bps": 2450,
+    "seconds": 216029338,
+    "expected_floor": "29193822227128963427"
+  },
+  {
+    "principal": "8729481226859936353",
+    "rate_bps": 5273,
+    "seconds": 4047592571,
+    "expected_floor": "590390050164080262195"
+  },
+  {
+    "principal": "2812324859246069742",
+    "rate_bps": 1648,
+    "seconds": 3963239120,
+    "expected_floor": "58206167147422581321"
+  },
+  {
+    "principal": "15418887969471268831",
+    "rate_bps": 2999,
+    "seconds": 2070759977,
+    "expected_floor": "303427762171352308599"
+  },
+  {
+    "principal": "10593103525850702212",
+    "rate_bps": 5643,
+    "seconds": 3683508822,
+    "expected_floor": "697735811993031025875"
+  },
+  {
+    "principal": "1868029699132683373",
+    "rate_bps": 4060,
+    "seconds": 2064092519,
+    "expected_floor": "49606090693314275188"
+  },
+  {
+    "principal": "13393561501526422890",
+    "rate_bps": 7672,
+    "seconds": 3903319212,
+    "expected_floor": "1270968457501081856331"
+  },
+  {
+    "principal": "15939578479623892875",
+    "rate_bps": 6919,
+    "seconds": 3774800309,
+    "expected_floor": "1319198587991833382434"
+  },
+  {
+    "principal": "5130255701394258208",
+    "rate_bps": 1743,
+    "seconds": 248367954,
+    "expected_floor": "7037655297953130511"
+  },
+  {
+    "principal": "14833822937322876089",
+    "rate_bps": 9243,
+    "seconds": 1745151635,
+    "expected_floor": "758220016309705018318"
+  },
+  {
+    "principal": "10813214832954045990",
+    "rate_bps": 1088,
+    "seconds": 3362333640,
+    "expected_floor": "125348911059315492667"
+  },
+  {
+    "principal": "15582930835979567991",
+    "rate_bps": 6316,
+    "seconds": 2760966017,
+    "expected_floor": "861089628885468606693"
+  },
+  {
+    "principal": "12275849669014874620",
+    "rate_bps": 4164,
+    "seconds": 885534606,
+    "expected_floor": "143437878389547195203"
+  },
+  {
+    "principal": "10285941261023399749",
+    "rate_bps": 9595,
+    "seconds": 352072703,
+    "expected_floor": "110107627873782973090"
+  },
+  {
+    "principal": "3758704485819688482",
+    "rate_bps": 4580,
+    "seconds": 1036721188,
+    "expected_floor": "56553783861415373835"
+  },
+  {
+    "principal": "8491529717177208739",
+    "rate_bps": 3790,
+    "seconds": 661524365,
+    "expected_floor": "67463213036764301047"
+  },
+  {
+    "principal": "12231332451418910744",
+    "rate_bps": 8664,
+    "seconds": 2794875658,
+    "expected_floor": "938535573302061100687"
+  },
+  {
+    "principal": "15060361974313666577",
+    "rate_bps": 4148,
+    "seconds": 160596395,
+    "expected_floor": "31791131322625829305"
+  },
+  {
+    "principal": "10734048836294222174",
+    "rate_bps": 8029,
+    "seconds": 2678215104,
+    "expected_floor": "731419462897644754930"
+  },
+  {
+    "principal": "8523527040899358735",
+    "rate_bps": 3428,
+    "seconds": 2723200473,
+    "expected_floor": "252136548395067412135"
+  },
+  {
+    "principal": "6931592101219305332",
+    "rate_bps": 5450,
+    "seconds": 3049200070,
+    "expected_floor": "365015624145559146846"
+  },
+  {
+    "principal": "14794531271497630493",
+    "rate_bps": 5866,
+    "seconds": 3757775767,
+    "expected_floor": "1033404059275926742959"
+  },
+  {
+    "principal": "17315981554347819994",
+    "rate_bps": 802,
+    "seconds": 2162589852,
+    "expected_floor": "95168160827994299825"
+  },
+  {
+    "principal": "12983024007082508475",
+    "rate_bps": 6339,
+    "seconds": 2645554789,
+    "expected_floor": "689936950779825640281"
+  },
+  {
+    "principal": "17705562342132739088",
+    "rate_bps": 9665,
+    "seconds": 2901546946,
+    "expected_floor": "1573393014982236388184"
+  },
+  {
+    "principal": "12683732504212466793",
+    "rate_bps": 7049,
+    "seconds": 1491307971,
+    "expected_floor": "422510938464393768662"
+  },
+  {
+    "principal": "16557677835615611286",
+    "rate_bps": 6795,
+    "seconds": 2710480056,
+    "expected_floor": "966342628852029644623"
+  },
+  {
+    "principal": "5224173530329496999",
+    "rate_bps": 9920,
+    "seconds": 3561678129,
+    "expected_floor": "584897774489653374271"
+  },
+  {
+    "principal": "10269153943226030572",
+    "rate_bps": 4849,
+    "seconds": 2147778814,
+    "expected_floor": "338900676293524719435"
+  },
+  {
+    "principal": "7923414114381475829",
+    "rate_bps": 2817,
+    "seconds": 664773679,
+    "expected_floor": "47018530352530311868"
+  },
+  {
+    "principal": "2987139178619580050",
+    "rate_bps": 7895,
+    "seconds": 883751444,
+    "expected_floor": "66044059754880439096"
+  },
+  {
+    "principal": "8949213225673777875",
+    "rate_bps": 3242,
+    "seconds": 2884957757,
+    "expected_floor": "265236542243585297670"
+  },
+  {
+    "principal": "5296233548957617416",
+    "rate_bps": 7501,
+    "seconds": 1194111354,
+    "expected_floor": "150323595265353796439"
+  },
+  {
+    "principal": "352081044311128513",
+    "rate_bps": 2375,
+    "seconds": 1117088475,
+    "expected_floor": "2959987396242344770"
+  },
+  {
+    "principal": "16047887629255241422",
+    "rate_bps": 1395,
+    "seconds": 3083533488,
+    "expected_floor": "218744319873738510744"
+  },
+  {
+    "principal": "16472134269395876927",
+    "rate_bps": 7720,
+    "seconds": 2963395977,
+    "expected_floor": "1194133532375160867725"
+  },
+  {
+    "principal": "8556856374188179812",
+    "rate_bps": 9815,
+    "seconds": 3783148854,
+    "expected_floor": "1006825042151948639783"
+  },
+  {
+    "principal": "13682101151151781325",
+    "rate_bps": 303,
+    "seconds": 3286838727,
+    "expected_floor": "43178728923910872565"
+  },
+  {
+    "principal": "13061621868491785802",
+    "rate_bps": 5737,
+    "seconds": 3615844492,
+    "expected_floor": "858593772184280151817"
+  },
+  {
+    "principal": "2892542651934201323",
+    "rate_bps": 2647,
+    "seconds": 3182522133,
+    "expected_floor": "77214911573125214648"
+  },
+  {
+    "principal": "10579288836585321216",
+    "rate_bps": 2860,
+    "seconds": 1520834610,
+    "expected_floor": "145814437821429986654"
+  },
+  {
+    "principal": "15050793049539252249",
+    "rate_bps": 3868,
+    "seconds": 2791930099,
+    "expected_floor": "515046479815667749557"
+  },
+  {
+    "principal": "17219627872694653190",
+    "rate_bps": 3514,
+    "seconds": 493369768,
+    "expected_floor": "94600642455105263870"
+  },
+  {
+    "principal": "12477706923289607127",
+    "rate_bps": 4483,
+    "seconds": 3246124769,
+    "expected_floor": "575393247517210025304"
+  },
+  {
+    "principal": "215389785058385372",
+    "rate_bps": 1591,
+    "seconds": 4024845934,
+    "expected_floor": "4370595117126288819"
+  },
+  {
+    "principal": "2121599301839254693",
+    "rate_bps": 6457,
+    "seconds": 3938130015,
+    "expected_floor": "170954380339947306800"
+  },
+  {
+    "principal": "8620702343700998914",
+    "rate_bps": 1058,
+    "seconds": 1661643780,
+    "expected_floor": "48024436400434234139"
+  },
+  {
+    "principal": "75634030383577603",
+    "rate_bps": 6985,
+    "seconds": 1193132269,
+    "expected_floor": "1997414869831459323"
+  },
+  {
+    "principal": "10819349529527647736",
+    "rate_bps": 9607,
+    "seconds": 3495046122,
+    "expected_floor": "1151165819930527708502"
+  },
+  {
+    "principal": "17067271700222332785",
+    "rate_bps": 1244,
+    "seconds": 4039448587,
+    "expected_floor": "271770679622150569289"
+  },
+  {
+    "principal": "16894209987123949630",
+    "rate_bps": 6800,
+    "seconds": 1181432736,
+    "expected_floor": "430082561880483096182"
+  },
+  {
+    "principal": "5966506998155795567",
+    "rate_bps": 2277,
+    "seconds": 847483193,
+    "expected_floor": "36484660725217928384"
+  },
+  {
+    "principal": "4967628927234232148",
+    "rate_bps": 2465,
+    "seconds": 4098516134,
+    "expected_floor": "159033549792369254009"
+  },
+  {
+    "principal": "16653928322426178685",
+    "rate_bps": 7080,
+    "seconds": 291292151,
+    "expected_floor": "108836549400989141586"
+  },
+  {
+    "principal": "5452198948140776634",
+    "rate_bps": 8058,
+    "seconds": 462136444,
+    "expected_floor": "64337652233881099633"
+  },
+  {
+    "principal": "7859339977396121371",
+    "rate_bps": 7717,
+    "seconds": 1521896389,
+    "expected_floor": "292493147235401686929"
+  },
+  {
+    "principal": "3510821419828284912",
+    "rate_bps": 2981,
+    "seconds": 2822294690,
+    "expected_floor": "93598547011798155441"
+  },
+  {
+    "principal": "603181839413270473",
+    "rate_bps": 5641,
+    "seconds": 3291588643,
+    "expected_floor": "35489995572959085264"
+  },
+  {
+    "principal": "3285689024150924406",
+    "rate_bps": 1461,
+    "seconds": 390914712,
+    "expected_floor": "5946408234247776197"
+  },
+  {
+    "principal": "261185144101846535",
+    "rate_bps": 87,
+    "seconds": 3999734929,
+    "expected_floor": "288001644328480907"
+  },
+  {
+    "principal": "11208619238192870860",
+    "rate_bps": 1269,
+    "seconds": 2794225630,
+    "expected_floor": "125942190636265481527"
+  },
+  {
+    "principal": "10852702928695663957",
+    "rate_bps": 7902,
+    "seconds": 3724120207,
+    "expected_floor": "1012032976941881211940"
+  },
+  {
+    "principal": "17374027417101261682",
+    "rate_bps": 3044,
+    "seconds": 2945135092,
+    "expected_floor": "493567328476139003428"
+  },
+  {
+    "principal": "6525501676007937331",
+    "rate_bps": 9472,
+    "seconds": 3468390301,
+    "expected_floor": "679328118212148104992"
+  },
+  {
+    "principal": "15057962044187345640",
+    "rate_bps": 7780,
+    "seconds": 3707099738,
+    "expected_floor": "1376182714838347148711"
+  },
+  {
+    "principal": "6462454692245113121",
+    "rate_bps": 4920,
+    "seconds": 3000797499,
+    "expected_floor": "302339810249253918962"
+  },
+  {
+    "principal": "11847923301292107182",
+    "rate_bps": 5736,
+    "seconds": 1819938448,
+    "expected_floor": "391926031154415237016"
+  },
+  {
+    "principal": "10619483921918034079",
+    "rate_bps": 8773,
+    "seconds": 1280897257,
+    "expected_floor": "378148053845933894670"
+  },
+  {
+    "principal": "12121717109947003204",
+    "rate_bps": 912,
+    "seconds": 954365974,
+    "expected_floor": "33432585408404243550"
+  },
+  {
+    "principal": "7409284700106622765",
+    "rate_bps": 4315,
+    "seconds": 690019879,
+    "expected_floor": "69906042774588027273"
+  },
+  {
+    "principal": "5510284940355757866",
+    "rate_bps": 82,
+    "seconds": 2806002796,
+    "expected_floor": "4017649459560885124"
+  },
+  {
+    "principal": "6060752548058254411",
+    "rate_bps": 3183,
+    "seconds": 4071722101,
+    "expected_floor": "248907139370263247462"
+  },
+  {
+    "principal": "3271433228202032352",
+    "rate_bps": 8312,
+    "seconds": 389625106,
+    "expected_floor": "33572722552392690630"
+  },
+  {
+    "principal": "5618774080296829817",
+    "rate_bps": 6041,
+    "seconds": 135732051,
+    "expected_floor": "14599193021893178893"
+  },
+  {
+    "principal": "10141370535856339942",
+    "rate_bps": 8352,
+    "seconds": 4057177992,
+    "expected_floor": "1088948222730562709837"
+  },
+  {
+    "principal": "17388621614197179447",
+    "rate_bps": 8277,
+    "seconds": 1301245505,
+    "expected_floor": "593462644534540365692"
+  },
+  {
+    "principal": "5323379563670348220",
+    "rate_bps": 3719,
+    "seconds": 861285710,
+    "expected_floor": "54032726913477080906"
+  },
+  {
+    "principal": "1097320963674810885",
+    "rate_bps": 5861,
+    "seconds": 256249023,
+    "expected_floor": "5222322030506500284"
+  },
+  {
+    "principal": "11400733008625762274",
+    "rate_bps": 7642,
+    "seconds": 605391844,
+    "expected_floor": "167136924777078515924"
+  },
+  {
+    "principal": "18024282543947986019",
+    "rate_bps": 1924,
+    "seconds": 3571515981,
+    "expected_floor": "392474717038065780397"
+  },
+  {
+    "principal": "12345083770346019800",
+    "rate_bps": 4080,
+    "seconds": 826719434,
+    "expected_floor": "131949693014032859566"
+  },
+  {
+    "principal": "10880002231735740113",
+    "rate_bps": 2997,
+    "seconds": 2715205227,
+    "expected_floor": "280552679770811148097"
+  },
+  {
+    "principal": "8500149862080515870",
+    "rate_bps": 9893,
+    "seconds": 1244558720,
+    "expected_floor": "331639320509005785042"
+  },
+  {
+    "principal": "9743982767214733519",
+    "rate_bps": 8192,
+    "seconds": 1791292569,
+    "expected_floor": "453094727039745187097"
+  },
+  {
+    "principal": "17119732453060863796",
+    "rate_bps": 5495,
+    "seconds": 524648326,
+    "expected_floor": "156397207509440120408"
+  },
+  {
+    "principal": "13173082742941836765",
+    "rate_bps": 9855,
+    "seconds": 306216023,
+    "expected_floor": "125970250512547647988"
+  },
+  {
+    "principal": "5168003603307136410",
+    "rate_bps": 3884,
+    "seconds": 4029290588,
+    "expected_floor": "256287043596552589907"
+  },
+  {
+    "principal": "391887610344074619",
+    "rate_bps": 3190,
+    "seconds": 399913253,
+    "expected_floor": "1584214726440775290"
+  },
+  {
+    "principal": "3164147602920341456",
+    "rate_bps": 3763,
+    "seconds": 2323009922,
+    "expected_floor": "87647200793321083571"
+  },
+  {
+    "principal": "2851912839374656297",
+    "rate_bps": 1020,
+    "seconds": 3660894851,
+    "expected_floor": "33745798443959042143"
+  },
+  {
+    "principal": "3159568179678576470",
+    "rate_bps": 2122,
+    "seconds": 2262003832,
+    "expected_floor": "48057644466131739917"
+  },
+  {
+    "principal": "6905563865706516071",
+    "rate_bps": 9331,
+    "seconds": 4055360497,
+    "expected_floor": "828042894725346069649"
+  },
+  {
+    "principal": "16419810579496313260",
+    "rate_bps": 6254,
+    "seconds": 48385726,
+    "expected_floor": "15744878526152169637"
+  },
+  {
+    "principal": "4383930997919816373",
+    "rate_bps": 4343,
+    "seconds": 1254853871,
+    "expected_floor": "75708166198613149144"
+  },
+  {
+    "principal": "1807199844795996242",
+    "rate_bps": 2831,
+    "seconds": 3721443796,
+    "expected_floor": "60332809192403793689"
+  },
+  {
+    "principal": "16423074903683258259",
+    "rate_bps": 1277,
+    "seconds": 1474394365,
+    "expected_floor": "97983977783454404082"
+  },
+  {
+    "principal": "8736427438744029384",
+    "rate_bps": 2907,
+    "seconds": 716428090,
+    "expected_floor": "57656402964471867484"
+  },
+  {
+    "principal": "6396625828411566209",
+    "rate_bps": 455,
+    "seconds": 2163128219,
+    "expected_floor": "19949896174926789172"
+  },
+  {
+    "principal": "8497278012413881486",
+    "rate_bps": 1166,
+    "seconds": 4009717872,
+    "expected_floor": "125889128565998436125"
+  },
+  {
+    "principal": "11207341930776483071",
+    "rate_bps": 9813,
+    "seconds": 4071267401,
+    "expected_floor": "1418829082349389692622"
+  },
+  {
+    "principal": "8642374694834155812",
+    "rate_bps": 3334,
+    "seconds": 2897378038,
+    "expected_floor": "264545198645300772650"
+  },
+  {
+    "principal": "1961751195189323917",
+    "rate_bps": 5179,
+    "seconds": 2852560519,
+    "expected_floor": "91837644639747020102"
+  },
+  {
+    "principal": "13453670944363599882",
+    "rate_bps": 6580,
+    "seconds": 1997557836,
+    "expected_floor": "560353501792417708164"
+  },
+  {
+    "principal": "14941001844490982059",
+    "rate_bps": 6746,
+    "seconds": 546781653,
+    "expected_floor": "174636903686598671812"
+  },
+  {
+    "principal": "726325598546712256",
+    "rate_bps": 4665,
+    "seconds": 3053396466,
+    "expected_floor": "32784021831689021353"
+  },
+  {
+    "principal": "16891601038458586841",
+    "rate_bps": 1780,
+    "seconds": 3840265651,
+    "expected_floor": "365887959667184529356"
+  },
+  {
+    "principal": "3923500234910955206",
+    "rate_bps": 8686,
+    "seconds": 392385896,
+    "expected_floor": "42374338300359794844"
+  },
+  {
+    "principal": "13569628479133326487",
+    "rate_bps": 4671,
+    "seconds": 3185802657,
+    "expected_floor": "639871442005079308714"
+  },
+  {
+    "principal": "1038134020185814428",
+    "rate_bps": 5417,
+    "seconds": 3473925166,
+    "expected_floor": "61905430861839420867"
+  },
+  {
+    "principal": "9316681501496799077",
+    "rate_bps": 4699,
+    "seconds": 1257574687,
+    "expected_floor": "174460259480624172901"
+  },
+  {
+    "principal": "14623785402356786370",
+    "rate_bps": 5480,
+    "seconds": 4246977476,
+    "expected_floor": "1078490575813162098130"
+  },
+  {
+    "principal": "15348168675667066563",
+    "rate_bps": 1718,
+    "seconds": 1917834157,
+    "expected_floor": "160245855152199898328"
+  },
+  {
+    "principal": "5955602945824491960",
+    "rate_bps": 8829,
+    "seconds": 804003242,
+    "expected_floor": "133964918978268215342"
+  },
+  {
+    "principal": "14715941520797732401",
+    "rate_bps": 1991,
+    "seconds": 3986650315,
+    "expected_floor": "370137843127249946526"
+  },
+  {
+    "principal": "16298143996566748670",
+    "rate_bps": 9772,
+    "seconds": 1235484512,
+    "expected_floor": "623526545108374146805"
+  },
+  {
+    "principal": "10464067539268535599",
+    "rate_bps": 3607,
+    "seconds": 4046252025,
+    "expected_floor": "483944589813867339800"
+  },
+  {
+    "principal": "8527067775180328724",
+    "rate_bps": 4556,
+    "seconds": 3953683046,
+    "expected_floor": "486722377275887375480"
+  },
+  {
+    "principal": "15686860319721312061",
+    "rate_bps": 3791,
+    "seconds": 3556656311,
+    "expected_floor": "670235993661316013291"
+  },
+  {
+    "principal": "9716861810756509306",
+    "rate_bps": 744,
+    "seconds": 3086605372,
+    "expected_floor": "70709229126621291295"
+  },
+  {
+    "principal": "4372014891515575259",
+    "rate_bps": 5004,
+    "seconds": 3618088581,
+    "expected_floor": "250826929561792091184"
+  },
+  {
+    "principal": "2587224653917634992",
+    "rate_bps": 5895,
+    "seconds": 2401412706,
+    "expected_floor": "116059524668099508968"
+  },
+  {
+    "principal": "2011462571681603209",
+    "rate_bps": 5386,
+    "seconds": 1153764579,
+    "expected_floor": "39608786736278859578"
+  },
+  {
+    "principal": "15629678338695389750",
+    "rate_bps": 9076,
+    "seconds": 1004162648,
+    "expected_floor": "451382401925492904377"
+  },
+  {
+    "principal": "13605138261870440135",
+    "rate_bps": 6287,
+    "seconds": 357907281,
+    "expected_floor": "97009214122534886306"
+  },
+  {
+    "principal": "460199099605785996",
+    "rate_bps": 5330,
+    "seconds": 251522462,
+    "expected_floor": "1954995589634042792"
+  },
+  {
+    "principal": "7345697907030468629",
+    "rate_bps": 2871,
+    "seconds": 3899496783,
+    "expected_floor": "260597866444110524043"
+  },
+  {
+    "principal": "4363820616276813106",
+    "rate_bps": 9629,
+    "seconds": 2511704500,
+    "expected_floor": "334435717062793467967"
+  },
+  {
+    "principal": "334628017070303731",
+    "rate_bps": 8353,
+    "seconds": 184488541,
+    "expected_floor": "1634068320805722579"
+  },
+  {
+    "principal": "3465218658827689640",
+    "rate_bps": 2685,
+    "seconds": 551459866,
+    "expected_floor": "16258664826657413245"
+  },
+  {
+    "principal": "3116380856778479585",
+    "rate_bps": 2278,
+    "seconds": 2409887227,
+    "expected_floor": "54212196071735778075"
+  },
+  {
+    "principal": "7358541175476208494",
+    "rate_bps": 5233,
+    "seconds": 403907152,
+    "expected_floor": "49285598561417621801"
+  },
+  {
+    "principal": "16711160384007584095",
+    "rate_bps": 2930,
+    "seconds": 3417233321,
+    "expected_floor": "530206311327988201341"
+  },
+  {
+    "principal": "5007655276400951556",
+    "rate_bps": 6040,
+    "seconds": 1541819862,
+    "expected_floor": "147775021858166290807"
+  },
+  {
+    "principal": "10080501189080668653",
+    "rate_bps": 6264,
+    "seconds": 2851237607,
+    "expected_floor": "570510074294137978360"
+  },
+  {
+    "principal": "8980237366626916586",
+    "rate_bps": 8709,
+    "seconds": 439204908,
+    "expected_floor": "108847716933028561135"
+  },
+  {
+    "principal": "2671099538624178443",
+    "rate_bps": 1650,
+    "seconds": 737834805,
+    "expected_floor": "10304553711014130051"
+  },
+  {
+    "principal": "5906787884470026400",
+    "rate_bps": 1617,
+    "seconds": 3161448146,
+    "expected_floor": "95684918470294904902"
+  },
+  {
+    "principal": "7722161590951598649",
+    "rate_bps": 4587,
+    "seconds": 3098382355,
+    "expected_floor": "347775248032690442582"
+  },
+  {
+    "principal": "14124079482930348454",
+    "rate_bps": 3968,
+    "seconds": 3553581896,
+    "expected_floor": "631094184133402751498"
+  },
+  {
+    "principal": "12913150964097828087",
+    "rate_bps": 5127,
+    "seconds": 2341477633,
+    "expected_floor": "491226279081722496831"
+  },
+  {
+    "principal": "1815261769404586364",
+    "rate_bps": 5695,
+    "seconds": 1728801550,
+    "expected_floor": "56633599572307841840"
+  },
+  {
+    "principal": "2661305197999637701",
+    "rate_bps": 6330,
+    "seconds": 1243620735,
+    "expected_floor": "66386898515997216816"
+  },
+  {
+    "principal": "17934823053956684194",
+    "rate_bps": 7422,
+    "seconds": 2657958820,
+    "expected_floor": "1121146401383681938812"
+  },
+  {
+    "principal": "9658348308944738595",
+    "rate_bps": 9084,
+    "seconds": 2231514381,
+    "expected_floor": "620405603586764462603"
+  },
+  {
+    "principal": "8056263822243874712",
+    "rate_bps": 2303,
+    "seconds": 3334098570,
+    "expected_floor": "196020767797379214224"
+  },
+  {
+    "principal": "2966856587969283473",
+    "rate_bps": 1243,
+    "seconds": 1224162091,
+    "expected_floor": "14305486830370576820"
+  },
+  {
+    "principal": "7578099441534385374",
+    "rate_bps": 118,
+    "seconds": 3615742272,
+    "expected_floor": "10245562495489851665"
+  },
+  {
+    "principal": "17348501560259998095",
+    "rate_bps": 3965,
+    "seconds": 4023610201,
+    "expected_floor": "877035342120309368044"
+  },
+  {
+    "principal": "703976621532481268",
+    "rate_bps": 6873,
+    "seconds": 1651189062,
+    "expected_floor": "25316135803990172241"
+  },
+  {
+    "principal": "14879381242645104797",
+    "rate_bps": 1143,
+    "seconds": 2884508951,
+    "expected_floor": "155452970688695416333"
+  },
+  {
+    "principal": "1031978399852398426",
+    "rate_bps": 3361,
+    "seconds": 3761434652,
+    "expected_floor": "41341732616135593399"
+  },
+  {
+    "principal": "14786800554604862011",
+    "rate_bps": 6447,
+    "seconds": 3770854373,
+    "expected_floor": "1139115283734397228054"
+  },
+  {
+    "principal": "1795826217378599824",
+    "rate_bps": 6347,
+    "seconds": 95800130,
+    "expected_floor": "3460150087830567732"
+  },
+  {
+    "principal": "2911537581199718889",
+    "rate_bps": 4209,
+    "seconds": 3518650179,
+    "expected_floor": "136638614822884115889"
+  },
+  {
+    "principal": "8487697001313604886",
+    "rate_bps": 2909,
+    "seconds": 4128865336,
+    "expected_floor": "323043003973198006427"
+  },
+  {
+    "principal": "9679369044496097063",
+    "rate_bps": 4603,
+    "seconds": 2488738481,
+    "expected_floor": "351368900149858188781"
+  },
+  {
+    "principal": "9135816139261307244",
+    "rate_bps": 6192,
+    "seconds": 416767102,
+    "expected_floor": "74708112033257963931"
+  },
+  {
+    "principal": "15901024943760688501",
+    "rate_bps": 2277,
+    "seconds": 355972527,
+    "expected_floor": "40841404057537442041"
+  },
+  {
+    "principal": "7027043796108919314",
+    "rate_bps": 9520,
+    "seconds": 3782326676,
+    "expected_floor": "801797462217589523213"
+  },
+  {
+    "principal": "1078474572859804755",
+    "rate_bps": 4453,
+    "seconds": 1873558461,
+    "expected_floor": "28511882151151985198"
+  },
+  {
+    "principal": "2789042875664549000",
+    "rate_bps": 9380,
+    "seconds": 1139684602,
+    "expected_floor": "94479751568259323199"
+  },
+  {
+    "principal": "8802348372063213377",
+    "rate_bps": 61,
+    "seconds": 1708409947,
+    "expected_floor": "2906809106089547650"
+  },
+  {
+    "principal": "1105702079979563598",
+    "rate_bps": 1505,
+    "seconds": 3027051568,
+    "expected_floor": "15962116601038146414"
+  },
+  {
+    "principal": "5036463417082949055",
+    "rate_bps": 4715,
+    "seconds": 2206049033,
+    "expected_floor": "166004008411427986654"
+  },
+  {
+    "principal": "1471632653648896228",
+    "rate_bps": 4716,
+    "seconds": 3111514294,
+    "expected_floor": "68429134256477941486"
+  },
+  {
+    "principal": "1241633964808674125",
+    "rate_bps": 383,
+    "seconds": 4030484295,
+    "expected_floor": "6073592138818789935"
+  },
+  {
+    "principal": "10019913404537940426",
+    "rate_bps": 6035,
+    "seconds": 399538188,
+    "expected_floor": "76558879968663042055"
+  },
+  {
+    "principal": "13243111948743511915",
+    "rate_bps": 7207,
+    "seconds": 1030964373,
+    "expected_floor": "311805852806439048010"
+  },
+  {
+    "principal": "9925491979220253312",
+    "rate_bps": 4213,
+    "seconds": 3288558514,
+    "expected_floor": "435757738679098982939"
+  },
+  {
+    "principal": "17429856748915178905",
+    "rate_bps": 6697,
+    "seconds": 591815283,
+    "expected_floor": "218905324813657378168"
+  },
+  {
+    "principal": "1429198602484112518",
+    "rate_bps": 2813,
+    "seconds": 3771707688,
+    "expected_floor": "48050330032409305554"
+  },
+  {
+    "principal": "7704432068533714263",
+    "rate_bps": 8972,
+    "seconds": 866995297,
+    "expected_floor": "189907741865436901516"
+  },
+  {
+    "principal": "9711985925855579484",
+    "rate_bps": 9230,
+    "seconds": 1933623790,
+    "expected_floor": "549259729913944697972"
+  },
+  {
+    "principal": "5523683848904550949",
+    "rate_bps": 6501,
+    "seconds": 2636073439,
+    "expected_floor": "299959428642318410128"
+  },
+  {
+    "principal": "8820109849281437314",
+    "rate_bps": 6471,
+    "seconds": 3962178436,
+    "expected_floor": "716597777364059805322"
+  },
+  {
+    "principal": "1125099716759389059",
+    "rate_bps": 6644,
+    "seconds": 915416685,
+    "expected_floor": "21683805144245945843"
+  },
+  {
+    "principal": "14014728222994814328",
+    "rate_bps": 4154,
+    "seconds": 2217299818,
+    "expected_floor": "409045507011753124896"
+  },
+  {
+    "principal": "4121788963520384241",
+    "rate_bps": 7681,
+    "seconds": 3434484107,
+    "expected_floor": "344556987031966037815"
+  },
+  {
+    "principal": "12678517717532380094",
+    "rate_bps": 6485,
+    "seconds": 2055602976,
+    "expected_floor": "535566905921275531142"
+  },
+  {
+    "principal": "12564661959420734959",
+    "rate_bps": 2361,
+    "seconds": 349208249,
+    "expected_floor": "32826707305435187244"
+  },
+  {
+    "principal": "1477777144524869332",
+    "rate_bps": 2339,
+    "seconds": 3766857766,
+    "expected_floor": "41258593799086181782"
+  },
+  {
+    "principal": "14457184611679621629",
+    "rate_bps": 1556,
+    "seconds": 1399326071,
+    "expected_floor": "99748937402199228025"
+  },
+  {
+    "principal": "1139647567763177530",
+    "rate_bps": 1309,
+    "seconds": 2316129276,
+    "expected_floor": "10948863553274654946"
+  },
+  {
+    "principal": "13699996557503711387",
+    "rate_bps": 6865,
+    "seconds": 3183427909,
+    "expected_floor": "948750574575664499981"
+  },
+  {
+    "principal": "8169920367105684848",
+    "rate_bps": 2018,
+    "seconds": 1369948194,
+    "expected_floor": "71571342313158238993"
+  },
+  {
+    "principal": "12220470956094596425",
+    "rate_bps": 1694,
+    "seconds": 1928114595,
+    "expected_floor": "126482436825119764784"
+  },
+  {
+    "principal": "9149558893708417014",
+    "rate_bps": 6832,
+    "seconds": 3913873944,
+    "expected_floor": "775266256263207047619"
+  },
+  {
+    "principal": "7761697672196874119",
+    "rate_bps": 3617,
+    "seconds": 2916456977,
+    "expected_floor": "259451889752694031683"
+  },
+  {
+    "principal": "8852878533773952332",
+    "rate_bps": 6718,
+    "seconds": 1114020702,
+    "expected_floor": "209948994676385173400"
+  },
+  {
+    "principal": "9867597481246356181",
+    "rate_bps": 5252,
+    "seconds": 327279119,
+    "expected_floor": "53746535292108657932"
+  },
+  {
+    "principal": "6045225223653732082",
+    "rate_bps": 7986,
+    "seconds": 4282200436,
+    "expected_floor": "655095801272426918872"
+  },
+  {
+    "principal": "6678399393692237491",
+    "rate_bps": 8937,
+    "seconds": 3514889501,
+    "expected_floor": "664770678216603807438"
+  },
+  {
+    "principal": "7118336152113576552",
+    "rate_bps": 5727,
+    "seconds": 2891619802,
+    "expected_floor": "373544975549343019711"
+  },
+  {
+    "principal": "12609931264783705761",
+    "rate_bps": 7390,
+    "seconds": 777495227,
+    "expected_floor": "229588918463150298623"
+  },
+  {
+    "principal": "4625000661075943726",
+    "rate_bps": 6635,
+    "seconds": 2227533328,
+    "expected_floor": "216607240617674679063"
+  },
+  {
+    "principal": "15500014616183779871",
+    "rate_bps": 5536,
+    "seconds": 1244593769,
+    "expected_floor": "338416745370045661736"
+  },
+  {
+    "principal": "4412205753696080068",
+    "rate_bps": 799,
+    "seconds": 2354668438,
+    "expected_floor": "26304395842909280499"
+  },
+  {
+    "principal": "1935187020080180397",
+    "rate_bps": 4978,
+    "seconds": 2822520743,
+    "expected_floor": "86161055364402232113"
+  },
+  {
+    "principal": "6763612702951967402",
+    "rate_bps": 9839,
+    "seconds": 2872083436,
+    "expected_floor": "605651471768438873154"
+  },
+  {
+    "principal": "12421916486522422731",
+    "rate_bps": 7718,
+    "seconds": 3248071157,
+    "expected_floor": "986767750005421383716"
+  },
+  {
+    "principal": "13667328948946240608",
+    "rate_bps": 8843,
+    "seconds": 2050082962,
+    "expected_floor": "785146576700743734539"
+  },
+  {
+    "principal": "15037810939655237881",
+    "rate_bps": 7785,
+    "seconds": 3901244627,
+    "expected_floor": "1447246319518555287005"
+  },
+  {
+    "principal": "15923554816321603430",
+    "rate_bps": 3390,
+    "seconds": 1813796616,
+    "expected_floor": "310258969501522237736"
+  },
+  {
+    "principal": "13640152894911530423",
+    "rate_bps": 4915,
+    "seconds": 928189377,
+    "expected_floor": "197185686687383773405"
+  },
+  {
+    "principal": "1141045902973751612",
+    "rate_bps": 2269,
+    "seconds": 1067968718,
+    "expected_floor": "8761776618544977551"
+  },
+  {
+    "principal": "14844987643674992517",
+    "rate_bps": 5465,
+    "seconds": 3091889727,
+    "expected_floor": "794858890071841108922"
+  },
+  {
+    "principal": "9867672181994681186",
+    "rate_bps": 2394,
+    "seconds": 4270992228,
+    "expected_floor": "319715486499024314932"
+  },
+  {
+    "principal": "17537373268792819171",
+    "rate_bps": 2078,
+    "seconds": 1955702733,
+    "expected_floor": "225844211827544624470"
+  },
+  {
+    "principal": "9423101743867212632",
+    "rate_bps": 3687,
+    "seconds": 2326863946,
+    "expected_floor": "256173405242459011985"
+  },
+  {
+    "principal": "11077441042568504401",
+    "rate_bps": 2270,
+    "seconds": 900986859,
+    "expected_floor": "71792618577751046672"
+  },
+  {
+    "principal": "8981006009062304414",
+    "rate_bps": 6776,
+    "seconds": 2908912896,
+    "expected_floor": "560951268192667659396"
+  },
+  {
+    "principal": "4955729404643408463",
+    "rate_bps": 3443,
+    "seconds": 2453414425,
+    "expected_floor": "132651313536768066797"
+  },
+  {
+    "principal": "14201146468016907956",
+    "rate_bps": 970,
+    "seconds": 384830214,
+    "expected_floor": "16798106723268949853"
+  },
+  {
+    "principal": "13442558724926303069",
+    "rate_bps": 5124,
+    "seconds": 3888381399,
+    "expected_floor": "848703422066833593855"
+  },
+  {
+    "principal": "12675189129721137434",
+    "rate_bps": 5812,
+    "seconds": 2327906268,
+    "expected_floor": "543427455576549246375"
+  },
+  {
+    "principal": "3867088141299484411",
+    "rate_bps": 9254,
+    "seconds": 1026909861,
+    "expected_floor": "116450651669031212590"
+  },
+  {
+    "principal": "9386596857041348432",
+    "rate_bps": 1487,
+    "seconds": 3933242626,
+    "expected_floor": "173966611496005669845"
+  },
+  {
+    "principal": "4683308042674299049",
+    "rate_bps": 6977,
+    "seconds": 1043602435,
+    "expected_floor": "108056914885018211780"
+  },
+  {
+    "principal": "10899472531282258646",
+    "rate_bps": 169,
+    "seconds": 3173042168,
+    "expected_floor": "18520984249977994775"
+  },
+  {
+    "principal": "14140473241922613223",
+    "rate_bps": 5440,
+    "seconds": 2766709105,
+    "expected_floor": "674407476509153800350"
+  },
+  {
+    "principal": "10350311900757618988",
+    "rate_bps": 4056,
+    "seconds": 2174986814,
+    "expected_floor": "289337047070806262575"
+  },
+  {
+    "principal": "7947249947009036341",
+    "rate_bps": 7082,
+    "seconds": 161750639,
+    "expected_floor": "28847941752991835391"
+  },
+  {
+    "principal": "8752489400731233234",
+    "rate_bps": 7038,
+    "seconds": 1632631124,
+    "expected_floor": "318687449450863713042"
+  },
+  {
+    "principal": "6498040850886099219",
+    "rate_bps": 5496,
+    "seconds": 1075134077,
+    "expected_floor": "121671208451470841109"
+  },
+  {
+    "principal": "12056442254322335816",
+    "rate_bps": 3983,
+    "seconds": 110876346,
+    "expected_floor": "16871916397975212721"
+  },
+  {
+    "principal": "4003943024875046401",
+    "rate_bps": 8428,
+    "seconds": 3087405339,
+    "expected_floor": "330143004750824094807"
+  },
+  {
+    "principal": "8145804609444374542",
+    "rate_bps": 7608,
+    "seconds": 1037309936,
+    "expected_floor": "203708458925768193862"
+  },
+  {
+    "principal": "18140860425204385407",
+    "rate_bps": 737,
+    "seconds": 3554339273,
+    "expected_floor": "150584504040128111892"
+  },
+  {
+    "principal": "13717984602140332196",
+    "rate_bps": 1495,
+    "seconds": 4018710134,
+    "expected_floor": "261164545432233693544"
+  },
+  {
+    "principal": "6977132023029648909",
+    "rate_bps": 4610,
+    "seconds": 1632256007,
+    "expected_floor": "166365080599235598440"
+  },
+  {
+    "principal": "3315502032433658762",
+    "rate_bps": 6963,
+    "seconds": 3280330700,
+    "expected_floor": "239971328065265477633"
+  },
+  {
+    "principal": "16415980382080601131",
+    "rate_bps": 3504,
+    "seconds": 1761972053,
+    "expected_floor": "321163343505213556406"
+  },
+  {
+    "principal": "15965115018835779136",
+    "rate_bps": 9187,
+    "seconds": 2691888498,
+    "expected_floor": "1251119715283798952300"
+  },
+  {
+    "principal": "977260339663615065",
+    "rate_bps": 4930,
+    "seconds": 4031461171,
+    "expected_floor": "61548249767500783350"
+  },
+  {
+    "principal": "3552054110271406662",
+    "rate_bps": 2704,
+    "seconds": 393039080,
+    "expected_floor": "11962391941303946357"
+  },
+  {
+    "principal": "11383573928888573463",
+    "rate_bps": 6957,
+    "seconds": 463035169,
+    "expected_floor": "116201209082930783208"
+  },
+  {
+    "principal": "16519049083810669852",
+    "rate_bps": 3829,
+    "seconds": 3963150254,
+    "expected_floor": "794341002828162751054"
+  },
+  {
+    "principal": "10973631402006029541",
+    "rate_bps": 6590,
+    "seconds": 4093231775,
+    "expected_floor": "937989879866188530431"
+  },
+  {
+    "principal": "12754029218982434882",
+    "rate_bps": 8599,
+    "seconds": 568171332,
+    "expected_floor": "197456168865152430315"
+  },
+  {
+    "principal": "10799045842744805443",
+    "rate_bps": 89,
+    "seconds": 4036933933,
+    "expected_floor": "12294845235338931790"
+  },
+  {
+    "principal": "6556715126431179064",
+    "rate_bps": 2128,
+    "seconds": 2429141290,
+    "expected_floor": "107400609910550653039"
+  },
+  {
+    "principal": "11448092714829368241",
+    "rate_bps": 9039,
+    "seconds": 3838373451,
+    "expected_floor": "1258626246676535491745"
+  },
+  {
+    "principal": "5604694190351423870",
+    "rate_bps": 9146,
+    "seconds": 3738257120,
+    "expected_floor": "607223149748587255408"
+  },
+  {
+    "principal": "1650724916078188207",
+    "rate_bps": 5237,
+    "seconds": 506353017,
+    "expected_floor": "13870966261059824647"
+  },
+  {
+    "principal": "11472590046601711252",
+    "rate_bps": 4752,
+    "seconds": 178402790,
+    "expected_floor": "30820209173497232535"
+  },
+  {
+    "principal": "11396853211916014781",
+    "rate_bps": 1684,
+    "seconds": 3931768375,
+    "expected_floor": "239117300947437369005"
+  },
+  {
+    "principal": "8590785406840267258",
+    "rate_bps": 6594,
+    "seconds": 1803946940,
+    "expected_floor": "323818462059964722650"
+  },
+  {
+    "principal": "17407414743197930843",
+    "rate_bps": 6047,
+    "seconds": 1908218885,
+    "expected_floor": "636500087829651793104"
+  },
+  {
+    "principal": "4050672981732813104",
+    "rate_bps": 2393,
+    "seconds": 1535646178,
+    "expected_floor": "47169044398696284942"
+  },
+  {
+    "principal": "4488884990959234057",
+    "rate_bps": 9701,
+    "seconds": 1835570787,
+    "expected_floor": "253292396682728218291"
+  },
+  {
+    "principal": "15190264277505412534",
+    "rate_bps": 8580,
+    "seconds": 2371413464,
+    "expected_floor": "979390600768770090708"
+  },
+  {
+    "principal": "16929648997042622535",
+    "rate_bps": 1502,
+    "seconds": 3232250065,
+    "expected_floor": "260446708003205372549"
+  },
+  {
+    "principal": "3778813203426716940",
+    "rate_bps": 7538,
+    "seconds": 2693171486,
+    "expected_floor": "243092521208182575384"
+  },
+  {
+    "principal": "6155167301643107733",
+    "rate_bps": 3402,
+    "seconds": 32926415,
+    "expected_floor": "2184814913929647889"
+  },
+  {
+    "principal": "8964156725346171058",
+    "rate_bps": 3646,
+    "seconds": 2917273908,
+    "expected_floor": "302133822925336021969"
+  },
+  {
+    "principal": "6649293185110594419",
+    "rate_bps": 7615,
+    "seconds": 2399213533,
+    "expected_floor": "384955319770496879181"
+  },
+  {
+    "principal": "7336524537054385704",
+    "rate_bps": 5602,
+    "seconds": 2468994970,
+    "expected_floor": "321550890714959744922"
+  },
+  {
+    "principal": "302061306734916961",
+    "rate_bps": 8243,
+    "seconds": 1974964091,
+    "expected_floor": "15582446097098337680"
+  },
+  {
+    "principal": "4167765743887236846",
+    "rate_bps": 5119,
+    "seconds": 2287012304,
+    "expected_floor": "154615476890314334005"
+  },
+  {
+    "principal": "7466414902741330655",
+    "rate_bps": 2745,
+    "seconds": 1486447913,
+    "expected_floor": "96538422290110780970"
+  },
+  {
+    "principal": "3460631405919903876",
+    "rate_bps": 6967,
+    "seconds": 1375451478,
+    "expected_floor": "105085419567367031744"
+  },
+  {
+    "principal": "17133944965549178733",
+    "rate_bps": 6199,
+    "seconds": 247353447,
+    "expected_floor": "83251679522082648495"
+  },
+  {
+    "principal": "10597319139891723370",
+    "rate_bps": 6720,
+    "seconds": 67668908,
+    "expected_floor": "15270402608465450181"
+  },
+  {
+    "principal": "532556459600142987",
+    "rate_bps": 6832,
+    "seconds": 676269237,
+    "expected_floor": "7797029538535284294"
+  },
+  {
+    "principal": "940184393097644064",
+    "rate_bps": 8203,
+    "seconds": 205451858,
+    "expected_floor": "5021018890448839571"
+  },
+  {
+    "principal": "4801882974606378937",
+    "rate_bps": 7533,
+    "seconds": 1181170067,
+    "expected_floor": "135390441591453737015"
+  },
+  {
+    "principal": "7217472328084196646",
+    "rate_bps": 6484,
+    "seconds": 4168782536,
+    "expected_floor": "618206272683753542630"
+  },
+  {
+    "principal": "10295245658565412471",
+    "rate_bps": 8837,
+    "seconds": 1771584129,
+    "expected_floor": "510739424494694859057"
+  },
+  {
+    "principal": "9075267766457780476",
+    "rate_bps": 5368,
+    "seconds": 1827382926,
+    "expected_floor": "282096404393702498960"
+  },
+  {
+    "principal": "9259683391670467141",
+    "rate_bps": 1550,
+    "seconds": 2357532415,
+    "expected_floor": "107221416743273931759"
+  },
+  {
+    "principal": "4798575111275810082",
+    "rate_bps": 1128,
+    "seconds": 3594804004,
+    "expected_floor": "61658456164341341445"
+  },
+  {
+    "principal": "16213310816971547299",
+    "rate_bps": 3933,
+    "seconds": 542071437,
+    "expected_floor": "109533814364517751722"
+  },
+  {
+    "principal": "8491572722337799960",
+    "rate_bps": 5357,
+    "seconds": 3773510154,
+    "expected_floor": "543940424078521942033"
+  },
+  {
+    "principal": "1342092378267468561",
+    "rate_bps": 4137,
+    "seconds": 3737973931,
+    "expected_floor": "65765818877467054908"
+  },
+  {
+    "principal": "17513862501020096606",
+    "rate_bps": 5938,
+    "seconds": 1904894144,
+    "expected_floor": "627753306166601278270"
+  },
+  {
+    "principal": "14228468696799101711",
+    "rate_bps": 3023,
+    "seconds": 4072610009,
+    "expected_floor": "555092254083359157390"
+  },
+  {
+    "principal": "6422582190451689076",
+    "rate_bps": 5857,
+    "seconds": 345256134,
+    "expected_floor": "41154973923591557138"
+  },
+  {
+    "principal": "8868050317030477341",
+    "rate_bps": 6230,
+    "seconds": 1082269335,
+    "expected_floor": "189473109069153799760"
+  },
+  {
+    "principal": "3548549325482543834",
+    "rate_bps": 1783,
+    "seconds": 1771331484,
+    "expected_floor": "35513875217160768900"
+  },
+  {
+    "principal": "16177774372742149051",
+    "rate_bps": 1907,
+    "seconds": 2985189733,
+    "expected_floor": "291835042608730770449"
+  },
+  {
+    "principal": "12071157258628152080",
+    "rate_bps": 1107,
+    "seconds": 1147567810,
+    "expected_floor": "48592687498068959236"
+  },
+  {
+    "principal": "9336825484362123113",
+    "rate_bps": 2446,
+    "seconds": 1583489219,
+    "expected_floor": "114595308454205663140"
+  },
+  {
+    "principal": "1994404971397185686",
+    "rate_bps": 5316,
+    "seconds": 3920188344,
+    "expected_floor": "131704703897045289347"
+  },
+  {
+    "principal": "2210651125282734247",
+    "rate_bps": 1210,
+    "seconds": 1277976625,
+    "expected_floor": "10832395878048235193"
+  },
+  {
+    "principal": "15071919506956859628",
+    "rate_bps": 6588,
+    "seconds": 1023883262,
+    "expected_floor": "322157786677771967447"
+  },
+  {
+    "principal": "8456780346309565173",
+    "rate_bps": 9014,
+    "seconds": 3939551023,
+    "expected_floor": "951623956918826329481"
+  },
+  {
+    "principal": "17850357570968343954",
+    "rate_bps": 8427,
+    "seconds": 3207297300,
+    "expected_floor": "1528815811361095237367"
+  },
+  {
+    "principal": "1199498065044616659",
+    "rate_bps": 4942,
+    "seconds": 1440514365,
+    "expected_floor": "27059260223243078642"
+  },
+  {
+    "principal": "17009679102498077704",
+    "rate_bps": 6663,
+    "seconds": 645707898,
+    "expected_floor": "231898567120696749121"
+  },
+  {
+    "principal": "1422722739568538817",
+    "rate_bps": 5693,
+    "seconds": 2118393307,
+    "expected_floor": "54370594950953305384"
+  },
+  {
+    "principal": "9832740391980852686",
+    "rate_bps": 5403,
+    "seconds": 16010160,
+    "expected_floor": "2695263596017293894"
+  },
+  {
+    "principal": "7925442015156051775",
+    "rate_bps": 3284,
+    "seconds": 2491576457,
+    "expected_floor": "205492933917497847724"
+  },
+  {
+    "principal": "13607009568132841572",
+    "rate_bps": 2050,
+    "seconds": 1990892598,
+    "expected_floor": "175978825993507885520"
+  },
+  {
+    "principal": "4730652336522903757",
+    "rate_bps": 9415,
+    "seconds": 133198023,
+    "expected_floor": "18799018198778055314"
+  },
+  {
+    "principal": "2146404070866357578",
+    "rate_bps": 1170,
+    "seconds": 3287320460,
+    "expected_floor": "26159860320733936086"
+  },
+  {
+    "principal": "3613679672852334827",
+    "rate_bps": 6646,
+    "seconds": 940448277,
+    "expected_floor": "71571634885961202528"
+  },
+  {
+    "principal": "2894005585589273088",
+    "rate_bps": 7716,
+    "seconds": 2802695986,
+    "expected_floor": "198318673281537165851"
+  },
+  {
+    "principal": "8989782910140017433",
+    "rate_bps": 2175,
+    "seconds": 448023539,
+    "expected_floor": "27759096764258888099"
+  },
+  {
+    "principal": "14698072035300829190",
+    "rate_bps": 3544,
+    "seconds": 2566662312,
+    "expected_floor": "423661355377240929244"
+  },
+  {
+    "principal": "14265685454311259863",
+    "rate_bps": 2528,
+    "seconds": 2926029281,
+    "expected_floor": "334383172852200896364"
+  },
+  {
+    "principal": "10040989442083912924",
+    "rate_bps": 9112,
+    "seconds": 2310552942,
+    "expected_floor": "669887969572886024291"
+  },
+  {
+    "principal": "14084497983266217893",
+    "rate_bps": 1457,
+    "seconds": 2722397023,
+    "expected_floor": "177030631191206443233"
+  },
+  {
+    "principal": "3192619437059494402",
+    "rate_bps": 478,
+    "seconds": 3489557252,
+    "expected_floor": "16874907888829573749"
+  },
+  {
+    "principal": "1185468797772582147",
+    "rate_bps": 5180,
+    "seconds": 1027312621,
+    "expected_floor": "19990264656257054705"
+  },
+  {
+    "principal": "14561315005044272376",
+    "rate_bps": 6947,
+    "seconds": 1502442218,
+    "expected_floor": "481605798819712171886"
+  },
+  {
+    "principal": "17587054654711712369",
+    "rate_bps": 6310,
+    "seconds": 3432516363,
+    "expected_floor": "1207066290428341570746"
+  },
+  {
+    "principal": "4647321478264710974",
+    "rate_bps": 8148,
+    "seconds": 3158690464,
+    "expected_floor": "379015384242478836134"
+  },
+  {
+    "principal": "4710546330614857583",
+    "rate_bps": 5431,
+    "seconds": 3456527417,
+    "expected_floor": "280212252608525357600"
+  },
+  {
+    "principal": "9845389036018323028",
+    "rate_bps": 5993,
+    "seconds": 3787324326,
+    "expected_floor": "708118090730949085859"
+  },
+  {
+    "principal": "9386071422343976829",
+    "rate_bps": 5879,
+    "seconds": 865355511,
+    "expected_floor": "151313581727767802635"
+  },
+  {
+    "principal": "17356606281740157882",
+    "rate_bps": 5667,
+    "seconds": 1982071676,
+    "expected_floor": "617779386455831929178"
+  },
+  {
+    "principal": "1006056122012049947",
+    "rate_bps": 8584,
+    "seconds": 2556507845,
+    "expected_floor": "69960850389884425275"
+  },
+  {
+    "principal": "13006671178743602416",
+    "rate_bps": 7523,
+    "seconds": 1485026210,
+    "expected_floor": "460455192202719496585"
+  },
+  {
+    "principal": "13119674891457884873",
+    "rate_bps": 5770,
+    "seconds": 2465774371,
+    "expected_floor": "591491153495564530968"
+  },
+  {
+    "principal": "11130536250880410486",
+    "rate_bps": 3807,
+    "seconds": 3586789784,
+    "expected_floor": "481616017610286785121"
+  },
+  {
+    "principal": "10754795115712020743",
+    "rate_bps": 5370,
+    "seconds": 2525829009,
+    "expected_floor": "462249453813211188037"
+  },
+  {
+    "principal": "17616215098757125324",
+    "rate_bps": 7877,
+    "seconds": 3374167774,
+    "expected_floor": "1483666040061476474266"
+  },
+  {
+    "principal": "2385601653132675157",
+    "rate_bps": 8445,
+    "seconds": 2525705103,
+    "expected_floor": "161241286859784494333"
+  },
+  {
+    "principal": "18314208993413595762",
+    "rate_bps": 9757,
+    "seconds": 2741252340,
+    "expected_floor": "1552206576538262517299"
+  },
+  {
+    "principal": "2797793722934306867",
+    "rate_bps": 730,
+    "seconds": 4030691997,
+    "expected_floor": "26086402897718288505"
+  },
+  {
+    "principal": "7316504756116320744",
+    "rate_bps": 8793,
+    "seconds": 688677210,
+    "expected_floor": "140395270091799511941"
+  },
+  {
+    "principal": "15923795873776157729",
+    "rate_bps": 3568,
+    "seconds": 2357443643,
+    "expected_floor": "424432664191401174123"
+  },
+  {
+    "principal": "13974020296605686958",
+    "rate_bps": 6988,
+    "seconds": 947248528,
+    "expected_floor": "293112431400165412602"
+  },
+  {
+    "principal": "5415167794425226143",
+    "rate_bps": 6573,
+    "seconds": 3350072297,
+    "expected_floor": "377855512902671264325"
+  },
+  {
+    "principal": "13914534434436362308",
+    "rate_bps": 8717,
+    "seconds": 1955417878,
+    "expected_floor": "751573295037961473841"
+  },
+  {
+    "principal": "6112727872857199149",
+    "rate_bps": 107,
+    "seconds": 137928999,
+    "expected_floor": "285871234577082617"
+  },
+  {
+    "principal": "17765636322459987498",
+    "rate_bps": 7724,
+    "seconds": 242602860,
+    "expected_floor": "105490896197055439148"
+  },
+  {
+    "principal": "12090381746581552971",
+    "rate_bps": 5872,
+    "seconds": 349878133,
+    "expected_floor": "78711627791198441912"
+  },
+  {
+    "principal": "1670820067081047008",
+    "rate_bps": 7424,
+    "seconds": 1851218962,
+    "expected_floor": "72764821592797091914"
+  },
+  {
+    "principal": "1002389818495835769",
+    "rate_bps": 1207,
+    "seconds": 3238686291,
+    "expected_floor": "12416775607854630724"
+  },
+  {
+    "principal": "8460443887511999206",
+    "rate_bps": 6250,
+    "seconds": 4138339976,
+    "expected_floor": "693418407023897442570"
+  },
+  {
+    "principal": "7544548067021260599",
+    "rate_bps": 2513,
+    "seconds": 2065672513,
+    "expected_floor": "124103269149043145905"
+  },
+  {
+    "principal": "52461853527539900",
+    "rate_bps": 9404,
+    "seconds": 3734414414,
+    "expected_floor": "5838143889246869353"
+  },
+  {
+    "principal": "2214913855493707013",
+    "rate_bps": 9483,
+    "seconds": 965734335,
+    "expected_floor": "64277103142849469694"
+  },
+  {
+    "principal": "14117776788953196258",
+    "rate_bps": 4548,
+    "seconds": 4148415204,
+    "expected_floor": "844043864695082855343"
+  },
+  {
+    "principal": "10439904162495678307",
+    "rate_bps": 6556,
+    "seconds": 1157320013,
+    "expected_floor": "251006491298634571676"
+  },
+  {
+    "principal": "2365896052029934296",
+    "rate_bps": 8982,
+    "seconds": 1831371722,
+    "expected_floor": "123322195317856041594"
+  },
+  {
+    "principal": "14436888814020059601",
+    "rate_bps": 9994,
+    "seconds": 4211224939,
+    "expected_floor": "1925384313871850362299"
+  },
+  {
+    "principal": "14906550646593635870",
+    "rate_bps": 2313,
+    "seconds": 163284096,
+    "expected_floor": "17839912167164759562"
+  },
+  {
+    "principal": "7132508353545718735",
+    "rate_bps": 8177,
+    "seconds": 4061941657,
+    "expected_floor": "750699282603786143746"
+  },
+  {
+    "principal": "15349443961650112052",
+    "rate_bps": 649,
+    "seconds": 1930925702,
+    "expected_floor": "60953541052444826274"
+  },
+  {
+    "principal": "14935790490102493405",
+    "rate_bps": 5695,
+    "seconds": 1894285143,
+    "expected_floor": "510579445549537002420"
+  },
+  {
+    "principal": "14426671285122960538",
+    "rate_bps": 6592,
+    "seconds": 913110876,
+    "expected_floor": "275171140387260931021"
+  },
+  {
+    "principal": "2910684367998263419",
+    "rate_bps": 4921,
+    "seconds": 61709349,
+    "expected_floor": "2800886280662179796"
+  },
+  {
+    "principal": "5832936181820247760",
+    "rate_bps": 2023,
+    "seconds": 1599584386,
+    "expected_floor": "59811720712888989133"
+  },
+  {
+    "principal": "14506754378293407273",
+    "rate_bps": 7861,
+    "seconds": 2969855363,
+    "expected_floor": "1073196841846222692890"
+  },
+  {
+    "principal": "2224473132528850518",
+    "rate_bps": 9533,
+    "seconds": 3379765112,
+    "expected_floor": "227111595960108532994"
+  },
+  {
+    "principal": "17513453609190723943",
+    "rate_bps": 7103,
+    "seconds": 4074921713,
+    "expected_floor": "1606308337032228558895"
+  },
+  {
+    "principal": "17128508031342002348",
+    "rate_bps": 714,
+    "seconds": 2327971262,
+    "expected_floor": "90217626064532375739"
+  },
+  {
+    "principal": "10287345921355269557",
+    "rate_bps": 627,
+    "seconds": 3145576431,
+    "expected_floor": "64293513474044177681"
+  },
+  {
+    "principal": "16226970184582299474",
+    "rate_bps": 6401,
+    "seconds": 2630105300,
+    "expected_floor": "865674121184505381694"
+  },
+  {
+    "principal": "18312724845701016211",
+    "rate_bps": 9068,
+    "seconds": 2109867005,
+    "expected_floor": "1110236739990045553275"
+  },
+  {
+    "principal": "10029092546014984136",
+    "rate_bps": 7203,
+    "seconds": 2538658362,
+    "expected_floor": "581132744050554747692"
+  },
+  {
+    "principal": "13917777024772121473",
+    "rate_bps": 5854,
+    "seconds": 4283329179,
+    "expected_floor": "1105859815823535871743"
+  },
+  {
+    "principal": "4714568213974360974",
+    "rate_bps": 5704,
+    "seconds": 3012411248,
+    "expected_floor": "256703466935175306419"
+  },
+  {
+    "principal": "5488707270084311039",
+    "rate_bps": 5459,
+    "seconds": 3056875337,
+    "expected_floor": "290239772109761323200"
+  },
+  {
+    "principal": "15061658627553062948",
+    "rate_bps": 3086,
+    "seconds": 3063665142,
+    "expected_floor": "451238399328074051202"
+  },
+  {
+    "principal": "3165268450220340109",
+    "rate_bps": 1528,
+    "seconds": 787407239,
+    "expected_floor": "12067834324451165534"
+  },
+  {
+    "principal": "14677648214322716426",
+    "rate_bps": 4901,
+    "seconds": 2731568972,
+    "expected_floor": "622657725507967501457"
+  },
+  {
+    "principal": "5764582420367918507",
+    "rate_bps": 389,
+    "seconds": 2135745749,
+    "expected_floor": "15176199879695208584"
+  },
+  {
+    "principal": "14423268914310571456",
+    "rate_bps": 7516,
+    "seconds": 1939065074,
+    "expected_floor": "666099164850767649286"
+  },
+  {
+    "principal": "18269779130627908057",
+    "rate_bps": 7999,
+    "seconds": 2973868211,
+    "expected_floor": "1377167437045738118136"
+  },
+  {
+    "principal": "6993034171976814022",
+    "rate_bps": 9254,
+    "seconds": 2201764968,
+    "expected_floor": "451504554923631165387"
+  },
+  {
+    "principal": "17518106945091215255",
+    "rate_bps": 7315,
+    "seconds": 1691891873,
+    "expected_floor": "687021203665669651369"
+  },
+  {
+    "principal": "12750573876903564444",
+    "rate_bps": 3774,
+    "seconds": 3682523950,
+    "expected_floor": "561530358267270264896"
+  },
+  {
+    "principal": "2437455623545543269",
+    "rate_bps": 2613,
+    "seconds": 985625631,
+    "expected_floor": "19892261007677973856"
+  },
+  {
+    "principal": "18237678771244452802",
+    "rate_bps": 9783,
+    "seconds": 1749842628,
+    "expected_floor": "989319662443463377824"
+  },
+  {
+    "principal": "4153351872873517507",
+    "rate_bps": 9963,
+    "seconds": 4180057773,
+    "expected_floor": "548109303379289971309"
+  },
+  {
+    "principal": "9704569352109045944",
+    "rate_bps": 698,
+    "seconds": 573858986,
+    "expected_floor": "12317793244485150640"
+  },
+  {
+    "principal": "1972297799047285041",
+    "rate_bps": 5832,
+    "seconds": 1524852683,
+    "expected_floor": "55579409270986092295"
+  },
+  {
+    "principal": "8425020665878639870",
+    "rate_bps": 8450,
+    "seconds": 2560855648,
+    "expected_floor": "577708576838497548787"
+  },
+  {
+    "principal": "1710018909260294191",
+    "rate_bps": 5290,
+    "seconds": 622379769,
+    "expected_floor": "17840543669471933596"
+  },
+  {
+    "principal": "8224071166594666004",
+    "rate_bps": 7115,
+    "seconds": 496566630,
+    "expected_floor": "92073643269771220024"
+  },
+  {
+    "principal": "17808494797331913277",
+    "rate_bps": 5586,
+    "seconds": 165070775,
+    "expected_floor": "52034857349842053079"
+  },
+  {
+    "principal": "8525762183462610298",
+    "rate_bps": 19,
+    "seconds": 61291324,
+    "expected_floor": "31461675774892677"
+  },
+  {
+    "principal": "6887350194520436443",
+    "rate_bps": 4279,
+    "seconds": 376148357,
+    "expected_floor": "35127695079096368897"
+  },
+  {
+    "principal": "17767042480037564592",
+    "rate_bps": 7278,
+    "seconds": 878349666,
+    "expected_floor": "359907308151656063522"
+  },
+  {
+    "principal": "16620555764246772105",
+    "rate_bps": 4963,
+    "seconds": 2187141091,
+    "expected_floor": "571692704194606693123"
+  },
+  {
+    "principal": "8451037286807025974",
+    "rate_bps": 2904,
+    "seconds": 2958851416,
+    "expected_floor": "230104874954085466389"
+  },
+  {
+    "principal": "4215276612768248263",
+    "rate_bps": 5808,
+    "seconds": 3091478097,
+    "expected_floor": "239836287757471472370"
+  },
+  {
+    "principal": "10204298233996131468",
+    "rate_bps": 9680,
+    "seconds": 2615944350,
+    "expected_floor": "818809803945394104064"
+  },
+  {
+    "principal": "4436006092384391957",
+    "rate_bps": 8645,
+    "seconds": 4093656143,
+    "expected_floor": "497467284076275045733"
+  },
+  {
+    "principal": "810003466764700722",
+    "rate_bps": 388,
+    "seconds": 562270388,
+    "expected_floor": "559963665973279816"
+  },
+  {
+    "principal": "12897361741823163635",
+    "rate_bps": 1952,
+    "seconds": 3791396189,
+    "expected_floor": "302465535784446717426"
+  },
+  {
+    "principal": "18380432692633849256",
+    "rate_bps": 4498,
+    "seconds": 29500186,
+    "expected_floor": "7728513486459429311"
+  },
+  {
+    "principal": "8055489180036469473",
+    "rate_bps": 6135,
+    "seconds": 3648792827,
+    "expected_floor": "571415115003047341874"
+  },
+  {
+    "principal": "15097399238325582446",
+    "rate_bps": 4718,
+    "seconds": 3941855568,
+    "expected_floor": "889727095485993585603"
+  },
+  {
+    "principal": "3462918260386667615",
+    "rate_bps": 6496,
+    "seconds": 2821517993,
+    "expected_floor": "201125489343550190183"
+  },
+  {
+    "principal": "16567666092823871492",
+    "rate_bps": 6052,
+    "seconds": 4224591062,
+    "expected_floor": "1342273330343721439348"
+  },
+  {
+    "principal": "17615545866737165549",
+    "rate_bps": 9929,
+    "seconds": 4285215207,
+    "expected_floor": "2375036490482517231726"
+  },
+  {
+    "principal": "9303778002203828202",
+    "rate_bps": 2063,
+    "seconds": 4097334060,
+    "expected_floor": "249204553703097942274"
+  },
+  {
+    "principal": "6005368589109320715",
+    "rate_bps": 7099,
+    "seconds": 2080154165,
+    "expected_floor": "281014286690965367026"
+  },
+  {
+    "principal": "13806779635131830176",
+    "rate_bps": 2699,
+    "seconds": 3694855634,
+    "expected_floor": "436303588525707486472"
+  },
+  {
+    "principal": "15337596115568866617",
+    "rate_bps": 4443,
+    "seconds": 2268193555,
+    "expected_floor": "489789821386393520410"
+  },
+  {
+    "principal": "4973885654013434022",
+    "rate_bps": 292,
+    "seconds": 610978376,
+    "expected_floor": "2811904204233709578"
+  },
+  {
+    "principal": "17554009482234611703",
+    "rate_bps": 2389,
+    "seconds": 78206977,
+    "expected_floor": "10392834473564485577"
+  },
+  {
+    "principal": "9029101377391523964",
+    "rate_bps": 7514,
+    "seconds": 3295207950,
+    "expected_floor": "708426143097021513728"
+  },
+  {
+    "principal": "8710440844141932485",
+    "rate_bps": 5788,
+    "seconds": 1915422847,
+    "expected_floor": "306005585953946180170"
+  },
+  {
+    "principal": "7756003985095000226",
+    "rate_bps": 1531,
+    "seconds": 1934654116,
+    "expected_floor": "72796848576103496613"
+  },
+  {
+    "principal": "16600625143552175139",
+    "rate_bps": 5383,
+    "seconds": 3746922509,
+    "expected_floor": "1061010219796620806708"
+  },
+  {
+    "principal": "16917770282356602520",
+    "rate_bps": 5553,
+    "seconds": 321459594,
+    "expected_floor": "95695875896616153471"
+  },
+  {
+    "principal": "4209650833926766737",
+    "rate_bps": 1090,
+    "seconds": 2165550635,
+    "expected_floor": "31487410702419842711"
+  },
+  {
+    "principal": "13728826568498443230",
+    "rate_bps": 2962,
+    "seconds": 2612389952,
+    "expected_floor": "336629762386355969712"
+  },
+  {
+    "principal": "16328190121781826703",
+    "rate_bps": 348,
+    "seconds": 2970863193,
+    "expected_floor": "53492879770025350951"
+  },
+  {
+    "principal": "10960132505425184244",
+    "rate_bps": 8531,
+    "seconds": 2319072326,
+    "expected_floor": "687109689557413663429"
+  },
+  {
+    "principal": "9620831054982599581",
+    "rate_bps": 5708,
+    "seconds": 1941381143,
+    "expected_floor": "337834029025253953825"
+  },
+  {
+    "principal": "16340451617338199642",
+    "rate_bps": 6073,
+    "seconds": 3943354140,
+    "expected_floor": "1240021316254198142001"
+  },
+  {
+    "principal": "3410053599652793659",
+    "rate_bps": 1504,
+    "seconds": 926095077,
+    "expected_floor": "15050836919856548025"
+  },
+  {
+    "principal": "1274328729535324816",
+    "rate_bps": 9597,
+    "seconds": 3338940994,
+    "expected_floor": "129396266666409168786"
+  },
+  {
+    "principal": "244312586969748713",
+    "rate_bps": 8305,
+    "seconds": 4107987523,
+    "expected_floor": "26412567986344438929"
+  },
+  {
+    "principal": "7476482577765297174",
+    "rate_bps": 5023,
+    "seconds": 3929942840,
+    "expected_floor": "467673509092546499170"
+  },
+  {
+    "principal": "9887770194827141671",
+    "rate_bps": 1685,
+    "seconds": 1103797681,
+    "expected_floor": "58275200940690142581"
+  },
+  {
+    "principal": "4057151840289359980",
+    "rate_bps": 5087,
+    "seconds": 3935572862,
+    "expected_floor": "257387226054614112086"
+  },
+  {
+    "principal": "5782384579124949109",
+    "rate_bps": 9025,
+    "seconds": 3194673327,
+    "expected_floor": "528295208688284369428"
+  },
+  {
+    "principal": "954698234843457810",
+    "rate_bps": 608,
+    "seconds": 3688511636,
+    "expected_floor": "6784485047145419488"
+  },
+  {
+    "principal": "15299619452299566931",
+    "rate_bps": 2680,
+    "seconds": 3297101501,
+    "expected_floor": "428394387847070994245"
+  },
+  {
+    "principal": "6142419065698005896",
+    "rate_bps": 8650,
+    "seconds": 2362981370,
+    "expected_floor": "397843146291710167798"
+  },
+  {
+    "principal": "4637289324032627265",
+    "rate_bps": 5777,
+    "seconds": 3253008219,
+    "expected_floor": "276151720746218556142"
+  },
+  {
+    "principal": "14217317191045620046",
+    "rate_bps": 4120,
+    "seconds": 1264612144,
+    "expected_floor": "234729811318264341308"
+  },
+  {
+    "principal": "17841501407059939519",
+    "rate_bps": 1413,
+    "seconds": 1773157897,
+    "expected_floor": "141650138630492701909"
+  },
+  {
+    "principal": "5885361279130263524",
+    "rate_bps": 2488,
+    "seconds": 1461471158,
+    "expected_floor": "67812504691360757008"
+  },
+  {
+    "principal": "5418494079126300237",
+    "rate_bps": 3413,
+    "seconds": 1627755079,
+    "expected_floor": "95389370652303327684"
+  },
+  {
+    "principal": "1702116425835376842",
+    "rate_bps": 3699,
+    "seconds": 702912268,
+    "expected_floor": "14023962771039339382"
+  },
+  {
+    "principal": "4390220744419574379",
+    "rate_bps": 8146,
+    "seconds": 1401024405,
+    "expected_floor": "158771481308680056284"
+  },
+  {
+    "principal": "3262486573346883968",
+    "rate_bps": 1707,
+    "seconds": 3787788978,
+    "expected_floor": "66844251262952540242"
+  },
+  {
+    "principal": "17976761041671690393",
+    "rate_bps": 2382,
+    "seconds": 45299059,
+    "expected_floor": "6146649033102672876"
+  },
+  {
+    "principal": "989037976193004422",
+    "rate_bps": 8778,
+    "seconds": 871211048,
+    "expected_floor": "23967787808798694028"
+  },
+  {
+    "principal": "13113915712096206935",
+    "rate_bps": 9045,
+    "seconds": 4155180897,
+    "expected_floor": "1561805427561862948804"
+  },
+  {
+    "principal": "7454320029368446044",
+    "rate_bps": 2778,
+    "seconds": 2974595310,
+    "expected_floor": "195192981206766267078"
+  },
+  {
+    "principal": "8268858923686565157",
+    "rate_bps": 2610,
+    "seconds": 2418715871,
+    "expected_floor": "165411986396201094075"
+  },
+  {
+    "principal": "3190256809163457922",
+    "rate_bps": 3791,
+    "seconds": 2626144900,
+    "expected_floor": "100645450150337482890"
+  },
+  {
+    "principal": "10710119758169216643",
+    "rate_bps": 7454,
+    "seconds": 1092612461,
+    "expected_floor": "276405001727737081459"
+  },
+  {
+    "principal": "11733280002433287288",
+    "rate_bps": 4652,
+    "seconds": 1853789802,
+    "expected_floor": "320638495791344656816"
+  },
+  {
+    "principal": "18393450612839188465",
+    "rate_bps": 9457,
+    "seconds": 2792031371,
+    "expected_floor": "1538979823672248189934"
+  },
+  {
+    "principal": "2310401907490767550",
+    "rate_bps": 1003,
+    "seconds": 967479840,
+    "expected_floor": "7104383950611729594"
+  },
+  {
+    "principal": "8483725472184733935",
+    "rate_bps": 1985,
+    "seconds": 1680169401,
+    "expected_floor": "89659481235979279651"
+  },
+  {
+    "principal": "8828668297196604884",
+    "rate_bps": 1776,
+    "seconds": 3052619558,
+    "expected_floor": "151672511074503881311"
+  },
+  {
+    "principal": "16202613604155186429",
+    "rate_bps": 3633,
+    "seconds": 2279704695,
+    "expected_floor": "425231178064372176240"
+  },
+  {
+    "principal": "12989415096013981498",
+    "rate_bps": 6543,
+    "seconds": 2916070140,
+    "expected_floor": "785345056945015299134"
+  },
+  {
+    "principal": "16214467130695941019",
+    "rate_bps": 5100,
+    "seconds": 278670405,
+    "expected_floor": "73023011328707353092"
+  },
+  {
+    "principal": "18057108315447133296",
+    "rate_bps": 2042,
+    "seconds": 449619746,
+    "expected_floor": "52534590309946449260"
+  },
+  {
+    "principal": "3185423215498674249",
+    "rate_bps": 9850,
+    "seconds": 441828515,
+    "expected_floor": "43929184944864300976"
+  },
+  {
+    "principal": "15704639254529765110",
+    "rate_bps": 1248,
+    "seconds": 1255155992,
+    "expected_floor": "77953619838095314217"
+  },
+  {
+    "principal": "11152116631551451783",
+    "rate_bps": 2534,
+    "seconds": 4002256145,
+    "expected_floor": "358397380107434614527"
+  },
+  {
+    "principal": "13401538848058713164",
+    "rate_bps": 9751,
+    "seconds": 951177822,
+    "expected_floor": "393877864421709772293"
+  },
+  {
+    "principal": "7042827150075633109",
+    "rate_bps": 8520,
+    "seconds": 2098562319,
+    "expected_floor": "399029062675070574426"
+  },
+  {
+    "principal": "3257007688620266994",
+    "rate_bps": 9135,
+    "seconds": 2852139124,
+    "expected_floor": "268902026058661680612"
+  },
+  {
+    "principal": "6365140143602241971",
+    "rate_bps": 3779,
+    "seconds": 2432106525,
+    "expected_floor": "185380260386173934091"
+  },
+  {
+    "principal": "12513605915167025512",
+    "rate_bps": 6437,
+    "seconds": 4044039386,
+    "expected_floor": "1032232176164735699068"
+  },
+  {
+    "principal": "139059290157031841",
+    "rate_bps": 3008,
+    "seconds": 56677819,
+    "expected_floor": "75125435557800677"
+  },
+  {
+    "principal": "4639483285193087022",
+    "rate_bps": 5455,
+    "seconds": 898319632,
+    "expected_floor": "72042917695110880357"
+  },
+  {
+    "principal": "10624127363978728735",
+    "rate_bps": 5883,
+    "seconds": 1255545193,
+    "expected_floor": "248668342399627742798"
+  },
+  {
+    "principal": "15470325854747365316",
+    "rate_bps": 4705,
+    "seconds": 796801686,
+    "expected_floor": "183783012686550915981"
+  },
+  {
+    "principal": "6116138065929320365",
+    "rate_bps": 8073,
+    "seconds": 2669019815,
+    "expected_floor": "417599590441743548995"
+  },
+  {
+    "principal": "2874943059329143210",
+    "rate_bps": 4227,
+    "seconds": 521151212,
+    "expected_floor": "20068794245367733146"
+  },
+  {
+    "principal": "7677772512099088587",
+    "rate_bps": 6599,
+    "seconds": 2457128181,
+    "expected_floor": "394491104182763324125"
+  },
+  {
+    "principal": "5551275430917837664",
+    "rate_bps": 1321,
+    "seconds": 3517575058,
+    "expected_floor": "81740068898027114554"
+  },
+  {
+    "principal": "11333688781230967801",
+    "rate_bps": 9101,
+    "seconds": 127768531,
+    "expected_floor": "41761907948978519667"
+  },
+  {
+    "principal": "8766043680776380006",
+    "rate_bps": 5392,
+    "seconds": 2138883592,
+    "expected_floor": "320358827667826564777"
+  },
+  {
+    "principal": "5401952458546890935",
+    "rate_bps": 9615,
+    "seconds": 3740616385,
+    "expected_floor": "615657608631531532235"
+  },
+  {
+    "principal": "1129277328748425276",
+    "rate_bps": 5115,
+    "seconds": 2384617422,
+    "expected_floor": "43647662740962367934"
+  },
+  {
+    "principal": "16447434297412913797",
+    "rate_bps": 4829,
+    "seconds": 689332543,
+    "expected_floor": "173492290313220489864"
+  },
+  {
+    "principal": "7788526519260797538",
+    "rate_bps": 2299,
+    "seconds": 2620025444,
+    "expected_floor": "148660577678061617117"
+  },
+  {
+    "principal": "12062046863748485347",
+    "rate_bps": 2526,
+    "seconds": 740160205,
+    "expected_floor": "71462157206325572263"
+  },
+  {
+    "principal": "6744923748483195480",
+    "rate_bps": 4551,
+    "seconds": 4138526538,
+    "expected_floor": "402555400369174870913"
+  },
+  {
+    "principal": "12562212012942942033",
+    "rate_bps": 5751,
+    "seconds": 2814470891,
+    "expected_floor": "644320991434006215939"
+  },
+  {
+    "principal": "18266356475506516382",
+    "rate_bps": 32,
+    "seconds": 2369358848,
+    "expected_floor": "4388628117318271084"
+  },
+  {
+    "principal": "10802818518009584975",
+    "rate_bps": 6520,
+    "seconds": 2422570265,
+    "expected_floor": "540700898413971426205"
+  },
+  {
+    "principal": "17378065805393716660",
+    "rate_bps": 8166,
+    "seconds": 4055638534,
+    "expected_floor": "1823753283095606998024"
+  },
+  {
+    "principal": "14310786420054718045",
+    "rate_bps": 3638,
+    "seconds": 2209218775,
+    "expected_floor": "364469300468981505635"
+  },
+  {
+    "principal": "11869454331194069018",
+    "rate_bps": 8486,
+    "seconds": 3241010908,
+    "expected_floor": "1034451912444339178141"
+  },
+  {
+    "principal": "2651773240351668731",
+    "rate_bps": 9098,
+    "seconds": 2436813221,
+    "expected_floor": "186294739389505359308"
+  },
+  {
+    "principal": "16665539581784634960",
+    "rate_bps": 3494,
+    "seconds": 1194060802,
+    "expected_floor": "220325495127661923928"
+  },
+  {
+    "principal": "5227160893105568681",
+    "rate_bps": 9111,
+    "seconds": 681946883,
+    "expected_floor": "102914956830027485832"
+  },
+  {
+    "principal": "59065030457999830",
+    "rate_bps": 3050,
+    "seconds": 432699128,
+    "expected_floor": "247008742369931172"
+  },
+  {
+    "principal": "811082625750627047",
+    "rate_bps": 4363,
+    "seconds": 564468849,
+    "expected_floor": "6329746599445168261"
+  },
+  {
+    "principal": "8600184015591215148",
+    "rate_bps": 1990,
+    "seconds": 473784638,
+    "expected_floor": "25694361391281142252"
+  },
+  {
+    "principal": "16866257528466791221",
+    "rate_bps": 745,
+    "seconds": 1985495407,
+    "expected_floor": "79056925297732525167"
+  },
+  {
+    "principal": "15006845382363452114",
+    "rate_bps": 1943,
+    "seconds": 2653780052,
+    "expected_floor": "245201524906635835689"
+  },
+  {
+    "principal": "1552644903727223827",
+    "rate_bps": 2952,
+    "seconds": 1994901885,
+    "expected_floor": "28973840760306725044"
+  },
+  {
+    "principal": "9739443840600502088",
+    "rate_bps": 4290,
+    "seconds": 2060639674,
+    "expected_floor": "272828377293995237462"
+  },
+  {
+    "principal": "11396755524935074049",
+    "rate_bps": 7988,
+    "seconds": 2361902107,
+    "expected_floor": "681360910993917924579"
+  },
+  {
+    "principal": "415610275572834062",
+    "rate_bps": 627,
+    "seconds": 4264322800,
+    "expected_floor": "3521274832442196596"
+  },
+  {
+    "principal": "8802601846871337343",
+    "rate_bps": 2257,
+    "seconds": 532055241,
+    "expected_floor": "33496187286180957407"
+  },
+  {
+    "principal": "16297914250005417892",
+    "rate_bps": 8044,
+    "seconds": 1072430454,
+    "expected_floor": "445522109819948409292"
+  },
+  {
+    "principal": "13449794690619447565",
+    "rate_bps": 611,
+    "seconds": 1760854791,
+    "expected_floor": "45853917094375205936"
+  },
+  {
+    "principal": "1307119266091631242",
+    "rate_bps": 865,
+    "seconds": 1659895500,
+    "expected_floor": "5947139200708270313"
+  },
+  {
+    "principal": "6562249329824399147",
+    "rate_bps": 6884,
+    "seconds": 158153301,
+    "expected_floor": "22639554823027544607"
+  },
+  {
+    "principal": "10895488034502077760",
+    "rate_bps": 4105,
+    "seconds": 224500850,
+    "expected_floor": "31818072869159221369"
+  },
+  {
+    "principal": "9087945488774631257",
+    "rate_bps": 9,
+    "seconds": 2647198259,
+    "expected_floor": "686105221189000339"
+  },
+  {
+    "principal": "3317360139509209414",
+    "rate_bps": 204,
+    "seconds": 1221606376,
+    "expected_floor": "2619691271751307910"
+  },
+  {
+    "principal": "10053154967398785303",
+    "rate_bps": 7520,
+    "seconds": 1604326945,
+    "expected_floor": "384334285311201352512"
+  },
+  {
+    "principal": "4608094329993085980",
+    "rate_bps": 13,
+    "seconds": 451008174,
+    "expected_floor": "85614073066612026"
+  },
+  {
+    "principal": "14616986664327745509",
+    "rate_bps": 2086,
+    "seconds": 3041273247,
+    "expected_floor": "293848602334884139145"
+  },
+  {
+    "principal": "14115624533581954882",
+    "rate_bps": 5010,
+    "seconds": 1584421444,
+    "expected_floor": "355062305163774604871"
+  },
+  {
+    "principal": "15072501926535043907",
+    "rate_bps": 9936,
+    "seconds": 1910998061,
+    "expected_floor": "906887070484088113841"
+  },
+  {
+    "principal": "13929309124591161400",
+    "rate_bps": 34,
+    "seconds": 36440106,
+    "expected_floor": "54687007358714066"
+  },
+  {
+    "principal": "8583646838960408241",
+    "rate_bps": 9943,
+    "seconds": 99541323,
+    "expected_floor": "26920847130597768053"
+  },
+  {
+    "principal": "15417877164167549054",
+    "rate_bps": 7654,
+    "seconds": 2769999328,
+    "expected_floor": "1035830598095562543737"
+  },
+  {
+    "principal": "4813733560560728495",
+    "rate_bps": 6160,
+    "seconds": 200028281,
+    "expected_floor": "18795340430690505642"
+  },
+  {
+    "principal": "10630217219380153748",
+    "rate_bps": 1918,
+    "seconds": 3800878310,
+    "expected_floor": "245567415869911437917"
+  },
+  {
+    "principal": "12149341005059694525",
+    "rate_bps": 3109,
+    "seconds": 141855031,
+    "expected_floor": "16979082552226071090"
+  },
+  {
+    "principal": "7675616299518060794",
+    "rate_bps": 6073,
+    "seconds": 1314745020,
+    "expected_floor": "194202181875726967476"
+  },
+  {
+    "principal": "1813912032336054363",
+    "rate_bps": 4403,
+    "seconds": 3954378501,
+    "expected_floor": "100078128739447009669"
+  },
+  {
+    "principal": "16897070286980266032",
+    "rate_bps": 4123,
+    "seconds": 2006581474,
+    "expected_floor": "442973326995264874756"
+  },
+  {
+    "principal": "17077782157871793929",
+    "rate_bps": 8742,
+    "seconds": 2040703331,
+    "expected_floor": "965424193194512303024"
+  },
+  {
+    "principal": "2904008980137665718",
+    "rate_bps": 6580,
+    "seconds": 317002968,
+    "expected_floor": "19194783142504780066"
+  },
+  {
+    "principal": "13140222327171797831",
+    "rate_bps": 2974,
+    "seconds": 1109996497,
+    "expected_floor": "137455245770618302905"
+  },
+  {
+    "principal": "11080327339031088140",
+    "rate_bps": 6609,
+    "seconds": 4281253918,
+    "expected_floor": "993471382966265885354"
+  },
+  {
+    "principal": "4173869596755110037",
+    "rate_bps": 353,
+    "seconds": 3565882831,
+    "expected_floor": "16648560304545925190"
+  },
+  {
+    "principal": "619186519175700402",
+    "rate_bps": 5022,
+    "seconds": 4271509556,
+    "expected_floor": "42089679230886461403"
+  },
+  {
+    "principal": "1438718829110371955",
+    "rate_bps": 5176,
+    "seconds": 1777345245,
+    "expected_floor": "41940926944201150957"
+  },
+  {
+    "principal": "1574143084722799912",
+    "rate_bps": 9713,
+    "seconds": 178742938,
+    "expected_floor": "8660092277283397461"
+  },
+  {
+    "principal": "2907554674496041057",
+    "rate_bps": 7371,
+    "seconds": 4042375803,
+    "expected_floor": "274528236203668562761"
+  },
+  {
+    "principal": "14926180864453293550",
+    "rate_bps": 438,
+    "seconds": 3992705232,
+    "expected_floor": "82715346252253198005"
+  },
+  {
+    "principal": "3060985137078193631",
+    "rate_bps": 5855,
+    "seconds": 1080655913,
+    "expected_floor": "61372185252280390295"
+  },
+  {
+    "principal": "7317554444959506308",
+    "rate_bps": 106,
+    "seconds": 2539491414,
+    "expected_floor": "6241868420133132417"
+  },
+  {
+    "principal": "7164100976369109613",
+    "rate_bps": 1728,
+    "seconds": 3522761575,
+    "expected_floor": "138192578447491210741"
+  },
+  {
+    "principal": "12152427154382193514",
+    "rate_bps": 4433,
+    "seconds": 951921324,
+    "expected_floor": "162501676633000135878"
+  },
+  {
+    "principal": "10457328607925589387",
+    "rate_bps": 8867,
+    "seconds": 3439540149,
+    "expected_floor": "1010633942288546451306"
+  },
+  {
+    "principal": "16058741242480301856",
+    "rate_bps": 865,
+    "seconds": 174332242,
+    "expected_floor": "7673638854957379565"
+  },
+  {
+    "principal": "4950296277348360889",
+    "rate_bps": 984,
+    "seconds": 4044197011,
+    "expected_floor": "62424436059402493926"
+  },
+  {
+    "principal": "9427023690158384166",
+    "rate_bps": 199,
+    "seconds": 1168114120,
+    "expected_floor": "6943988316372772969"
+  },
+  {
+    "principal": "5309841920264112503",
+    "rate_bps": 800,
+    "seconds": 583234945,
+    "expected_floor": "7850750019834040715"
+  },
+  {
+    "principal": "1986097407429126140",
+    "rate_bps": 3289,
+    "seconds": 3951238542,
+    "expected_floor": "81788774398726108673"
+  },
+  {
+    "principal": "12771079760398984517",
+    "rate_bps": 2789,
+    "seconds": 2433874431,
+    "expected_floor": "274707383669653844796"
+  },
+  {
+    "principal": "18033671550707758114",
+    "rate_bps": 9145,
+    "seconds": 59873828,
+    "expected_floor": "31289665739068509260"
+  },
+  {
+    "principal": "7142290151894119843",
+    "rate_bps": 112,
+    "seconds": 2819925389,
+    "expected_floor": "7148076018177111815"
+  },
+  {
+    "principal": "9663334785580961304",
+    "rate_bps": 9470,
+    "seconds": 2071197962,
+    "expected_floor": "600612889141632676590"
+  },
+  {
+    "principal": "1284006445312392721",
+    "rate_bps": 1286,
+    "seconds": 3855312811,
+    "expected_floor": "20172690560920342424"
+  },
+  {
+    "principal": "18296462426588942174",
+    "rate_bps": 991,
+    "seconds": 2215014336,
+    "expected_floor": "127266282080459337224"
+  },
+  {
+    "principal": "5268352267378583055",
+    "rate_bps": 1207,
+    "seconds": 819033049,
+    "expected_floor": "16503632174987555926"
+  },
+  {
+    "principal": "8621602589772776820",
+    "rate_bps": 6380,
+    "seconds": 2170374086,
+    "expected_floor": "378302583603444506353"
+  },
+  {
+    "principal": "12490851650357319965",
+    "rate_bps": 1606,
+    "seconds": 462234007,
+    "expected_floor": "29382958251434477097"
+  },
+  {
+    "principal": "2582598294475854298",
+    "rate_bps": 1406,
+    "seconds": 848707228,
+    "expected_floor": "9765536651697958019"
+  },
+  {
+    "principal": "7955683938669422267",
+    "rate_bps": 1194,
+    "seconds": 2526071909,
+    "expected_floor": "76036757798249029940"
+  },
+  {
+    "principal": "11551892491494656528",
+    "rate_bps": 5687,
+    "seconds": 3952010690,
+    "expected_floor": "822717073788440458208"
+  },
+  {
+    "principal": "1880824786253980265",
+    "rate_bps": 2385,
+    "seconds": 2334438339,
+    "expected_floor": "33182963006011422151"
+  },
+  {
+    "principal": "14564702235637831574",
+    "rate_bps": 9286,
+    "seconds": 1708655288,
+    "expected_floor": "732286077865964064427"
+  },
+  {
+    "principal": "5863722114977186727",
+    "rate_bps": 4304,
+    "seconds": 3140606769,
+    "expected_floor": "251162755261941433226"
+  },
+  {
+    "principal": "13731030939728697324",
+    "rate_bps": 843,
+    "seconds": 528346878,
+    "expected_floor": "19379648636515180003"
+  },
+  {
+    "principal": "7163801934782039541",
+    "rate_bps": 9731,
+    "seconds": 2785405487,
+    "expected_floor": "615297998244095794741"
+  },
+  {
+    "principal": "6632606379061935250",
+    "rate_bps": 3475,
+    "seconds": 1165883412,
+    "expected_floor": "85151085636949857211"
+  },
+  {
+    "principal": "8642177096724121811",
+    "rate_bps": 7163,
+    "seconds": 564661309,
+    "expected_floor": "110764904233990999885"
+  },
+  {
+    "principal": "16940876284937169672",
+    "rate_bps": 3501,
+    "seconds": 352370554,
+    "expected_floor": "66225252655944913225"
+  },
+  {
+    "principal": "10239744667105669057",
+    "rate_bps": 6676,
+    "seconds": 1723257051,
+    "expected_floor": "373294466733987655446"
+  },
+  {
+    "principal": "13199553177631710414",
+    "rate_bps": 9372,
+    "seconds": 1102158512,
+    "expected_floor": "432047604896250847672"
+  },
+  {
+    "principal": "17856519737522848319",
+    "rate_bps": 7936,
+    "seconds": 2298940297,
+    "expected_floor": "1032338687516338424901"
+  },
+  {
+    "principal": "3114619598836236132",
+    "rate_bps": 2718,
+    "seconds": 2563437366,
+    "expected_floor": "68765912123000422664"
+  },
+  {
+    "principal": "16993177079286205389",
+    "rate_bps": 556,
+    "seconds": 1367061447,
+    "expected_floor": "40929217650923219504"
+  },
+  {
+    "principal": "11598380934711792714",
+    "rate_bps": 1883,
+    "seconds": 2544871052,
+    "expected_floor": "176120335090146042546"
+  },
+  {
+    "principal": "5082990536359623659",
+    "rate_bps": 921,
+    "seconds": 902743317,
+    "expected_floor": "13391808990050374557"
+  },
+  {
+    "principal": "17874251248178204928",
+    "rate_bps": 411,
+    "seconds": 1378444850,
+    "expected_floor": "32088920569530502602"
+  },
+  {
+    "principal": "5049511077327095321",
+    "rate_bps": 1692,
+    "seconds": 1363353331,
+    "expected_floor": "36910858329703264564"
+  },
+  {
+    "principal": "436820115715882758",
+    "rate_bps": 4794,
+    "seconds": 2678331304,
+    "expected_floor": "17773010174174123078"
+  },
+  {
+    "principal": "15184471140031791575",
+    "rate_bps": 2453,
+    "seconds": 3581371617,
+    "expected_floor": "422710113899791647628"
+  },
+  {
+    "principal": "7077091152492813276",
+    "rate_bps": 8673,
+    "seconds": 1744712814,
+    "expected_floor": "339347082214087497203"
+  },
+  {
+    "principal": "15596106781915302565",
+    "rate_bps": 8716,
+    "seconds": 4241612383,
+    "expected_floor": "1827092070415606946193"
+  },
+  {
+    "principal": "18162478056103983362",
+    "rate_bps": 7930,
+    "seconds": 3754306052,
+    "expected_floor": "1713460102139619792375"
+  },
+  {
+    "principal": "6783941084661211139",
+    "rate_bps": 23,
+    "seconds": 675108589,
+    "expected_floor": "333794802364785266"
+  },
+  {
+    "principal": "5796813912645065720",
+    "rate_bps": 3835,
+    "seconds": 3774659050,
+    "expected_floor": "265906216030999543426"
+  },
+  {
+    "principal": "4746403764661994865",
+    "rate_bps": 3165,
+    "seconds": 271515147,
+    "expected_floor": "12924938628956103723"
+  },
+  {
+    "principal": "5406263181240213054",
+    "rate_bps": 1612,
+    "seconds": 548690336,
+    "expected_floor": "15152544396936470747"
+  },
+  {
+    "principal": "17165449315992314479",
+    "rate_bps": 2133,
+    "seconds": 3710732089,
+    "expected_floor": "430528260122989972189"
+  },
+  {
+    "principal": "1456498991546977620",
+    "rate_bps": 325,
+    "seconds": 455447206,
+    "expected_floor": "683168171149307256"
+  },
+  {
+    "principal": "17052857951617852029",
+    "rate_bps": 94,
+    "seconds": 642763255,
+    "expected_floor": "3264916677755105489"
+  },
+  {
+    "principal": "2758616765740255930",
+    "rate_bps": 7369,
+    "seconds": 4279263868,
+    "expected_floor": "275654462503376591021"
+  },
+  {
+    "principal": "655596143481214235",
+    "rate_bps": 75,
+    "seconds": 1282417093,
+    "expected_floor": "199812652222885214"
+  },
+  {
+    "principal": "10644665467035659248",
+    "rate_bps": 6649,
+    "seconds": 4135754402,
+    "expected_floor": "927553831716033999729"
+  },
+  {
+    "principal": "7555609174023671241",
+    "rate_bps": 3652,
+    "seconds": 4278439459,
+    "expected_floor": "374094805660541664773"
+  },
+  {
+    "principal": "16900041507849181814",
+    "rate_bps": 3242,
+    "seconds": 3059433624,
+    "expected_floor": "531175273390456899144"
+  },
+  {
+    "principal": "9326296689020322823",
+    "rate_bps": 9365,
+    "seconds": 4225176209,
+    "expected_floor": "1169385939079741699318"
+  },
+  {
+    "principal": "8646955161011401676",
+    "rate_bps": 6010,
+    "seconds": 2401431006,
+    "expected_floor": "395461150560177132762"
+  },
+  {
+    "principal": "1643739641834271573",
+    "rate_bps": 2906,
+    "seconds": 3709916815,
+    "expected_floor": "56155053301002480384"
+  },
+  {
+    "principal": "9674971267137612146",
+    "rate_bps": 7891,
+    "seconds": 554774516,
+    "expected_floor": "134212900913247600393"
+  },
+  {
+    "principal": "10865389232931404595",
+    "rate_bps": 6011,
+    "seconds": 430409117,
+    "expected_floor": "89077805986784671472"
+  },
+  {
+    "principal": "2340142351575671016",
+    "rate_bps": 9602,
+    "seconds": 2723604570,
+    "expected_floor": "193929583731164693058"
+  },
+  {
+    "principal": "1956787965801070369",
+    "rate_bps": 9080,
+    "seconds": 3371102011,
+    "expected_floor": "189800584224536387195"
+  },
+  {
+    "principal": "12303806782558229422",
+    "rate_bps": 9465,
+    "seconds": 705014928,
+    "expected_floor": "260168352289127895561"
+  },
+  {
+    "principal": "4162439746528888479",
+    "rate_bps": 5831,
+    "seconds": 1504126697,
+    "expected_floor": "115683509120263046147"
+  },
+  {
+    "principal": "13989404488825564996",
+    "rate_bps": 5155,
+    "seconds": 4213974550,
+    "expected_floor": "962976831486222933323"
+  },
+  {
+    "principal": "7403358066048834861",
+    "rate_bps": 6868,
+    "seconds": 3268699175,
+    "expected_floor": "526659627366797419424"
+  },
+  {
+    "principal": "8957726245649347882",
+    "rate_bps": 6028,
+    "seconds": 721384044,
+    "expected_floor": "123433656573200955959"
+  },
+  {
+    "principal": "1368094907573350987",
+    "rate_bps": 9693,
+    "seconds": 3764904565,
+    "expected_floor": "158206544136938931466"
+  },
+  {
+    "principal": "15774750728039127776",
+    "rate_bps": 3881,
+    "seconds": 2183758610,
+    "expected_floor": "423649610277095559741"
+  },
+  {
+    "principal": "13785754833211586937",
+    "rate_bps": 7444,
+    "seconds": 843170131,
+    "expected_floor": "274187821821723339499"
+  },
+  {
+    "principal": "6330471515484432870",
+    "rate_bps": 6141,
+    "seconds": 4103372168,
+    "expected_floor": "505489452081699360095"
+  },
+  {
+    "principal": "4078682269478292023",
+    "rate_bps": 7779,
+    "seconds": 684975169,
+    "expected_floor": "68867530109024249338"
+  },
+  {
+    "principal": "17071779856942358460",
+    "rate_bps": 9590,
+    "seconds": 3427474254,
+    "expected_floor": "1778146925194282251361"
+  },
+  {
+    "principal": "9834897323867308037",
+    "rate_bps": 4595,
+    "seconds": 484299455,
+    "expected_floor": "69353017108423552755"
+  },
+  {
+    "principal": "17906234445872844258",
+    "rate_bps": 6190,
+    "seconds": 2068187620,
+    "expected_floor": "726408441601919338236"
+  },
+  {
+    "principal": "11614244316764133987",
+    "rate_bps": 5593,
+    "seconds": 268015693,
+    "expected_floor": "55168608961096417398"
+  },
+  {
+    "principal": "16291958260182186456",
+    "rate_bps": 817,
+    "seconds": 1161710282,
+    "expected_floor": "48999225042575626383"
+  },
+  {
+    "principal": "12756022780894829777",
+    "rate_bps": 975,
+    "seconds": 4059145323,
+    "expected_floor": "159974416482469942242"
+  },
+  {
+    "principal": "17186715648923368734",
+    "rate_bps": 8989,
+    "seconds": 1708954496,
+    "expected_floor": "836624934572127235223"
+  },
+  {
+    "principal": "5676553371182034639",
+    "rate_bps": 5804,
+    "seconds": 1930930841,
+    "expected_floor": "201592737036047979696"
+  },
+  {
+    "principal": "17633537013095294260",
+    "rate_bps": 2113,
+    "seconds": 1356705158,
+    "expected_floor": "160184481516016688066"
+  },
+  {
+    "principal": "13474635244299779037",
+    "rate_bps": 6289,
+    "seconds": 4128539223,
+    "expected_floor": "1108641318114917132323"
+  },
+  {
+    "principal": "16876408188470989722",
+    "rate_bps": 9565,
+    "seconds": 4177778268,
+    "expected_floor": "2137009313034665986232"
+  },
+  {
+    "principal": "11358300824225174395",
+    "rate_bps": 840,
+    "seconds": 199821093,
+    "expected_floor": "6041294622114353403"
+  },
+  {
+    "principal": "12959055588455751120",
+    "rate_bps": 2952,
+    "seconds": 4293730178,
+    "expected_floor": "520499705772259248703"
+  },
+  {
+    "principal": "3099486305564854569",
+    "rate_bps": 8224,
+    "seconds": 2602039427,
+    "expected_floor": "210175809732072352389"
+  },
+  {
+    "principal": "13881170523488398678",
+    "rate_bps": 9127,
+    "seconds": 472305272,
+    "expected_floor": "189615120384574572194"
+  },
+  {
+    "principal": "3527355807098164327",
+    "rate_bps": 3600,
+    "seconds": 1999690225,
+    "expected_floor": "80465650553857914900"
+  },
+  {
+    "principal": "10807289655089782700",
+    "rate_bps": 720,
+    "seconds": 873839806,
+    "expected_floor": "21546520409740959678"
+  },
+  {
+    "principal": "9969039834019393717",
+    "rate_bps": 4514,
+    "seconds": 1345573615,
+    "expected_floor": "191874995029652783436"
+  },
+  {
+    "principal": "9651568432881280594",
+    "rate_bps": 9732,
+    "seconds": 1938536404,
+    "expected_floor": "576992261565947522881"
+  },
+  {
+    "principal": "17550043252022640019",
+    "rate_bps": 6257,
+    "seconds": 2441514749,
+    "expected_floor": "849571101287408758745"
+  },
+  {
+    "principal": "8783611888622577352",
+    "rate_bps": 3832,
+    "seconds": 1327620410,
+    "expected_floor": "141601740504298340801"
+  },
+  {
+    "principal": "6785732621777886849",
+    "rate_bps": 409,
+    "seconds": 2524061083,
+    "expected_floor": "22198107222291007834"
+  },
+  {
+    "principal": "2176567419640584846",
+    "rate_bps": 7345,
+    "seconds": 3417312880,
+    "expected_floor": "173118986358152919501"
+  },
+  {
+    "principal": "1255242528122444543",
+    "rate_bps": 1152,
+    "seconds": 2522993225,
+    "expected_floor": "11560915881121787095"
+  },
+  {
+    "principal": "4234076097213935396",
+    "rate_bps": 8739,
+    "seconds": 3380160758,
+    "expected_floor": "396327115901006039447"
+  },
+  {
+    "principal": "15591603323301772941",
+    "rate_bps": 7691,
+    "seconds": 1700471943,
+    "expected_floor": "646158545092164090922"
+  },
+  {
+    "principal": "15962741411571230218",
+    "rate_bps": 8798,
+    "seconds": 1373933132,
+    "expected_floor": "611438900255305878054"
+  },
+  {
+    "principal": "17202071979342444715",
+    "rate_bps": 145,
+    "seconds": 2909179861,
+    "expected_floor": "22994044536395163089"
+  },
+  {
+    "principal": "8359522435413996736",
+    "rate_bps": 8809,
+    "seconds": 1272737778,
+    "expected_floor": "296990833917908669633"
+  },
+  {
+    "principal": "6290722108880862425",
+    "rate_bps": 4851,
+    "seconds": 736195507,
+    "expected_floor": "71190324233208716366"
+  },
+  {
+    "principal": "9324320329731777734",
+    "rate_bps": 7089,
+    "seconds": 1445540712,
+    "expected_floor": "302780932238825430709"
+  },
+  {
+    "principal": "10042261790171996823",
+    "rate_bps": 7548,
+    "seconds": 3522229153,
+    "expected_floor": "846013066148897907188"
+  },
+  {
+    "principal": "2458193530797175708",
+    "rate_bps": 3042,
+    "seconds": 677499438,
+    "expected_floor": "16053888907035390005"
+  },
+  {
+    "principal": "12373282783444092261",
+    "rate_bps": 592,
+    "seconds": 4186822431,
+    "expected_floor": "97182310563779456677"
+  },
+  {
+    "principal": "10041380485488816834",
+    "rate_bps": 5744,
+    "seconds": 2454272452,
+    "expected_floor": "448566318275418988445"
+  },
+  {
+    "principal": "17145483498946225347",
+    "rate_bps": 1086,
+    "seconds": 1088514477,
+    "expected_floor": "64225841654915432291"
+  },
+  {
+    "principal": "7782325426015496120",
+    "rate_bps": 8320,
+    "seconds": 1320201130,
+    "expected_floor": "270874951563148653893"
+  },
+  {
+    "principal": "11740966412008621105",
+    "rate_bps": 9558,
+    "seconds": 2615892683,
+    "expected_floor": "930222474118482957704"
+  },
+  {
+    "principal": "8323640929856007166",
+    "rate_bps": 2665,
+    "seconds": 842472800,
+    "expected_floor": "59219191190670709709"
+  },
+  {
+    "principal": "6078781991586253615",
+    "rate_bps": 6886,
+    "seconds": 3634929145,
+    "expected_floor": "482142670617891957146"
+  },
+  {
+    "principal": "18316405472415370516",
+    "rate_bps": 7624,
+    "seconds": 394106982,
+    "expected_floor": "174394706506864307704"
+  },
+  {
+    "principal": "7891126758709388605",
+    "rate_bps": 1419,
+    "seconds": 3157478071,
+    "expected_floor": "112036050614668738268"
+  },
+  {
+    "principal": "9112748755970387066",
+    "rate_bps": 3077,
+    "seconds": 430479932,
+    "expected_floor": "38249506506196599708"
+  },
+  {
+    "principal": "3781819333927920091",
+    "rate_bps": 2261,
+    "seconds": 395541637,
+    "expected_floor": "10717403446450947424"
+  },
+  {
+    "principal": "6542782364597313456",
+    "rate_bps": 7268,
+    "seconds": 2202432610,
+    "expected_floor": "331876158705837368728"
+  },
+  {
+    "principal": "7565049613679367305",
+    "rate_bps": 9818,
+    "seconds": 1228485347,
+    "expected_floor": "289135103506539496821"
+  },
+  {
+    "principal": "11640567545958961206",
+    "rate_bps": 11,
+    "seconds": 586329176,
+    "expected_floor": "237905443225527474"
+  },
+  {
+    "principal": "14557615710462768327",
+    "rate_bps": 914,
+    "seconds": 2757177681,
+    "expected_floor": "116251143549170701680"
+  },
+  {
+    "principal": "12917802981861579660",
+    "rate_bps": 5080,
+    "seconds": 3360578462,
+    "expected_floor": "698815358659065576771"
+  },
+  {
+    "principal": "17615238453649669653",
+    "rate_bps": 1254,
+    "seconds": 3113672527,
+    "expected_floor": "217949075256744511175"
+  },
+  {
+    "principal": "12839538021920404274",
+    "rate_bps": 47,
+    "seconds": 1394970548,
+    "expected_floor": "2667523947808900838"
+  },
+  {
+    "principal": "8087351131032784883",
+    "rate_bps": 7531,
+    "seconds": 2363304029,
+    "expected_floor": "456115231494712170598"
+  },
+  {
+    "principal": "1659648487331904680",
+    "rate_bps": 8705,
+    "seconds": 1272556058,
+    "expected_floor": "58258305092956569275"
+  },
+  {
+    "principal": "13307320709084564961",
+    "rate_bps": 8826,
+    "seconds": 4061682683,
+    "expected_floor": "1511668526379740317453"
+  },
+  {
+    "principal": "7866466951749972334",
+    "rate_bps": 7096,
+    "seconds": 1063829584,
+    "expected_floor": "188174783758058662287"
+  },
+  {
+    "principal": "8167120074571317087",
+    "rate_bps": 2623,
+    "seconds": 2806975913,
+    "expected_floor": "190546927418697501128"
+  },
+  {
+    "principal": "17248609301131476740",
+    "rate_bps": 7097,
+    "seconds": 1655307222,
+    "expected_floor": "642101276178353918669"
+  },
+  {
+    "principal": "2767417688812023789",
+    "rate_bps": 4803,
+    "seconds": 3697800423,
+    "expected_floor": "155749549764156600112"
+  },
+  {
+    "principal": "7463993300574217962",
+    "rate_bps": 2356,
+    "seconds": 529988140,
+    "expected_floor": "29533077909809272289"
+  },
+  {
+    "principal": "11569387073864027915",
+    "rate_bps": 3241,
+    "seconds": 3244477749,
+    "expected_floor": "385505177689253010521"
+  },
+  {
+    "principal": "7891130425587523232",
+    "rate_bps": 4201,
+    "seconds": 1958358226,
+    "expected_floor": "205721684862004264029"
+  },
+  {
+    "principal": "14327562819587248185",
+    "rate_bps": 6154,
+    "seconds": 4193924627,
+    "expected_floor": "1171781041590768666256"
+  },
+  {
+    "principal": "5390587469299543974",
+    "rate_bps": 3299,
+    "seconds": 1243232584,
+    "expected_floor": "70059467161120397936"
+  },
+  {
+    "principal": "4386869080835377911",
+    "rate_bps": 5011,
+    "seconds": 2313589505,
+    "expected_floor": "161161542332326164963"
+  },
+  {
+    "principal": "10790866197947733884",
+    "rate_bps": 501,
+    "seconds": 1614436622,
+    "expected_floor": "27657381917849995357"
+  },
+  {
+    "principal": "17888729775656999621",
+    "rate_bps": 5651,
+    "seconds": 2134502271,
+    "expected_floor": "683750198072720191845"
+  },
+  {
+    "principal": "13590242796980463522",
+    "rate_bps": 6008,
+    "seconds": 352827812,
+    "expected_floor": "91288481724494644473"
+  },
+  {
+    "principal": "4316342013492428579",
+    "rate_bps": 1455,
+    "seconds": 1619839757,
+    "expected_floor": "32236429226160412597"
+  },
+  {
+    "principal": "16024661050942268824",
+    "rate_bps": 2847,
+    "seconds": 936107146,
+    "expected_floor": "135331193780821417576"
+  },
+  {
+    "principal": "7890287585895365521",
+    "rate_bps": 4337,
+    "seconds": 3270779179,
+    "expected_floor": "354674130110621550365"
+  },
+  {
+    "principal": "8117480541895043806",
+    "rate_bps": 9133,
+    "seconds": 1484519232,
+    "expected_floor": "348751894199109000289"
+  },
+  {
+    "principal": "15004754456289654671",
+    "rate_bps": 7290,
+    "seconds": 2012750169,
+    "expected_floor": "697657593966387448583"
+  },
+  {
+    "principal": "17435559436140512500",
+    "rate_bps": 3268,
+    "seconds": 3086832454,
+    "expected_floor": "557348741845497701443"
+  },
+  {
+    "principal": "17968412351467937437",
+    "rate_bps": 2983,
+    "seconds": 235152151,
+    "expected_floor": "39939989605234287075"
+  },
+  {
+    "principal": "9690148557455955290",
+    "rate_bps": 6698,
+    "seconds": 238464540,
+    "expected_floor": "49045076840049926036"
+  },
+  {
+    "principal": "6747128550554337339",
+    "rate_bps": 8290,
+    "seconds": 4127687141,
+    "expected_floor": "731604419930058097504"
+  },
+  {
+    "principal": "8317787328734228880",
+    "rate_bps": 6738,
+    "seconds": 268867906,
+    "expected_floor": "47750048429740070664"
+  },
+  {
+    "principal": "7762186439420424169",
+    "rate_bps": 8805,
+    "seconds": 390036803,
+    "expected_floor": "84472442338405858290"
+  },
+  {
+    "principal": "17768019069244785430",
+    "rate_bps": 4243,
+    "seconds": 3396786744,
+    "expected_floor": "811477267837529621809"
+  },
+  {
+    "principal": "4414941199411291431",
+    "rate_bps": 476,
+    "seconds": 4267841713,
+    "expected_floor": "28420794422180159617"
+  },
+  {
+    "principal": "16998105636596787052",
+    "rate_bps": 3379,
+    "seconds": 3653552766,
+    "expected_floor": "664967060071146675667"
+  },
+  {
+    "principal": "17289552934107454325",
+    "rate_bps": 3828,
+    "seconds": 3080846255,
+    "expected_floor": "646132746066106881264"
+  },
+  {
+    "principal": "16307521104008155154",
+    "rate_bps": 6185,
+    "seconds": 169260948,
+    "expected_floor": "54097906015227807661"
+  },
+  {
+    "principal": "17178556267453231699",
+    "rate_bps": 8837,
+    "seconds": 3544404413,
+    "expected_floor": "1705025263122378087638"
+  },
+  {
+    "principal": "5676692931999343240",
+    "rate_bps": 866,
+    "seconds": 1559642874,
+    "expected_floor": "24295983998325487345"
+  },
+  {
+    "principal": "30998143389486401",
+    "rate_bps": 8709,
+    "seconds": 2730076763,
+    "expected_floor": "2335473075213420165"
+  },
+  {
+    "principal": "6083873349384312910",
+    "rate_bps": 7228,
+    "seconds": 2447884848,
+    "expected_floor": "341102832282806392757"
+  },
+  {
+    "principal": "17274997336005309375",
+    "rate_bps": 3512,
+    "seconds": 2022103305,
+    "expected_floor": "388751312441354510246"
+  },
+  {
+    "principal": "8140789834609598180",
+    "rate_bps": 5409,
+    "seconds": 2042011318,
+    "expected_floor": "284929687794291030817"
+  },
+  {
+    "principal": "16121197087544815949",
+    "rate_bps": 4777,
+    "seconds": 793957703,
+    "expected_floor": "193751881341822337409"
+  },
+  {
+    "principal": "5006990966890444746",
+    "rate_bps": 8644,
+    "seconds": 1531885068,
+    "expected_floor": "210094063958285249866"
+  },
+  {
+    "principal": "12411727456632403307",
+    "rate_bps": 799,
+    "seconds": 2230622869,
+    "expected_floor": "70097284342722501679"
+  },
+  {
+    "principal": "4038436157431715968",
+    "rate_bps": 7160,
+    "seconds": 3594172850,
+    "expected_floor": "329322372960731166848"
+  },
+  {
+    "principal": "18118483346860503961",
+    "rate_bps": 7196,
+    "seconds": 2086930547,
+    "expected_floor": "862217880130444572375"
+  },
+  {
+    "principal": "6098485080112302726",
+    "rate_bps": 1404,
+    "seconds": 3391065896,
+    "expected_floor": "92007098576878011332"
+  },
+  {
+    "principal": "6619610460897444695",
+    "rate_bps": 6827,
+    "seconds": 231522913,
+    "expected_floor": "33155253089188543663"
+  },
+  {
+    "principal": "7013937449450130268",
+    "rate_bps": 7486,
+    "seconds": 734834670,
+    "expected_floor": "122263657252928038199"
+  },
+  {
+    "principal": "7736186796529123365",
+    "rate_bps": 6151,
+    "seconds": 2117734367,
+    "expected_floor": "319330346341857145947"
+  },
+  {
+    "principal": "6534255781473610882",
+    "rate_bps": 3843,
+    "seconds": 666470788,
+    "expected_floor": "53032691251998079965"
+  },
+  {
+    "principal": "17244124769021929859",
+    "rate_bps": 5769,
+    "seconds": 3633560685,
+    "expected_floor": "1145434200630211571494"
+  },
+  {
+    "principal": "555778897166906232",
+    "rate_bps": 1068,
+    "seconds": 3473399146,
+    "expected_floor": "6533171087679956627"
+  },
+  {
+    "principal": "7955023726826947313",
+    "rate_bps": 9806,
+    "seconds": 3219388299,
+    "expected_floor": "795797851690509229908"
+  },
+  {
+    "principal": "17656187848043198910",
+    "rate_bps": 4975,
+    "seconds": 2674073888,
+    "expected_floor": "744319611308287923522"
+  },
+  {
+    "principal": "6034551641877984239",
+    "rate_bps": 6643,
+    "seconds": 1058944185,
+    "expected_floor": "134517368680011794646"
+  },
+  {
+    "principal": "12338239664556838100",
+    "rate_bps": 6903,
+    "seconds": 3478445606,
+    "expected_floor": "938798365403624246403"
+  },
+  {
+    "principal": "2964403565015427069",
+    "rate_bps": 8843,
+    "seconds": 3839822711,
+    "expected_floor": "318965827859781693861"
+  },
+  {
+    "principal": "4167318444956421690",
+    "rate_bps": 6778,
+    "seconds": 937824764,
+    "expected_floor": "83941356297787256413"
+  },
+  {
+    "principal": "1112862336943697563",
+    "rate_bps": 9998,
+    "seconds": 1910314821,
+    "expected_floor": "67352784511909715849"
+  },
+  {
+    "principal": "3910994843294815088",
+    "rate_bps": 569,
+    "seconds": 1235586594,
+    "expected_floor": "8713020387551646049"
+  },
+  {
+    "principal": "11897159975988779849",
+    "rate_bps": 6318,
+    "seconds": 922933155,
+    "expected_floor": "219831135675042558724"
+  },
+  {
+    "principal": "13274859801268995574",
+    "rate_bps": 3844,
+    "seconds": 2255181848,
+    "expected_floor": "364662346529300375979"
+  },
+  {
+    "principal": "6864520417775838599",
+    "rate_bps": 7198,
+    "seconds": 74027025,
+    "expected_floor": "11590665503475226960"
+  },
+  {
+    "principal": "16729163893046461260",
+    "rate_bps": 3647,
+    "seconds": 3396405598,
+    "expected_floor": "656637347084221942616"
+  },
+  {
+    "principal": "5900684185837881557",
+    "rate_bps": 6763,
+    "seconds": 3433900047,
+    "expected_floor": "434235615737368634161"
+  },
+  {
+    "principal": "16106323582517378290",
+    "rate_bps": 5569,
+    "seconds": 379006836,
+    "expected_floor": "107725052407068583129"
+  },
+  {
+    "principal": "16731044014925112499",
+    "rate_bps": 5775,
+    "seconds": 4031843101,
+    "expected_floor": "1234453360896252329377"
+  },
+  {
+    "principal": "3686956368889829480",
+    "rate_bps": 4541,
+    "seconds": 3673140186,
+    "expected_floor": "194873612769655932964"
+  },
+  {
+    "principal": "1502584104060443809",
+    "rate_bps": 1319,
+    "seconds": 321783995,
+    "expected_floor": "2020896435017929661"
+  },
+  {
+    "principal": "16061769696997461806",
+    "rate_bps": 5498,
+    "seconds": 3286570000,
+    "expected_floor": "919680651003146919811"
+  },
+  {
+    "principal": "2612192991127795743",
+    "rate_bps": 63,
+    "seconds": 2048996457,
+    "expected_floor": "1068520969847923835"
+  },
+  {
+    "principal": "8147537827553005252",
+    "rate_bps": 3517,
+    "seconds": 362221974,
+    "expected_floor": "32890432149380924695"
+  },
+  {
+    "principal": "5097789594384794285",
+    "rate_bps": 9043,
+    "seconds": 3379807655,
+    "expected_floor": "493721972611354921756"
+  },
+  {
+    "principal": "7004270000018167978",
+    "rate_bps": 320,
+    "seconds": 2151924204,
+    "expected_floor": "15283958875848785572"
+  },
+  {
+    "principal": "4401218301752028107",
+    "rate_bps": 2759,
+    "seconds": 2763257845,
+    "expected_floor": "106326631488617652566"
+  },
+  {
+    "principal": "8448554946988974688",
+    "rate_bps": 6582,
+    "seconds": 1574311570,
+    "expected_floor": "277413141868194368898"
+  },
+  {
+    "principal": "15964918280581670649",
+    "rate_bps": 6491,
+    "seconds": 3069635283,
+    "expected_floor": "1008001364488602327829"
+  },
+  {
+    "principal": "15808796506227242342",
+    "rate_bps": 9140,
+    "seconds": 1139881224,
+    "expected_floor": "521916032420003505252"
+  },
+  {
+    "principal": "2687477331127487415",
+    "rate_bps": 4489,
+    "seconds": 515604929,
+    "expected_floor": "19710947825973405136"
+  },
+  {
+    "principal": "17808478064302165820",
+    "rate_bps": 1426,
+    "seconds": 386979534,
+    "expected_floor": "31140842743773032670"
+  },
+  {
+    "principal": "13437764095198852485",
+    "rate_bps": 4287,
+    "seconds": 2867217471,
+    "expected_floor": "523404151898109256831"
+  },
+  {
+    "principal": "15080007668085539170",
+    "rate_bps": 6511,
+    "seconds": 580299108,
+    "expected_floor": "180549875639254712320"
+  },
+  {
+    "principal": "608609982960624611",
+    "rate_bps": 2394,
+    "seconds": 3599646157,
+    "expected_floor": "16619542435244944434"
+  },
+  {
+    "principal": "2766224402287825240",
+    "rate_bps": 9874,
+    "seconds": 1994174026,
+    "expected_floor": "172599534159135078179"
+  },
+  {
+    "principal": "7107067848890702417",
+    "rate_bps": 1065,
+    "seconds": 2408766955,
+    "expected_floor": "57773793771195094427"
+  },
+  {
+    "principal": "1308639254743029918",
+    "rate_bps": 9545,
+    "seconds": 3248790272,
+    "expected_floor": "128591891699933149830"
+  },
+  {
+    "principal": "14482441825366556751",
+    "rate_bps": 9437,
+    "seconds": 2687686681,
+    "expected_floor": "1163993137198652076028"
+  },
+  {
+    "principal": "4861735688151295156",
+    "rate_bps": 4176,
+    "seconds": 1316763910,
+    "expected_floor": "84714115778864961147"
+  },
+  {
+    "principal": "15802971647621038429",
+    "rate_bps": 2121,
+    "seconds": 2652636119,
+    "expected_floor": "281743004217705171699"
+  },
+  {
+    "principal": "3591168780872374042",
+    "rate_bps": 6639,
+    "seconds": 2884552156,
+    "expected_floor": "217927940396400721570"
+  },
+  {
+    "principal": "14108482318156197115",
+    "rate_bps": 972,
+    "seconds": 2578201765,
+    "expected_floor": "112036490803310879715"
+  },
+  {
+    "principal": "13944977262241449296",
+    "rate_bps": 3428,
+    "seconds": 3885716226,
+    "expected_floor": "588607426764549988046"
+  },
+  {
+    "principal": "5594719033536353961",
+    "rate_bps": 7182,
+    "seconds": 4267393539,
+    "expected_floor": "543353426570677111835"
+  },
+  {
+    "principal": "8688177176835561686",
+    "rate_bps": 5771,
+    "seconds": 1049110008,
+    "expected_floor": "166685110034590085022"
+  },
+  {
+    "principal": "2939912158823331303",
+    "rate_bps": 6057,
+    "seconds": 965056369,
+    "expected_floor": "54455361096435829269"
+  },
+  {
+    "principal": "10318547225311522604",
+    "rate_bps": 5945,
+    "seconds": 3494582334,
+    "expected_floor": "679300172922445550934"
+  },
+  {
+    "principal": "9908202267309737525",
+    "rate_bps": 2001,
+    "seconds": 1594909807,
+    "expected_floor": "100201474829232082624"
+  },
+  {
+    "principal": "7290926690651814354",
+    "rate_bps": 8391,
+    "seconds": 719255380,
+    "expected_floor": "139436221177285783775"
+  },
+  {
+    "principal": "4101155101491570451",
+    "rate_bps": 4261,
+    "seconds": 866014333,
+    "expected_floor": "47955546125260623893"
+  },
+  {
+    "principal": "18386293705543212616",
+    "rate_bps": 494,
+    "seconds": 2990400698,
+    "expected_floor": "86068961049511300482"
+  },
+  {
+    "principal": "2835834849682717697",
+    "rate_bps": 7757,
+    "seconds": 1380808475,
+    "expected_floor": "96250768018358224566"
+  },
+  {
+    "principal": "16699721278882502158",
+    "rate_bps": 8828,
+    "seconds": 3390617072,
+    "expected_floor": "1583967711933306101504"
+  },
+  {
+    "principal": "17091739413860420735",
+    "rate_bps": 7169,
+    "seconds": 2687901641,
+    "expected_floor": "1043648488678070347502"
+  },
+  {
+    "principal": "2311380064520687268",
+    "rate_bps": 4158,
+    "seconds": 2437108854,
+    "expected_floor": "74221001224433484247"
+  },
+  {
+    "principal": "8165128478187971597",
+    "rate_bps": 6496,
+    "seconds": 2049099271,
+    "expected_floor": "344403907916149906059"
+  },
+  {
+    "principal": "1495890916921362826",
+    "rate_bps": 4183,
+    "seconds": 3182304716,
+    "expected_floor": "63099451637125652212"
+  },
+  {
+    "principal": "5643619959000461867",
+    "rate_bps": 6144,
+    "seconds": 288941397,
+    "expected_floor": "31747882833919925540"
+  },
+  {
+    "principal": "11628543478826662976",
+    "rate_bps": 8562,
+    "seconds": 218383218,
+    "expected_floor": "68899463265510862727"
+  },
+  {
+    "principal": "1654134741134666329",
+    "rate_bps": 302,
+    "seconds": 3515538739,
+    "expected_floor": "5565007409053179586"
+  },
+  {
+    "principal": "900863933902729286",
+    "rate_bps": 5147,
+    "seconds": 2571578088,
+    "expected_floor": "37784103133681504305"
+  },
+  {
+    "principal": "11354553793157735447",
+    "rate_bps": 1840,
+    "seconds": 2177552673,
+    "expected_floor": "144162596940020043720"
+  },
+  {
+    "principal": "5411546998887326492",
+    "rate_bps": 7032,
+    "seconds": 2180959662,
+    "expected_floor": "262992862885542053607"
+  },
+  {
+    "principal": "11411638248708045541",
+    "rate_bps": 4424,
+    "seconds": 2643888287,
+    "expected_floor": "422962873622479229146"
+  },
+  {
+    "principal": "2027268527285560898",
+    "rate_bps": 8127,
+    "seconds": 2446793028,
+    "expected_floor": "127742321700229944324"
+  },
+  {
+    "principal": "4429848777713757763",
+    "rate_bps": 4455,
+    "seconds": 1276399405,
+    "expected_floor": "79821380627890136497"
+  },
+  {
+    "principal": "4927170319395962680",
+    "rate_bps": 8431,
+    "seconds": 633491242,
+    "expected_floor": "83389872981817137476"
+  },
+  {
+    "principal": "10443298869021721009",
+    "rate_bps": 510,
+    "seconds": 3537425483,
+    "expected_floor": "59702321115642136096"
+  },
+  {
+    "principal": "2138332994362738558",
+    "rate_bps": 8893,
+    "seconds": 1844995296,
+    "expected_floor": "111176993532868069082"
+  },
+  {
+    "principal": "10997066724355628207",
+    "rate_bps": 1041,
+    "seconds": 2437811065,
+    "expected_floor": "88434895403477232460"
+  },
+  {
+    "principal": "15645449519267417236",
+    "rate_bps": 9272,
+    "seconds": 2053858278,
+    "expected_floor": "944121688176005469165"
+  },
+  {
+    "principal": "15346884431150656189",
+    "rate_bps": 8066,
+    "seconds": 4212329527,
+    "expected_floor": "1652330089636627521445"
+  },
+  {
+    "principal": "483891339299319802",
+    "rate_bps": 4933,
+    "seconds": 864602556,
+    "expected_floor": "6539906097972333936"
+  },
+  {
+    "principal": "6659739176850897755",
+    "rate_bps": 1675,
+    "seconds": 3222073861,
+    "expected_floor": "113894710943496857706"
+  },
+  {
+    "principal": "8858865809609951024",
+    "rate_bps": 5327,
+    "seconds": 3042961378,
+    "expected_floor": "455043896072288437128"
+  },
+  {
+    "principal": "17471492496198885897",
+    "rate_bps": 5391,
+    "seconds": 3877682275,
+    "expected_floor": "1157357664995814764596"
+  },
+  {
+    "principal": "8749295985714052022",
+    "rate_bps": 508,
+    "seconds": 1317356504,
+    "expected_floor": "18553941116809772409"
+  },
+  {
+    "principal": "14438600025908221511",
+    "rate_bps": 3550,
+    "seconds": 617492177,
+    "expected_floor": "100295380821252726968"
+  },
+  {
+    "principal": "13482845186325506828",
+    "rate_bps": 1974,
+    "seconds": 4115330846,
+    "expected_floor": "347079916686917331878"
+  },
+  {
+    "principal": "10523708187883000725",
+    "rate_bps": 2401,
+    "seconds": 3106123983,
+    "expected_floor": "248699995197153577516"
+  },
+  {
+    "principal": "16270071186201724594",
+    "rate_bps": 5310,
+    "seconds": 757468980,
+    "expected_floor": "207369489884336360296"
+  },
+  {
+    "principal": "6545347649064073587",
+    "rate_bps": 8950,
+    "seconds": 2965581277,
+    "expected_floor": "550505443803417971158"
+  },
+  {
+    "principal": "5992791491151934504",
+    "rate_bps": 321,
+    "seconds": 1666772378,
+    "expected_floor": "10160299906157368564"
+  },
+  {
+    "principal": "12802928969213717345",
+    "rate_bps": 7117,
+    "seconds": 317715835,
+    "expected_floor": "91736294862854625451"
+  },
+  {
+    "principal": "18242404247460424942",
+    "rate_bps": 1357,
+    "seconds": 2369431504,
+    "expected_floor": "185866925211002249374"
+  },
+  {
+    "principal": "17460489287467741407",
+    "rate_bps": 8296,
+    "seconds": 1658690345,
+    "expected_floor": "761353769997777347860"
+  },
+  {
+    "principal": "17819872370109849220",
+    "rate_bps": 5512,
+    "seconds": 2612225878,
+    "expected_floor": "813056186130105197465"
+  },
+  {
+    "principal": "1851289238600045933",
+    "rate_bps": 7798,
+    "seconds": 1958205031,
+    "expected_floor": "89580132896442933985"
+  },
+  {
+    "principal": "14250947169065912938",
+    "rate_bps": 2381,
+    "seconds": 4140157356,
+    "expected_floor": "445159869234206465482"
+  },
+  {
+    "principal": "8770154687813142667",
+    "rate_bps": 7533,
+    "seconds": 4279984821,
+    "expected_floor": "896011291471917022539"
+  },
+  {
+    "principal": "8399199808455747104",
+    "rate_bps": 1039,
+    "seconds": 4181540946,
+    "expected_floor": "115634079370066459498"
+  },
+  {
+    "principal": "14603783245986168249",
+    "rate_bps": 4022,
+    "seconds": 402120595,
+    "expected_floor": "74844483220164876662"
+  },
+  {
+    "principal": "13069105772174162726",
+    "rate_bps": 3548,
+    "seconds": 534343880,
+    "expected_floor": "78513864943682702565"
+  },
+  {
+    "principal": "8436279677915204727",
+    "rate_bps": 6571,
+    "seconds": 1224833,
+    "expected_floor": "215156934462151667"
+  },
+  {
+    "principal": "2528627521014302460",
+    "rate_bps": 647,
+    "seconds": 2693698702,
+    "expected_floor": "13964782981801260730"
+  },
+  {
+    "principal": "8971868662819459141",
+    "rate_bps": 27,
+    "seconds": 3533888767,
+    "expected_floor": "2712661352373117488"
+  },
+  {
+    "principal": "15164266974094416674",
+    "rate_bps": 8703,
+    "seconds": 900913444,
+    "expected_floor": "376764092797449045648"
+  },
+  {
+    "principal": "3428754190913276067",
+    "rate_bps": 3080,
+    "seconds": 4005425293,
+    "expected_floor": "134039172117247392460"
+  },
+  {
+    "principal": "5122118198500637976",
+    "rate_bps": 149,
+    "seconds": 1714470922,
+    "expected_floor": "4146312406032394109"
+  },
+  {
+    "principal": "2618791827772291345",
+    "rate_bps": 2613,
+    "seconds": 3465403051,
+    "expected_floor": "75143284321995831245"
+  },
+  {
+    "principal": "6828227933125527134",
+    "rate_bps": 9202,
+    "seconds": 1192656576,
+    "expected_floor": "237466132320230249634"
+  },
+  {
+    "principal": "6061234308540860687",
+    "rate_bps": 3312,
+    "seconds": 2357710553,
+    "expected_floor": "149981578895462578731"
+  },
+  {
+    "principal": "2513724339165168756",
+    "rate_bps": 8600,
+    "seconds": 3961151174,
+    "expected_floor": "271352327831931923278"
+  },
+  {
+    "principal": "3204962511733154845",
+    "rate_bps": 947,
+    "seconds": 555492503,
+    "expected_floor": "5342532440165395179"
+  },
+  {
+    "principal": "15231989497674848474",
+    "rate_bps": 9438,
+    "seconds": 1273765276,
+    "expected_floor": "580259210760883054453"
+  },
+  {
+    "principal": "12512184617436256699",
+    "rate_bps": 7988,
+    "seconds": 2073507685,
+    "expected_floor": "656708869976228204124"
+  },
+  {
+    "principal": "13106422934908459280",
+    "rate_bps": 4603,
+    "seconds": 2456505538,
+    "expected_floor": "469611727150493065871"
+  },
+  {
+    "principal": "8284766145609874793",
+    "rate_bps": 2702,
+    "seconds": 2401978051,
+    "expected_floor": "170384728367557661498"
+  },
+  {
+    "principal": "11193443396362219158",
+    "rate_bps": 2653,
+    "seconds": 2249896376,
+    "expected_floor": "211718840324213514027"
+  },
+  {
+    "principal": "3872415811320350375",
+    "rate_bps": 5752,
+    "seconds": 1364940337,
+    "expected_floor": "96340869877634700756"
+  },
+  {
+    "principal": "3469776020947400428",
+    "rate_bps": 9013,
+    "seconds": 392734206,
+    "expected_floor": "38919349607572027310"
+  },
+  {
+    "principal": "14953467685256278261",
+    "rate_bps": 4137,
+    "seconds": 155127087,
+    "expected_floor": "30409628014046731575"
+  },
+  {
+    "principal": "17855278722150704018",
+    "rate_bps": 3403,
+    "seconds": 933525268,
+    "expected_floor": "179742465099432165997"
+  },
+  {
+    "principal": "14833608434792225747",
+    "rate_bps": 8697,
+    "seconds": 1062704957,
+    "expected_floor": "434435213428333019934"
+  },
+  {
+    "principal": "12120902989402954248",
+    "rate_bps": 365,
+    "seconds": 45663866,
+    "expected_floor": "640171815398160860"
+  },
+  {
+    "principal": "12795113525854530241",
+    "rate_bps": 8628,
+    "seconds": 2884469723,
+    "expected_floor": "1009058389655428069102"
+  },
+  {
+    "principal": "17891519726115902414",
+    "rate_bps": 4133,
+    "seconds": 3926059440,
+    "expected_floor": "919952788759507901116"
+  },
+  {
+    "principal": "1537026012528305471",
+    "rate_bps": 3934,
+    "seconds": 3190793865,
+    "expected_floor": "61137877072999698162"
+  },
+  {
+    "principal": "4942055674371817060",
+    "rate_bps": 9517,
+    "seconds": 937380406,
+    "expected_floor": "139707463281557346730"
+  },
+  {
+    "principal": "16442470040481453773",
+    "rate_bps": 1004,
+    "seconds": 1351284423,
+    "expected_floor": "70687655131924338274"
+  },
+  {
+    "principal": "6990400151937653578",
+    "rate_bps": 1786,
+    "seconds": 3267544460,
+    "expected_floor": "129270976612003480145"
+  },
+  {
+    "principal": "6505921160530669291",
+    "rate_bps": 3375,
+    "seconds": 3874713621,
+    "expected_floor": "269598961946658024149"
+  },
+  {
+    "principal": "17256782796056535040",
+    "rate_bps": 2695,
+    "seconds": 1274613042,
+    "expected_floor": "187842125250101772777"
+  },
+  {
+    "principal": "2574118659778978073",
+    "rate_bps": 7939,
+    "seconds": 4195742195,
+    "expected_floor": "271705977550098865030"
+  },
+  {
+    "principal": "15462017367130347014",
+    "rate_bps": 1006,
+    "seconds": 2707424936,
+    "expected_floor": "133449390602953237501"
+  },
+  {
+    "principal": "7920073353667151063",
+    "rate_bps": 6024,
+    "seconds": 1722490849,
+    "expected_floor": "260415675918336183951"
+  },
+  {
+    "principal": "4007075179699223260",
+    "rate_bps": 7632,
+    "seconds": 2058890094,
+    "expected_floor": "199523957038552605742"
+  },
+  {
+    "principal": "17566040967173682597",
+    "rate_bps": 5490,
+    "seconds": 2858631519,
+    "expected_floor": "873575502150719809081"
+  },
+  {
+    "principal": "9564597719873560578",
+    "rate_bps": 740,
+    "seconds": 39971076,
+    "expected_floor": "896479371543351434"
+  },
+  {
+    "principal": "9961729132252001027",
+    "rate_bps": 5186,
+    "seconds": 941826541,
+    "expected_floor": "154182186036855227901"
+  },
+  {
+    "principal": "1236133860439886584",
+    "rate_bps": 7998,
+    "seconds": 1453326570,
+    "expected_floor": "45530890990648099235"
+  },
+  {
+    "principal": "6948249135865512049",
+    "rate_bps": 1104,
+    "seconds": 1804202251,
+    "expected_floor": "43855665803187971474"
+  },
+  {
+    "principal": "15324669402908087614",
+    "rate_bps": 364,
+    "seconds": 3820415136,
+    "expected_floor": "67530363571843470614"
+  },
+  {
+    "principal": "7335943975520814447",
+    "rate_bps": 9425,
+    "seconds": 2415403577,
+    "expected_floor": "529203981395725991620"
+  },
+  {
+    "principal": "5300336449897155668",
+    "rate_bps": 1280,
+    "seconds": 2424383910,
+    "expected_floor": "52120771289952332420"
+  },
+  {
+    "principal": "2846443245467282813",
+    "rate_bps": 3201,
+    "seconds": 2576305399,
+    "expected_floor": "74384351253211467309"
+  },
+  {
+    "principal": "12394389024084169146",
+    "rate_bps": 7080,
+    "seconds": 642826620,
+    "expected_floor": "178750912235040831169"
+  },
+  {
+    "principal": "4966810682831013915",
+    "rate_bps": 4424,
+    "seconds": 2799897797,
+    "expected_floor": "194953455162698449461"
+  },
+  {
+    "principal": "9436605918261246704",
+    "rate_bps": 5738,
+    "seconds": 1916109218,
+    "expected_floor": "328770359000651440422"
+  },
+  {
+    "principal": "10492474146840684745",
+    "rate_bps": 9232,
+    "seconds": 3092439331,
+    "expected_floor": "949228839957263836095"
+  },
+  {
+    "principal": "2615634498763125110",
+    "rate_bps": 693,
+    "seconds": 687894424,
+    "expected_floor": "3951191814765329877"
+  },
+  {
+    "principal": "1904650369499105031",
+    "rate_bps": 6900,
+    "seconds": 1313148305,
+    "expected_floor": "54685749200969265553"
+  },
+  {
+    "principal": "16101146009361109708",
+    "rate_bps": 5701,
+    "seconds": 3902547166,
+    "expected_floor": "1135146783444809842729"
+  },
+  {
+    "principal": "16063529705484721749",
+    "rate_bps": 5673,
+    "seconds": 1639610767,
+    "expected_floor": "473467920277304688525"
+  },
+  {
+    "principal": "7693521659121619058",
+    "rate_bps": 270,
+    "seconds": 2559717108,
+    "expected_floor": "16849109352859473438"
+  },
+  {
+    "principal": "2968101321316027955",
+    "rate_bps": 5897,
+    "seconds": 2062782621,
+    "expected_floor": "114408777955548959479"
+  },
+  {
+    "principal": "14202011235705606120",
+    "rate_bps": 5189,
+    "seconds": 953511770,
+    "expected_floor": "222666874842165162919"
+  },
+  {
+    "principal": "13650112710653491745",
+    "rate_bps": 259,
+    "seconds": 404628027,
+    "expected_floor": "4533023763466772376"
+  },
+  {
+    "principal": "609092666533464750",
+    "rate_bps": 5999,
+    "seconds": 2972285840,
+    "expected_floor": "34415084323280508391"
+  },
+  {
+    "principal": "4242709743238293919",
+    "rate_bps": 8456,
+    "seconds": 843334121,
+    "expected_floor": "95874696169909154728"
+  },
+  {
+    "principal": "944131746355916356",
+    "rate_bps": 9256,
+    "seconds": 3166633238,
+    "expected_floor": "87689934524914595235"
+  },
+  {
+    "principal": "7300853642164561965",
+    "rate_bps": 9654,
+    "seconds": 150218535,
+    "expected_floor": "33550615507756824401"
+  },
+  {
+    "principal": "1209712212314274858",
+    "rate_bps": 3446,
+    "seconds": 1826427244,
+    "expected_floor": "24126579094828717036"
+  },
+  {
+    "principal": "6352722737710245195",
+    "rate_bps": 3277,
+    "seconds": 2237205877,
+    "expected_floor": "147583677166803967254"
+  },
+  {
+    "principal": "7106969294005922272",
+    "rate_bps": 8343,
+    "seconds": 1118808594,
+    "expected_floor": "210212486476662645804"
+  },
+  {
+    "principal": "17611718160520664185",
+    "rate_bps": 5789,
+    "seconds": 196940883,
+    "expected_floor": "63626376366903554669"
+  },
+  {
+    "principal": "5073563813434376422",
+    "rate_bps": 7340,
+    "seconds": 1536355464,
+    "expected_floor": "181299634802848579197"
+  },
+  {
+    "principal": "14632545435298467127",
+    "rate_bps": 9321,
+    "seconds": 2259427137,
+    "expected_floor": "976510152248894195719"
+  },
+  {
+    "principal": "9586479947346558652",
+    "rate_bps": 2909,
+    "seconds": 3966997070,
+    "expected_floor": "350558742244985487072"
+  },
+  {
+    "principal": "3534821247146978053",
+    "rate_bps": 5363,
+    "seconds": 1764734399,
+    "expected_floor": "106010928402113975568"
+  },
+  {
+    "principal": "14146423769314309346",
+    "rate_bps": 5468,
+    "seconds": 538724580,
+    "expected_floor": "132049874773196463815"
+  },
+  {
+    "principal": "15696349459858156899",
+    "rate_bps": 862,
+    "seconds": 1708909389,
+    "expected_floor": "73269123088605916445"
+  },
+  {
+    "principal": "7429253413409564888",
+    "rate_bps": 5454,
+    "seconds": 2844266954,
+    "expected_floor": "365196573860695604675"
+  },
+  {
+    "principal": "345088989712603089",
+    "rate_bps": 6036,
+    "seconds": 916789099,
+    "expected_floor": "6051259922753788897"
+  },
+  {
+    "principal": "11299610264272483358",
+    "rate_bps": 5709,
+    "seconds": 3465650816,
+    "expected_floor": "708442069958063333287"
+  },
+  {
+    "principal": "3628339224805020111",
+    "rate_bps": 7449,
+    "seconds": 498533785,
+    "expected_floor": "42696913955775431532"
+  },
+  {
+    "principal": "12786786781775750196",
+    "rate_bps": 1720,
+    "seconds": 2828518534,
+    "expected_floor": "197126464155706857686"
+  },
+  {
+    "principal": "11591335168359630557",
+    "rate_bps": 5314,
+    "seconds": 1371833687,
+    "expected_floor": "267764199120194646524"
+  },
+  {
+    "principal": "16768621831723424410",
+    "rate_bps": 3523,
+    "seconds": 2817439068,
+    "expected_floor": "527424839165061645401"
+  },
+  {
+    "principal": "1662842702751991419",
+    "rate_bps": 5524,
+    "seconds": 1619554853,
+    "expected_floor": "47140754965058673185"
+  },
+  {
+    "principal": "15700792471628606672",
+    "rate_bps": 1576,
+    "seconds": 1547077250,
+    "expected_floor": "121306987893783910127"
+  },
+  {
+    "principal": "4582534508185756713",
+    "rate_bps": 1633,
+    "seconds": 1215269763,
+    "expected_floor": "28817788795002583386"
+  },
+  {
+    "principal": "7904532355555525718",
+    "rate_bps": 9807,
+    "seconds": 4008607096,
+    "expected_floor": "984695335398267768767"
+  },
+  {
+    "principal": "7247456346166663015",
+    "rate_bps": 1536,
+    "seconds": 2929939697,
+    "expected_floor": "103355011275239934878"
+  },
+  {
+    "principal": "2680152633196805804",
+    "rate_bps": 3052,
+    "seconds": 4007490494,
+    "expected_floor": "103875371645549972788"
+  },
+  {
+    "principal": "8294391911995022261",
+    "rate_bps": 1143,
+    "seconds": 3102602735,
+    "expected_floor": "93207956450414661545"
+  },
+  {
+    "principal": "12883797753349033298",
+    "rate_bps": 7663,
+    "seconds": 3525785300,
+    "expected_floor": "1103048529427055973858"
+  },
+  {
+    "principal": "9815263770038194323",
+    "rate_bps": 3567,
+    "seconds": 3274643965,
+    "expected_floor": "363299839211752215964"
+  },
+  {
+    "principal": "4899562566060381640",
+    "rate_bps": 7438,
+    "seconds": 1109846074,
+    "expected_floor": "128165833110547106886"
+  },
+  {
+    "principal": "16268355903826499969",
+    "rate_bps": 1557,
+    "seconds": 4133081243,
+    "expected_floor": "331743370374622863279"
+  },
+  {
+    "principal": "4074420954089197966",
+    "rate_bps": 9174,
+    "seconds": 2808503664,
+    "expected_floor": "332656229114870544629"
+  },
+  {
+    "principal": "17335536793896910335",
+    "rate_bps": 6886,
+    "seconds": 3274927433,
+    "expected_floor": "1238802367206048718934"
+  },
+  {
+    "principal": "18153932196118130212",
+    "rate_bps": 9252,
+    "seconds": 3578429430,
+    "expected_floor": "1904560719471721169193"
+  },
+  {
+    "principal": "2067609183102503309",
+    "rate_bps": 8751,
+    "seconds": 4249577351,
+    "expected_floor": "243650837115101653093"
+  },
+  {
+    "principal": "14859741866178882826",
+    "rate_bps": 6973,
+    "seconds": 4098665804,
+    "expected_floor": "1345765751433746564881"
+  },
+  {
+    "principal": "17873157794305584043",
+    "rate_bps": 4345,
+    "seconds": 3672390357,
+    "expected_floor": "903724261625268255647"
+  },
+  {
+    "principal": "18039661331638813632",
+    "rate_bps": 8488,
+    "seconds": 785979122,
+    "expected_floor": "381364965707672926172"
+  },
+  {
+    "principal": "6051563393826723801",
+    "rate_bps": 4115,
+    "seconds": 80037555,
+    "expected_floor": "6315784060714542517"
+  },
+  {
+    "principal": "1092649528300321734",
+    "rate_bps": 189,
+    "seconds": 2761320,
+    "expected_floor": "1806988789220030"
+  },
+  {
+    "principal": "232914349019702679",
+    "rate_bps": 5070,
+    "seconds": 892186273,
+    "expected_floor": "3338533772685997557"
+  },
+  {
+    "principal": "14198001536806032028",
+    "rate_bps": 8245,
+    "seconds": 2780350766,
+    "expected_floor": "1031367640689127008022"
+  },
+  {
+    "principal": "12764297877110829157",
+    "rate_bps": 5648,
+    "seconds": 929053215,
+    "expected_floor": "212240491237430690855"
+  },
+  {
+    "principal": "2937649442254363074",
+    "rate_bps": 8994,
+    "seconds": 3944347844,
+    "expected_floor": "330235754710086611839"
+  },
+  {
+    "principal": "4962821388201457603",
+    "rate_bps": 4613,
+    "seconds": 2038445229,
+    "expected_floor": "147879229687567441401"
+  },
+  {
+    "principal": "8852719172174714552",
+    "rate_bps": 6724,
+    "seconds": 2774594218,
+    "expected_floor": "523359247390601638133"
+  },
+  {
+    "principal": "4752654837324611377",
+    "rate_bps": 4432,
+    "seconds": 1622625739,
+    "expected_floor": "108305477158330870901"
+  },
+  {
+    "principal": "4047606546360623870",
+    "rate_bps": 8642,
+    "seconds": 2254351456,
+    "expected_floor": "249879258496697747285"
+  },
+  {
+    "principal": "7039606731565919791",
+    "rate_bps": 4531,
+    "seconds": 1004304633,
+    "expected_floor": "101508862039092584727"
+  },
+  {
+    "principal": "7756098389180763156",
+    "rate_bps": 6272,
+    "seconds": 3377868646,
+    "expected_floor": "520700685635363082235"
+  },
+  {
+    "principal": "11676081920830042173",
+    "rate_bps": 9892,
+    "seconds": 2601766327,
+    "expected_floor": "952238118734050292565"
+  },
+  {
+    "principal": "15798006969303004026",
+    "rate_bps": 7314,
+    "seconds": 1778252092,
+    "expected_floor": "651098385257845754743"
+  },
+  {
+    "principal": "4026318961952756955",
+    "rate_bps": 4067,
+    "seconds": 186607493,
+    "expected_floor": "9682944889017307987"
+  },
+  {
+    "principal": "8771055223611371184",
+    "rate_bps": 9967,
+    "seconds": 1810258786,
+    "expected_floor": "501479287960943423883"
+  },
+  {
+    "principal": "3430867535120379785",
+    "rate_bps": 6621,
+    "seconds": 1230587363,
+    "expected_floor": "88580070612701901191"
+  },
+  {
+    "principal": "8855514080352626486",
+    "rate_bps": 2290,
+    "seconds": 60611416,
+    "expected_floor": "3894930595176670525"
+  },
+  {
+    "principal": "13506172945525028807",
+    "rate_bps": 4557,
+    "seconds": 160312401,
+    "expected_floor": "31266155725517987987"
+  },
+  {
+    "principal": "4136262009606273676",
+    "rate_bps": 3461,
+    "seconds": 2216989342,
+    "expected_floor": "100570191857772734435"
+  },
+  {
+    "principal": "14379811596266875157",
+    "rate_bps": 8073,
+    "seconds": 3912335951,
+    "expected_floor": "1439197254374383669325"
+  },
+  {
+    "principal": "15917599039604628018",
+    "rate_bps": 3094,
+    "seconds": 2593885876,
+    "expected_floor": "404803974024891053150"
+  },
+  {
+    "principal": "10455338071515652851",
+    "rate_bps": 6413,
+    "seconds": 1000485725,
+    "expected_floor": "212572093423519597126"
+  },
+  {
+    "principal": "6509971830311660456",
+    "rate_bps": 3936,
+    "seconds": 4012192026,
+    "expected_floor": "325770641037190306861"
+  },
+  {
+    "principal": "17546317446190663905",
+    "rate_bps": 2084,
+    "seconds": 2306379515,
+    "expected_floor": "267245562024283690897"
+  },
+  {
+    "principal": "11474898976983885934",
+    "rate_bps": 8920,
+    "seconds": 2238811984,
+    "expected_floor": "726151737762564031849"
+  },
+  {
+    "principal": "17245995470816698975",
+    "rate_bps": 4129,
+    "seconds": 4178913449,
+    "expected_floor": "942958457072185911470"
+  },
+  {
+    "principal": "1180170761770925572",
+    "rate_bps": 7332,
+    "seconds": 2155467478,
+    "expected_floor": "59102358884346730822"
+  },
+  {
+    "principal": "16204785237974563565",
+    "rate_bps": 8527,
+    "seconds": 4041783271,
+    "expected_floor": "1769736457237997351851"
+  },
+  {
+    "principal": "10571065250491035114",
+    "rate_bps": 4698,
+    "seconds": 206149932,
+    "expected_floor": "32442252101710680598"
+  },
+  {
+    "principal": "8042395384325095947",
+    "rate_bps": 4842,
+    "seconds": 741144629,
+    "expected_floor": "91455368501659005825"
+  },
+  {
+    "principal": "8460317956118310304",
+    "rate_bps": 1259,
+    "seconds": 1978487762,
+    "expected_floor": "66779292922657118476"
+  },
+  {
+    "principal": "4390022458047884089",
+    "rate_bps": 4647,
+    "seconds": 3238430995,
+    "expected_floor": "209348616343258631249"
+  },
+  {
+    "principal": "10879528410902496934",
+    "rate_bps": 1949,
+    "seconds": 3034425416,
+    "expected_floor": "203889288331629427937"
+  },
+  {
+    "principal": "287053576767917559",
+    "rate_bps": 6548,
+    "seconds": 1262996993,
+    "expected_floor": "7522634872348808721"
+  },
+  {
+    "principal": "9132022016739522172",
+    "rate_bps": 1830,
+    "seconds": 713019406,
+    "expected_floor": "37758559942887929263"
+  },
+  {
+    "principal": "3843058473973319109",
+    "rate_bps": 6844,
+    "seconds": 558681727,
+    "expected_floor": "46563701153948244291"
+  },
+  {
+    "principal": "9578359724542512802",
+    "rate_bps": 713,
+    "seconds": 4086495396,
+    "expected_floor": "88435720836834351244"
+  },
+  {
+    "principal": "1276984525884920355",
+    "rate_bps": 4795,
+    "seconds": 950539789,
+    "expected_floor": "18443382784455877918"
+  },
+  {
+    "principal": "1561486483480958104",
+    "rate_bps": 4593,
+    "seconds": 614638474,
+    "expected_floor": "13968521787001603514"
+  },
+  {
+    "principal": "992713603401496209",
+    "rate_bps": 8830,
+    "seconds": 3197670443,
+    "expected_floor": "88820745146955187112"
+  },
+  {
+    "principal": "9882244042530611678",
+    "rate_bps": 3262,
+    "seconds": 2111178304,
+    "expected_floor": "215655470020650171801"
+  },
+  {
+    "principal": "12649205369539680911",
+    "rate_bps": 2731,
+    "seconds": 1954577497,
+    "expected_floor": "213960631597170217382"
+  },
+  {
+    "principal": "17767563161197249524",
+    "rate_bps": 774,
+    "seconds": 3686033990,
+    "expected_floor": "160629089348661371555"
+  },
+  {
+    "principal": "15354943961069578653",
+    "rate_bps": 3604,
+    "seconds": 718611991,
+    "expected_floor": "126015367623056638036"
+  },
+  {
+    "principal": "1973856048425442394",
+    "rate_bps": 8430,
+    "seconds": 3115748636,
+    "expected_floor": "164286356437968676932"
+  },
+  {
+    "principal": "10630728205587919675",
+    "rate_bps": 6194,
+    "seconds": 1296035045,
+    "expected_floor": "270425096755405869450"
+  },
+  {
+    "principal": "16600562488109613200",
+    "rate_bps": 1077,
+    "seconds": 3502047298,
+    "expected_floor": "198406797545710982437"
+  },
+  {
+    "principal": "18431999885481560809",
+    "rate_bps": 7186,
+    "seconds": 3907522627,
+    "expected_floor": "1640050444976021771587"
+  },
+  {
+    "principal": "5374083783609981462",
+    "rate_bps": 6868,
+    "seconds": 113477944,
+    "expected_floor": "13272178408222112419"
+  },
+  {
+    "principal": "5722184458806847527",
+    "rate_bps": 931,
+    "seconds": 4196242353,
+    "expected_floor": "70838299984982203006"
+  },
+  {
+    "principal": "8182472831819597420",
+    "rate_bps": 1136,
+    "seconds": 3597238654,
+    "expected_floor": "105956642404784500041"
+  },
+  {
+    "principal": "196633952701040245",
+    "rate_bps": 3386,
+    "seconds": 2967281327,
+    "expected_floor": "6260373143610848097"
+  },
+  {
+    "principal": "12457386326156228370",
+    "rate_bps": 9706,
+    "seconds": 3693557396,
+    "expected_floor": "1415168342987089624825"
+  },
+  {
+    "principal": "4750576433859102035",
+    "rate_bps": 482,
+    "seconds": 3420773565,
+    "expected_floor": "24820681891608880963"
+  },
+  {
+    "principal": "1722592862503506312",
+    "rate_bps": 6612,
+    "seconds": 2756200954,
+    "expected_floor": "99476935969775304735"
+  },
+  {
+    "principal": "2276702643874269249",
+    "rate_bps": 9907,
+    "seconds": 3092405595,
+    "expected_floor": "221024775512816232318"
+  },
+  {
+    "principal": "8326538904650452814",
+    "rate_bps": 2450,
+    "seconds": 4160950576,
+    "expected_floor": "268979505050795026402"
+  },
+  {
+    "principal": "5992766104326919871",
+    "rate_bps": 8653,
+    "seconds": 3758191625,
+    "expected_floor": "617545533122247881107"
+  },
+  {
+    "principal": "11465141956312980964",
+    "rate_bps": 3604,
+    "seconds": 289732022,
+    "expected_floor": "37936455296082790468"
+  },
+  {
+    "principal": "16216786836995570765",
+    "rate_bps": 8998,
+    "seconds": 186914887,
+    "expected_floor": "86427255540670870193"
+  },
+  {
+    "principal": "17591702053311086282",
+    "rate_bps": 5682,
+    "seconds": 470537484,
+    "expected_floor": "149038801365126110175"
+  },
+  {
+    "principal": "5051860231410739307",
+    "rate_bps": 2223,
+    "seconds": 30098837,
+    "expected_floor": "1071116075178173860"
+  },
+  {
+    "principal": "12015625018053535616",
+    "rate_bps": 4758,
+    "seconds": 2439274674,
+    "expected_floor": "441903604275292689329"
+  },
+  {
+    "principal": "11691460478417948313",
+    "rate_bps": 1947,
+    "seconds": 1079565171,
+    "expected_floor": "77871692727339875682"
+  },
+  {
+    "principal": "16152800126330675590",
+    "rate_bps": 9045,
+    "seconds": 325418536,
+    "expected_floor": "150658871556530892650"
+  },
+  {
+    "principal": "14134066828076156503",
+    "rate_bps": 3328,
+    "seconds": 2786229601,
+    "expected_floor": "415301397764634915062"
+  },
+  {
+    "principal": "8340252707412486748",
+    "rate_bps": 1030,
+    "seconds": 3535841006,
+    "expected_floor": "96250987872872900740"
+  },
+  {
+    "principal": "3488492200400710437",
+    "rate_bps": 3436,
+    "seconds": 390951647,
+    "expected_floor": "14849437112340036514"
+  },
+  {
+    "principal": "4211052996115321730",
+    "rate_bps": 7335,
+    "seconds": 4257171588,
+    "expected_floor": "416685140430609855206"
+  },
+  {
+    "principal": "29909619066584195",
+    "rate_bps": 2746,
+    "seconds": 753633133,
+    "expected_floor": "196140569217135036"
+  },
+  {
+    "principal": "5403291105266393720",
+    "rate_bps": 28,
+    "seconds": 2512725098,
+    "expected_floor": "1204640355464562480"
+  },
+  {
+    "principal": "8203704691881770481",
+    "rate_bps": 6561,
+    "seconds": 3374377611,
+    "expected_floor": "575532390298475739573"
+  },
+  {
+    "principal": "15854332181098967230",
+    "rate_bps": 3083,
+    "seconds": 464498720,
+    "expected_floor": "71945234508028441732"
+  },
+  {
+    "principal": "12531560177012922095",
+    "rate_bps": 7857,
+    "seconds": 3585806265,
+    "expected_floor": "1118780148438622219794"
+  },
+  {
+    "principal": "14191817337933597652",
+    "rate_bps": 2850,
+    "seconds": 480933158,
+    "expected_floor": "61640141394659103329"
+  },
+  {
+    "principal": "14676124583125971709",
+    "rate_bps": 2444,
+    "seconds": 442535543,
+    "expected_floor": "50298702452587048728"
+  },
+  {
+    "principal": "826649146052089146",
+    "rate_bps": 4711,
+    "seconds": 2555408636,
+    "expected_floor": "31534846166448044996"
+  },
+  {
+    "principal": "15583707248663486875",
+    "rate_bps": 1489,
+    "seconds": 293732933,
+    "expected_floor": "21598030671965337494"
+  },
+  {
+    "principal": "15432456913564672624",
+    "rate_bps": 8969,
+    "seconds": 3459413282,
+    "expected_floor": "1517321384221436867776"
+  },
+  {
+    "principal": "8033358312117106249",
+    "rate_bps": 4911,
+    "seconds": 2029251235,
+    "expected_floor": "253687415639137082530"
+  },
+  {
+    "principal": "7390891779468139766",
+    "rate_bps": 6699,
+    "seconds": 203065112,
+    "expected_floor": "31859442278509104007"
+  },
+  {
+    "principal": "2418197794638407815",
+    "rate_bps": 3146,
+    "seconds": 527010577,
+    "expected_floor": "12704743561472392035"
+  },
+  {
+    "principal": "4092015199905079884",
+    "rate_bps": 5257,
+    "seconds": 3886301278,
+    "expected_floor": "264915710027017983875"
+  },
+  {
+    "principal": "1271146361553384405",
+    "rate_bps": 2634,
+    "seconds": 2991115023,
+    "expected_floor": "31735144222947328215"
+  },
+  {
+    "principal": "2452673153737597938",
+    "rate_bps": 6615,
+    "seconds": 3036819060,
+    "expected_floor": "156129322587188456185"
+  },
+  {
+    "principal": "18402102855115290547",
+    "rate_bps": 5834,
+    "seconds": 529471005,
+    "expected_floor": "180124211900337491199"
+  },
+  {
+    "principal": "3848064910691387240",
+    "rate_bps": 4238,
+    "seconds": 1510486746,
+    "expected_floor": "78057797583405093703"
+  },
+  {
+    "principal": "18192323178355005345",
+    "rate_bps": 9656,
+    "seconds": 230636475,
+    "expected_floor": "128383568862760915678"
+  },
+  {
+    "principal": "2925124519028704814",
+    "rate_bps": 8606,
+    "seconds": 2681398032,
+    "expected_floor": "213896175391687915417"
+  },
+  {
+    "principal": "11246956055666514719",
+    "rate_bps": 9045,
+    "seconds": 135286633,
+    "expected_floor": "43610843895489212979"
+  },
+  {
+    "principal": "17920548839220547012",
+    "rate_bps": 8250,
+    "seconds": 782493846,
+    "expected_floor": "366591354427992946730"
+  },
+  {
+    "principal": "7572419492184575405",
+    "rate_bps": 6639,
+    "seconds": 3612706983,
+    "expected_floor": "575527532862520265443"
+  },
+  {
+    "principal": "15831617241263005610",
+    "rate_bps": 2023,
+    "seconds": 1053516012,
+    "expected_floor": "106919849263000929815"
+  },
+  {
+    "principal": "3361361885581057739",
+    "rate_bps": 7168,
+    "seconds": 676799221,
+    "expected_floor": "51673651397360369738"
+  },
+  {
+    "principal": "4511578892198818144",
+    "rate_bps": 2293,
+    "seconds": 246824338,
+    "expected_floor": "8091268716601405286"
+  },
+  {
+    "principal": "5077052580320100857",
+    "rate_bps": 8591,
+    "seconds": 2794733011,
+    "expected_floor": "386270674472410061440"
+  },
+  {
+    "principal": "5919808981256178790",
+    "rate_bps": 9685,
+    "seconds": 695837704,
+    "expected_floor": "126418696653495459501"
+  },
+  {
+    "principal": "13149950966076886711",
+    "rate_bps": 4354,
+    "seconds": 648395969,
+    "expected_floor": "117638342637705694244"
+  },
+  {
+    "principal": "7439149967362649660",
+    "rate_bps": 2001,
+    "seconds": 3396554190,
+    "expected_floor": "160215667412476315928"
+  },
+  {
+    "principal": "15127358319002083461",
+    "rate_bps": 9978,
+    "seconds": 3988399935,
+    "expected_floor": "1907661553330098416199"
+  },
+  {
+    "principal": "4024198606100867170",
+    "rate_bps": 9304,
+    "seconds": 30861412,
+    "expected_floor": "3661515975627941822"
+  },
+  {
+    "principal": "18371292797734745827",
+    "rate_bps": 8049,
+    "seconds": 2749532365,
+    "expected_floor": "1288357872007641739947"
+  },
+  {
+    "principal": "8226965748915388504",
+    "rate_bps": 5703,
+    "seconds": 4215305546,
+    "expected_floor": "626712206592162981095"
+  },
+  {
+    "principal": "11146963666870326609",
+    "rate_bps": 2136,
+    "seconds": 2636665067,
+    "expected_floor": "198933916162173105909"
+  },
+  {
+    "principal": "11938829905856909214",
+    "rate_bps": 4175,
+    "seconds": 3131288064,
+    "expected_floor": "494580853918716034076"
+  },
+  {
+    "principal": "5643290815557165903",
+    "rate_bps": 1122,
+    "seconds": 4054070041,
+    "expected_floor": "81341573401706264410"
+  },
+  {
+    "principal": "12735808768674816948",
+    "rate_bps": 3546,
+    "seconds": 489705478,
+    "expected_floor": "70080348972949866189"
+  },
+  {
+    "principal": "14996183636432555101",
+    "rate_bps": 6423,
+    "seconds": 3876456151,
+    "expected_floor": "1183176623774664042800"
+  },
+  {
+    "principal": "10030013406744305178",
+    "rate_bps": 2827,
+    "seconds": 3137578204,
+    "expected_floor": "281914824801292833667"
+  },
+  {
+    "principal": "6114174829280141307",
+    "rate_bps": 4917,
+    "seconds": 2256381861,
+    "expected_floor": "214954575458626329673"
+  },
+  {
+    "principal": "3232288472395011152",
+    "rate_bps": 2591,
+    "seconds": 3149838850,
+    "expected_floor": "83591456898259943471"
+  },
+  {
+    "principal": "11067694359311757737",
+    "rate_bps": 6740,
+    "seconds": 1867830531,
+    "expected_floor": "441520178633188710721"
+  },
+  {
+    "principal": "14330402012938399702",
+    "rate_bps": 4928,
+    "seconds": 2606355704,
+    "expected_floor": "583255431760428149065"
+  },
+  {
+    "principal": "16197769027453516007",
+    "rate_bps": 1181,
+    "seconds": 478810737,
+    "expected_floor": "29024517777520864849"
+  },
+  {
+    "principal": "14660030343060901420",
+    "rate_bps": 1616,
+    "seconds": 2379009854,
+    "expected_floor": "178594672408759570311"
+  },
+  {
+    "principal": "1651780094274679093",
+    "rate_bps": 4284,
+    "seconds": 1942783855,
+    "expected_floor": "43563444239208272049"
+  },
+  {
+    "principal": "10195991370861535442",
+    "rate_bps": 1686,
+    "seconds": 2003072596,
+    "expected_floor": "109113817857462264996"
+  },
+  {
+    "principal": "1022611572358904339",
+    "rate_bps": 5832,
+    "seconds": 2788745085,
+    "expected_floor": "52702724777248761770"
+  },
+  {
+    "principal": "5631500974310214984",
+    "rate_bps": 6625,
+    "seconds": 2631723962,
+    "expected_floor": "311133241665352631902"
+  },
+  {
+    "principal": "4479332411702785793",
+    "rate_bps": 3572,
+    "seconds": 3096914459,
+    "expected_floor": "157018196770799305811"
+  },
+  {
+    "principal": "8997963979528883470",
+    "rate_bps": 4371,
+    "seconds": 295240944,
+    "expected_floor": "36795751309768897487"
+  },
+  {
+    "principal": "2728444353913581439",
+    "rate_bps": 6195,
+    "seconds": 2237250249,
+    "expected_floor": "119830400154128029419"
+  },
+  {
+    "principal": "12036887835409911204",
+    "rate_bps": 5139,
+    "seconds": 3549342582,
+    "expected_floor": "695723677032470773561"
+  },
+  {
+    "principal": "18265838194739719949",
+    "rate_bps": 4093,
+    "seconds": 1154812167,
+    "expected_floor": "273582765116531926295"
+  },
+  {
+    "principal": "14724213644231938186",
+    "rate_bps": 9564,
+    "seconds": 1136671948,
+    "expected_floor": "507227571784491787395"
+  },
+  {
+    "principal": "1164407557944993067",
+    "rate_bps": 4407,
+    "seconds": 2959642709,
+    "expected_floor": "48126400945415263749"
+  },
+  {
+    "principal": "1319489029743053632",
+    "rate_bps": 8131,
+    "seconds": 2405100146,
+    "expected_floor": "81767165410081462599"
+  },
+  {
+    "principal": "15207060148964771161",
+    "rate_bps": 5576,
+    "seconds": 999338035,
+    "expected_floor": "268519901243519238529"
+  },
+  {
+    "principal": "8986357556182959942",
+    "rate_bps": 5452,
+    "seconds": 2027035112,
+    "expected_floor": "314700074892747923992"
+  },
+  {
+    "principal": "16145663214229137175",
+    "rate_bps": 3879,
+    "seconds": 2988018721,
+    "expected_floor": "593000440371620087393"
+  },
+  {
+    "principal": "6017762427295138332",
+    "rate_bps": 8608,
+    "seconds": 294634670,
+    "expected_floor": "48363439472437555017"
+  },
+  {
+    "principal": "1589077853755237861",
+    "rate_bps": 7768,
+    "seconds": 1558899615,
+    "expected_floor": "60977353959636187141"
+  },
+  {
+    "principal": "12296148879956626754",
+    "rate_bps": 5885,
+    "seconds": 739366980,
+    "expected_floor": "169539799080975840540"
+  },
+  {
+    "principal": "11266558406831915331",
+    "rate_bps": 8823,
+    "seconds": 2938444333,
+    "expected_floor": "925595111619049870793"
+  },
+  {
+    "principal": "15583202935899319864",
+    "rate_bps": 798,
+    "seconds": 3951859242,
+    "expected_floor": "155724562022054332735"
+  },
+  {
+    "principal": "18061032435387120817",
+    "rate_bps": 8502,
+    "seconds": 4219914059,
+    "expected_floor": "2053351560035052767978"
+  },
+  {
+    "principal": "15942068896314277502",
+    "rate_bps": 7033,
+    "seconds": 2842293216,
+    "expected_floor": "1009834515432097830065"
+  },
+  {
+    "principal": "15032924686472413103",
+    "rate_bps": 2696,
+    "seconds": 3730040441,
+    "expected_floor": "479041284207053255563"
+  },
+  {
+    "principal": "1139706245577051028",
+    "rate_bps": 9265,
+    "seconds": 3258841830,
+    "expected_floor": "109042968779448960608"
+  },
+  {
+    "principal": "1002285672144483773",
+    "rate_bps": 7406,
+    "seconds": 1916112695,
+    "expected_floor": "45070493246812526407"
+  },
+  {
+    "principal": "339332336399218426",
+    "rate_bps": 419,
+    "seconds": 2332567740,
+    "expected_floor": "1050919784675980154"
+  },
+  {
+    "principal": "9725204450925604443",
+    "rate_bps": 4842,
+    "seconds": 516611333,
+    "expected_floor": "77087415847551128284"
+  },
+  {
+    "principal": "5569642723106805296",
+    "rate_bps": 1125,
+    "seconds": 81383138,
+    "expected_floor": "1615884533799969071"
+  },
+  {
+    "principal": "1195696391202864393",
+    "rate_bps": 6983,
+    "seconds": 1709363043,
+    "expected_floor": "45226533721272929404"
+  },
+  {
+    "principal": "10242284044176265910",
+    "rate_bps": 7128,
+    "seconds": 2956554968,
+    "expected_floor": "683984873756142042880"
+  },
+  {
+    "principal": "15944752405228411207",
+    "rate_bps": 3436,
+    "seconds": 2560043473,
+    "expected_floor": "444441196529236606251"
+  },
+  {
+    "principal": "14565403307508861452",
+    "rate_bps": 7763,
+    "seconds": 1926966814,
+    "expected_floor": "690434316556768231245"
+  },
+  {
+    "principal": "8613533361266589333",
+    "rate_bps": 4208,
+    "seconds": 1606439887,
+    "expected_floor": "184509011897484081199"
+  },
+  {
+    "principal": "6209001705083039154",
+    "rate_bps": 2489,
+    "seconds": 2844134964,
+    "expected_floor": "139281331518097495637"
+  },
+  {
+    "principal": "12607272216871554163",
+    "rate_bps": 6869,
+    "seconds": 2474260701,
+    "expected_floor": "678978678694882241819"
+  },
+  {
+    "principal": "252243992920073000",
+    "rate_bps": 4643,
+    "seconds": 2369680538,
+    "expected_floor": "8794382501163097854"
+  },
+  {
+    "principal": "7657652950585337441",
+    "rate_bps": 892,
+    "seconds": 2343708795,
+    "expected_floor": "50729457385401119656"
+  },
+  {
+    "principal": "1321955693424845806",
+    "rate_bps": 2598,
+    "seconds": 3591206608,
+    "expected_floor": "39083411997122572086"
+  },
+  {
+    "principal": "13744972779152118751",
+    "rate_bps": 6165,
+    "seconds": 4025857577,
+    "expected_floor": "1081014214690186198462"
+  },
+  {
+    "principal": "12881270721805016452",
+    "rate_bps": 9788,
+    "seconds": 1325219414,
+    "expected_floor": "529464066492073349848"
+  },
+  {
+    "principal": "3191945512985436269",
+    "rate_bps": 7385,
+    "seconds": 2801441127,
+    "expected_floor": "209258689853168472230"
+  },
+  {
+    "principal": "15206040849868755306",
+    "rate_bps": 9342,
+    "seconds": 2921490604,
+    "expected_floor": "1315093231652839080068"
+  },
+  {
+    "principal": "6125551126985915275",
+    "rate_bps": 3108,
+    "seconds": 4002909621,
+    "expected_floor": "241489357855961748548"
+  },
+  {
+    "principal": "13061886101318350112",
+    "rate_bps": 4258,
+    "seconds": 3368707922,
+    "expected_floor": "593705319710689882617"
+  },
+  {
+    "principal": "4882928841799456953",
+    "rate_bps": 2585,
+    "seconds": 1797665427,
+    "expected_floor": "71902806468899515993"
+  },
+  {
+    "principal": "2878899947653321254",
+    "rate_bps": 8045,
+    "seconds": 4146520008,
+    "expected_floor": "304321347638369372303"
+  },
+  {
+    "principal": "16707891561310523255",
+    "rate_bps": 656,
+    "seconds": 830860161,
+    "expected_floor": "28856885460320993313"
+  },
+  {
+    "principal": "1861699395206768124",
+    "rate_bps": 4262,
+    "seconds": 2081295246,
+    "expected_floor": "52330240199792177526"
+  },
+  {
+    "principal": "16163017627596290885",
+    "rate_bps": 6946,
+    "seconds": 20430847,
+    "expected_floor": "7268413560862811325"
+  },
+  {
+    "principal": "14695104293810127394",
+    "rate_bps": 4851,
+    "seconds": 3702003748,
+    "expected_floor": "836251354728852835220"
+  },
+  {
+    "principal": "15935722165498911651",
+    "rate_bps": 6882,
+    "seconds": 608910221,
+    "expected_floor": "211609769737433576248"
+  },
+  {
+    "principal": "3319816494333619224",
+    "rate_bps": 2830,
+    "seconds": 2434893578,
+    "expected_floor": "72489738161335684689"
+  },
+  {
+    "principal": "13812196209262867473",
+    "rate_bps": 6302,
+    "seconds": 1226067371,
+    "expected_floor": "338182792286354855039"
+  },
+  {
+    "principal": "17200293707082366302",
+    "rate_bps": 5985,
+    "seconds": 716869056,
+    "expected_floor": "233849197979638741616"
+  },
+  {
+    "principal": "16189013775746378767",
+    "rate_bps": 4023,
+    "seconds": 904014297,
+    "expected_floor": "186569976577095915421"
+  },
+  {
+    "principal": "10273739310582236020",
+    "rate_bps": 137,
+    "seconds": 1154184646,
+    "expected_floor": "5147785405707176630"
+  },
+  {
+    "principal": "6271404177769262877",
+    "rate_bps": 5849,
+    "seconds": 19867543,
+    "expected_floor": "2309333240852469972"
+  },
+  {
+    "principal": "1490829136539181018",
+    "rate_bps": 8174,
+    "seconds": 630586524,
+    "expected_floor": "24350238742751821560"
+  },
+  {
+    "principal": "7685233486619364539",
+    "rate_bps": 2080,
+    "seconds": 2432803429,
+    "expected_floor": "123231987692788705700"
+  },
+  {
+    "principal": "1569554131856271376",
+    "rate_bps": 9474,
+    "seconds": 687584194,
+    "expected_floor": "32398999304895723610"
+  },
+  {
+    "principal": "18259700177511995497",
+    "rate_bps": 2213,
+    "seconds": 443931075,
+    "expected_floor": "56844262402825461546"
+  },
+  {
+    "principal": "8559285442168849814",
+    "rate_bps": 6283,
+    "seconds": 3127992504,
+    "expected_floor": "533047985128993219851"
+  },
+  {
+    "principal": "6112276973384944039",
+    "rate_bps": 1239,
+    "seconds": 1051250993,
+    "expected_floor": "25227649243247473551"
+  },
+  {
+    "principal": "11499376705812862444",
+    "rate_bps": 5027,
+    "seconds": 348609790,
+    "expected_floor": "63858512579480902384"
+  },
+  {
+    "principal": "16125604521516391413",
+    "rate_bps": 3358,
+    "seconds": 3296473135,
+    "expected_floor": "565642808644989186724"
+  },
+  {
+    "principal": "6020459434004597394",
+    "rate_bps": 5777,
+    "seconds": 94303764,
+    "expected_floor": "10393386128916151570"
+  },
+  {
+    "principal": "9371661198603366099",
+    "rate_bps": 8414,
+    "seconds": 3739951677,
+    "expected_floor": "934503884878954050009"
+  },
+  {
+    "principal": "868314941985769736",
+    "rate_bps": 5968,
+    "seconds": 3752119674,
+    "expected_floor": "61613914783925762157"
+  },
+  {
+    "principal": "9586134225385498049",
+    "rate_bps": 8761,
+    "seconds": 4259854043,
+    "expected_floor": "1133673351048744999816"
+  },
+  {
+    "principal": "12537538834799708878",
+    "rate_bps": 7223,
+    "seconds": 1776826544,
+    "expected_floor": "509883516736689844192"
+  },
+  {
+    "principal": "6871311047908182079",
+    "rate_bps": 5990,
+    "seconds": 1677476233,
+    "expected_floor": "218785652979864235000"
+  },
+  {
+    "principal": "13877395650305260900",
+    "rate_bps": 3361,
+    "seconds": 1139253558,
+    "expected_floor": "168380932126842972873"
+  },
+  {
+    "principal": "11006750333447086541",
+    "rate_bps": 7192,
+    "seconds": 3038656967,
+    "expected_floor": "762230815719774578970"
+  },
+  {
+    "principal": "13886222108766528074",
+    "rate_bps": 6088,
+    "seconds": 3039421580,
+    "expected_floor": "814227425941293595864"
+  },
+  {
+    "principal": "2496315399283548651",
+    "rate_bps": 4560,
+    "seconds": 2071730965,
+    "expected_floor": "74729777405840189027"
+  },
+  {
+    "principal": "12760255018899123968",
+    "rate_bps": 2128,
+    "seconds": 2222765106,
+    "expected_floor": "191258427599369060135"
+  },
+  {
+    "principal": "12471908964697766937",
+    "rate_bps": 1954,
+    "seconds": 3308045555,
+    "expected_floor": "255461234211304652687"
+  },
+  {
+    "principal": "14212623216927157510",
+    "rate_bps": 9081,
+    "seconds": 238024104,
+    "expected_floor": "97347519645761249665"
+  },
+  {
+    "principal": "7468637206932621271",
+    "rate_bps": 9507,
+    "seconds": 2449660641,
+    "expected_floor": "551171578826332662923"
+  },
+  {
+    "principal": "10342515789373020636",
+    "rate_bps": 3380,
+    "seconds": 2984649326,
+    "expected_floor": "330622372411242676036"
+  },
+  {
+    "principal": "2886728132318339237",
+    "rate_bps": 1063,
+    "seconds": 1526244447,
+    "expected_floor": "14840867199065733534"
+  },
+  {
+    "principal": "7749941154060338946",
+    "rate_bps": 4161,
+    "seconds": 2815535108,
+    "expected_floor": "287708770225994443496"
+  },
+  {
+    "principal": "12841465116154136067",
+    "rate_bps": 4321,
+    "seconds": 2632772845,
+    "expected_floor": "462922474013402375826"
+  },
+  {
+    "principal": "3053305429171354104",
+    "rate_bps": 828,
+    "seconds": 2859943914,
+    "expected_floor": "22911532333340264813"
+  },
+  {
+    "principal": "2858892764219587441",
+    "rate_bps": 7625,
+    "seconds": 2393433099,
+    "expected_floor": "165331284171982570209"
+  },
+  {
+    "principal": "4461822604275092542",
+    "rate_bps": 2826,
+    "seconds": 1968011168,
+    "expected_floor": "78633579981244101454"
+  },
+  {
+    "principal": "3899185927141845103",
+    "rate_bps": 9916,
+    "seconds": 375848249,
+    "expected_floor": "46048875222909021678"
+  },
+  {
+    "principal": "4937478680903306068",
+    "rate_bps": 3159,
+    "seconds": 835764390,
+    "expected_floor": "41308055815565475757"
+  },
+  {
+    "principal": "11809456429541734525",
+    "rate_bps": 9209,
+    "seconds": 1028837367,
+    "expected_floor": "354556248353172227207"
+  },
+  {
+    "principal": "264443112953518266",
+    "rate_bps": 1859,
+    "seconds": 1541742716,
+    "expected_floor": "2401704594439273993"
+  },
+  {
+    "principal": "5931304173864205083",
+    "rate_bps": 8139,
+    "seconds": 3619289029,
+    "expected_floor": "553656680058948991541"
+  },
+  {
+    "principal": "5090144159032658416",
+    "rate_bps": 9910,
+    "seconds": 3147589794,
+    "expected_floor": "503127317435903534045"
+  },
+  {
+    "principal": "486736512656360393",
+    "rate_bps": 4930,
+    "seconds": 1860564003,
+    "expected_floor": "14147558311035369664"
+  },
+  {
+    "principal": "17973480283144439926",
+    "rate_bps": 949,
+    "seconds": 2646187672,
+    "expected_floor": "143026024313744074723"
+  },
+  {
+    "principal": "9017435240736344583",
+    "rate_bps": 4517,
+    "seconds": 3184986257,
+    "expected_floor": "411089816216868852215"
+  },
+  {
+    "principal": "8935982950505837004",
+    "rate_bps": 2416,
+    "seconds": 3314113502,
+    "expected_floor": "226726702879148833313"
+  },
+  {
+    "principal": "5435732991786994005",
+    "rate_bps": 2784,
+    "seconds": 3562544271,
+    "expected_floor": "170837673869865973321"
+  },
+  {
+    "principal": "6192424920761923442",
+    "rate_bps": 7554,
+    "seconds": 2045193716,
+    "expected_floor": "303157427280454814973"
+  },
+  {
+    "principal": "12080199436489892147",
+    "rate_bps": 6348,
+    "seconds": 1143184285,
+    "expected_floor": "277794281247202146153"
+  },
+  {
+    "principal": "10662137173320253160",
+    "rate_bps": 8127,
+    "seconds": 3699897946,
+    "expected_floor": "1015921855551753341096"
+  },
+  {
+    "principal": "12479055538772407585",
+    "rate_bps": 97,
+    "seconds": 705779003,
+    "expected_floor": "2707186768081325937"
+  },
+  {
+    "principal": "12016583690081714606",
+    "rate_bps": 407,
+    "seconds": 1038174864,
+    "expected_floor": "16089478481397341050"
+  },
+  {
+    "principal": "13863986553057905823",
+    "rate_bps": 865,
+    "seconds": 2173000937,
+    "expected_floor": "82577205621951443002"
+  },
+  {
+    "principal": "1605998193685654852",
+    "rate_bps": 5327,
+    "seconds": 2839925782,
+    "expected_floor": "76989371202338327363"
+  },
+  {
+    "principal": "5730354142379160365",
+    "rate_bps": 4601,
+    "seconds": 2325211687,
+    "expected_floor": "194263954895059773078"
+  },
+  {
+    "principal": "12858747536708993834",
+    "rate_bps": 2273,
+    "seconds": 1141813356,
+    "expected_floor": "105752162521921610415"
+  },
+  {
+    "principal": "18434694250741241931",
+    "rate_bps": 4324,
+    "seconds": 867055733,
+    "expected_floor": "219010366193121496113"
+  },
+  {
+    "principal": "414791285885532384",
+    "rate_bps": 3148,
+    "seconds": 2682900754,
+    "expected_floor": "11101073754993098277"
+  },
+  {
+    "principal": "13356827066645032825",
+    "rate_bps": 6074,
+    "seconds": 4252788563,
+    "expected_floor": "1093321566483569004035"
+  },
+  {
+    "principal": "17735093805596989414",
+    "rate_bps": 5700,
+    "seconds": 2611305352,
+    "expected_floor": "836492472890307109119"
+  },
+  {
+    "principal": "1728317598976249911",
+    "rate_bps": 730,
+    "seconds": 3299367489,
+    "expected_floor": "13190860758143865207"
+  },
+  {
+    "principal": "9405666399895592380",
+    "rate_bps": 6762,
+    "seconds": 789580110,
+    "expected_floor": "159131798115936188665"
+  },
+  {
+    "principal": "11352748977905522181",
+    "rate_bps": 9404,
+    "seconds": 3464861887,
+    "expected_floor": "1172183534056713919240"
+  },
+  {
+    "principal": "18067651672197635042",
+    "rate_bps": 7050,
+    "seconds": 1439074276,
+    "expected_floor": "580858125718607900751"
+  },
+  {
+    "principal": "5838692089582026851",
+    "rate_bps": 2459,
+    "seconds": 1990340173,
+    "expected_floor": "90551874156496335954"
+  },
+  {
+    "principal": "3094996392124536792",
+    "rate_bps": 6424,
+    "seconds": 2315638986,
+    "expected_floor": "145892365164086885504"
+  },
+  {
+    "principal": "16918166760435012305",
+    "rate_bps": 4881,
+    "seconds": 2031913579,
+    "expected_floor": "531695977456036899559"
+  },
+  {
+    "principal": "745228149614045982",
+    "rate_bps": 1281,
+    "seconds": 3017453952,
+    "expected_floor": "9127988097555640998"
+  },
+  {
+    "principal": "17597038951089517775",
+    "rate_bps": 9148,
+    "seconds": 570056857,
+    "expected_floor": "290790328588969933727"
+  },
+  {
+    "principal": "11938551705104507700",
+    "rate_bps": 4463,
+    "seconds": 1782963078,
+    "expected_floor": "301034946074365416608"
+  },
+  {
+    "principal": "11809137589042319837",
+    "rate_bps": 3142,
+    "seconds": 871925847,
+    "expected_floor": "102517958240925340404"
+  },
+  {
+    "principal": "2022654553494495642",
+    "rate_bps": 4446,
+    "seconds": 3006108764,
+    "expected_floor": "85662727367765492429"
+  },
+  {
+    "principal": "2658991385416317307",
+    "rate_bps": 3377,
+    "seconds": 831249701,
+    "expected_floor": "23652416934868874425"
+  },
+  {
+    "principal": "6749679630207925200",
+    "rate_bps": 6612,
+    "seconds": 1681124738,
+    "expected_floor": "237745319923735514514"
+  },
+  {
+    "principal": "14610740204924157737",
+    "rate_bps": 3667,
+    "seconds": 1762336387,
+    "expected_floor": "299204395755341152883"
+  },
+  {
+    "principal": "5079967756971793238",
+    "rate_bps": 3328,
+    "seconds": 2982816888,
+    "expected_floor": "159796366371390294768"
+  },
+  {
+    "principal": "3697786968723741287",
+    "rate_bps": 1265,
+    "seconds": 3376009201,
+    "expected_floor": "50041701459023503093"
+  },
+  {
+    "principal": "5746078693071953324",
+    "rate_bps": 7602,
+    "seconds": 2870553278,
+    "expected_floor": "397338894792974873672"
+  },
+  {
+    "principal": "3168472780188305077",
+    "rate_bps": 5306,
+    "seconds": 2779519215,
+    "expected_floor": "148075408624100416934"
+  },
+  {
+    "principal": "18425054295291425874",
+    "rate_bps": 8690,
+    "seconds": 680965588,
+    "expected_floor": "345501352226299519338"
+  },
+  {
+    "principal": "4475202526106198931",
+    "rate_bps": 9988,
+    "seconds": 1119593725,
+    "expected_floor": "158579745479157154788"
+  },
+  {
+    "principal": "10870458979129885896",
+    "rate_bps": 1201,
+    "seconds": 1616899898,
+    "expected_floor": "66891364557179646923"
+  },
+  {
+    "principal": "17896979034042291329",
+    "rate_bps": 7113,
+    "seconds": 3473245083,
+    "expected_floor": "1401083441657291849882"
+  },
+  {
+    "principal": "6130490940997011598",
+    "rate_bps": 7351,
+    "seconds": 3065031792,
+    "expected_floor": "437696117464112998974"
+  },
+  {
+    "principal": "11887424678751461631",
+    "rate_bps": 1696,
+    "seconds": 1823017033,
+    "expected_floor": "116466328633054862425"
+  },
+  {
+    "principal": "13095216551260794148",
+    "rate_bps": 5879,
+    "seconds": 3390035702,
+    "expected_floor": "827020832881571436387"
+  },
+  {
+    "principal": "6464204972631413901",
+    "rate_bps": 9223,
+    "seconds": 2797578887,
+    "expected_floor": "528525203696456073435"
+  },
+  {
+    "principal": "3600770287517594634",
+    "rate_bps": 6512,
+    "seconds": 4194880588,
+    "expected_floor": "311691847899641429285"
+  },
+  {
+    "principal": "13140173560230780587",
+    "rate_bps": 819,
+    "seconds": 935716309,
+    "expected_floor": "31909884725338429817"
+  },
+  {
+    "principal": "15448118613188186816",
+    "rate_bps": 5482,
+    "seconds": 210353650,
+    "expected_floor": "56449579565928319855"
+  },
+  {
+    "principal": "17066431134418793177",
+    "rate_bps": 4515,
+    "seconds": 3958184371,
+    "expected_floor": "966479217834354535700"
+  },
+  {
+    "principal": "6905096730094850758",
+    "rate_bps": 169,
+    "seconds": 4047442280,
+    "expected_floor": "14966945193981748945"
+  },
+  {
+    "principal": "2594852899022973079",
+    "rate_bps": 493,
+    "seconds": 3197004193,
+    "expected_floor": "12959817951962642009"
+  },
+  {
+    "principal": "16636798557097816476",
+    "rate_bps": 1625,
+    "seconds": 1132707886,
+    "expected_floor": "97036937221317342710"
+  },
+  {
+    "principal": "17201421856908581733",
+    "rate_bps": 9400,
+    "seconds": 2755042591,
+    "expected_floor": "1411615929318102873848"
+  },
+  {
+    "principal": "15334755720067186882",
+    "rate_bps": 1233,
+    "seconds": 3804149700,
+    "expected_floor": "227925843399873419892"
+  },
+  {
+    "principal": "785793333349583555",
+    "rate_bps": 1188,
+    "seconds": 3540189101,
+    "expected_floor": "10472425372344014636"
+  },
+  {
+    "principal": "15185779325392012728",
+    "rate_bps": 2912,
+    "seconds": 373635498,
+    "expected_floor": "52356742575024344928"
+  },
+  {
+    "principal": "18445279636983118385",
+    "rate_bps": 207,
+    "seconds": 1497841867,
+    "expected_floor": "18122478269515889649"
+  },
+  {
+    "principal": "4421117731030014462",
+    "rate_bps": 3115,
+    "seconds": 85605216,
+    "expected_floor": "3735823858234726705"
+  },
+  {
+    "principal": "5864294555508576559",
+    "rate_bps": 8693,
+    "seconds": 2125747193,
+    "expected_floor": "343394316588576156621"
+  },
+  {
+    "principal": "236205959111756564",
+    "rate_bps": 3735,
+    "seconds": 589481574,
+    "expected_floor": "1647964012509463524"
+  },
+  {
+    "principal": "5540181004126190397",
+    "rate_bps": 78,
+    "seconds": 1450725559,
+    "expected_floor": "1986551608377784153"
+  },
+  {
+    "principal": "11355297956788664954",
+    "rate_bps": 9004,
+    "seconds": 1688688700,
+    "expected_floor": "547116296411127619306"
+  },
+  {
+    "principal": "6222852177480894427",
+    "rate_bps": 3951,
+    "seconds": 554652293,
+    "expected_floor": "43212894753487378630"
+  },
+  {
+    "principal": "2051571916806946224",
+    "rate_bps": 4385,
+    "seconds": 3728360034,
+    "expected_floor": "106284570060703552839"
+  },
+  {
+    "principal": "1787528235678812809",
+    "rate_bps": 9853,
+    "seconds": 851269859,
+    "expected_floor": "47509961980010928254"
+  },
+  {
+    "principal": "2161221667595468342",
+    "rate_bps": 1350,
+    "seconds": 3260746328,
+    "expected_floor": "30147140728122689876"
+  },
+  {
+    "principal": "1869276258530097863",
+    "rate_bps": 2842,
+    "seconds": 401155921,
+    "expected_floor": "6753156328445010431"
+  },
+  {
+    "principal": "13135114045865171340",
+    "rate_bps": 8231,
+    "seconds": 3211708830,
+    "expected_floor": "1100319091061484502886"
+  },
+  {
+    "principal": "4062159615198778389",
+    "rate_bps": 5275,
+    "seconds": 852501839,
+    "expected_floor": "57885635506078693059"
+  },
+  {
+    "principal": "9273995868585541938",
+    "rate_bps": 4714,
+    "seconds": 1743097268,
+    "expected_floor": "241476087938718244612"
+  },
+  {
+    "principal": "8024742536898786803",
+    "rate_bps": 4142,
+    "seconds": 508247645,
+    "expected_floor": "53531894082212129602"
+  },
+  {
+    "principal": "18374682474726988456",
+    "rate_bps": 5698,
+    "seconds": 3685005338,
+    "expected_floor": "1222577621598315355246"
+  },
+  {
+    "principal": "11408400953923257313",
+    "rate_bps": 6733,
+    "seconds": 1335673339,
+    "expected_floor": "325109515507632561714"
+  },
+  {
+    "principal": "9027149580319858542",
+    "rate_bps": 531,
+    "seconds": 755916368,
+    "expected_floor": "11481931249279562887"
+  },
+  {
+    "principal": "3060566562349499743",
+    "rate_bps": 5619,
+    "seconds": 3447669673,
+    "expected_floor": "187880861457912845817"
+  },
+  {
+    "principal": "13548821118520147204",
+    "rate_bps": 7575,
+    "seconds": 1161669078,
+    "expected_floor": "377800569484980093737"
+  },
+  {
+    "principal": "14762055518856775149",
+    "rate_bps": 5839,
+    "seconds": 3974986471,
+    "expected_floor": "1085717898392814226685"
+  },
+  {
+    "principal": "6764652190193792234",
+    "rate_bps": 5175,
+    "seconds": 709900332,
+    "expected_floor": "78749759882437333004"
+  },
+  {
+    "principal": "16372059657335420171",
+    "rate_bps": 1101,
+    "seconds": 3965395765,
+    "expected_floor": "226502608970603829790"
+  },
+  {
+    "principal": "4748707397793283232",
+    "rate_bps": 425,
+    "seconds": 3486808786,
+    "expected_floor": "22299160068024017094"
+  },
+  {
+    "principal": "15310438436262463033",
+    "rate_bps": 5938,
+    "seconds": 2354502675,
+    "expected_floor": "678301912977835274338"
+  },
+  {
+    "principal": "7131341954820382118",
+    "rate_bps": 6901,
+    "seconds": 3568637768,
+    "expected_floor": "556521298223096038401"
+  },
+  {
+    "principal": "243458319018184951",
+    "rate_bps": 7989,
+    "seconds": 2026703105,
+    "expected_floor": "12491172502648722771"
+  },
+  {
+    "principal": "15416930383920272764",
+    "rate_bps": 4522,
+    "seconds": 322520846,
+    "expected_floor": "71249577366834017236"
+  },
+  {
+    "principal": "17530534263955321029",
+    "rate_bps": 4633,
+    "seconds": 140751231,
+    "expected_floor": "36224774186777814395"
+  },
+  {
+    "principal": "7017667705883243938",
+    "rate_bps": 2883,
+    "seconds": 2129803172,
+    "expected_floor": "136544101769819418366"
+  },
+  {
+    "principal": "18348642985614877987",
+    "rate_bps": 2935,
+    "seconds": 2544328973,
+    "expected_floor": "434191535265577273582"
+  },
+  {
+    "principal": "13144516958668587928",
+    "rate_bps": 2946,
+    "seconds": 3383585418,
+    "expected_floor": "415193505035180027352"
+  },
+  {
+    "principal": "7772701621339795857",
+    "rate_bps": 2859,
+    "seconds": 604047147,
+    "expected_floor": "42535644931425458578"
+  },
+  {
+    "principal": "5062337556799756510",
+    "rate_bps": 4999,
+    "seconds": 2076448064,
+    "expected_floor": "166514226096526956612"
+  },
+  {
+    "principal": "13319244828339993999",
+    "rate_bps": 2453,
+    "seconds": 3601651545,
+    "expected_floor": "372884968077393306108"
+  },
+  {
+    "principal": "4405605297958912756",
+    "rate_bps": 7624,
+    "seconds": 3848241478,
+    "expected_floor": "409587621118636172014"
+  },
+  {
+    "principal": "5768718647209030813",
+    "rate_bps": 5433,
+    "seconds": 2049583383,
+    "expected_floor": "203554490394945476319"
+  },
+  {
+    "principal": "11809648656847872858",
+    "rate_bps": 1532,
+    "seconds": 1569352732,
+    "expected_floor": "89973029367414532600"
+  },
+  {
+    "principal": "14155154607632442939",
+    "rate_bps": 5305,
+    "seconds": 1826379749,
+    "expected_floor": "434597397619335986116"
+  },
+  {
+    "principal": "18071836131716403088",
+    "rate_bps": 5503,
+    "seconds": 4180109122,
+    "expected_floor": "1317302284081551024630"
+  },
+  {
+    "principal": "15991865089455580649",
+    "rate_bps": 5792,
+    "seconds": 433365827,
+    "expected_floor": "127197438486814890914"
+  },
+  {
+    "principal": "7054509102122496278",
+    "rate_bps": 6916,
+    "seconds": 254031928,
+    "expected_floor": "39274089005762178731"
+  },
+  {
+    "principal": "3577117946641722151",
+    "rate_bps": 6494,
+    "seconds": 1694305969,
+    "expected_floor": "124719229230187765171"
+  },
+  {
+    "principal": "3037739454123074924",
+    "rate_bps": 3389,
+    "seconds": 3498195070,
+    "expected_floor": "114120100904411907798"
+  },
+  {
+    "principal": "4750440294924153205",
+    "rate_bps": 2863,
+    "seconds": 1511801263,
+    "expected_floor": "65154729918169187051"
+  },
+  {
+    "principal": "1302724775601233426",
+    "rate_bps": 6146,
+    "seconds": 3255547284,
+    "expected_floor": "82597189321684199700"
+  },
+  {
+    "principal": "3165247241261602899",
+    "rate_bps": 3401,
+    "seconds": 3731515325,
+    "expected_floor": "127290365453664948282"
+  },
+  {
+    "principal": "6407577043664601224",
+    "rate_bps": 226,
+    "seconds": 1389252858,
+    "expected_floor": "6374991466059427199"
+  },
+  {
+    "principal": "11314044370981339969",
+    "rate_bps": 7861,
+    "seconds": 2997817435,
+    "expected_floor": "844883615098773791277"
+  },
+  {
+    "principal": "13307281817099929166",
+    "rate_bps": 830,
+    "seconds": 3987890224,
+    "expected_floor": "139574690803905822205"
+  },
+  {
+    "principal": "5296349978345224639",
+    "rate_bps": 462,
+    "seconds": 3491761929,
+    "expected_floor": "27074429190670942574"
+  },
+  {
+    "principal": "1289670926324767972",
+    "rate_bps": 6024,
+    "seconds": 231165110,
+    "expected_floor": "5690916214804501321"
+  },
+  {
+    "principal": "4527747290456934221",
+    "rate_bps": 9025,
+    "seconds": 2759416647,
+    "expected_floor": "357307969400180865931"
+  },
+  {
+    "principal": "10242134754528314826",
+    "rate_bps": 8292,
+    "seconds": 3692885004,
+    "expected_floor": "993828840906756442535"
+  },
+  {
+    "principal": "12585316209421736811",
+    "rate_bps": 7834,
+    "seconds": 4194693269,
+    "expected_floor": "1310520868815526434009"
+  },
+  {
+    "principal": "7109782299893675648",
+    "rate_bps": 1315,
+    "seconds": 54658994,
+    "expected_floor": "1619346261165680921"
+  },
+  {
+    "principal": "13262664802874829209",
+    "rate_bps": 4280,
+    "seconds": 4270960243,
+    "expected_floor": "768238599583818738979"
+  },
+  {
+    "principal": "10411655165399349382",
+    "rate_bps": 5143,
+    "seconds": 2143251752,
+    "expected_floor": "363668362015039462687"
+  },
+  {
+    "principal": "12347468596396198231",
+    "rate_bps": 4716,
+    "seconds": 4034672737,
+    "expected_floor": "744485208088807331320"
+  },
+  {
+    "principal": "6866409100564662620",
+    "rate_bps": 9637,
+    "seconds": 2519244270,
+    "expected_floor": "528247981766170950052"
+  },
+  {
+    "principal": "9782847370699626021",
+    "rate_bps": 3795,
+    "seconds": 191157727,
+    "expected_floor": "22488730955948614353"
+  },
+  {
+    "principal": "7571347250564414082",
+    "rate_bps": 5191,
+    "seconds": 2392393604,
+    "expected_floor": "297956496825252511344"
+  },
+  {
+    "principal": "2206949190395514755",
+    "rate_bps": 9048,
+    "seconds": 1848070765,
+    "expected_floor": "116939048675649048703"
+  },
+  {
+    "principal": "2018796726213022072",
+    "rate_bps": 7840,
+    "seconds": 2998299498,
+    "expected_floor": "150376405469444484223"
+  },
+  {
+    "principal": "10836433397555132657",
+    "rate_bps": 4649,
+    "seconds": 1914822027,
+    "expected_floor": "305682347517258496182"
+  },
+  {
+    "principal": "11536733949131384766",
+    "rate_bps": 1857,
+    "seconds": 512769824,
+    "expected_floor": "34810741441122353875"
+  },
+  {
+    "principal": "11716237696764705263",
+    "rate_bps": 3035,
+    "seconds": 1476127417,
+    "expected_floor": "166328529907026696856"
+  },
+  {
+    "principal": "1488499063120628436",
+    "rate_bps": 1028,
+    "seconds": 2381581350,
+    "expected_floor": "11547903177842222491"
+  },
+  {
+    "principal": "12887545708125781501",
+    "rate_bps": 544,
+    "seconds": 3630567799,
+    "expected_floor": "80656561335772652349"
+  },
+  {
+    "principal": "14687076715801713722",
+    "rate_bps": 4424,
+    "seconds": 1057935356,
+    "expected_floor": "217823958396426629351"
+  },
+  {
+    "principal": "15593720380993049755",
+    "rate_bps": 7998,
+    "seconds": 529198405,
+    "expected_floor": "209144140508761245921"
+  },
+  {
+    "principal": "12784846321344409968",
+    "rate_bps": 8992,
+    "seconds": 2557697058,
+    "expected_floor": "931744734381504937191"
+  },
+  {
+    "principal": "15736637373895512393",
+    "rate_bps": 8267,
+    "seconds": 2418605475,
+    "expected_floor": "997059187031570462085"
+  },
+  {
+    "principal": "17346535813651821558",
+    "rate_bps": 9094,
+    "seconds": 1272821272,
+    "expected_floor": "636254936216222494024"
+  },
+  {
+    "principal": "11097667647400995719",
+    "rate_bps": 4298,
+    "seconds": 1871545873,
+    "expected_floor": "282875044297191987872"
+  },
+  {
+    "principal": "2384361839790096716",
+    "rate_bps": 6900,
+    "seconds": 2152429406,
+    "expected_floor": "112213782783571655543"
+  },
+  {
+    "principal": "11089386245809839829",
+    "rate_bps": 3783,
+    "seconds": 3722997263,
+    "expected_floor": "494917261796822451281"
+  },
+  {
+    "principal": "4456944113997531890",
+    "rate_bps": 752,
+    "seconds": 4114689396,
+    "expected_floor": "43700672404401967347"
+  },
+  {
+    "principal": "42567817315027635",
+    "rate_bps": 9636,
+    "seconds": 1320231197,
+    "expected_floor": "1716027317941269195"
+  },
+  {
+    "principal": "14816277898034984552",
+    "rate_bps": 6109,
+    "seconds": 1582610906,
+    "expected_floor": "453920113862293202537"
+  },
+  {
+    "principal": "8971119671753396897",
+    "rate_bps": 4382,
+    "seconds": 2736025275,
+    "expected_floor": "340827917685912055877"
+  },
+  {
+    "principal": "14564416768845331758",
+    "rate_bps": 8885,
+    "seconds": 961851920,
+    "expected_floor": "394416231552384806762"
+  },
+  {
+    "principal": "17091931272436039199",
+    "rate_bps": 1636,
+    "seconds": 614689385,
+    "expected_floor": "54466088009572772863"
+  },
+  {
+    "principal": "4160267292917648580",
+    "rate_bps": 8094,
+    "seconds": 1789181846,
+    "expected_floor": "190912757444090098400"
+  },
+  {
+    "principal": "10099744864250271917",
+    "rate_bps": 7394,
+    "seconds": 2025540519,
+    "expected_floor": "479321398032877620352"
+  },
+  {
+    "principal": "14886352283025450666",
+    "rate_bps": 8225,
+    "seconds": 3399942124,
+    "expected_floor": "1319142632022209559792"
+  },
+  {
+    "principal": "10069947222836154827",
+    "rate_bps": 2047,
+    "seconds": 1298025973,
+    "expected_floor": "84786059703317682964"
+  },
+  {
+    "principal": "5406746151204470880",
+    "rate_bps": 8930,
+    "seconds": 3561645202,
+    "expected_floor": "544921729113346630162"
+  },
+  {
+    "principal": "4348212920687631609",
+    "rate_bps": 9828,
+    "seconds": 2255851731,
+    "expected_floor": "305479826007518176682"
+  },
+  {
+    "principal": "15423369976147977062",
+    "rate_bps": 667,
+    "seconds": 2685801224,
+    "expected_floor": "87553802175753033906"
+  },
+  {
+    "principal": "13413189284276588983",
+    "rate_bps": 9805,
+    "seconds": 649328577,
+    "expected_floor": "270607731650272586057"
+  },
+  {
+    "principal": "7090124077490752828",
+    "rate_bps": 879,
+    "seconds": 2554971342,
+    "expected_floor": "50457389363824499947"
+  },
+  {
+    "principal": "13787055057095052165",
+    "rate_bps": 6037,
+    "seconds": 2710702655,
+    "expected_floor": "714941652524477970829"
+  },
+  {
+    "principal": "10571732701743910754",
+    "rate_bps": 4608,
+    "seconds": 2850760548,
+    "expected_floor": "440063569392770125692"
+  },
+  {
+    "principal": "9478675961520851427",
+    "rate_bps": 6364,
+    "seconds": 3290092493,
+    "expected_floor": "628900569291779887411"
+  },
+  {
+    "principal": "11933514494816448344",
+    "rate_bps": 509,
+    "seconds": 1943551050,
+    "expected_floor": "37409175174711259467"
+  },
+  {
+    "principal": "14987779060772687953",
+    "rate_bps": 8923,
+    "seconds": 2155987947,
+    "expected_floor": "913672464947778172705"
+  },
+  {
+    "principal": "17801001967287240350",
+    "rate_bps": 1571,
+    "seconds": 3895900416,
+    "expected_floor": "345242707155158569566"
+  },
+  {
+    "principal": "14455896387986720335",
+    "rate_bps": 5251,
+    "seconds": 3032059417,
+    "expected_floor": "729324470815981988491"
+  },
+  {
+    "principal": "4707946259616424628",
+    "rate_bps": 9405,
+    "seconds": 1306027782,
+    "expected_floor": "183247789719570693957"
+  },
+  {
+    "principal": "9449425428814731101",
+    "rate_bps": 3048,
+    "seconds": 243534295,
+    "expected_floor": "22226778714358997983"
+  },
+  {
+    "principal": "13222798890482394394",
+    "rate_bps": 2474,
+    "seconds": 1584169948,
+    "expected_floor": "164218050170087022752"
+  },
+  {
+    "principal": "16449393092562309883",
+    "rate_bps": 2455,
+    "seconds": 2276659877,
+    "expected_floor": "291336945270319051420"
+  },
+  {
+    "principal": "15364274540300116816",
+    "rate_bps": 259,
+    "seconds": 3012960514,
+    "expected_floor": "37992799521163067540"
+  },
+  {
+    "principal": "13477719588675603625",
+    "rate_bps": 131,
+    "seconds": 731015171,
+    "expected_floor": "4089875944826453000"
+  },
+  {
+    "principal": "16650263259369981654",
+    "rate_bps": 28,
+    "seconds": 2688517112,
+    "expected_floor": "3971805509225639847"
+  },
+  {
+    "principal": "3110258262036036583",
+    "rate_bps": 964,
+    "seconds": 4206005617,
+    "expected_floor": "39961277874452542419"
+  },
+  {
+    "principal": "15527444067275926828",
+    "rate_bps": 8159,
+    "seconds": 1153599038,
+    "expected_floor": "463113909139178055597"
+  },
+  {
+    "principal": "2605985662251818037",
+    "rate_bps": 2783,
+    "seconds": 1686940271,
+    "expected_floor": "38768675784391809111"
+  },
+  {
+    "principal": "805266178167113682",
+    "rate_bps": 8284,
+    "seconds": 4089312596,
+    "expected_floor": "86442216073902159553"
+  },
+  {
+    "principal": "2462215543359556883",
+    "rate_bps": 9424,
+    "seconds": 4273433213,
+    "expected_floor": "314220344150298369915"
+  },
+  {
+    "principal": "15627464446777637960",
+    "rate_bps": 127,
+    "seconds": 716174010,
+    "expected_floor": "4504087613223467293"
+  },
+  {
+    "principal": "13060445637777125889",
+    "rate_bps": 754,
+    "seconds": 1873075483,
+    "expected_floor": "58449480293069413938"
+  },
+  {
+    "principal": "10680372948596540430",
+    "rate_bps": 2550,
+    "seconds": 1152209904,
+    "expected_floor": "99438424655093773918"
+  },
+  {
+    "principal": "11595666080549524095",
+    "rate_bps": 3185,
+    "seconds": 4280374729,
+    "expected_floor": "500936828028382121773"
+  },
+  {
+    "principal": "12032328356730981540",
+    "rate_bps": 9955,
+    "seconds": 4140696182,
+    "expected_floor": "1571666290050368876977"
+  },
+  {
+    "principal": "5206211076819286541",
+    "rate_bps": 5743,
+    "seconds": 2030783495,
+    "expected_floor": "192406724413415385485"
+  },
+  {
+    "principal": "5662394629361653642",
+    "rate_bps": 165,
+    "seconds": 1697012684,
+    "expected_floor": "5024180098593156114"
+  },
+  {
+    "principal": "11895618902659160107",
+    "rate_bps": 6910,
+    "seconds": 385629013,
+    "expected_floor": "100445578292756963024"
+  },
+  {
+    "principal": "10387296701804583488",
+    "rate_bps": 8001,
+    "seconds": 2221248882,
+    "expected_floor": "584978712761019955129"
+  },
+  {
+    "principal": "10810123532818948185",
+    "rate_bps": 4162,
+    "seconds": 2346353459,
+    "expected_floor": "334520087187322789793"
+  },
+  {
+    "principal": "6717573197884415558",
+    "rate_bps": 6007,
+    "seconds": 1467025640,
+    "expected_floor": "187587448614845555110"
+  },
+  {
+    "principal": "8201033255357065751",
+    "rate_bps": 676,
+    "seconds": 546064161,
+    "expected_floor": "9593011738819449795"
+  },
+  {
+    "principal": "13825973205058085148",
+    "rate_bps": 5322,
+    "seconds": 3113532334,
+    "expected_floor": "725972206452407158811"
+  },
+  {
+    "principal": "6109516337463021797",
+    "rate_bps": 413,
+    "seconds": 2739097247,
+    "expected_floor": "21900819530396477251"
+  },
+  {
+    "principal": "8978949807511450690",
+    "rate_bps": 937,
+    "seconds": 2636158788,
+    "expected_floor": "70280158767558494121"
+  },
+  {
+    "principal": "16281900902267278403",
+    "rate_bps": 732,
+    "seconds": 3407471917,
+    "expected_floor": "128689912726101432807"
+  },
+  {
+    "principal": "8216543961906879800",
+    "rate_bps": 2761,
+    "seconds": 1133174058,
+    "expected_floor": "81460720381906224438"
+  },
+  {
+    "principal": "4281745844433729457",
+    "rate_bps": 4061,
+    "seconds": 804829771,
+    "expected_floor": "44345947657610224543"
+  },
+  {
+    "principal": "2000145312390477182",
+    "rate_bps": 6387,
+    "seconds": 3345973984,
+    "expected_floor": "135449391285543126342"
+  },
+  {
+    "principal": "3028027814349546159",
+    "rate_bps": 8568,
+    "seconds": 587055481,
+    "expected_floor": "48263020460663433989"
+  },
+  {
+    "principal": "17743543546074008212",
+    "rate_bps": 6084,
+    "seconds": 2852426214,
+    "expected_floor": "975753266834607689886"
+  },
+  {
+    "principal": "13096222848789528765",
+    "rate_bps": 7518,
+    "seconds": 500961847,
+    "expected_floor": "156296431435425976644"
+  },
+  {
+    "principal": "14343719687884570106",
+    "rate_bps": 4834,
+    "seconds": 3302721468,
+    "expected_floor": "725665402641595500065"
+  },
+  {
+    "principal": "12154105996884615515",
+    "rate_bps": 7071,
+    "seconds": 938264581,
+    "expected_floor": "255520184244961819902"
+  },
+  {
+    "principal": "2692249135799215408",
+    "rate_bps": 8171,
+    "seconds": 1443345890,
+    "expected_floor": "100613651196769784921"
+  },
+  {
+    "principal": "1562709139825072137",
+    "rate_bps": 4750,
+    "seconds": 2783502947,
+    "expected_floor": "65472583802421242267"
+  },
+  {
+    "principal": "15580525865875106230",
+    "rate_bps": 3370,
+    "seconds": 2818679256,
+    "expected_floor": "468979333148765535821"
+  },
+  {
+    "principal": "18045317346103598151",
+    "rate_bps": 3608,
+    "seconds": 3447989457,
+    "expected_floor": "711365854054061812835"
+  },
+  {
+    "principal": "11040081549336422668",
+    "rate_bps": 413,
+    "seconds": 1742693662,
+    "expected_floor": "25179054489151843134"
+  },
+  {
+    "principal": "2529598155839515029",
+    "rate_bps": 9542,
+    "seconds": 2019620559,
+    "expected_floor": "154474487886257136481"
+  },
+  {
+    "principal": "1525122689010668722",
+    "rate_bps": 590,
+    "seconds": 3820621108,
+    "expected_floor": "10893985611627910640"
+  },
+  {
+    "principal": "15614658338626510707",
+    "rate_bps": 780,
+    "seconds": 1108689885,
+    "expected_floor": "42789105416944163772"
+  },
+  {
+    "principal": "15314475003302384168",
+    "rate_bps": 3900,
+    "seconds": 2019031962,
+    "expected_floor": "382125436029287777984"
+  },
+  {
+    "principal": "8652424385863491937",
+    "rate_bps": 5001,
+    "seconds": 188242811,
+    "expected_floor": "25811253702714470729"
+  },
+  {
+    "principal": "1197597714293496558",
+    "rate_bps": 4168,
+    "seconds": 947144144,
+    "expected_floor": "14981344129632505861"
+  },
+  {
+    "principal": "14862535401910433503",
+    "rate_bps": 101,
+    "seconds": 397529385,
+    "expected_floor": "1890947823484930501"
+  },
+  {
+    "principal": "9927101441557240964",
+    "rate_bps": 4246,
+    "seconds": 2705003862,
+    "expected_floor": "361298677640347903566"
+  },
+  {
+    "principal": "17773710150971812717",
+    "rate_bps": 9973,
+    "seconds": 415325287,
+    "expected_floor": "233285808080446930555"
+  },
+  {
+    "principal": "9946037885137246314",
+    "rate_bps": 4354,
+    "seconds": 3469936556,
+    "expected_floor": "476163499180939507156"
+  },
+  {
+    "principal": "14047785709011086987",
+    "rate_bps": 5274,
+    "seconds": 3413620917,
+    "expected_floor": "801418425405400360692"
+  },
+  {
+    "principal": "10351406428046869536",
+    "rate_bps": 272,
+    "seconds": 1762365010,
+    "expected_floor": "15723895879653258989"
+  },
+  {
+    "principal": "9418782506150540217",
+    "rate_bps": 3381,
+    "seconds": 2593686931,
+    "expected_floor": "261730012499383145637"
+  },
+  {
+    "principal": "18048733028624754982",
+    "rate_bps": 1763,
+    "seconds": 998788808,
+    "expected_floor": "100709104308840105471"
+  },
+  {
+    "principal": "16891533956017197687",
+    "rate_bps": 3322,
+    "seconds": 3877447297,
+    "expected_floor": "689462508437806795793"
+  },
+  {
+    "principal": "2861565347691382012",
+    "rate_bps": 7772,
+    "seconds": 1845592718,
+    "expected_floor": "130067370623839904156"
+  },
+  {
+    "principal": "16356214338594661957",
+    "rate_bps": 14,
+    "seconds": 3436225279,
+    "expected_floor": "2493380106555306482"
+  },
+  {
+    "principal": "4777194073722956066",
+    "rate_bps": 5614,
+    "seconds": 1752258340,
+    "expected_floor": "148915348366449326294"
+  },
+  {
+    "principal": "4004631423624588963",
+    "rate_bps": 9599,
+    "seconds": 2025621133,
+    "expected_floor": "246741837570122321188"
+  },
+  {
+    "principal": "15139131484463176472",
+    "rate_bps": 6486,
+    "seconds": 3964030474,
+    "expected_floor": "1233419819324731635108"
+  },
+  {
+    "principal": "4402435666031161105",
+    "rate_bps": 2294,
+    "seconds": 90095787,
+    "expected_floor": "2883280853024278020"
+  },
+  {
+    "principal": "956293494390600798",
+    "rate_bps": 5946,
+    "seconds": 2666699968,
+    "expected_floor": "48049214777017513072"
+  },
+  {
+    "principal": "8610347396877012751",
+    "rate_bps": 2294,
+    "seconds": 1558217945,
+    "expected_floor": "97530021972475565733"
+  },
+  {
+    "principal": "17788847281526768244",
+    "rate_bps": 6752,
+    "seconds": 2070973638,
+    "expected_floor": "788226159207537120754"
+  },
+  {
+    "principal": "13180652928907901469",
+    "rate_bps": 9248,
+    "seconds": 1808149143,
+    "expected_floor": "698417364058320349683"
+  },
+  {
+    "principal": "8135927144766301914",
+    "rate_bps": 9414,
+    "seconds": 798219164,
+    "expected_floor": "193731137354489979912"
+  },
+  {
+    "principal": "5066187385396756411",
+    "rate_bps": 5341,
+    "seconds": 114298213,
+    "expected_floor": "9800298427611696988"
+  },
+  {
+    "principal": "13467967518998525712",
+    "rate_bps": 162,
+    "seconds": 2671778498,
+    "expected_floor": "18471984614488022325"
+  },
+  {
+    "principal": "836843174383874921",
+    "rate_bps": 969,
+    "seconds": 3708054723,
+    "expected_floor": "9528181535806659490"
+  },
+  {
+    "principal": "16092083651048791190",
+    "rate_bps": 6316,
+    "seconds": 1927024568,
+    "expected_floor": "620637034780185185088"
+  },
+  {
+    "principal": "11450177378991115431",
+    "rate_bps": 195,
+    "seconds": 3004845105,
+    "expected_floor": "21260082650408841905"
+  },
+  {
+    "principal": "4401779548020552940",
+    "rate_bps": 4799,
+    "seconds": 127538174,
+    "expected_floor": "8537196267835674348"
+  },
+  {
+    "principal": "1822208142897710837",
+    "rate_bps": 9937,
+    "seconds": 2277331759,
+    "expected_floor": "130669914972456465773"
+  },
+  {
+    "principal": "6888489285382467986",
+    "rate_bps": 3581,
+    "seconds": 527267092,
+    "expected_floor": "41214971889607006052"
+  },
+  {
+    "principal": "16278244789405483475",
+    "rate_bps": 672,
+    "seconds": 811773245,
+    "expected_floor": "28138932289664679166"
+  },
+  {
+    "principal": "17626702116862179336",
+    "rate_bps": 5376,
+    "seconds": 2613367930,
+    "expected_floor": "784742033412962499222"
+  },
+  {
+    "principal": "3674999898864574657",
+    "rate_bps": 6166,
+    "seconds": 212265435,
+    "expected_floor": "15241796708250328082"
+  },
+  {
+    "principal": "3532872555834196430",
+    "rate_bps": 1741,
+    "seconds": 828475312,
+    "expected_floor": "16147390433453889169"
+  },
+  {
+    "principal": "16118252204096006975",
+    "rate_bps": 9161,
+    "seconds": 2859261065,
+    "expected_floor": "1337860013157673213232"
+  },
+  {
+    "principal": "6410454932120353892",
+    "rate_bps": 5376,
+    "seconds": 2900621366,
+    "expected_floor": "316763538625218397817"
+  },
+  {
+    "principal": "6135740225299344589",
+    "rate_bps": 135,
+    "seconds": 792034503,
+    "expected_floor": "2078934787766116708"
+  },
+  {
+    "principal": "8463566060623767882",
+    "rate_bps": 2791,
+    "seconds": 3739550604,
+    "expected_floor": "279916611545341335949"
+  },
+  {
+    "principal": "18241365357818778859",
+    "rate_bps": 7656,
+    "seconds": 594069013,
+    "expected_floor": "262900976692636871160"
+  },
+  {
+    "principal": "1728500374250176000",
+    "rate_bps": 7586,
+    "seconds": 3954465586,
+    "expected_floor": "164310814926687421005"
+  },
+  {
+    "principal": "3562557762060900121",
+    "rate_bps": 1786,
+    "seconds": 1653053427,
+    "expected_floor": "33329307662762553706"
+  },
+  {
+    "principal": "14521256382210884614",
+    "rate_bps": 7055,
+    "seconds": 1444144296,
+    "expected_floor": "468821838328947396695"
+  },
+  {
+    "principal": "15365196134769101527",
+    "rate_bps": 1236,
+    "seconds": 2273220065,
+    "expected_floor": "136802518521956394802"
+  },
+  {
+    "principal": "11647794693403015388",
+    "rate_bps": 8342,
+    "seconds": 4253555054,
+    "expected_floor": "1309670314586245956866"
+  },
+  {
+    "principal": "7893110879510039461",
+    "rate_bps": 5554,
+    "seconds": 3197241183,
+    "expected_floor": "444145749637847084360"
+  },
+  {
+    "principal": "8990945184665955842",
+    "rate_bps": 403,
+    "seconds": 1075144452,
+    "expected_floor": "12344492698787221817"
+  },
+  {
+    "principal": "7132036380327778563",
+    "rate_bps": 6115,
+    "seconds": 2258286573,
+    "expected_floor": "312093767918258240576"
+  },
+  {
+    "principal": "2596786790191425784",
+    "rate_bps": 4972,
+    "seconds": 3431108330,
+    "expected_floor": "140377620431405249885"
+  },
+  {
+    "principal": "15986696935250769521",
+    "rate_bps": 5986,
+    "seconds": 697030411,
+    "expected_floor": "211369935029176368367"
+  },
+  {
+    "principal": "6496328302554366782",
+    "rate_bps": 5162,
+    "seconds": 1165493920,
+    "expected_floor": "123848859036381861839"
+  },
+  {
+    "principal": "1031835416110173039",
+    "rate_bps": 7636,
+    "seconds": 2692339769,
+    "expected_floor": "67220579040982341373"
+  },
+  {
+    "principal": "12196035684259318356",
+    "rate_bps": 9491,
+    "seconds": 4011087782,
+    "expected_floor": "1471258074223653313088"
+  },
+  {
+    "principal": "894764705838809981",
+    "rate_bps": 5543,
+    "seconds": 3248116471,
+    "expected_floor": "51048307798942540007"
+  },
+  {
+    "principal": "11079950936392835002",
+    "rate_bps": 4535,
+    "seconds": 265125756,
+    "expected_floor": "42214639170720062229"
+  },
+  {
+    "principal": "10721341501825183259",
+    "rate_bps": 856,
+    "seconds": 250929861,
+    "expected_floor": "7297452440189573846"
+  },
+  {
+    "principal": "12910995680714823920",
+    "rate_bps": 8548,
+    "seconds": 3266793378,
+    "expected_floor": "1142462486979397055310"
+  },
+  {
+    "principal": "18005803346093137609",
+    "rate_bps": 5572,
+    "seconds": 3535603491,
+    "expected_floor": "1124043703805206800369"
+  },
+  {
+    "principal": "11200254796387524470",
+    "rate_bps": 8819,
+    "seconds": 2223426968,
+    "expected_floor": "695930943338450616770"
+  },
+  {
+    "principal": "3232190965562215687",
+    "rate_bps": 8460,
+    "seconds": 2056061841,
+    "expected_floor": "178155642159775603990"
+  },
+  {
+    "principal": "5742669232040775884",
+    "rate_bps": 8992,
+    "seconds": 367694558,
+    "expected_floor": "60166304279599111718"
+  },
+  {
+    "principal": "14832298212046763093",
+    "rate_bps": 313,
+    "seconds": 3841572751,
+    "expected_floor": "56514238656395995754"
+  },
+  {
+    "principal": "7633892889559375474",
+    "rate_bps": 692,
+    "seconds": 890252532,
+    "expected_floor": "14902578117383277001"
+  },
+  {
+    "principal": "3531642807046403123",
+    "rate_bps": 8863,
+    "seconds": 2771887773,
+    "expected_floor": "274934472645196492392"
+  },
+  {
+    "principal": "12948907157951655400",
+    "rate_bps": 9107,
+    "seconds": 2104393050,
+    "expected_floor": "786377982511424618268"
+  },
+  {
+    "principal": "3075120573775687713",
+    "rate_bps": 2634,
+    "seconds": 2932377659,
+    "expected_floor": "75265136656970256292"
+  },
+  {
+    "principal": "18147234499167238318",
+    "rate_bps": 6240,
+    "seconds": 1076697488,
+    "expected_floor": "386353431275692366956"
+  },
+  {
+    "principal": "6228588765167972255",
+    "rate_bps": 739,
+    "seconds": 2003466217,
+    "expected_floor": "29222149146554986726"
+  },
+  {
+    "principal": "11824666382110829636",
+    "rate_bps": 7290,
+    "seconds": 2965416726,
+    "expected_floor": "810024566786273748703"
+  },
+  {
+    "principal": "9682579850089692717",
+    "rate_bps": 7972,
+    "seconds": 4156534055,
+    "expected_floor": "1016683448222920918540"
+  },
+  {
+    "principal": "6617016359126714922",
+    "rate_bps": 1464,
+    "seconds": 546590572,
+    "expected_floor": "16778821519261855678"
+  },
+  {
+    "principal": "8149036320056675147",
+    "rate_bps": 5290,
+    "seconds": 459760501,
+    "expected_floor": "62804334176310739824"
+  },
+  {
+    "principal": "8539773203785189344",
+    "rate_bps": 7183,
+    "seconds": 2312632338,
+    "expected_floor": "449526015221290393991"
+  },
+  {
+    "principal": "10966902375883278969",
+    "rate_bps": 7023,
+    "seconds": 3078601299,
+    "expected_floor": "751373938007048548271"
+  },
+  {
+    "principal": "3936595262077234918",
+    "rate_bps": 9568,
+    "seconds": 617335432,
+    "expected_floor": "73681620531889097533"
+  },
+  {
+    "principal": "9019090394777621303",
+    "rate_bps": 5338,
+    "seconds": 315135297,
+    "expected_floor": "48076671394394884606"
+  },
+  {
+    "principal": "11807595442765167804",
+    "rate_bps": 5988,
+    "seconds": 2216722510,
+    "expected_floor": "496650206892863757449"
+  },
+  {
+    "principal": "2492092445578936581",
+    "rate_bps": 7949,
+    "seconds": 4242504639,
+    "expected_floor": "266314617358935684959"
+  },
+  {
+    "principal": "16738112418768421602",
+    "rate_bps": 8339,
+    "seconds": 2353317604,
+    "expected_floor": "1040871292418610818073"
+  },
+  {
+    "principal": "6268634065027306339",
+    "rate_bps": 6471,
+    "seconds": 1917614413,
+    "expected_floor": "246491323313622604596"
+  },
+  {
+    "principal": "13392438411551770328",
+    "rate_bps": 1237,
+    "seconds": 3602358218,
+    "expected_floor": "189109038793249871502"
+  },
+  {
+    "principal": "4220386747013778897",
+    "rate_bps": 8715,
+    "seconds": 1767374187,
+    "expected_floor": "205989072751572329766"
+  },
+  {
+    "principal": "17571350210584388126",
+    "rate_bps": 3619,
+    "seconds": 2243412096,
+    "expected_floor": "452062838721011277440"
+  },
+  {
+    "principal": "10505538404588181455",
+    "rate_bps": 2724,
+    "seconds": 2950806425,
+    "expected_floor": "267585250607341758188"
+  },
+  {
+    "principal": "14003393665501979188",
+    "rate_bps": 6249,
+    "seconds": 2246570630,
+    "expected_floor": "622959671188083684360"
+  },
+  {
+    "principal": "11624617614910397661",
+    "rate_bps": 9782,
+    "seconds": 1286638423,
+    "expected_floor": "463616499958455688094"
+  },
+  {
+    "principal": "2436779021241100442",
+    "rate_bps": 3180,
+    "seconds": 2327868252,
+    "expected_floor": "57160720890638060288"
+  },
+  {
+    "principal": "17167768467055733883",
+    "rate_bps": 2639,
+    "seconds": 2935179301,
+    "expected_floor": "421389691086610237937"
+  },
+  {
+    "principal": "4154256566943386320",
+    "rate_bps": 2037,
+    "seconds": 132469890,
+    "expected_floor": "3552201167377628402"
+  },
+  {
+    "principal": "11756008650530740777",
+    "rate_bps": 934,
+    "seconds": 2901062019,
+    "expected_floor": "100939190934919717047"
+  },
+  {
+    "principal": "4220057744892736086",
+    "rate_bps": 156,
+    "seconds": 3568950136,
+    "expected_floor": "7445253768853760319"
+  },
+  {
+    "principal": "7006596495735233895",
+    "rate_bps": 4524,
+    "seconds": 4143205105,
+    "expected_floor": "416161758362484222731"
+  },
+  {
+    "principal": "1250658702668283052",
+    "rate_bps": 2655,
+    "seconds": 1489559998,
+    "expected_floor": "15673188926544285814"
+  },
+  {
+    "principal": "10412521479039775157",
+    "rate_bps": 6605,
+    "seconds": 3329113071,
+    "expected_floor": "725526552301793693648"
+  },
+  {
+    "principal": "10268609053556906834",
+    "rate_bps": 9530,
+    "seconds": 3873060052,
+    "expected_floor": "1201032567677350479826"
+  },
+  {
+    "principal": "11532670830364063379",
+    "rate_bps": 4544,
+    "seconds": 1076637693,
+    "expected_floor": "178786133556851619195"
+  },
+  {
+    "principal": "17430013397381641160",
+    "rate_bps": 9277,
+    "seconds": 2580346426,
+    "expected_floor": "1322145730138812064819"
+  },
+  {
+    "principal": "15866956295943196545",
+    "rate_bps": 1892,
+    "seconds": 3497342619,
+    "expected_floor": "332697065893993472910"
+  },
+  {
+    "principal": "9192391186005884814",
+    "rate_bps": 640,
+    "seconds": 1770978160,
+    "expected_floor": "33015487167273393945"
+  },
+  {
+    "principal": "18186863106145534975",
+    "rate_bps": 2655,
+    "seconds": 3267535689,
+    "expected_floor": "499963956186828073632"
+  },
+  {
+    "principal": "15404343758981721124",
+    "rate_bps": 4700,
+    "seconds": 2546544118,
+    "expected_floor": "584235976937723668814"
+  },
+  {
+    "principal": "15371408879296421773",
+    "rate_bps": 6610,
+    "seconds": 297266567,
+    "expected_floor": "95709982105694553791"
+  },
+  {
+    "principal": "7080102746713832202",
+    "rate_bps": 4409,
+    "seconds": 3541625676,
+    "expected_floor": "350330823128500211039"
+  },
+  {
+    "principal": "8863974018026279339",
+    "rate_bps": 4185,
+    "seconds": 4094398677,
+    "expected_floor": "481293612364580912295"
+  },
+  {
+    "principal": "3002999081913196992",
+    "rate_bps": 2826,
+    "seconds": 3572393202,
+    "expected_floor": "96068861534149813818"
+  },
+  {
+    "principal": "7531958507428203993",
+    "rate_bps": 9814,
+    "seconds": 2438524083,
+    "expected_floor": "571185342845068389469"
+  },
+  {
+    "principal": "3827970947254905286",
+    "rate_bps": 1083,
+    "seconds": 2573729896,
+    "expected_floor": "33810850062143027806"
+  },
+  {
+    "principal": "7112250362113502103",
+    "rate_bps": 3440,
+    "seconds": 2652054689,
+    "expected_floor": "205609883553618179254"
+  },
+  {
+    "principal": "2559915254333427868",
+    "rate_bps": 9897,
+    "seconds": 4056069934,
+    "expected_floor": "325634661226895430979"
+  },
+  {
+    "principal": "18372316191730927205",
+    "rate_bps": 7957,
+    "seconds": 4027645983,
+    "expected_floor": "1865780683852390816606"
+  },
+  {
+    "principal": "15569527902272677826",
+    "rate_bps": 5982,
+    "seconds": 3912726212,
+    "expected_floor": "1154774926456244160364"
+  },
+  {
+    "principal": "17953007581784350147",
+    "rate_bps": 370,
+    "seconds": 2104085165,
+    "expected_floor": "44289245888112660304"
+  },
+  {
+    "principal": "16352394397351736504",
+    "rate_bps": 9768,
+    "seconds": 2438824106,
+    "expected_floor": "1234421610340091894561"
+  },
+  {
+    "principal": "2783834666642011441",
+    "rate_bps": 7715,
+    "seconds": 899363787,
+    "expected_floor": "61208367810780981119"
+  },
+  {
+    "principal": "5173874284288299262",
+    "rate_bps": 380,
+    "seconds": 510249568,
+    "expected_floor": "3178909375265791050"
+  },
+  {
+    "principal": "8995445840869176367",
+    "rate_bps": 2474,
+    "seconds": 3509595897,
+    "expected_floor": "247500189056885302256"
+  },
+  {
+    "principal": "4101010094368115220",
+    "rate_bps": 5323,
+    "seconds": 350444902,
+    "expected_floor": "24241700646278805582"
+  },
+  {
+    "principal": "16987654442747856445",
+    "rate_bps": 409,
+    "seconds": 2657145783,
+    "expected_floor": "58501653533646255764"
+  },
+  {
+    "principal": "10503181643176968570",
+    "rate_bps": 1797,
+    "seconds": 2040837948,
+    "expected_floor": "122060039847207003285"
+  },
+  {
+    "principal": "17718649769560013531",
+    "rate_bps": 4345,
+    "seconds": 2304982405,
+    "expected_floor": "562320675661945696017"
+  },
+  {
+    "principal": "94484833673628848",
+    "rate_bps": 6955,
+    "seconds": 3393333602,
+    "expected_floor": "7066133329671636417"
+  },
+  {
+    "principal": "11750258417826686345",
+    "rate_bps": 8213,
+    "seconds": 3043322851,
+    "expected_floor": "930664826742108228563"
+  },
+  {
+    "principal": "12150198813849556278",
+    "rate_bps": 4425,
+    "seconds": 3475847512,
+    "expected_floor": "592179552800601649493"
+  },
+  {
+    "principal": "6396117460957085127",
+    "rate_bps": 1413,
+    "seconds": 4285014609,
+    "expected_floor": "122717622390193138601"
+  },
+  {
+    "principal": "17464596277917431948",
+    "rate_bps": 3796,
+    "seconds": 1781334174,
+    "expected_floor": "374219304301140510079"
+  },
+  {
+    "principal": "5385395004469739285",
+    "rate_bps": 2157,
+    "seconds": 1181927503,
+    "expected_floor": "43506543388725808213"
+  },
+  {
+    "principal": "2930272246921357362",
+    "rate_bps": 3338,
+    "seconds": 721652916,
+    "expected_floor": "22367564992067416410"
+  },
+  {
+    "principal": "13064080384287344883",
+    "rate_bps": 1751,
+    "seconds": 1691896157,
+    "expected_floor": "122640730004809897858"
+  },
+  {
+    "principal": "3193526271421352360",
+    "rate_bps": 81,
+    "seconds": 22560538,
+    "expected_floor": "18492728644866461"
+  },
+  {
+    "principal": "10910777814984326881",
+    "rate_bps": 7458,
+    "seconds": 4102354171,
+    "expected_floor": "1057809043911075710360"
+  },
+  {
+    "principal": "7019771089234826862",
+    "rate_bps": 8238,
+    "seconds": 2789158224,
+    "expected_floor": "511109463812072494152"
+  },
+  {
+    "principal": "15348075590801238111",
+    "rate_bps": 9582,
+    "seconds": 1418550953,
+    "expected_floor": "661075510075048930839"
+  },
+  {
+    "principal": "10269873534273846276",
+    "rate_bps": 2928,
+    "seconds": 2700443862,
+    "expected_floor": "257316333393856467106"
+  },
+  {
+    "principal": "1292749411533148397",
+    "rate_bps": 7510,
+    "seconds": 2155232743,
+    "expected_floor": "66304727578551526877"
+  },
+  {
+    "principal": "14615843444872510442",
+    "rate_bps": 4437,
+    "seconds": 3920287532,
+    "expected_floor": "805614483558995909866"
+  },
+  {
+    "principal": "10908279525562001419",
+    "rate_bps": 6907,
+    "seconds": 837635637,
+    "expected_floor": "199984756323558359003"
+  },
+  {
+    "principal": "10435638924461444000",
+    "rate_bps": 9908,
+    "seconds": 1919918546,
+    "expected_floor": "629048134354229587138"
+  },
+  {
+    "principal": "16811815693854449977",
+    "rate_bps": 2590,
+    "seconds": 199962387,
+    "expected_floor": "27590446553296956531"
+  },
+  {
+    "principal": "14186219841767617702",
+    "rate_bps": 2591,
+    "seconds": 429950536,
+    "expected_floor": "50078190321854963261"
+  },
+  {
+    "principal": "16435119753076724727",
+    "rate_bps": 4427,
+    "seconds": 1115046913,
+    "expected_floor": "257081939367134229003"
+  },
+  {
+    "principal": "9355306930454852732",
+    "rate_bps": 5106,
+    "seconds": 174505486,
+    "expected_floor": "26414595740627455087"
+  },
+  {
+    "principal": "2173176449620892613",
+    "rate_bps": 1105,
+    "seconds": 3833500799,
+    "expected_floor": "29170834885633226108"
+  },
+  {
+    "principal": "9053226856139824290",
+    "rate_bps": 2039,
+    "seconds": 656766628,
+    "expected_floor": "38417379595945828381"
+  },
+  {
+    "principal": "8701812937411311651",
+    "rate_bps": 4181,
+    "seconds": 2911546381,
+    "expected_floor": "335667780027924157026"
+  },
+  {
+    "principal": "4910425669587120792",
+    "rate_bps": 4687,
+    "seconds": 384577930,
+    "expected_floor": "28047521224371364927"
+  },
+  {
+    "principal": "10641708321072065681",
+    "rate_bps": 1337,
+    "seconds": 2737666603,
+    "expected_floor": "123429607893744464760"
+  },
+  {
+    "principal": "823329215063019486",
+    "rate_bps": 7900,
+    "seconds": 3259376704,
+    "expected_floor": "67178640010844271034"
+  },
+  {
+    "principal": "12687081475422003343",
+    "rate_bps": 9905,
+    "seconds": 3464311385,
+    "expected_floor": "1379523689702278910436"
+  },
+  {
+    "principal": "1923344771421602292",
+    "rate_bps": 7695,
+    "seconds": 3305019462,
+    "expected_floor": "155001470908627313479"
+  },
+  {
+    "principal": "1512919007474286493",
+    "rate_bps": 7277,
+    "seconds": 2885889047,
+    "expected_floor": "100680118226500622586"
+  },
+  {
+    "principal": "7466932990362823258",
+    "rate_bps": 607,
+    "seconds": 1773292316,
+    "expected_floor": "25468731214698389601"
+  },
+  {
+    "principal": "13085892441864509755",
+    "rate_bps": 1846,
+    "seconds": 2229060325,
+    "expected_floor": "170629020569406270096"
+  },
+  {
+    "principal": "5234151571002908304",
+    "rate_bps": 5309,
+    "seconds": 2034617922,
+    "expected_floor": "179158706711912180668"
+  },
+  {
+    "principal": "13802312243459227881",
+    "rate_bps": 3542,
+    "seconds": 1510291011,
+    "expected_floor": "233968330081527416518"
+  },
+  {
+    "principal": "14459548790551234582",
+    "rate_bps": 483,
+    "seconds": 1402529592,
+    "expected_floor": "31039158449124102169"
+  },
+  {
+    "principal": "8095421273323400743",
+    "rate_bps": 6500,
+    "seconds": 1862306225,
+    "expected_floor": "310527407988881827743"
+  },
+  {
+    "principal": "11521820656137372780",
+    "rate_bps": 5761,
+    "seconds": 3087986558,
+    "expected_floor": "649516847073231727573"
+  },
+  {
+    "principal": "13504675875922975861",
+    "rate_bps": 2241,
+    "seconds": 1667196079,
+    "expected_floor": "159885373159299118455"
+  },
+  {
+    "principal": "5364500070571574546",
+    "rate_bps": 9889,
+    "seconds": 734278804,
+    "expected_floor": "123435095392329401095"
+  },
+  {
+    "principal": "10202707986613152595",
+    "rate_bps": 5250,
+    "seconds": 986968765,
+    "expected_floor": "167522907417918040930"
+  },
+  {
+    "principal": "3897774475052445576",
+    "rate_bps": 8689,
+    "seconds": 1485330426,
+    "expected_floor": "159406348941787107703"
+  },
+  {
+    "principal": "16003194335239994945",
+    "rate_bps": 9801,
+    "seconds": 1104135003,
+    "expected_floor": "548776214082989007634"
+  },
+  {
+    "principal": "15329769373611982158",
+    "rate_bps": 7033,
+    "seconds": 3807751984,
+    "expected_floor": "1300891046524682296544"
+  },
+  {
+    "principal": "5373590732406791359",
+    "rate_bps": 6115,
+    "seconds": 2028120585,
+    "expected_floor": "211179060594687100765"
+  },
+  {
+    "principal": "2251438681239247844",
+    "rate_bps": 4004,
+    "seconds": 1597875126,
+    "expected_floor": "45644984210876662634"
+  },
+  {
+    "principal": "3423664123817398861",
+    "rate_bps": 1428,
+    "seconds": 2874318407,
+    "expected_floor": "44529751176758358875"
+  },
+  {
+    "principal": "1531035531553901770",
+    "rate_bps": 1148,
+    "seconds": 193073932,
+    "expected_floor": "1075342553061473380"
+  },
+  {
+    "principal": "1717316384527208043",
+    "rate_bps": 3007,
+    "seconds": 2644810645,
+    "expected_floor": "43278715112916801926"
+  },
+  {
+    "principal": "17186989321194751360",
+    "rate_bps": 8015,
+    "seconds": 466857650,
+    "expected_floor": "203790458470291263119"
+  },
+  {
+    "principal": "8079694205504554137",
+    "rate_bps": 2863,
+    "seconds": 1729003891,
+    "expected_floor": "126738416247318401480"
+  },
+  {
+    "principal": "3008070259872321414",
+    "rate_bps": 6929,
+    "seconds": 2133679144,
+    "expected_floor": "140923584838688980257"
+  },
+  {
+    "principal": "15310180079374470231",
+    "rate_bps": 910,
+    "seconds": 487191393,
+    "expected_floor": "21508856958563648172"
+  },
+  {
+    "principal": "10347956233974671452",
+    "rate_bps": 6530,
+    "seconds": 1711576302,
+    "expected_floor": "366488255815567481251"
+  },
+  {
+    "principal": "18423474943818580261",
+    "rate_bps": 1534,
+    "seconds": 176175327,
+    "expected_floor": "15777494114340881560"
+  },
+  {
+    "principal": "14305365515708866946",
+    "rate_bps": 8007,
+    "seconds": 1246152324,
+    "expected_floor": "452309752693303656991"
+  },
+  {
+    "principal": "769350357207212675",
+    "rate_bps": 385,
+    "seconds": 3427212653,
+    "expected_floor": "3216784553774977101"
+  },
+  {
+    "principal": "11326327678588534904",
+    "rate_bps": 193,
+    "seconds": 366719594,
+    "expected_floor": "2540250695699195605"
+  },
+  {
+    "principal": "2079543098416460785",
+    "rate_bps": 1220,
+    "seconds": 1793511563,
+    "expected_floor": "14418761893095351601"
+  },
+  {
+    "principal": "11618582315689975486",
+    "rate_bps": 8276,
+    "seconds": 402968096,
+    "expected_floor": "122783587212333612946"
+  },
+  {
+    "principal": "773067493259451631",
+    "rate_bps": 7751,
+    "seconds": 4125148601,
+    "expected_floor": "78326871348252964270"
+  },
+  {
+    "principal": "12556377278431234516",
+    "rate_bps": 3679,
+    "seconds": 322020134,
+    "expected_floor": "47138222661813879222"
+  },
+  {
+    "principal": "11881027126808217853",
+    "rate_bps": 6989,
+    "seconds": 3471807607,
+    "expected_floor": "913525576916010036368"
+  },
+  {
+    "principal": "17911036659482141498",
+    "rate_bps": 2285,
+    "seconds": 2619420412,
+    "expected_floor": "339709871898512741126"
+  },
+  {
+    "principal": "11895358036072974235",
+    "rate_bps": 4148,
+    "seconds": 3422017605,
+    "expected_floor": "535050209497009668467"
+  },
+  {
+    "principal": "7979714920586133616",
+    "rate_bps": 1284,
+    "seconds": 2556969762,
+    "expected_floor": "83018336164770336986"
+  },
+  {
+    "principal": "15015844369889700937",
+    "rate_bps": 6237,
+    "seconds": 748818595,
+    "expected_floor": "222227681789671174118"
+  },
+  {
+    "principal": "5773401259344415478",
+    "rate_bps": 8149,
+    "seconds": 3048531224,
+    "expected_floor": "454488334884465365929"
+  },
+  {
+    "principal": "10290723254944575111",
+    "rate_bps": 9241,
+    "seconds": 617971985,
+    "expected_floor": "186221443815870939210"
+  },
+  {
+    "principal": "18092106882584649804",
+    "rate_bps": 6000,
+    "seconds": 2221321822,
+    "expected_floor": "764095973538703976953"
+  },
+  {
+    "principal": "7705462311224003029",
+    "rate_bps": 7621,
+    "seconds": 4287369487,
+    "expected_floor": "797806568992375739717"
+  },
+  {
+    "principal": "17794345184708260338",
+    "rate_bps": 8726,
+    "seconds": 1196698740,
+    "expected_floor": "588813944179825622053"
+  },
+  {
+    "principal": "5364366695777754547",
+    "rate_bps": 8525,
+    "seconds": 2914462749,
+    "expected_floor": "422345029028331059130"
+  },
+  {
+    "principal": "13759723043244844392",
+    "rate_bps": 5524,
+    "seconds": 3621077210,
+    "expected_floor": "872162039798967493217"
+  },
+  {
+    "principal": "10410279081507687841",
+    "rate_bps": 7591,
+    "seconds": 2200805819,
+    "expected_floor": "551111054398783034260"
+  },
+  {
+    "principal": "12841994079420003374",
+    "rate_bps": 1305,
+    "seconds": 6979856,
+    "expected_floor": "370668322694062489"
+  },
+  {
+    "principal": "5731107077673656607",
+    "rate_bps": 5418,
+    "seconds": 4292511081,
+    "expected_floor": "422362139620740434912"
+  },
+  {
+    "principal": "7617896722414242756",
+    "rate_bps": 7314,
+    "seconds": 3113850518,
+    "expected_floor": "549773534634575864475"
+  },
+  {
+    "principal": "15399136345182528429",
+    "rate_bps": 8442,
+    "seconds": 1571098279,
+    "expected_floor": "647203858663656681885"
+  },
+  {
+    "principal": "62852153770962346",
+    "rate_bps": 4665,
+    "seconds": 2480316140,
+    "expected_floor": "2304490301321136992"
+  },
+  {
+    "principal": "4409922739860964555",
+    "rate_bps": 1692,
+    "seconds": 1137277173,
+    "expected_floor": "26890179093846923632"
+  },
+  {
+    "principal": "17105019736521723744",
+    "rate_bps": 1887,
+    "seconds": 2660404114,
+    "expected_floor": "272106629854854628169"
+  },
+  {
+    "principal": "640567374543681529",
+    "rate_bps": 2723,
+    "seconds": 110814163,
+    "expected_floor": "612496709795471969"
+  },
+  {
+    "principal": "6427794789906135654",
+    "rate_bps": 8995,
+    "seconds": 398885384,
+    "expected_floor": "73081478852761140446"
+  },
+  {
+    "principal": "13208207392379393207",
+    "rate_bps": 8154,
+    "seconds": 1323709121,
+    "expected_floor": "451755221457937462485"
+  },
+  {
+    "principal": "1777586534046837820",
+    "rate_bps": 7473,
+    "seconds": 1888762830,
+    "expected_floor": "79505870001396932398"
+  },
+  {
+    "principal": "16999601552199464581",
+    "rate_bps": 3402,
+    "seconds": 1986915647,
+    "expected_floor": "364123337091089667485"
+  },
+  {
+    "principal": "3500684065098921570",
+    "rate_bps": 7866,
+    "seconds": 2329110116,
+    "expected_floor": "203232385257107611009"
+  },
+  {
+    "principal": "8336477630543961315",
+    "rate_bps": 9946,
+    "seconds": 1731665613,
+    "expected_floor": "454978746529088718216"
+  },
+  {
+    "principal": "17075387929396813400",
+    "rate_bps": 9609,
+    "seconds": 3500409674,
+    "expected_floor": "1819967701578533358584"
+  },
+  {
+    "principal": "4642865320156973905",
+    "rate_bps": 1387,
+    "seconds": 3919525611,
+    "expected_floor": "79981968081192602119"
+  },
+  {
+    "principal": "6242931720399207838",
+    "rate_bps": 8852,
+    "seconds": 3126708224,
+    "expected_floor": "547536882803133729999"
+  },
+  {
+    "principal": "9737546106805135695",
+    "rate_bps": 9296,
+    "seconds": 426961177,
+    "expected_floor": "122470097057913686065"
+  },
+  {
+    "principal": "18156768774916334004",
+    "rate_bps": 6041,
+    "seconds": 3497295366,
+    "expected_floor": "1215558162545663598528"
+  },
+  {
+    "principal": "16810899283298787933",
+    "rate_bps": 622,
+    "seconds": 3296595159,
+    "expected_floor": "109230263263880390444"
+  },
+  {
+    "principal": "3608743574961744922",
+    "rate_bps": 6775,
+    "seconds": 103375580,
+    "expected_floor": "8009018841422334542"
+  },
+  {
+    "principal": "14070223794522621435",
+    "rate_bps": 6971,
+    "seconds": 3444342181,
+    "expected_floor": "1070528937203884491404"
+  },
+  {
+    "principal": "16953502572377240144",
+    "rate_bps": 7257,
+    "seconds": 3206645762,
+    "expected_floor": "1250154183642934850818"
+  },
+  {
+    "principal": "8800504632023410601",
+    "rate_bps": 952,
+    "seconds": 3809737475,
+    "expected_floor": "101142947832994905083"
+  },
+  {
+    "principal": "7828521689317121494",
+    "rate_bps": 2815,
+    "seconds": 3174642424,
+    "expected_floor": "221691482108875333924"
+  },
+  {
+    "principal": "1888112157385981671",
+    "rate_bps": 253,
+    "seconds": 67045489,
+    "expected_floor": "101487815703137722"
+  },
+  {
+    "principal": "8880841701932993580",
+    "rate_bps": 7664,
+    "seconds": 3844881726,
+    "expected_floor": "829256038747381241786"
+  },
+  {
+    "principal": "8490137858259420981",
+    "rate_bps": 4003,
+    "seconds": 3780169071,
+    "expected_floor": "407106081041951021884"
+  },
+  {
+    "principal": "16453545186583162578",
+    "rate_bps": 4501,
+    "seconds": 267088980,
+    "expected_floor": "62678775528903015464"
+  },
+  {
+    "principal": "1254741122696388627",
+    "rate_bps": 4646,
+    "seconds": 1830417789,
+    "expected_floor": "33812680276477166365"
+  },
+  {
+    "principal": "13201629617032637256",
+    "rate_bps": 660,
+    "seconds": 1270282682,
+    "expected_floor": "35072594159944361678"
+  },
+  {
+    "principal": "14715560636037115137",
+    "rate_bps": 2070,
+    "seconds": 662081563,
+    "expected_floor": "63907920341535685679"
+  },
+  {
+    "principal": "3380770706373688078",
+    "rate_bps": 9146,
+    "seconds": 3545604848,
+    "expected_floor": "347402771761485844143"
+  },
+  {
+    "principal": "14218375982351005055",
+    "rate_bps": 6766,
+    "seconds": 1032646857,
+    "expected_floor": "314796465991063045101"
+  },
+  {
+    "principal": "919747599204780964",
+    "rate_bps": 6337,
+    "seconds": 3942734198,
+    "expected_floor": "72819199885068051951"
+  },
+  {
+    "principal": "18260406312178533645",
+    "rate_bps": 2638,
+    "seconds": 3334835975,
+    "expected_floor": "509044487491016440074"
+  },
+  {
+    "principal": "4144108288741023370",
+    "rate_bps": 707,
+    "seconds": 2447407820,
+    "expected_floor": "22722331179125345955"
+  },
+  {
+    "principal": "1046395866036063019",
+    "rate_bps": 2403,
+    "seconds": 1962141269,
+    "expected_floor": "15634215401178265535"
+  },
+  {
+    "principal": "10580750936198883648",
+    "rate_bps": 1341,
+    "seconds": 3693361266,
+    "expected_floor": "166059257793451372534"
+  },
+  {
+    "principal": "1054494998921214809",
+    "rate_bps": 6248,
+    "seconds": 1919440435,
+    "expected_floor": "40073402415861036489"
+  },
+  {
+    "principal": "2561397103019488582",
+    "rate_bps": 4732,
+    "seconds": 2770597864,
+    "expected_floor": "106412140190074184444"
+  },
+  {
+    "principal": "9737595388746935575",
+    "rate_bps": 1477,
+    "seconds": 4246929953,
+    "expected_floor": "193554534954758241531"
+  },
+  {
+    "principal": "9181650419025330204",
+    "rate_bps": 9292,
+    "seconds": 1779282606,
+    "expected_floor": "481028624556060007567"
+  },
+  {
+    "principal": "16328246906834271205",
+    "rate_bps": 1323,
+    "seconds": 547336607,
+    "expected_floor": "37467087247775568148"
+  },
+  {
+    "principal": "8228308539817499458",
+    "rate_bps": 7317,
+    "seconds": 1426282052,
+    "expected_floor": "272110357779506097843"
+  },
+  {
+    "principal": "12259766777975498563",
+    "rate_bps": 7674,
+    "seconds": 3488788525,
+    "expected_floor": "1040099006458524693296"
+  },
+  {
+    "principal": "11115927715522792504",
+    "rate_bps": 5118,
+    "seconds": 498934826,
+    "expected_floor": "89946826980544518716"
+  },
+  {
+    "principal": "6826731003269722801",
+    "rate_bps": 8400,
+    "seconds": 539929931,
+    "expected_floor": "98112764456828943053"
+  },
+  {
+    "principal": "17518119479026592894",
+    "rate_bps": 8541,
+    "seconds": 940118496,
+    "expected_floor": "445733048778373091167"
+  },
+  {
+    "principal": "2133740470855910831",
+    "rate_bps": 1457,
+    "seconds": 2404097145,
+    "expected_floor": "23683680407080333778"
+  },
+  {
+    "principal": "7435277420925487508",
+    "rate_bps": 7109,
+    "seconds": 566175974,
+    "expected_floor": "94831617970840352082"
+  },
+  {
+    "principal": "7723470410064972733",
+    "rate_bps": 8231,
+    "seconds": 2919666999,
+    "expected_floor": "588158587911806148091"
+  },
+  {
+    "principal": "13425421580869633274",
+    "rate_bps": 322,
+    "seconds": 1359144636,
+    "expected_floor": "18618535288843853569"
+  },
+  {
+    "principal": "16206794090913551451",
+    "rate_bps": 9123,
+    "seconds": 997372677,
+    "expected_floor": "467291938379880808392"
+  },
+  {
+    "principal": "2748954368518222896",
+    "rate_bps": 7677,
+    "seconds": 2565446882,
+    "expected_floor": "171560827078897925709"
+  },
+  {
+    "principal": "15932636876865155849",
+    "rate_bps": 1191,
+    "seconds": 1462957411,
+    "expected_floor": "87968489720942318391"
+  },
+  {
+    "principal": "14906983279003943094",
+    "rate_bps": 7229,
+    "seconds": 2782777560,
+    "expected_floor": "950260144440959821789"
+  },
+  {
+    "principal": "4403367742979727175",
+    "rate_bps": 8506,
+    "seconds": 4086636497,
+    "expected_floor": "485034217017274836963"
+  },
+  {
+    "principal": "9464579785315043340",
+    "rate_bps": 6403,
+    "seconds": 3294075934,
+    "expected_floor": "632578573495308201856"
+  },
+  {
+    "principal": "4334000039160894613",
+    "rate_bps": 5006,
+    "seconds": 3003488719,
+    "expected_floor": "206491316989191566569"
+  },
+  {
+    "principal": "13077252269742504882",
+    "rate_bps": 402,
+    "seconds": 1271008308,
+    "expected_floor": "21173223264199880383"
+  },
+  {
+    "principal": "13262673781376512627",
+    "rate_bps": 3464,
+    "seconds": 3969142493,
+    "expected_floor": "577832139810544124873"
+  },
+  {
+    "principal": "4874615475121291560",
+    "rate_bps": 8919,
+    "seconds": 346391194,
+    "expected_floor": "47722084184510557979"
+  },
+  {
+    "principal": "11433076787755342945",
+    "rate_bps": 749,
+    "seconds": 1099075195,
+    "expected_floor": "29824170766674844387"
+  },
+  {
+    "principal": "6678934771170578926",
+    "rate_bps": 387,
+    "seconds": 611259600,
+    "expected_floor": "5006565390600851102"
+  },
+  {
+    "principal": "8437590411258714591",
+    "rate_bps": 5555,
+    "seconds": 168946729,
+    "expected_floor": "25092753678878942533"
+  },
+  {
+    "principal": "4685678861387783044",
+    "rate_bps": 1084,
+    "seconds": 2188176470,
+    "expected_floor": "35219256146931991115"
+  },
+  {
+    "principal": "8846713485348419181",
+    "rate_bps": 9743,
+    "seconds": 2047614823,
+    "expected_floor": "559266701605330495103"
+  },
+  {
+    "principal": "2090556911455838058",
+    "rate_bps": 1346,
+    "seconds": 3369576108,
+    "expected_floor": "30045425432258448550"
+  },
+  {
+    "principal": "7713974677640257931",
+    "rate_bps": 6495,
+    "seconds": 3317425077,
+    "expected_floor": "526689330265797635367"
+  },
+  {
+    "principal": "2760897947599000352",
+    "rate_bps": 2061,
+    "seconds": 3389044050,
+    "expected_floor": "61108495622022053950"
+  },
+  {
+    "principal": "912288599002910393",
+    "rate_bps": 7540,
+    "seconds": 1448007827,
+    "expected_floor": "31562437511302041289"
+  },
+  {
+    "principal": "9186716225919746086",
+    "rate_bps": 9133,
+    "seconds": 1560133064,
+    "expected_floor": "414793013623845554923"
+  },
+  {
+    "principal": "9343998654489302391",
+    "rate_bps": 3304,
+    "seconds": 1356358017,
+    "expected_floor": "132691522591264492963"
+  },
+  {
+    "principal": "16748411129967191036",
+    "rate_bps": 7228,
+    "seconds": 1718155662,
+    "expected_floor": "659098461027577553489"
+  },
+  {
+    "principal": "2109895384650142021",
+    "rate_bps": 1127,
+    "seconds": 3849160191,
+    "expected_floor": "29003262724778639501"
+  },
+  {
+    "principal": "3535501862659461154",
+    "rate_bps": 7319,
+    "seconds": 1225692708,
+    "expected_floor": "100503330288491295707"
+  },
+  {
+    "principal": "1529949823307334051",
+    "rate_bps": 6058,
+    "seconds": 470929805,
+    "expected_floor": "13831161977059530193"
+  },
+  {
+    "principal": "15630709349302618648",
+    "rate_bps": 7111,
+    "seconds": 1738478858,
+    "expected_floor": "612314878774690381513"
+  },
+  {
+    "principal": "9342687058619017745",
+    "rate_bps": 8057,
+    "seconds": 3010278315,
+    "expected_floor": "718038694583079973141"
+  },
+  {
+    "principal": "3095003862935956318",
+    "rate_bps": 2361,
+    "seconds": 331262912,
+    "expected_floor": "7670541618470935324"
+  },
+  {
+    "principal": "15783829771372196367",
+    "rate_bps": 6127,
+    "seconds": 830660569,
+    "expected_floor": "254553983036484655598"
+  },
+  {
+    "principal": "8079587294790713716",
+    "rate_bps": 7073,
+    "seconds": 2148115398,
+    "expected_floor": "388997201343028979864"
+  },
+  {
+    "principal": "4214266807664936221",
+    "rate_bps": 4631,
+    "seconds": 283192727,
+    "expected_floor": "17513580262790632331"
+  },
+  {
+    "principal": "316659447608733146",
+    "rate_bps": 1516,
+    "seconds": 3655711388,
+    "expected_floor": "5561085671570110709"
+  },
+  {
+    "principal": "10495071408183882427",
+    "rate_bps": 6016,
+    "seconds": 218265701,
+    "expected_floor": "43669151436107658392"
+  },
+  {
+    "principal": "3974598759913473552",
+    "rate_bps": 2603,
+    "seconds": 3845685698,
+    "expected_floor": "126077410668641131865"
+  },
+  {
+    "principal": "11385207676311932521",
+    "rate_bps": 3418,
+    "seconds": 2262237123,
+    "expected_floor": "278963364986154671483"
+  },
+  {
+    "principal": "387417659740992406",
+    "rate_bps": 7992,
+    "seconds": 526040760,
+    "expected_floor": "5161195596304040240"
+  },
+  {
+    "principal": "16342531938286849959",
+    "rate_bps": 2489,
+    "seconds": 3736061745,
+    "expected_floor": "481564336912134275769"
+  },
+  {
+    "principal": "1867782814026683372",
+    "rate_bps": 2043,
+    "seconds": 3756051198,
+    "expected_floor": "45417400978323149364"
+  },
+  {
+    "principal": "6072847066876686837",
+    "rate_bps": 8582,
+    "seconds": 50492975,
+    "expected_floor": "8338882361195783064"
+  },
+  {
+    "principal": "7519560861838645394",
+    "rate_bps": 8269,
+    "seconds": 4111463444,
+    "expected_floor": "810098702940105566901"
+  },
+  {
+    "principal": "11989604100853421267",
+    "rate_bps": 207,
+    "seconds": 1673410621,
+    "expected_floor": "13160540993923260814"
+  },
+  {
+    "principal": "8611014350364124936",
+    "rate_bps": 9260,
+    "seconds": 655940474,
+    "expected_floor": "165739399854182395542"
+  },
+  {
+    "principal": "5177473356658219969",
+    "rate_bps": 447,
+    "seconds": 2284428507,
+    "expected_floor": "16753247317260527197"
+  },
+  {
+    "principal": "2773311136034961614",
+    "rate_bps": 8386,
+    "seconds": 2960053936,
+    "expected_floor": "218146932788795419876"
+  },
+  {
+    "principal": "4650562757456072255",
+    "rate_bps": 8093,
+    "seconds": 3246487433,
+    "expected_floor": "387190603175394861479"
+  },
+  {
+    "principal": "3066827442677316452",
+    "rate_bps": 4029,
+    "seconds": 1658081078,
+    "expected_floor": "64921478872890173934"
+  },
+  {
+    "principal": "9077677408050689997",
+    "rate_bps": 6391,
+    "seconds": 1859174343,
+    "expected_floor": "341790284098040514643"
+  },
+  {
+    "principal": "10186649989377159242",
+    "rate_bps": 3268,
+    "seconds": 2952012428,
+    "expected_floor": "311406480719997974046"
+  },
+  {
+    "principal": "6604211531388356587",
+    "rate_bps": 4183,
+    "seconds": 247034133,
+    "expected_floor": "21625284865752901646"
+  },
+  {
+    "principal": "1060367105155845376",
+    "rate_bps": 1250,
+    "seconds": 1906311730,
+    "expected_floor": "8006748971185750494"
+  },
+  {
+    "principal": "3704035542342087193",
+    "rate_bps": 8378,
+    "seconds": 2183555827,
+    "expected_floor": "214721649261370034141"
+  },
+  {
+    "principal": "2310989880230271750",
+    "rate_bps": 4011,
+    "seconds": 3909866408,
+    "expected_floor": "114844091713192620450"
+  },
+  {
+    "principal": "7259084948358041047",
+    "rate_bps": 1777,
+    "seconds": 1998475489,
+    "expected_floor": "81689110193707512127"
+  },
+  {
+    "principal": "5546098595747354588",
+    "rate_bps": 4376,
+    "seconds": 1302204526,
+    "expected_floor": "100147504679300678755"
+  },
+  {
+    "principal": "3502238079347652261",
+    "rate_bps": 3513,
+    "seconds": 2234477151,
+    "expected_floor": "87115566780677956406"
+  },
+  {
+    "principal": "4572241056024581378",
+    "rate_bps": 5511,
+    "seconds": 992814596,
+    "expected_floor": "79272712046890409718"
+  },
+  {
+    "principal": "10311349268308765699",
+    "rate_bps": 7803,
+    "seconds": 623674093,
+    "expected_floor": "159012344740580031945"
+  },
+  {
+    "principal": "17823102333188249592",
+    "rate_bps": 8165,
+    "seconds": 2898384362,
+    "expected_floor": "1336569358435706923952"
+  },
+  {
+    "principal": "4328975179772014961",
+    "rate_bps": 6430,
+    "seconds": 3962751499,
+    "expected_floor": "349533608500790553459"
+  },
+  {
+    "principal": "9272600052389870142",
+    "rate_bps": 4479,
+    "seconds": 3291911584,
+    "expected_floor": "433238242762833695188"
+  },
+  {
+    "principal": "2487631292999020143",
+    "rate_bps": 1221,
+    "seconds": 1580249913,
+    "expected_floor": "15209799297241958415"
+  },
+  {
+    "principal": "468554633557395796",
+    "rate_bps": 2404,
+    "seconds": 3091984038,
+    "expected_floor": "11036413823384979615"
+  },
+  {
+    "principal": "12884076387614510717",
+    "rate_bps": 4455,
+    "seconds": 3596998135,
+    "expected_floor": "654240228583054740282"
+  },
+  {
+    "principal": "16356198132997334714",
+    "rate_bps": 6383,
+    "seconds": 2986991228,
+    "expected_floor": "988182565445222456744"
+  },
+  {
+    "principal": "17209124853944099099",
+    "rate_bps": 2423,
+    "seconds": 2090061253,
+    "expected_floor": "276164115803844367961"
+  },
+  {
+    "principal": "77527168051079152",
+    "rate_bps": 2311,
+    "seconds": 2005284514,
+    "expected_floor": "1138481291957939433"
+  },
+  {
+    "principal": "5868583520655604169",
+    "rate_bps": 5741,
+    "seconds": 2480413219,
+    "expected_floor": "264813978895750732788"
+  },
+  {
+    "principal": "4920680623413818998",
+    "rate_bps": 8254,
+    "seconds": 1298660504,
+    "expected_floor": "167140350331853828037"
+  },
+  {
+    "principal": "17518372845140725767",
+    "rate_bps": 6264,
+    "seconds": 3026648721,
+    "expected_floor": "1052455073378947948339"
+  },
+  {
+    "principal": "4197246404721192908",
+    "rate_bps": 6434,
+    "seconds": 3384789470,
+    "expected_floor": "289649789021971966279"
+  },
+  {
+    "principal": "14979369073768996693",
+    "rate_bps": 6528,
+    "seconds": 1134518927,
+    "expected_floor": "351545421112552512353"
+  },
+  {
+    "principal": "7192522931946898802",
+    "rate_bps": 3210,
+    "seconds": 973941748,
+    "expected_floor": "71254993172973030256"
+  },
+  {
+    "principal": "5171961296962864947",
+    "rate_bps": 7596,
+    "seconds": 3459232157,
+    "expected_floor": "430641584509242622559"
+  },
+  {
+    "principal": "7902566406129425640",
+    "rate_bps": 9218,
+    "seconds": 193528922,
+    "expected_floor": "44673169705123695627"
+  },
+  {
+    "principal": "14404080414795229985",
+    "rate_bps": 9482,
+    "seconds": 1447279419,
+    "expected_floor": "626374266890235508048"
+  },
+  {
+    "principal": "16470037341483347886",
+    "rate_bps": 3208,
+    "seconds": 671934608,
+    "expected_floor": "112499861130194569311"
+  },
+  {
+    "principal": "16951352754005856927",
+    "rate_bps": 131,
+    "seconds": 1140036329,
+    "expected_floor": "8022142664363496938"
+  },
+  {
+    "principal": "11716582691237718852",
+    "rate_bps": 8138,
+    "seconds": 3274670614,
+    "expected_floor": "989423686373096047759"
+  },
+  {
+    "principal": "11297908629247117613",
+    "rate_bps": 5239,
+    "seconds": 7041063,
+    "expected_floor": "1320628665012110044"
+  },
+  {
+    "principal": "2888774195005657386",
+    "rate_bps": 1525,
+    "seconds": 1919807084,
+    "expected_floor": "26800139980745031834"
+  },
+  {
+    "principal": "10240207865392266827",
+    "rate_bps": 7314,
+    "seconds": 1820626549,
+    "expected_floor": "432096384900892823557"
+  },
+  {
+    "principal": "234708114848978656",
+    "rate_bps": 3261,
+    "seconds": 4034535186,
+    "expected_floor": "9785171559209385458"
+  },
+  {
+    "principal": "51629128625087865",
+    "rate_bps": 4762,
+    "seconds": 3922136403,
+    "expected_floor": "3055645108586372778"
+  },
+  {
+    "principal": "2166468478067803622",
+    "rate_bps": 1698,
+    "seconds": 1728461192,
+    "expected_floor": "20148639491841869773"
+  },
+  {
+    "principal": "15737875124683150903",
+    "rate_bps": 701,
+    "seconds": 2701971521,
+    "expected_floor": "94458471372828373259"
+  },
+  {
+    "principal": "9419973778882780092",
+    "rate_bps": 3945,
+    "seconds": 3685021518,
+    "expected_floor": "433943075400649731061"
+  },
+  {
+    "principal": "3981449528988183557",
+    "rate_bps": 6789,
+    "seconds": 2755485375,
+    "expected_floor": "236015848365765550435"
+  },
+  {
+    "principal": "17647187129880340962",
+    "rate_bps": 5244,
+    "seconds": 865535460,
+    "expected_floor": "253816044664347308091"
+  },
+  {
+    "principal": "5520911783345497699",
+    "rate_bps": 9687,
+    "seconds": 2296038477,
+    "expected_floor": "389112607186729752925"
+  },
+  {
+    "principal": "10602113651904034264",
+    "rate_bps": 9440,
+    "seconds": 2141021898,
+    "expected_floor": "679018476505116190570"
+  },
+  {
+    "principal": "11323112576191219921",
+    "rate_bps": 9791,
+    "seconds": 3075960939,
+    "expected_floor": "1080611847720534493302"
+  },
+  {
+    "principal": "18000089962381465886",
+    "rate_bps": 514,
+    "seconds": 3022573440,
+    "expected_floor": "88615703452363539745"
+  },
+  {
+    "principal": "18137926612145175247",
+    "rate_bps": 8784,
+    "seconds": 4151121561,
+    "expected_floor": "2095759540096829937132"
+  },
+  {
+    "principal": "262966163692544308",
+    "rate_bps": 8301,
+    "seconds": 3950905734,
+    "expected_floor": "27328952466490116447"
+  },
+  {
+    "principal": "10576922176416819165",
+    "rate_bps": 855,
+    "seconds": 1273794135,
+    "expected_floor": "36502339615952602639"
+  },
+  {
+    "principal": "17907294095441440666",
+    "rate_bps": 8136,
+    "seconds": 2661765724,
+    "expected_floor": "1228872335046816812634"
+  },
+  {
+    "principal": "7928134944532504443",
+    "rate_bps": 4116,
+    "seconds": 146715429,
+    "expected_floor": "15171140155450730651"
+  },
+  {
+    "principal": "7409691646626191824",
+    "rate_bps": 6675,
+    "seconds": 927644546,
+    "expected_floor": "145388157814894337739"
+  },
+  {
+    "principal": "6374461317452526889",
+    "rate_bps": 2476,
+    "seconds": 3289269379,
+    "expected_floor": "164508978368864201256"
+  },
+  {
+    "principal": "14385277284433365334",
+    "rate_bps": 8759,
+    "seconds": 3351087736,
+    "expected_floor": "1337995322668047368172"
+  },
+  {
+    "principal": "15665941781047042151",
+    "rate_bps": 7803,
+    "seconds": 1741866481,
+    "expected_floor": "674728430596530545878"
+  },
+  {
+    "principal": "11279333589091343276",
+    "rate_bps": 2072,
+    "seconds": 3891042494,
+    "expected_floor": "288160997578558355449"
+  },
+  {
+    "principal": "17447519521762614453",
+    "rate_bps": 2908,
+    "seconds": 3409207023,
+    "expected_floor": "548122339159239075833"
+  },
+  {
+    "principal": "2051570636828951122",
+    "rate_bps": 4490,
+    "seconds": 2096214996,
+    "expected_floor": "61187776551102702226"
+  },
+  {
+    "principal": "10417374183980681619",
+    "rate_bps": 5055,
+    "seconds": 3951082237,
+    "expected_floor": "659312828249740695554"
+  },
+  {
+    "principal": "11368094610016232136",
+    "rate_bps": 8476,
+    "seconds": 3731750202,
+    "expected_floor": "1139428886202791974899"
+  },
+  {
+    "principal": "14740140259788376705",
+    "rate_bps": 520,
+    "seconds": 2863196571,
+    "expected_floor": "69542797630048759319"
+  },
+  {
+    "principal": "17127272875950306958",
+    "rate_bps": 6609,
+    "seconds": 805390960,
+    "expected_floor": "288886170891960450689"
+  },
+  {
+    "principal": "17838935427222808319",
+    "rate_bps": 4699,
+    "seconds": 4118822473,
+    "expected_floor": "1094065907459570453991"
+  },
+  {
+    "principal": "11256256631586269988",
+    "rate_bps": 1789,
+    "seconds": 779519222,
+    "expected_floor": "49742451863331477946"
+  },
+  {
+    "principal": "16058258164279208589",
+    "rate_bps": 1502,
+    "seconds": 3996397703,
+    "expected_floor": "305445057402791884158"
+  },
+  {
+    "principal": "9289841088388530698",
+    "rate_bps": 8139,
+    "seconds": 4017949260,
+    "expected_floor": "962675267829191334588"
+  },
+  {
+    "principal": "3118156065103545515",
+    "rate_bps": 7859,
+    "seconds": 1068841941,
+    "expected_floor": "82999343405117417054"
+  },
+  {
+    "principal": "2882266739468054720",
+    "rate_bps": 4796,
+    "seconds": 2013727730,
+    "expected_floor": "88208437267342068843"
+  },
+  {
+    "principal": "8032273789258279129",
+    "rate_bps": 1305,
+    "seconds": 2768814003,
+    "expected_floor": "91968442300538676826"
+  },
+  {
+    "principal": "18405328739299360966",
+    "rate_bps": 7716,
+    "seconds": 1755639656,
+    "expected_floor": "790072985989990696722"
+  },
+  {
+    "principal": "9554230622272237207",
+    "rate_bps": 5219,
+    "seconds": 62644129,
+    "expected_floor": "9898272941423574788"
+  },
+  {
+    "principal": "16014125770852249500",
+    "rate_bps": 9345,
+    "seconds": 2692066862,
+    "expected_floor": "1276628147821792217703"
+  },
+  {
+    "principal": "3588387007292109157",
+    "rate_bps": 9585,
+    "seconds": 3404686111,
+    "expected_floor": "371077399780989597637"
+  },
+  {
+    "principal": "3816289824859705026",
+    "rate_bps": 6157,
+    "seconds": 1854158276,
+    "expected_floor": "138055381322288941673"
+  },
+  {
+    "principal": "3205725929152524483",
+    "rate_bps": 8401,
+    "seconds": 2830407085,
+    "expected_floor": "241547368373675924622"
+  },
+  {
+    "principal": "16641945733072135096",
+    "rate_bps": 3698,
+    "seconds": 111789994,
+    "expected_floor": "21800676681598104866"
+  },
+  {
+    "principal": "4550784052373680177",
+    "rate_bps": 7135,
+    "seconds": 2779981515,
+    "expected_floor": "286034320445716304235"
+  },
+  {
+    "principal": "14163203829457946622",
+    "rate_bps": 2032,
+    "seconds": 1112365408,
+    "expected_floor": "101444549233424757474"
+  },
+  {
+    "principal": "11091251744128554799",
+    "rate_bps": 1268,
+    "seconds": 1666189817,
+    "expected_floor": "74254080618178879911"
+  },
+  {
+    "principal": "8260972240046704916",
+    "rate_bps": 1264,
+    "seconds": 2392323174,
+    "expected_floor": "79157873148331656045"
+  },
+  {
+    "principal": "15598573632530026813",
+    "rate_bps": 9100,
+    "seconds": 583882423,
+    "expected_floor": "262632044287082818243"
+  },
+  {
+    "principal": "1851084273042819194",
+    "rate_bps": 5307,
+    "seconds": 418780732,
+    "expected_floor": "13036409775579816816"
+  },
+  {
+    "principal": "9444917579058327003",
+    "rate_bps": 5620,
+    "seconds": 1947936901,
+    "expected_floor": "327646403886323123439"
+  },
+  {
+    "principal": "9566614789022587824",
+    "rate_bps": 5548,
+    "seconds": 536744034,
+    "expected_floor": "90273025510698750638"
+  },
+  {
+    "principal": "11514144518039077001",
+    "rate_bps": 3449,
+    "seconds": 2169601763,
+    "expected_floor": "273024065010253602840"
+  },
+  {
+    "principal": "17244572300969012278",
+    "rate_bps": 4220,
+    "seconds": 2584963160,
+    "expected_floor": "596094712321585952511"
+  },
+  {
+    "principal": "4896245655830036679",
+    "rate_bps": 7454,
+    "seconds": 4027260241,
+    "expected_floor": "465755846446005030672"
+  },
+  {
+    "principal": "6499757218534774668",
+    "rate_bps": 8971,
+    "seconds": 1952397214,
+    "expected_floor": "360746564496742408173"
+  },
+  {
+    "principal": "16612042952070507029",
+    "rate_bps": 1252,
+    "seconds": 3558435663,
+    "expected_floor": "234521425479349620572"
+  },
+  {
+    "principal": "13085487008742543154",
+    "rate_bps": 3987,
+    "seconds": 1408601012,
+    "expected_floor": "232873545450069199647"
+  },
+  {
+    "principal": "12467147084826631155",
+    "rate_bps": 12,
+    "seconds": 1061770333,
+    "expected_floor": "503355651069144094"
+  },
+  {
+    "principal": "7832705384313157800",
+    "rate_bps": 231,
+    "seconds": 1346356762,
+    "expected_floor": "7719336272122735685"
+  },
+  {
+    "principal": "15067156164142053857",
+    "rate_bps": 9261,
+    "seconds": 674310139,
+    "expected_floor": "298156922091925561016"
+  },
+  {
+    "principal": "12951486869940997486",
+    "rate_bps": 4670,
+    "seconds": 1627651152,
+    "expected_floor": "311956380672011882619"
+  },
+  {
+    "principal": "10081539911432178527",
+    "rate_bps": 832,
+    "seconds": 3191830953,
+    "expected_floor": "84837158691263391948"
+  },
+  {
+    "principal": "5025226450086116100",
+    "rate_bps": 3506,
+    "seconds": 2208389078,
+    "expected_floor": "123293213537167590967"
+  },
+  {
+    "principal": "10319625883834719213",
+    "rate_bps": 3822,
+    "seconds": 1535312103,
+    "expected_floor": "191887790552357593440"
+  },
+  {
+    "principal": "2537214319709668074",
+    "rate_bps": 6861,
+    "seconds": 3126425132,
+    "expected_floor": "172460102243108007482"
+  },
+  {
+    "principal": "16069294944306404107",
+    "rate_bps": 2316,
+    "seconds": 753105205,
+    "expected_floor": "88815151152361633707"
+  },
+  {
+    "principal": "14528888701672364704",
+    "rate_bps": 1827,
+    "seconds": 1304348882,
+    "expected_floor": "109713671176989003755"
+  },
+  {
+    "principal": "1631195655979072569",
+    "rate_bps": 9572,
+    "seconds": 4022567443,
+    "expected_floor": "199025220315845797319"
+  },
+  {
+    "principal": "14441338758867176358",
+    "rate_bps": 2253,
+    "seconds": 4087346504,
+    "expected_floor": "421411261049706485927"
+  },
+  {
+    "principal": "3080492863937337079",
+    "rate_bps": 6816,
+    "seconds": 3628302081,
+    "expected_floor": "241406666812622644578"
+  },
+  {
+    "principal": "10136296007459885948",
+    "rate_bps": 4151,
+    "seconds": 537870,
+    "expected_floor": "71714235473208340"
+  },
+  {
+    "principal": "16635050456834426565",
+    "rate_bps": 9439,
+    "seconds": 1704818559,
+    "expected_floor": "848250854960769292644"
+  },
+  {
+    "principal": "10621267997165650850",
+    "rate_bps": 1220,
+    "seconds": 1546433956,
+    "expected_floor": "63498520716542292703"
+  },
+  {
+    "principal": "12476866821172218659",
+    "rate_bps": 6305,
+    "seconds": 2857498381,
+    "expected_floor": "712315928983371101098"
+  },
+  {
+    "principal": "8582342456558772632",
+    "rate_bps": 9344,
+    "seconds": 4234082442,
+    "expected_floor": "1075954763395099339075"
+  },
+  {
+    "principal": "16607072258140645265",
+    "rate_bps": 143,
+    "seconds": 3961384235,
+    "expected_floor": "29810695918907968181"
+  },
+  {
+    "principal": "9642463225158665950",
+    "rate_bps": 9505,
+    "seconds": 3244045120,
+    "expected_floor": "942156462301405608839"
+  },
+  {
+    "principal": "17437278649455297423",
+    "rate_bps": 8421,
+    "seconds": 2347863385,
+    "expected_floor": "1092474304574502327549"
+  },
+  {
+    "principal": "4314738727357874420",
+    "rate_bps": 6709,
+    "seconds": 1787932486,
+    "expected_floor": "164005889125908374345"
+  },
+  {
+    "principal": "14782478795553442461",
+    "rate_bps": 3623,
+    "seconds": 1885351703,
+    "expected_floor": "319966130518415511011"
+  },
+  {
+    "principal": "5501753461526442330",
+    "rate_bps": 9424,
+    "seconds": 1311648284,
+    "expected_floor": "215501268625066872640"
+  },
+  {
+    "principal": "11227538920171686971",
+    "rate_bps": 1846,
+    "seconds": 3309383141,
+    "expected_floor": "217349852080022157638"
+  },
+  {
+    "principal": "16368279487888633232",
+    "rate_bps": 5529,
+    "seconds": 1092105538,
+    "expected_floor": "313191714487203671913"
+  },
+  {
+    "principal": "8669475213110320105",
+    "rate_bps": 5064,
+    "seconds": 1501153603,
+    "expected_floor": "208837108824323311347"
+  },
+  {
+    "principal": "369819753069879062",
+    "rate_bps": 510,
+    "seconds": 1143051832,
+    "expected_floor": "683159697159224946"
+  },
+  {
+    "principal": "5448777775780245799",
+    "rate_bps": 2183,
+    "seconds": 1210582193,
+    "expected_floor": "45629230615793386796"
+  },
+  {
+    "principal": "4231183216780321644",
+    "rate_bps": 985,
+    "seconds": 2098177662,
+    "expected_floor": "27709989028438816063"
+  },
+  {
+    "principal": "15555864748663129973",
+    "rate_bps": 1971,
+    "seconds": 2091288495,
+    "expected_floor": "203184588590163820589"
+  },
+  {
+    "principal": "5794121200055102482",
+    "rate_bps": 8928,
+    "seconds": 2303767444,
+    "expected_floor": "377638641483542632194"
+  },
+  {
+    "principal": "15865172778065952339",
+    "rate_bps": 7173,
+    "seconds": 287407549,
+    "expected_floor": "103642967910579189160"
+  },
+  {
+    "principal": "18149856288537599624",
+    "rate_bps": 8738,
+    "seconds": 2775998202,
+    "expected_floor": "1395084277907324290224"
+  },
+  {
+    "principal": "6828100186143078721",
+    "rate_bps": 6654,
+    "seconds": 364148315,
+    "expected_floor": "52427242865914214158"
+  },
+  {
+    "principal": "247030572555072590",
+    "rate_bps": 4221,
+    "seconds": 1204616752,
+    "expected_floor": "3980255841699754558"
+  },
+  {
+    "principal": "3449466517269905343",
+    "rate_bps": 1260,
+    "seconds": 172573961,
+    "expected_floor": "2376806240905200375"
+  },
+  {
+    "principal": "16732410222458772196",
+    "rate_bps": 6961,
+    "seconds": 4121426614,
+    "expected_floor": "1521155952984287864726"
+  },
+  {
+    "principal": "4443355450120658253",
+    "rate_bps": 4631,
+    "seconds": 3484410183,
+    "expected_floor": "227201473993266347805"
+  },
+  {
+    "principal": "2484253940316066762",
+    "rate_bps": 4228,
+    "seconds": 440087052,
+    "expected_floor": "14647570266621383506"
+  },
+  {
+    "principal": "17249679907280077163",
+    "rate_bps": 7389,
+    "seconds": 480724629,
+    "expected_floor": "194159709231305354608"
+  },
+  {
+    "principal": "7445984051309827200",
+    "rate_bps": 4672,
+    "seconds": 3407435186,
+    "expected_floor": "375619882416495900826"
+  },
+  {
+    "principal": "1460341828811808665",
+    "rate_bps": 1002,
+    "seconds": 701453427,
+    "expected_floor": "3252498618311638106"
+  },
+  {
+    "principal": "247252142416291462",
+    "rate_bps": 9060,
+    "seconds": 2175748904,
+    "expected_floor": "15444472062316261139"
+  },
+  {
+    "principal": "18341257187311521623",
+    "rate_bps": 3807,
+    "seconds": 1539026529,
+    "expected_floor": "340529010565904680791"
+  },
+  {
+    "principal": "1802447211860871004",
+    "rate_bps": 7778,
+    "seconds": 844401646,
+    "expected_floor": "37512464493647299180"
+  },
+  {
+    "principal": "1102212388493798437",
+    "rate_bps": 7672,
+    "seconds": 3298794463,
+    "expected_floor": "88394485439212106341"
+  },
+  {
+    "principal": "14042807597507315842",
+    "rate_bps": 5318,
+    "seconds": 2697495940,
+    "expected_floor": "638350365183592615080"
+  },
+  {
+    "principal": "16679707299945084291",
+    "rate_bps": 20,
+    "seconds": 2001397869,
+    "expected_floor": "2115669800343108190"
+  },
+  {
+    "principal": "6152130743000723320",
+    "rate_bps": 7148,
+    "seconds": 2939484522,
+    "expected_floor": "409616375937523158195"
+  },
+  {
+    "principal": "17347541716565290737",
+    "rate_bps": 2453,
+    "seconds": 1668268939,
+    "expected_floor": "224956002290209546318"
+  },
+  {
+    "principal": "9175431397013575102",
+    "rate_bps": 9046,
+    "seconds": 2014141728,
+    "expected_floor": "529747768295425504675"
+  },
+  {
+    "principal": "4575259577877250031",
+    "rate_bps": 846,
+    "seconds": 3748241593,
+    "expected_floor": "45973726767216699012"
+  },
+  {
+    "principal": "11018101259560388820",
+    "rate_bps": 4569,
+    "seconds": 2623748646,
+    "expected_floor": "418548873886823463487"
+  },
+  {
+    "principal": "244428877207671805",
+    "rate_bps": 4302,
+    "seconds": 2919044983,
+    "expected_floor": "9726570508983413536"
+  },
+  {
+    "principal": "9349147714975935034",
+    "rate_bps": 1912,
+    "seconds": 528977404,
+    "expected_floor": "29963536015500291195"
+  },
+  {
+    "principal": "4185032175820176027",
+    "rate_bps": 6209,
+    "seconds": 1187562309,
+    "expected_floor": "97785148480222451741"
+  },
+  {
+    "principal": "9401192939179872112",
+    "rate_bps": 4903,
+    "seconds": 3188795938,
+    "expected_floor": "465765825525212987229"
+  },
+  {
+    "principal": "16373796617492154185",
+    "rate_bps": 3694,
+    "seconds": 4267647907,
+    "expected_floor": "817957798453194665433"
+  },
+  {
+    "principal": "5653393219009749494",
+    "rate_bps": 1417,
+    "seconds": 3114275864,
+    "expected_floor": "79055512191063125687"
+  },
+  {
+    "principal": "15406857398731338119",
+    "rate_bps": 5631,
+    "seconds": 1866562577,
+    "expected_floor": "513142726585560932484"
+  },
+  {
+    "principal": "13581053883817115468",
+    "rate_bps": 9076,
+    "seconds": 3824543070,
+    "expected_floor": "1493838157435791556985"
+  },
+  {
+    "principal": "17808780091654698197",
+    "rate_bps": 4881,
+    "seconds": 3342054415,
+    "expected_floor": "920560908027844575826"
+  },
+  {
+    "principal": "16799973141421791474",
+    "rate_bps": 4483,
+    "seconds": 456862580,
+    "expected_floor": "109033247413290424645"
+  },
+  {
+    "principal": "14404054974057197747",
+    "rate_bps": 2376,
+    "seconds": 1822504733,
+    "expected_floor": "197649583854021756449"
+  },
+  {
+    "principal": "2104119891773002856",
+    "rate_bps": 3301,
+    "seconds": 3062482906,
+    "expected_floor": "67404006621567294760"
+  },
+  {
+    "principal": "15601720303810955425",
+    "rate_bps": 1460,
+    "seconds": 1577768123,
+    "expected_floor": "113884482852306922250"
+  },
+  {
+    "principal": "16715201062569421614",
+    "rate_bps": 4985,
+    "seconds": 1695830032,
+    "expected_floor": "447770133548892590835"
+  },
+  {
+    "principal": "7685193551327626271",
+    "rate_bps": 524,
+    "seconds": 3384123497,
+    "expected_floor": "43184543488241578887"
+  },
+  {
+    "principal": "4980904351175658180",
+    "rate_bps": 1280,
+    "seconds": 193097110,
+    "expected_floor": "3901126008663552399"
+  },
+  {
+    "principal": "7119045611847954093",
+    "rate_bps": 3882,
+    "seconds": 907202983,
+    "expected_floor": "79447056080737053955"
+  },
+  {
+    "principal": "16718222100508914858",
+    "rate_bps": 9359,
+    "seconds": 173686252,
+    "expected_floor": "86115437886780526164"
+  },
+  {
+    "principal": "12009332649590552523",
+    "rate_bps": 3505,
+    "seconds": 999859189,
+    "expected_floor": "133364970150122831749"
+  },
+  {
+    "principal": "10725341325951753824",
+    "rate_bps": 2621,
+    "seconds": 1569632914,
+    "expected_floor": "139820957859902461663"
+  },
+  {
+    "principal": "8431521575824347897",
+    "rate_bps": 118,
+    "seconds": 3607377619,
+    "expected_floor": "11373014750031165111"
+  },
+  {
+    "principal": "14824686429739077990",
+    "rate_bps": 2480,
+    "seconds": 9105672,
+    "expected_floor": "1060828629830838284"
+  },
+  {
+    "principal": "13729278253444552631",
+    "rate_bps": 4472,
+    "seconds": 3476843969,
+    "expected_floor": "676442266495912347622"
+  },
+  {
+    "principal": "14406185259430218556",
+    "rate_bps": 8574,
+    "seconds": 1129493198,
+    "expected_floor": "442091461766027658372"
+  },
+  {
+    "principal": "8819203640159576453",
+    "rate_bps": 404,
+    "seconds": 474861631,
+    "expected_floor": "5361346159320337047"
+  },
+  {
+    "principal": "1741811765363039586",
+    "rate_bps": 7230,
+    "seconds": 344958308,
+    "expected_floor": "13765822296716921539"
+  },
+  {
+    "principal": "7663921607523971043",
+    "rate_bps": 3313,
+    "seconds": 3174525389,
+    "expected_floor": "255415546056353643402"
+  },
+  {
+    "principal": "584489412649471320",
+    "rate_bps": 858,
+    "seconds": 27511370,
+    "expected_floor": "43719198083979140"
+  },
+  {
+    "principal": "98724089134237265",
+    "rate_bps": 4129,
+    "seconds": 2290133483,
+    "expected_floor": "2958181710749604206"
+  },
+  {
+    "principal": "1719977474480665758",
+    "rate_bps": 5484,
+    "seconds": 2702759680,
+    "expected_floor": "80783686828667562707"
+  },
+  {
+    "principal": "14114674697328020559",
+    "rate_bps": 7455,
+    "seconds": 1339048985,
+    "expected_floor": "446489262066029130844"
+  },
+  {
+    "principal": "7248681835374895284",
+    "rate_bps": 6612,
+    "seconds": 2500105478,
+    "expected_floor": "379704939914055377049"
+  },
+  {
+    "principal": "14008997130981715293",
+    "rate_bps": 5402,
+    "seconds": 3103526871,
+    "expected_floor": "744240276097001329112"
+  },
+  {
+    "principal": "9273316169613636378",
+    "rate_bps": 1174,
+    "seconds": 574243292,
+    "expected_floor": "19810485893303128305"
+  },
+  {
+    "principal": "9699534864002136315",
+    "rate_bps": 1808,
+    "seconds": 2269767845,
+    "expected_floor": "126132442774955771701"
+  },
+  {
+    "principal": "7854927113988096336",
+    "rate_bps": 5550,
+    "seconds": 3462459138,
+    "expected_floor": "478317017488794735306"
+  },
+  {
+    "principal": "3509008291238609577",
+    "rate_bps": 1890,
+    "seconds": 1171885571,
+    "expected_floor": "24627903229939464382"
+  },
+  {
+    "principal": "11268080651008996566",
+    "rate_bps": 1544,
+    "seconds": 1648812536,
+    "expected_floor": "90900140907299317952"
+  },
+  {
+    "principal": "349763129431769575",
+    "rate_bps": 6661,
+    "seconds": 1752138609,
+    "expected_floor": "12935343089492397943"
+  },
+  {
+    "principal": "1487731757552479020",
+    "rate_bps": 8020,
+    "seconds": 1594487870,
+    "expected_floor": "60285970208996544921"
+  },
+  {
+    "principal": "10554722774493442613",
+    "rate_bps": 6105,
+    "seconds": 2585325679,
+    "expected_floor": "527890433693388162865"
+  },
+  {
+    "principal": "12591052274361161170",
+    "rate_bps": 9065,
+    "seconds": 1005384532,
+    "expected_floor": "363628628229336778311"
+  },
+  {
+    "principal": "6423153753056670483",
+    "rate_bps": 9458,
+    "seconds": 559972477,
+    "expected_floor": "107797910368848912108"
+  },
+  {
+    "principal": "1544272660842486344",
+    "rate_bps": 1171,
+    "seconds": 4025614522,
+    "expected_floor": "23067955079806686242"
+  },
+  {
+    "principal": "1794782230054168577",
+    "rate_bps": 9862,
+    "seconds": 2416722715,
+    "expected_floor": "135550029415200497665"
+  },
+  {
+    "principal": "8998271235113660942",
+    "rate_bps": 5497,
+    "seconds": 764539376,
+    "expected_floor": "119834179771032950219"
+  },
+  {
+    "principal": "16620516675619723391",
+    "rate_bps": 8857,
+    "seconds": 1889307593,
+    "expected_floor": "881312374257681995686"
+  },
+  {
+    "principal": "15154176357900077732",
+    "rate_bps": 8517,
+    "seconds": 2687021174,
+    "expected_floor": "1098970680395483417451"
+  },
+  {
+    "principal": "9360052585182466061",
+    "rate_bps": 9675,
+    "seconds": 3724792327,
+    "expected_floor": "1068876082401450939421"
+  },
+  {
+    "principal": "12722977047695582602",
+    "rate_bps": 590,
+    "seconds": 971938252,
+    "expected_floor": "23119341656096425132"
+  },
+  {
+    "principal": "1861246250899258923",
+    "rate_bps": 8779,
+    "seconds": 4199518549,
+    "expected_floor": "217442494555791986021"
+  },
+  {
+    "principal": "18011519400753379392",
+    "rate_bps": 3187,
+    "seconds": 2258034546,
+    "expected_floor": "410732462150778457679"
+  },
+  {
+    "principal": "18239774196909495897",
+    "rate_bps": 7593,
+    "seconds": 2671388979,
+    "expected_floor": "1172373573156920285748"
+  },
+  {
+    "principal": "17907730050032077894",
+    "rate_bps": 4575,
+    "seconds": 3521832680,
+    "expected_floor": "914316146618583501002"
+  },
+  {
+    "principal": "12713094643458715671",
+    "rate_bps": 5980,
+    "seconds": 2011020577,
+    "expected_floor": "484467905206849870943"
+  },
+  {
+    "principal": "10133481220037287708",
+    "rate_bps": 2226,
+    "seconds": 318417326,
+    "expected_floor": "22760224987844837563"
+  },
+  {
+    "principal": "1596313913998878437",
+    "rate_bps": 3435,
+    "seconds": 2231375007,
+    "expected_floor": "38771592343731883242"
+  },
+  {
+    "principal": "7583767896186225218",
+    "rate_bps": 6917,
+    "seconds": 3283752260,
+    "expected_floor": "545844861258587881210"
+  },
+  {
+    "principal": "12797487476264270403",
+    "rate_bps": 1696,
+    "seconds": 3987700525,
+    "expected_floor": "274264204524788975041"
+  },
+  {
+    "principal": "15244843316803304248",
+    "rate_bps": 8623,
+    "seconds": 1780706090,
+    "expected_floor": "741770620536823277974"
+  },
+  {
+    "principal": "16427354900595027377",
+    "rate_bps": 3643,
+    "seconds": 2083037259,
+    "expected_floor": "395020725400806633739"
+  },
+  {
+    "principal": "9800626114743755646",
+    "rate_bps": 4706,
+    "seconds": 1798742240,
+    "expected_floor": "262887968682341547984"
+  },
+  {
+    "principal": "15312274836759308463",
+    "rate_bps": 8605,
+    "seconds": 1396537209,
+    "expected_floor": "583094754537579888803"
+  },
+  {
+    "principal": "16925756192165693588",
+    "rate_bps": 1519,
+    "seconds": 426622950,
+    "expected_floor": "34757305565821577171"
+  },
+  {
+    "principal": "8204470124191897277",
+    "rate_bps": 7763,
+    "seconds": 3535083575,
+    "expected_floor": "713470207065741881397"
+  },
+  {
+    "principal": "12203696509514091514",
+    "rate_bps": 6746,
+    "seconds": 2675852732,
+    "expected_floor": "698065181377616027093"
+  },
+  {
+    "principal": "12524835821785581403",
+    "rate_bps": 7472,
+    "seconds": 1499241989,
+    "expected_floor": "444607387750019396429"
+  },
+  {
+    "principal": "2664210910314021680",
+    "rate_bps": 3932,
+    "seconds": 3179250658,
+    "expected_floor": "105536555210057794784"
+  },
+  {
+    "principal": "12967268199791382025",
+    "rate_bps": 3860,
+    "seconds": 700516451,
+    "expected_floor": "111109238142775271260"
+  },
+  {
+    "principal": "18331385608697419702",
+    "rate_bps": 4578,
+    "seconds": 432930776,
+    "expected_floor": "115129223144420233040"
+  },
+  {
+    "principal": "17101815711384314439",
+    "rate_bps": 8826,
+    "seconds": 986323665,
+    "expected_floor": "471760561353394388232"
+  },
+  {
+    "principal": "7502458391237814028",
+    "rate_bps": 1834,
+    "seconds": 2017710878,
+    "expected_floor": "87974720380512175308"
+  },
+  {
+    "principal": "5510451895002824597",
+    "rate_bps": 9035,
+    "seconds": 3215867087,
+    "expected_floor": "507352139527893576382"
+  },
+  {
+    "principal": "12612259184875791026",
+    "rate_bps": 7978,
+    "seconds": 1369312052,
+    "expected_floor": "436601659921158059010"
+  },
+  {
+    "principal": "1592647376034743667",
+    "rate_bps": 617,
+    "seconds": 3270990301,
+    "expected_floor": "10185446776663417093"
+  },
+  {
+    "principal": "8769280305280839720",
+    "rate_bps": 7973,
+    "seconds": 1378290074,
+    "expected_floor": "305367193586058756135"
+  },
+  {
+    "principal": "7280593887807772513",
+    "rate_bps": 7729,
+    "seconds": 3734028667,
+    "expected_floor": "665830667966897959328"
+  },
+  {
+    "principal": "11622959991692757230",
+    "rate_bps": 5085,
+    "seconds": 167633872,
+    "expected_floor": "31395363048777314960"
+  },
+  {
+    "principal": "13276364650760158431",
+    "rate_bps": 4905,
+    "seconds": 4145415977,
+    "expected_floor": "855425778751935214049"
+  },
+  {
+    "principal": "12877819979418901124",
+    "rate_bps": 1186,
+    "seconds": 3801269078,
+    "expected_floor": "183971980858688173334"
+  },
+  {
+    "principal": "7786259232783434093",
+    "rate_bps": 9331,
+    "seconds": 2061165159,
+    "expected_floor": "474532403841231157694"
+  },
+  {
+    "principal": "15161935311009048170",
+    "rate_bps": 1825,
+    "seconds": 204490156,
+    "expected_floor": "17930233584124019314"
+  },
+  {
+    "principal": "8929246696413598859",
+    "rate_bps": 7100,
+    "seconds": 224661173,
+    "expected_floor": "45133314198294051166"
+  },
+  {
+    "principal": "5775396756844110368",
+    "rate_bps": 4331,
+    "seconds": 3685342290,
+    "expected_floor": "292108283082867649702"
+  },
+  {
+    "principal": "14707149199456725433",
+    "rate_bps": 7693,
+    "seconds": 1313418131,
+    "expected_floor": "470894123545659329349"
+  },
+  {
+    "principal": "3393656215647098662",
+    "rate_bps": 5683,
+    "seconds": 3414633672,
+    "expected_floor": "208682318357398736773"
+  },
+  {
+    "principal": "18321596828049053815",
+    "rate_bps": 3116,
+    "seconds": 2662833281,
+    "expected_floor": "481726769109739519970"
+  },
+  {
+    "principal": "5813797991100121852",
+    "rate_bps": 1581,
+    "seconds": 1430548622,
+    "expected_floor": "41666830285627227111"
+  },
+  {
+    "principal": "7512604320994147397",
+    "rate_bps": 7516,
+    "seconds": 4212025599,
+    "expected_floor": "753640661429681536401"
+  },
+  {
+    "principal": "17074851994011793186",
+    "rate_bps": 5735,
+    "seconds": 4001355044,
+    "expected_floor": "1241633699791905132043"
+  },
+  {
+    "principal": "3514345544074974371",
+    "rate_bps": 6520,
+    "seconds": 1045109901,
+    "expected_floor": "75883971373567315516"
+  },
+  {
+    "principal": "13260207033767328024",
+    "rate_bps": 3988,
+    "seconds": 4079737866,
+    "expected_floor": "683649887702742013928"
+  },
+  {
+    "principal": "9965038905949955345",
+    "rate_bps": 8007,
+    "seconds": 54503083,
+    "expected_floor": "13780530262478393215"
+  },
+  {
+    "principal": "9778589528235024990",
+    "rate_bps": 5354,
+    "seconds": 4179540672,
+    "expected_floor": "693392551137184563093"
+  },
+  {
+    "principal": "8553533016284304655",
+    "rate_bps": 5697,
+    "seconds": 3821615833,
+    "expected_floor": "590112502554619515766"
+  },
+  {
+    "principal": "5385292935808254068",
+    "rate_bps": 2466,
+    "seconds": 1117174470,
+    "expected_floor": "47013159596498816200"
+  },
+  {
+    "principal": "1270701872802205725",
+    "rate_bps": 7309,
+    "seconds": 2692755607,
+    "expected_floor": "79249148331540313010"
+  },
+  {
+    "principal": "5874788345798587610",
+    "rate_bps": 3517,
+    "seconds": 2492176796,
+    "expected_floor": "163169684574183088541"
+  },
+  {
+    "principal": "12514193884985812411",
+    "rate_bps": 7760,
+    "seconds": 3550012261,
+    "expected_floor": "1092422122756709816563"
+  },
+  {
+    "principal": "15063759156880053520",
+    "rate_bps": 2643,
+    "seconds": 3940870338,
+    "expected_floor": "497185787559412094526"
+  },
+  {
+    "principal": "10687087265806985577",
+    "rate_bps": 8997,
+    "seconds": 3354235587,
+    "expected_floor": "1021990058907565343062"
+  },
+  {
+    "principal": "10165437049591040662",
+    "rate_bps": 1391,
+    "seconds": 804089272,
+    "expected_floor": "36029106008009403462"
+  },
+  {
+    "principal": "9886687128197927591",
+    "rate_bps": 3239,
+    "seconds": 4050207281,
+    "expected_floor": "410993564683563320420"
+  },
+  {
+    "principal": "7408874740976415468",
+    "rate_bps": 1483,
+    "seconds": 2375778814,
+    "expected_floor": "82717126960919089916"
+  },
+  {
+    "principal": "15306931541059329269",
+    "rate_bps": 9216,
+    "seconds": 3863714095,
+    "expected_floor": "1727156220565377189406"
+  },
+  {
+    "principal": "9141436087024664466",
+    "rate_bps": 6635,
+    "seconds": 4136006420,
+    "expected_floor": "794936780401972074298"
+  },
+  {
+    "principal": "9655541769060001747",
+    "rate_bps": 7976,
+    "seconds": 2835202877,
+    "expected_floor": "691897826025418632065"
+  },
+  {
+    "principal": "17878002070441629192",
+    "rate_bps": 9396,
+    "seconds": 1906369146,
+    "expected_floor": "1014763936999186010351"
+  },
+  {
+    "principal": "15287211833166649025",
+    "rate_bps": 515,
+    "seconds": 544231387,
+    "expected_floor": "13577353655390319512"
+  },
+  {
+    "principal": "689588773024575438",
+    "rate_bps": 7685,
+    "seconds": 1460676016,
+    "expected_floor": "24529233946992367777"
+  },
+  {
+    "principal": "13837389094950302015",
+    "rate_bps": 3636,
+    "seconds": 3644461705,
+    "expected_floor": "581041900527815359543"
+  },
+  {
+    "principal": "12279241991317600868",
+    "rate_bps": 395,
+    "seconds": 1438164534,
+    "expected_floor": "22104121615221123443"
+  },
+  {
+    "principal": "8080284544529302221",
+    "rate_bps": 3559,
+    "seconds": 602931911,
+    "expected_floor": "54943832006262868319"
+  },
+  {
+    "principal": "7593342668735493962",
+    "rate_bps": 3897,
+    "seconds": 2555855244,
+    "expected_floor": "239660074896476544339"
+  },
+  {
+    "principal": "12992562389005007595",
+    "rate_bps": 9432,
+    "seconds": 1835932693,
+    "expected_floor": "712937389302294891889"
+  },
+  {
+    "principal": "13405418962144582656",
+    "rate_bps": 634,
+    "seconds": 104835378,
+    "expected_floor": "2823407394947017639"
+  },
+  {
+    "principal": "5211104367219969305",
+    "rate_bps": 6395,
+    "seconds": 3557375475,
+    "expected_floor": "375660956209469962689"
+  },
+  {
+    "principal": "15283209629013766662",
+    "rate_bps": 9950,
+    "seconds": 924304040,
+    "expected_floor": "445398279407908209515"
+  },
+  {
+    "principal": "17622989651263230167",
+    "rate_bps": 4687,
+    "seconds": 2430733281,
+    "expected_floor": "636220824164317874586"
+  },
+  {
+    "principal": "2273080471623382748",
+    "rate_bps": 561,
+    "seconds": 2452096878,
+    "expected_floor": "9908577931014305727"
+  },
+  {
+    "principal": "307858400302490021",
+    "rate_bps": 2313,
+    "seconds": 1590742367,
+    "expected_floor": "3589405484322673923"
+  },
+  {
+    "principal": "18240055657225567234",
+    "rate_bps": 8539,
+    "seconds": 152626436,
+    "expected_floor": "75328439158055589938"
+  },
+  {
+    "principal": "9863602962037260035",
+    "rate_bps": 6176,
+    "seconds": 2829209069,
+    "expected_floor": "546139947369355156005"
+  },
+  {
+    "principal": "16879482713986877176",
+    "rate_bps": 840,
+    "seconds": 993336554,
+    "expected_floor": "44630409288501043891"
+  },
+  {
+    "principal": "6255687628411612273",
+    "rate_bps": 4563,
+    "seconds": 2258484491,
+    "expected_floor": "204286030090099704038"
+  },
+  {
+    "principal": "15115035980439040318",
+    "rate_bps": 213,
+    "seconds": 1636377760,
+    "expected_floor": "16694306783018737959"
+  },
+  {
+    "principal": "6011277128300908911",
+    "rate_bps": 468,
+    "seconds": 2139852345,
+    "expected_floor": "19076225299191690096"
+  },
+  {
+    "principal": "14694144901326227540",
+    "rate_bps": 7135,
+    "seconds": 2104984998,
+    "expected_floor": "699331891201589573768"
+  },
+  {
+    "principal": "11635851956032199037",
+    "rate_bps": 2987,
+    "seconds": 733305079,
+    "expected_floor": "80763314802644790075"
+  },
+  {
+    "principal": "7895771866079276474",
+    "rate_bps": 1375,
+    "seconds": 2996452732,
+    "expected_floor": "103086252983822378488"
+  },
+  {
+    "principal": "17444417056697013275",
+    "rate_bps": 8207,
+    "seconds": 1352054981,
+    "expected_floor": "613382356859910768832"
+  },
+  {
+    "principal": "8435622464070399728",
+    "rate_bps": 6671,
+    "seconds": 3389595042,
+    "expected_floor": "604438228383423919214"
+  },
+  {
+    "principal": "7379945940011914441",
+    "rate_bps": 527,
+    "seconds": 1647783203,
+    "expected_floor": "20307660770758328992"
+  },
+  {
+    "principal": "8294268593510403446",
+    "rate_bps": 4913,
+    "seconds": 1750936472,
+    "expected_floor": "226095168174606523745"
+  },
+  {
+    "principal": "254806240706728711",
+    "rate_bps": 1446,
+    "seconds": 2607085969,
+    "expected_floor": "3043895500901131739"
+  },
+  {
+    "principal": "4186296934033215180",
+    "rate_bps": 7125,
+    "seconds": 3507028190,
+    "expected_floor": "331474548715605826274"
+  },
+  {
+    "principal": "3478782130553670229",
+    "rate_bps": 2338,
+    "seconds": 2689140111,
+    "expected_floor": "69307654372553911517"
+  },
+  {
+    "principal": "3633461368226212978",
+    "rate_bps": 2793,
+    "seconds": 4175309556,
+    "expected_floor": "134269136246444897248"
+  },
+  {
+    "principal": "16461437752429779507",
+    "rate_bps": 2482,
+    "seconds": 4010523805,
+    "expected_floor": "519238244173009678707"
+  },
+  {
+    "principal": "4522133803667983336",
+    "rate_bps": 2486,
+    "seconds": 1993837402,
+    "expected_floor": "71028117452847968202"
+  },
+  {
+    "principal": "5139436990911915553",
+    "rate_bps": 1013,
+    "seconds": 3498241595,
+    "expected_floor": "57712624394200021764"
+  },
+  {
+    "principal": "10722341211482465966",
+    "rate_bps": 8333,
+    "seconds": 1702934416,
+    "expected_floor": "482153097071541681692"
+  },
+  {
+    "principal": "15793456117057074591",
+    "rate_bps": 5418,
+    "seconds": 388017641,
+    "expected_floor": "105211613924197426961"
+  },
+  {
+    "principal": "10020648583978134084",
+    "rate_bps": 8030,
+    "seconds": 3499251990,
+    "expected_floor": "892241929752473659320"
+  },
+  {
+    "principal": "14661386332327187501",
+    "rate_bps": 1226,
+    "seconds": 1419457319,
+    "expected_floor": "80850717668228538700"
+  },
+  {
+    "principal": "7755256618484422698",
+    "rate_bps": 4979,
+    "seconds": 2845543788,
+    "expected_floor": "348176620234664917422"
+  },
+  {
+    "principal": "15324351641734607179",
+    "rate_bps": 2371,
+    "seconds": 1459992949,
+    "expected_floor": "168097190257899515640"
+  },
+  {
+    "principal": "3160667656244372960",
+    "rate_bps": 9514,
+    "seconds": 3285206546,
+    "expected_floor": "313040617627034423442"
+  },
+  {
+    "principal": "1471882937996722297",
+    "rate_bps": 4249,
+    "seconds": 1146249299,
+    "expected_floor": "22716170416132803618"
+  },
+  {
+    "principal": "16786635947960343782",
+    "rate_bps": 4107,
+    "seconds": 3528763528,
+    "expected_floor": "770915830461882774342"
+  },
+  {
+    "principal": "17407456105424787767",
+    "rate_bps": 9192,
+    "seconds": 2675247937,
+    "expected_floor": "1356455013780252489712"
+  },
+  {
+    "principal": "9094664914708249276",
+    "rate_bps": 9960,
+    "seconds": 631074382,
+    "expected_floor": "181143445648097597968"
+  },
+  {
+    "principal": "17014330003421304581",
+    "rate_bps": 9514,
+    "seconds": 1956594111,
+    "expected_floor": "1003632633216142048302"
+  },
+  {
+    "principal": "13412703828129534178",
+    "rate_bps": 6288,
+    "seconds": 3149743332,
+    "expected_floor": "841782835580376535787"
+  },
+  {
+    "principal": "9085560248639273315",
+    "rate_bps": 3784,
+    "seconds": 3930918733,
+    "expected_floor": "428245628770156657576"
+  },
+  {
+    "principal": "16083016193146578136",
+    "rate_bps": 7935,
+    "seconds": 1958161866,
+    "expected_floor": "791879411971955253390"
+  },
+  {
+    "principal": "10519884305338188753",
+    "rate_bps": 8632,
+    "seconds": 320529259,
+    "expected_floor": "92232951761276800690"
+  },
+  {
+    "principal": "3162362665150091294",
+    "rate_bps": 8125,
+    "seconds": 2939018880,
+    "expected_floor": "239294905422311250911"
+  },
+  {
+    "principal": "13109113453100473807",
+    "rate_bps": 1051,
+    "seconds": 681341337,
+    "expected_floor": "29746564099482191179"
+  },
+  {
+    "principal": "13399402704452673588",
+    "rate_bps": 4667,
+    "seconds": 2332565638,
+    "expected_floor": "462224697526793540168"
+  },
+  {
+    "principal": "10687715414503699165",
+    "rate_bps": 4633,
+    "seconds": 3786182999,
+    "expected_floor": "594079840589021402865"
+  },
+  {
+    "principal": "1123161786447181466",
+    "rate_bps": 6553,
+    "seconds": 1591882076,
+    "expected_floor": "37126961920648914826"
+  },
+  {
+    "principal": "3720657261022073467",
+    "rate_bps": 1141,
+    "seconds": 1861099045,
+    "expected_floor": "25036339333384752584"
+  },
+  {
+    "principal": "14940474374564620496",
+    "rate_bps": 5281,
+    "seconds": 3798213250,
+    "expected_floor": "949633292538490521535"
+  },
+  {
+    "principal": "4445627112791609385",
+    "rate_bps": 9574,
+    "seconds": 1584781187,
+    "expected_floor": "213742948263026932328"
+  },
+  {
+    "principal": "7841363905992941654",
+    "rate_bps": 3856,
+    "seconds": 4208277880,
+    "expected_floor": "403207940993410879786"
+  },
+  {
+    "principal": "18031427281334641511",
+    "rate_bps": 2786,
+    "seconds": 1272266993,
+    "expected_floor": "202528203317384418390"
+  },
+  {
+    "principal": "6771090474580081324",
+    "rate_bps": 8336,
+    "seconds": 1216630718,
+    "expected_floor": "217606133944077895492"
+  },
+  {
+    "principal": "13358814631784531893",
+    "rate_bps": 7581,
+    "seconds": 1677623791,
+    "expected_floor": "538375179445578426895"
+  },
+  {
+    "principal": "9778552649479940434",
+    "rate_bps": 6675,
+    "seconds": 1524445908,
+    "expected_floor": "315307208952900544604"
+  },
+  {
+    "principal": "11298762031108496531",
+    "rate_bps": 9360,
+    "seconds": 1958299133,
+    "expected_floor": "656268826291147937970"
+  },
+  {
+    "principal": "8622896512825971144",
+    "rate_bps": 2712,
+    "seconds": 507708474,
+    "expected_floor": "37622989747395837081"
+  },
+  {
+    "principal": "7576489389573408129",
+    "rate_bps": 2382,
+    "seconds": 228629659,
+    "expected_floor": "13074900062085495532"
+  },
+  {
+    "principal": "1569617020638129550",
+    "rate_bps": 7051,
+    "seconds": 2047318384,
+    "expected_floor": "71800229644313983083"
+  },
+  {
+    "principal": "12579584704909150719",
+    "rate_bps": 324,
+    "seconds": 887216457,
+    "expected_floor": "11458741860801732246"
+  },
+  {
+    "principal": "13095750024965581348",
+    "rate_bps": 8499,
+    "seconds": 2115492854,
+    "expected_floor": "746115051831815445284"
+  },
+  {
+    "principal": "10909942193001477517",
+    "rate_bps": 7211,
+    "seconds": 3962860423,
+    "expected_floor": "987922221345377511617"
+  },
+  {
+    "principal": "8018100729908742410",
+    "rate_bps": 7828,
+    "seconds": 3207932236,
+    "expected_floor": "638033590417662746388"
+  },
+  {
+    "principal": "5861626352661723051",
+    "rate_bps": 296,
+    "seconds": 1254287061,
+    "expected_floor": "6896088355279950792"
+  },
+  {
+    "principal": "15509281947232157632",
+    "rate_bps": 7540,
+    "seconds": 3855856370,
+    "expected_floor": "1428827887644570044336"
+  },
+  {
+    "principal": "9535565020746613721",
+    "rate_bps": 7238,
+    "seconds": 3606876851,
+    "expected_floor": "788846236787885354909"
+  },
+  {
+    "principal": "15286925753091037126",
+    "rate_bps": 5793,
+    "seconds": 3472219752,
+    "expected_floor": "974376768877108300145"
+  },
+  {
+    "principal": "9786863090195575191",
+    "rate_bps": 3622,
+    "seconds": 529046177,
+    "expected_floor": "59426694250337602063"
+  },
+  {
+    "principal": "14871016425230012060",
+    "rate_bps": 3337,
+    "seconds": 1067230510,
+    "expected_floor": "167822862811754705691"
+  },
+  {
+    "principal": "9799350759201463397",
+    "rate_bps": 5172,
+    "seconds": 3838952991,
+    "expected_floor": "616544810132769161565"
+  },
+  {
+    "principal": "10120757864136684994",
+    "rate_bps": 2452,
+    "seconds": 3802461380,
+    "expected_floor": "299015943300097123368"
+  },
+  {
+    "principal": "11581496073589867459",
+    "rate_bps": 940,
+    "seconds": 2229493933,
+    "expected_floor": "76912131205364207570"
+  },
+  {
+    "principal": "3969174208562746040",
+    "rate_bps": 7563,
+    "seconds": 1714032298,
+    "expected_floor": "163045679550251017307"
+  },
+  {
+    "principal": "17577449207575636785",
+    "rate_bps": 7911,
+    "seconds": 1502550475,
+    "expected_floor": "662082851150447122550"
+  },
+  {
+    "principal": "6556208646005571326",
+    "rate_bps": 8900,
+    "seconds": 3771000928,
+    "expected_floor": "697261113346429492025"
+  },
+  {
+    "principal": "10640318533817072175",
+    "rate_bps": 8266,
+    "seconds": 1695802617,
+    "expected_floor": "472630086593944628081"
+  },
+  {
+    "principal": "7218955028502628372",
+    "rate_bps": 5120,
+    "seconds": 2151713638,
+    "expected_floor": "252014078425233398727"
+  },
+  {
+    "principal": "262168338275605565",
+    "rate_bps": 112,
+    "seconds": 2478692791,
+    "expected_floor": "230630638111154216"
+  },
+  {
+    "principal": "18107883326702063482",
+    "rate_bps": 243,
+    "seconds": 2996532540,
+    "expected_floor": "41781977632689566819"
+  },
+  {
+    "principal": "9394394789296726235",
+    "rate_bps": 3069,
+    "seconds": 288822149,
+    "expected_floor": "26387134053025530185"
+  },
+  {
+    "principal": "11437259891441265328",
+    "rate_bps": 1001,
+    "seconds": 3480090466,
+    "expected_floor": "126253269591078888791"
+  },
+  {
+    "principal": "5327764217774709641",
+    "rate_bps": 7088,
+    "seconds": 1182896611,
+    "expected_floor": "141550538554204735881"
+  },
+  {
+    "principal": "16649373102721778486",
+    "rate_bps": 4220,
+    "seconds": 2467141464,
+    "expected_floor": "549288392799889074725"
+  },
+  {
+    "principal": "3832929642614342599",
+    "rate_bps": 9770,
+    "seconds": 433199185,
+    "expected_floor": "51405439304762984830"
+  },
+  {
+    "principal": "9538133306169292428",
+    "rate_bps": 4767,
+    "seconds": 3456462494,
+    "expected_floor": "498008117123766016313"
+  },
+  {
+    "principal": "6733593093937976597",
+    "rate_bps": 8723,
+    "seconds": 2344881743,
+    "expected_floor": "436445197899752240737"
+  },
+  {
+    "principal": "10520443478305027634",
+    "rate_bps": 455,
+    "seconds": 1388022452,
+    "expected_floor": "21054162381050462435"
+  },
+  {
+    "principal": "10655152198963572467",
+    "rate_bps": 6665,
+    "seconds": 3718143837,
+    "expected_floor": "836723623548752892161"
+  },
+  {
+    "principal": "17536661409888102312",
+    "rate_bps": 6579,
+    "seconds": 3092991258,
+    "expected_floor": "1130788879140910453968"
+  },
+  {
+    "principal": "16825581808230200545",
+    "rate_bps": 2552,
+    "seconds": 2594265851,
+    "expected_floor": "352989081713367362958"
+  },
+  {
+    "principal": "16680259194908968046",
+    "rate_bps": 7837,
+    "seconds": 3445410640,
+    "expected_floor": "1427215866339511548235"
+  },
+  {
+    "principal": "6047244662851497567",
+    "rate_bps": 9307,
+    "seconds": 982881449,
+    "expected_floor": "175292939961562455634"
+  },
+  {
+    "principal": "5604701377311767044",
+    "rate_bps": 6822,
+    "seconds": 3712036566,
+    "expected_floor": "449751345887566058448"
+  },
+  {
+    "principal": "13268531257335539437",
+    "rate_bps": 7086,
+    "seconds": 773047271,
+    "expected_floor": "230317047279244765368"
+  },
+  {
+    "principal": "10242374775272081898",
+    "rate_bps": 3773,
+    "seconds": 207361324,
+    "expected_floor": "25392838947547774232"
+  },
+  {
+    "principal": "9605210620516634123",
+    "rate_bps": 2259,
+    "seconds": 222143541,
+    "expected_floor": "15274002119620849324"
+  },
+  {
+    "principal": "12087944069621000608",
+    "rate_bps": 2485,
+    "seconds": 1371664338,
+    "expected_floor": "130563780113486841645"
+  },
+  {
+    "principal": "2014934293497894713",
+    "rate_bps": 7540,
+    "seconds": 3890205971,
+    "expected_floor": "187284080617112361912"
+  },
+  {
+    "principal": "4309118390427148966",
+    "rate_bps": 4886,
+    "seconds": 3534971976,
+    "expected_floor": "235843492228396344208"
+  },
+  {
+    "principal": "7547573898189462007",
+    "rate_bps": 8839,
+    "seconds": 1781840385,
+    "expected_floor": "376682408472829531783"
+  },
+  {
+    "principal": "1429744616626172540",
+    "rate_bps": 9705,
+    "seconds": 3827149838,
+    "expected_floor": "168277289622915323310"
+  },
+  {
+    "principal": "224873518626484677",
+    "rate_bps": 9964,
+    "seconds": 1002461823,
+    "expected_floor": "7117638217227991240"
+  },
+  {
+    "principal": "6751297095611148962",
+    "rate_bps": 9545,
+    "seconds": 2382886052,
+    "expected_floor": "486589194695005356590"
+  },
+  {
+    "principal": "6589850824088673827",
+    "rate_bps": 5728,
+    "seconds": 3187491341,
+    "expected_floor": "381262103258277770691"
+  },
+  {
+    "principal": "16664212396688117912",
+    "rate_bps": 4582,
+    "seconds": 1778761610,
+    "expected_floor": "430381562440840057025"
+  },
+  {
+    "principal": "11014134714662494865",
+    "rate_bps": 126,
+    "seconds": 2933022763,
+    "expected_floor": "12898297674536576038"
+  },
+  {
+    "principal": "347495048467627486",
+    "rate_bps": 4109,
+    "seconds": 3909501504,
+    "expected_floor": "17688955090565173351"
+  },
+  {
+    "principal": "5000914541658171023",
+    "rate_bps": 8763,
+    "seconds": 1057613913,
+    "expected_floor": "146867408966304899714"
+  },
+  {
+    "principal": "15188387731621707764",
+    "rate_bps": 4423,
+    "seconds": 3323512390,
+    "expected_floor": "707492678294218633348"
+  },
+  {
+    "principal": "5718157444259845533",
+    "rate_bps": 7430,
+    "seconds": 2000761367,
+    "expected_floor": "269361950818174584090"
+  },
+  {
+    "principal": "2506710259848558682",
+    "rate_bps": 2331,
+    "seconds": 2063468828,
+    "expected_floor": "38206772953586234822"
+  },
+  {
+    "principal": "4409847931153153851",
+    "rate_bps": 1524,
+    "seconds": 1577687269,
+    "expected_floor": "33598936773868832368"
+  },
+  {
+    "principal": "2343481079932517520",
+    "rate_bps": 282,
+    "seconds": 1084136514,
+    "expected_floor": "2270338242552299799"
+  },
+  {
+    "principal": "15661012881845499625",
+    "rate_bps": 726,
+    "seconds": 3358743619,
+    "expected_floor": "121012255250608793633"
+  },
+  {
+    "principal": "13246842934110058006",
+    "rate_bps": 6026,
+    "seconds": 1354646840,
+    "expected_floor": "342660177472141389762"
+  },
+  {
+    "principal": "10706453370329658407",
+    "rate_bps": 5273,
+    "seconds": 544440241,
+    "expected_floor": "97397913125556557484"
+  },
+  {
+    "principal": "630584366096106092",
+    "rate_bps": 2304,
+    "seconds": 260332926,
+    "expected_floor": "1198535236071399469"
+  },
+  {
+    "principal": "9586377077148578421",
+    "rate_bps": 2908,
+    "seconds": 1441901231,
+    "expected_floor": "127373902659080682952"
+  },
+  {
+    "principal": "9420500501300663058",
+    "rate_bps": 406,
+    "seconds": 1253126804,
+    "expected_floor": "15187666882848413323"
+  },
+  {
+    "principal": "3809919641405935955",
+    "rate_bps": 3408,
+    "seconds": 2438138045,
+    "expected_floor": "100315888942645745165"
+  },
+  {
+    "principal": "11471676266421603720",
+    "rate_bps": 3756,
+    "seconds": 697853434,
+    "expected_floor": "95282406862458989655"
+  },
+  {
+    "principal": "5028864826723169345",
+    "rate_bps": 5674,
+    "seconds": 3730647387,
+    "expected_floor": "337318009505375982654"
+  },
+  {
+    "principal": "12603089693463210830",
+    "rate_bps": 6649,
+    "seconds": 2352500016,
+    "expected_floor": "624682051623106240245"
+  },
+  {
+    "principal": "719984938795393727",
+    "rate_bps": 6304,
+    "seconds": 3025395721,
+    "expected_floor": "43512880831917065633"
+  },
+  {
+    "principal": "10956560091524323812",
+    "rate_bps": 7726,
+    "seconds": 3238416822,
+    "expected_floor": "868675771164406583071"
+  },
+  {
+    "principal": "17968168334578624589",
+    "rate_bps": 2667,
+    "seconds": 3247514695,
+    "expected_floor": "493144258499728388349"
+  },
+  {
+    "principal": "15722525427668687562",
+    "rate_bps": 2990,
+    "seconds": 2018005260,
+    "expected_floor": "300615812515597800535"
+  },
+  {
+    "principal": "1217107474655392875",
+    "rate_bps": 9452,
+    "seconds": 2802708885,
+    "expected_floor": "102170769845498809621"
+  },
+  {
+    "principal": "15660976445661700992",
+    "rate_bps": 3995,
+    "seconds": 18021554,
+    "expected_floor": "3572924921950150006"
+  },
+  {
+    "principal": "1600948919975819929",
+    "rate_bps": 4147,
+    "seconds": 4141098867,
+    "expected_floor": "87121058429876059374"
+  },
+  {
+    "principal": "7769287948166724998",
+    "rate_bps": 3699,
+    "seconds": 4148509224,
+    "expected_floor": "377792769696508545391"
+  },
+  {
+    "principal": "2177107109029909079",
+    "rate_bps": 4591,
+    "seconds": 3700517217,
+    "expected_floor": "117204841191795634698"
+  },
+  {
+    "principal": "14570652151999309404",
+    "rate_bps": 1003,
+    "seconds": 3944252142,
+    "expected_floor": "182658810995585108678"
+  },
+  {
+    "principal": "6566770191067289381",
+    "rate_bps": 4977,
+    "seconds": 3921870559,
+    "expected_floor": "406170845941030135672"
+  },
+  {
+    "principal": "2311471707047194498",
+    "rate_bps": 9203,
+    "seconds": 35538052,
+    "expected_floor": "2395563323711647240"
+  },
+  {
+    "principal": "3910258311073302659",
+    "rate_bps": 264,
+    "seconds": 2670900077,
+    "expected_floor": "8737014333066492833"
+  },
+  {
+    "principal": "17689481278145240696",
+    "rate_bps": 9351,
+    "seconds": 1858224234,
+    "expected_floor": "974018728241455432510"
+  },
+  {
+    "principal": "9416839773985925617",
+    "rate_bps": 517,
+    "seconds": 196916875,
+    "expected_floor": "3037908521452457202"
+  },
+  {
+    "principal": "17960758131034787006",
+    "rate_bps": 4600,
+    "seconds": 2930371616,
+    "expected_floor": "767186987646454493797"
+  },
+  {
+    "principal": "11820048790441288431",
+    "rate_bps": 9912,
+    "seconds": 1150712761,
+    "expected_floor": "427212080328983682255"
+  },
+  {
+    "principal": "10328636140284348372",
+    "rate_bps": 4812,
+    "seconds": 428396838,
+    "expected_floor": "67470027393850712778"
+  },
+  {
+    "principal": "3388673500873236221",
+    "rate_bps": 662,
+    "seconds": 630102647,
+    "expected_floor": "4479144290059975143"
+  },
+  {
+    "principal": "6133961673307631930",
+    "rate_bps": 5215,
+    "seconds": 960621820,
+    "expected_floor": "97374188400879863885"
+  },
+  {
+    "principal": "17006651076255624603",
+    "rate_bps": 3775,
+    "seconds": 3221073477,
+    "expected_floor": "655288312471670455690"
+  },
+  {
+    "principal": "9276693340632145520",
+    "rate_bps": 6858,
+    "seconds": 4184740130,
+    "expected_floor": "843636201886273368162"
+  },
+  {
+    "principal": "13513574481021002313",
+    "rate_bps": 6746,
+    "seconds": 3042981539,
+    "expected_floor": "879046657708254790374"
+  },
+  {
+    "principal": "2047149452884113654",
+    "rate_bps": 9416,
+    "seconds": 3349103384,
+    "expected_floor": "204569359990993937317"
+  },
+  {
+    "principal": "11121651276669465735",
+    "rate_bps": 5675,
+    "seconds": 2127656721,
+    "expected_floor": "425532497072436780166"
+  },
+  {
+    "principal": "13953533768304156236",
+    "rate_bps": 5134,
+    "seconds": 2398690398,
+    "expected_floor": "544515568806685150325"
+  },
+  {
+    "principal": "3585697840266616789",
+    "rate_bps": 966,
+    "seconds": 3839842063,
+    "expected_floor": "42146373415364393780"
+  },
+  {
+    "principal": "6419804840386707442",
+    "rate_bps": 5432,
+    "seconds": 3774229108,
+    "expected_floor": "417067049640407654154"
+  },
+  {
+    "principal": "9555437986443723699",
+    "rate_bps": 5944,
+    "seconds": 3144630813,
+    "expected_floor": "565972197374807617991"
+  },
+  {
+    "principal": "14377568015378252648",
+    "rate_bps": 3126,
+    "seconds": 3933359834,
+    "expected_floor": "560188405782456590240"
+  },
+  {
+    "principal": "16873210724522886049",
+    "rate_bps": 9780,
+    "seconds": 3819702203,
+    "expected_floor": "1997386559569426746585"
+  },
+  {
+    "principal": "10743219604132307502",
+    "rate_bps": 6675,
+    "seconds": 3612483344,
+    "expected_floor": "820894998525728872839"
+  },
+  {
+    "principal": "4877206181129479967",
+    "rate_bps": 8281,
+    "seconds": 2989800297,
+    "expected_floor": "382641538267618686343"
+  },
+  {
+    "principal": "13901186527293245892",
+    "rate_bps": 6117,
+    "seconds": 1348420758,
+    "expected_floor": "363338830319409711139"
+  },
+  {
+    "principal": "10210854613024438701",
+    "rate_bps": 174,
+    "seconds": 2986644647,
+    "expected_floor": "16814769827881515580"
+  },
+  {
+    "principal": "13437882413282196394",
+    "rate_bps": 7093,
+    "seconds": 2654067948,
+    "expected_floor": "801620595177675390469"
+  },
+  {
+    "principal": "659369946960128715",
+    "rate_bps": 9250,
+    "seconds": 1691078389,
+    "expected_floor": "32683657742851917477"
+  },
+  {
+    "principal": "10111348141451079008",
+    "rate_bps": 3782,
+    "seconds": 20896146,
+    "expected_floor": "2532169743427487794"
+  },
+  {
+    "principal": "14323460335826972153",
+    "rate_bps": 1294,
+    "seconds": 2813430227,
+    "expected_floor": "165239703924513333711"
+  },
+  {
+    "principal": "16110658638020569190",
+    "rate_bps": 3923,
+    "seconds": 3395510280,
+    "expected_floor": "680037224792474407895"
+  },
+  {
+    "principal": "7783395899571133111",
+    "rate_bps": 9730,
+    "seconds": 3619072193,
+    "expected_floor": "868510835178607040424"
+  },
+  {
+    "principal": "12683847785981667900",
+    "rate_bps": 7748,
+    "seconds": 8726990,
+    "expected_floor": "2717697687705172891"
+  },
+  {
+    "principal": "5758868942528646277",
+    "rate_bps": 643,
+    "seconds": 1127330623,
+    "expected_floor": "13228040180819255303"
+  },
+  {
+    "principal": "15595044219616183394",
+    "rate_bps": 72,
+    "seconds": 3072320612,
+    "expected_floor": "10931548209212469762"
+  },
+  {
+    "principal": "11285776598642737891",
+    "rate_bps": 5091,
+    "seconds": 4129010893,
+    "expected_floor": "751755488881828659433"
+  },
+  {
+    "principal": "16897762314794105944",
+    "rate_bps": 2103,
+    "seconds": 4141322570,
+    "expected_floor": "466340959428315322173"
+  },
+  {
+    "principal": "17776097097350758737",
+    "rate_bps": 3192,
+    "seconds": 220601579,
+    "expected_floor": "39664679193982425624"
+  },
+  {
+    "principal": "13158977446872755102",
+    "rate_bps": 1353,
+    "seconds": 208135680,
+    "expected_floor": "11742552440045779766"
+  },
+  {
+    "principal": "11947614089377017679",
+    "rate_bps": 5901,
+    "seconds": 2278661913,
+    "expected_floor": "509076122124691533183"
+  },
+  {
+    "principal": "10313874544900366260",
+    "rate_bps": 8974,
+    "seconds": 2340989958,
+    "expected_floor": "686599516579120163481"
+  },
+  {
+    "principal": "17387944970073323613",
+    "rate_bps": 8309,
+    "seconds": 2617119447,
+    "expected_floor": "1198164901748048479527"
+  },
+  {
+    "principal": "13646922885066684954",
+    "rate_bps": 8414,
+    "seconds": 580853980,
+    "expected_floor": "211349024456821100803"
+  },
+  {
+    "principal": "9909118096423611387",
+    "rate_bps": 8593,
+    "seconds": 3853210533,
+    "expected_floor": "1039677362285528719049"
+  },
+  {
+    "principal": "14004885266939842640",
+    "rate_bps": 835,
+    "seconds": 3511965186,
+    "expected_floor": "130140438516659162389"
+  },
+  {
+    "principal": "9685625289112001961",
+    "rate_bps": 7003,
+    "seconds": 65216771,
+    "expected_floor": "14017388650981693967"
+  },
+  {
+    "principal": "4143050001036331990",
+    "rate_bps": 1192,
+    "seconds": 4285042936,
+    "expected_floor": "67057543638930553245"
+  },
+  {
+    "principal": "17658017777292412135",
+    "rate_bps": 2333,
+    "seconds": 1476656753,
+    "expected_floor": "192766817435245181459"
+  },
+  {
+    "principal": "2667698359251913260",
+    "rate_bps": 4165,
+    "seconds": 2723916606,
+    "expected_floor": "95905070218439379764"
+  },
+  {
+    "principal": "8496310064742554933",
+    "rate_bps": 1545,
+    "seconds": 1055200111,
+    "expected_floor": "43892437367427960235"
+  },
+  {
+    "principal": "5707145623429119186",
+    "rate_bps": 7961,
+    "seconds": 3888280148,
+    "expected_floor": "559809364382755868455"
+  },
+  {
+    "principal": "3178482746237470227",
+    "rate_bps": 5627,
+    "seconds": 1267403645,
+    "expected_floor": "71830312882904794223"
+  },
+  {
+    "principal": "7598541769487976776",
+    "rate_bps": 721,
+    "seconds": 123799482,
+    "expected_floor": "2149217560105837974"
+  },
+  {
+    "principal": "6101595433577816833",
+    "rate_bps": 9343,
+    "seconds": 1499854363,
+    "expected_floor": "270941094523652931093"
+  },
+  {
+    "principal": "978337644673116430",
+    "rate_bps": 7249,
+    "seconds": 3277996272,
+    "expected_floor": "73666723276855947714"
+  },
+  {
+    "principal": "837798951369571199",
+    "rate_bps": 5039,
+    "seconds": 3360696009,
+    "expected_floor": "44958253723847146424"
+  },
+  {
+    "principal": "16329775301564893604",
+    "rate_bps": 86,
+    "seconds": 105121654,
+    "expected_floor": "467807175028522874"
+  },
+  {
+    "principal": "10237428444916767501",
+    "rate_bps": 6367,
+    "seconds": 1858475271,
+    "expected_floor": "383865029062878305729"
+  },
+  {
+    "principal": "5598181354341313674",
+    "rate_bps": 6098,
+    "seconds": 3444619468,
+    "expected_floor": "372624724663000115781"
+  },
+  {
+    "principal": "12921204077823602987",
+    "rate_bps": 3422,
+    "seconds": 3608099925,
+    "expected_floor": "505542393839098770300"
+  },
+  {
+    "principal": "17772620952031217472",
+    "rate_bps": 6336,
+    "seconds": 1941800562,
+    "expected_floor": "692894800605136435163"
+  },
+  {
+    "principal": "15973434686534103385",
+    "rate_bps": 6638,
+    "seconds": 3260021811,
+    "expected_floor": "1095347943002509252769"
+  },
+  {
+    "principal": "9852738465740038982",
+    "rate_bps": 4465,
+    "seconds": 1304810984,
+    "expected_floor": "181895541893413648743"
+  },
+  {
+    "principal": "7258158477927002903",
+    "rate_bps": 7667,
+    "seconds": 3233576993,
+    "expected_floor": "570205167616291940059"
+  },
+  {
+    "principal": "9504289754700971548",
+    "rate_bps": 3868,
+    "seconds": 2757468334,
+    "expected_floor": "321227487015094358406"
+  },
+  {
+    "principal": "11688975406244762085",
+    "rate_bps": 2770,
+    "seconds": 2154067871,
+    "expected_floor": "221009850045560533472"
+  },
+  {
+    "principal": "15855130137813281090",
+    "rate_bps": 5792,
+    "seconds": 1497683012,
+    "expected_floor": "435827169614099196885"
+  },
+  {
+    "principal": "5982654025590541635",
+    "rate_bps": 1633,
+    "seconds": 1414546989,
+    "expected_floor": "43791869387604715707"
+  },
+  {
+    "principal": "15350110611417934392",
+    "rate_bps": 9533,
+    "seconds": 415085098,
+    "expected_floor": "192474977382034111937"
+  },
+  {
+    "principal": "10515081044176447665",
+    "rate_bps": 8329,
+    "seconds": 4091974475,
+    "expected_floor": "1135623668171956505150"
+  },
+  {
+    "principal": "3891322619750292094",
+    "rate_bps": 1242,
+    "seconds": 3505926112,
+    "expected_floor": "53692994593492865735"
+  },
+  {
+    "principal": "7119671312047934383",
+    "rate_bps": 2616,
+    "seconds": 2664649337,
+    "expected_floor": "157265616480523452945"
+  },
+  {
+    "principal": "15879287269163796372",
+    "rate_bps": 2519,
+    "seconds": 2165331686,
+    "expected_floor": "274460365303975163897"
+  },
+  {
+    "principal": "13759930459930812861",
+    "rate_bps": 3199,
+    "seconds": 1005034295,
+    "expected_floor": "140186887554620260152"
+  },
+  {
+    "principal": "414352073889485562",
+    "rate_bps": 2097,
+    "seconds": 541959356,
+    "expected_floor": "1492212584631574618"
+  },
+  {
+    "principal": "13800770330013383259",
+    "rate_bps": 7661,
+    "seconds": 3249178885,
+    "expected_floor": "1088575225199761700906"
+  },
+  {
+    "principal": "5806998347067953712",
+    "rate_bps": 2336,
+    "seconds": 3016321762,
+    "expected_floor": "129657678453582186754"
+  },
+  {
+    "principal": "2429957418472401161",
+    "rate_bps": 9548,
+    "seconds": 3448970083,
+    "expected_floor": "253569219440641337693"
+  },
+  {
+    "principal": "14688234614409424566",
+    "rate_bps": 7445,
+    "seconds": 1943154392,
+    "expected_floor": "673345007525212193723"
+  },
+  {
+    "principal": "15325804305597785415",
+    "rate_bps": 409,
+    "seconds": 3542291921,
+    "expected_floor": "70360183806085806885"
+  },
+  {
+    "principal": "13518018748896380428",
+    "rate_bps": 9919,
+    "seconds": 1940130334,
+    "expected_floor": "824342846498119263124"
+  },
+  {
+    "principal": "6344358617431943829",
+    "rate_bps": 4693,
+    "seconds": 1314578383,
+    "expected_floor": "124028301764991415553"
+  },
+  {
+    "principal": "14475841142067005874",
+    "rate_bps": 1473,
+    "seconds": 1699613236,
+    "expected_floor": "114839870168640256245"
+  },
+  {
+    "principal": "8814946643862558835",
+    "rate_bps": 9321,
+    "seconds": 4114506973,
+    "expected_floor": "1071262818063117448670"
+  },
+  {
+    "principal": "18066456422279405352",
+    "rate_bps": 1392,
+    "seconds": 551325850,
+    "expected_floor": "43935604055294457480"
+  },
+  {
+    "principal": "2263511476730548833",
+    "rate_bps": 2742,
+    "seconds": 2455958651,
+    "expected_floor": "48302235929762314763"
+  },
+  {
+    "principal": "16611364556247957486",
+    "rate_bps": 2518,
+    "seconds": 1495315152,
+    "expected_floor": "198193680263954412352"
+  },
+  {
+    "principal": "12421734516092837855",
+    "rate_bps": 4429,
+    "seconds": 247341609,
+    "expected_floor": "43120236868738773307"
+  },
+  {
+    "principal": "11890444210821847428",
+    "rate_bps": 8571,
+    "seconds": 2980878934,
+    "expected_floor": "962653392034372596778"
+  },
+  {
+    "principal": "16012024434065755245",
+    "rate_bps": 5105,
+    "seconds": 3408766311,
+    "expected_floor": "882948254944117790483"
+  },
+  {
+    "principal": "10698247511940705642",
+    "rate_bps": 9138,
+    "seconds": 148694188,
+    "expected_floor": "46063169945114063722"
+  },
+  {
+    "principal": "12592812557884524427",
+    "rate_bps": 6102,
+    "seconds": 3530570165,
+    "expected_floor": "859678018320397233514"
+  },
+  {
+    "principal": "7834555728262820128",
+    "rate_bps": 8543,
+    "seconds": 2382824274,
+    "expected_floor": "505373923227516382934"
+  },
+  {
+    "principal": "2867285204433814713",
+    "rate_bps": 5448,
+    "seconds": 847740563,
+    "expected_floor": "41963044488694374104"
+  },
+  {
+    "principal": "5609172026852027942",
+    "rate_bps": 3235,
+    "seconds": 4146371528,
+    "expected_floor": "238417039611730061580"
+  },
+  {
+    "principal": "14955939024899349367",
+    "rate_bps": 2974,
+    "seconds": 12244865,
+    "expected_floor": "1725856507188003163"
+  },
+  {
+    "principal": "12056697359329747452",
+    "rate_bps": 6044,
+    "seconds": 714336142,
+    "expected_floor": "164949678008897716500"
+  },
+  {
+    "principal": "12633214600077944645",
+    "rate_bps": 5946,
+    "seconds": 3182644223,
+    "expected_floor": "757570237616427293734"
+  },
+  {
+    "principal": "5844512293744434722",
+    "rate_bps": 8546,
+    "seconds": 3368358948,
+    "expected_floor": "533120722089914276752"
+  },
+  {
+    "principal": "486039864261601187",
+    "rate_bps": 6355,
+    "seconds": 258500493,
+    "expected_floor": "2530141758193130204"
+  },
+  {
+    "principal": "5304360062820657176",
+    "rate_bps": 3697,
+    "seconds": 2129437450,
+    "expected_floor": "132325446375846319458"
+  },
+  {
+    "principal": "15841014437159116817",
+    "rate_bps": 2594,
+    "seconds": 2765494699,
+    "expected_floor": "360098924913247965697"
+  },
+  {
+    "principal": "2702028379888867678",
+    "rate_bps": 6266,
+    "seconds": 3205679552,
+    "expected_floor": "171987322970077824587"
+  },
+  {
+    "principal": "10518763728282531855",
+    "rate_bps": 7829,
+    "seconds": 2746455513,
+    "expected_floor": "716703614685222717084"
+  },
+  {
+    "principal": "786863011655352180",
+    "rate_bps": 8526,
+    "seconds": 3004682694,
+    "expected_floor": "63876205230139943713"
+  },
+  {
+    "principal": "3381365359753206557",
+    "rate_bps": 1212,
+    "seconds": 3399693207,
+    "expected_floor": "44149976775334506059"
+  },
+  {
+    "principal": "545174739083230170",
+    "rate_bps": 8320,
+    "seconds": 3481630876,
+    "expected_floor": "50042362982830502127"
+  },
+  {
+    "principal": "17226851922175006907",
+    "rate_bps": 6393,
+    "seconds": 2324909669,
+    "expected_floor": "811358409130262588641"
+  },
+  {
+    "principal": "17677701635074778128",
+    "rate_bps": 9884,
+    "seconds": 2688896962,
+    "expected_floor": "1488773842444398227685"
+  },
+  {
+    "principal": "4813950019420931177",
+    "rate_bps": 6621,
+    "seconds": 1346905539,
+    "expected_floor": "136037404289292455444"
+  },
+  {
+    "principal": "605424606174568854",
+    "rate_bps": 4153,
+    "seconds": 345251000,
+    "expected_floor": "2750761752425976070"
+  },
+  {
+    "principal": "10665713968876082599",
+    "rate_bps": 719,
+    "seconds": 457620785,
+    "expected_floor": "11120404830840130972"
+  },
+  {
+    "principal": "14297199970228834796",
+    "rate_bps": 6952,
+    "seconds": 13252862,
+    "expected_floor": "4174134737970312516"
+  },
+  {
+    "principal": "9587264356501915637",
+    "rate_bps": 4807,
+    "seconds": 3784883247,
+    "expected_floor": "552735482804957294718"
+  },
+  {
+    "principal": "6142124285842876050",
+    "rate_bps": 7005,
+    "seconds": 2479944212,
+    "expected_floor": "338115191371603104739"
+  },
+  {
+    "principal": "14599662282831952595",
+    "rate_bps": 3011,
+    "seconds": 807489085,
+    "expected_floor": "112482836342236914910"
+  },
+  {
+    "principal": "1291241414265636104",
+    "rate_bps": 7938,
+    "seconds": 1801251194,
+    "expected_floor": "58504443952886579881"
+  },
+  {
+    "principal": "8282479100595147201",
+    "rate_bps": 4043,
+    "seconds": 2239431387,
+    "expected_floor": "237628148267165808290"
+  },
+  {
+    "principal": "16815770556185487054",
+    "rate_bps": 5437,
+    "seconds": 2504357040,
+    "expected_floor": "725551733598538628885"
+  },
+  {
+    "principal": "16689267455724377151",
+    "rate_bps": 5283,
+    "seconds": 563522953,
+    "expected_floor": "157443787342950686994"
+  },
+  {
+    "principal": "3370186634291575140",
+    "rate_bps": 5552,
+    "seconds": 1972436278,
+    "expected_floor": "116950591844463472895"
+  },
+  {
+    "principal": "302672383937859021",
+    "rate_bps": 7318,
+    "seconds": 4271064519,
+    "expected_floor": "29977634998988874757"
+  },
+  {
+    "principal": "12344833117158866506",
+    "rate_bps": 3276,
+    "seconds": 135159948,
+    "expected_floor": "17321008122146041264"
+  },
+  {
+    "principal": "17697523043385994731",
+    "rate_bps": 3121,
+    "seconds": 1871103765,
+    "expected_floor": "327491596745878926889"
+  },
+  {
+    "principal": "17859216898102979328",
+    "rate_bps": 6590,
+    "seconds": 2576568370,
+    "expected_floor": "960916233571553826856"
+  },
+  {
+    "principal": "6606782640046434329",
+    "rate_bps": 7438,
+    "seconds": 137367795,
+    "expected_floor": "21390806197812469905"
+  },
+  {
+    "principal": "18214911090317461766",
+    "rate_bps": 1086,
+    "seconds": 2956439976,
+    "expected_floor": "185319867033857186473"
+  },
+  {
+    "principal": "8000984765637071831",
+    "rate_bps": 378,
+    "seconds": 80332513,
+    "expected_floor": "769879275990484973"
+  },
+  {
+    "principal": "8224928653746509276",
+    "rate_bps": 6847,
+    "seconds": 3139829358,
+    "expected_floor": "560317963647058627737"
+  },
+  {
+    "principal": "8695134633841642661",
+    "rate_bps": 8825,
+    "seconds": 4218826847,
+    "expected_floor": "1025837944213938543496"
+  },
+  {
+    "principal": "4436341067259323138",
+    "rate_bps": 8565,
+    "seconds": 433628164,
+    "expected_floor": "52211456603151671192"
+  },
+  {
+    "principal": "38514065385869827",
+    "rate_bps": 9548,
+    "seconds": 1090263277,
+    "expected_floor": "1270454719077004814"
+  },
+  {
+    "principal": "4536667428067112440",
+    "rate_bps": 1981,
+    "seconds": 1742496746,
+    "expected_floor": "49623732558215876604"
+  },
+  {
+    "principal": "7674362627436849009",
+    "rate_bps": 402,
+    "seconds": 2831986699,
+    "expected_floor": "27685706579239065201"
+  },
+  {
+    "principal": "12655469841379944510",
+    "rate_bps": 4711,
+    "seconds": 2372907936,
+    "expected_floor": "448299546128332093017"
+  },
+  {
+    "principal": "1875615758462383215",
+    "rate_bps": 2717,
+    "seconds": 881486137,
+    "expected_floor": "14234592235668083057"
+  },
+  {
+    "principal": "15303965896039221076",
+    "rate_bps": 6166,
+    "seconds": 781655206,
+    "expected_floor": "233732318606666117152"
+  },
+  {
+    "principal": "5851821644675015805",
+    "rate_bps": 456,
+    "seconds": 1904794615,
+    "expected_floor": "16106460474380626441"
+  },
+  {
+    "principal": "16620081190540981434",
+    "rate_bps": 6511,
+    "seconds": 2172558460,
+    "expected_floor": "744986393307915656562"
+  },
+  {
+    "principal": "10643767326072538907",
+    "rate_bps": 4121,
+    "seconds": 3137184709,
+    "expected_floor": "436047809599959703055"
+  },
+  {
+    "principal": "6645225328537306608",
+    "rate_bps": 928,
+    "seconds": 2856322210,
+    "expected_floor": "55816283742166858281"
+  },
+  {
+    "principal": "2736055698876968905",
+    "rate_bps": 7210,
+    "seconds": 3990503459,
+    "expected_floor": "249450238472118732889"
+  },
+  {
+    "principal": "15909402596833830006",
+    "rate_bps": 3170,
+    "seconds": 1164335768,
+    "expected_floor": "186074733745557667554"
+  },
+  {
+    "principal": "7178450716653966855",
+    "rate_bps": 9807,
+    "seconds": 1602679953,
+    "expected_floor": "357527733648193330774"
+  },
+  {
+    "principal": "13927054618813623756",
+    "rate_bps": 9889,
+    "seconds": 465975262,
+    "expected_floor": "203362349051376200565"
+  },
+  {
+    "principal": "16389917648809129301",
+    "rate_bps": 4551,
+    "seconds": 2868291727,
+    "expected_floor": "677958265892907390797"
+  },
+  {
+    "principal": "102503732194644850",
+    "rate_bps": 712,
+    "seconds": 3783469556,
+    "expected_floor": "874995760438020919"
+  },
+  {
+    "principal": "10084241093379616051",
+    "rate_bps": 4803,
+    "seconds": 936101789,
+    "expected_floor": "143672918865314657017"
+  },
+  {
+    "principal": "13554806919446756072",
+    "rate_bps": 1173,
+    "seconds": 2941915738,
+    "expected_floor": "148223686426076494286"
+  },
+  {
+    "principal": "6825942740752752929",
+    "rate_bps": 5729,
+    "seconds": 3448119611,
+    "expected_floor": "427287136547585265702"
+  },
+  {
+    "principal": "13523909959087988142",
+    "rate_bps": 761,
+    "seconds": 1753777808,
+    "expected_floor": "57194929707991266315"
+  },
+  {
+    "principal": "13880458428594821279",
+    "rate_bps": 4113,
+    "seconds": 552716521,
+    "expected_floor": "99991019920428126766"
+  },
+  {
+    "principal": "6884695410610301252",
+    "rate_bps": 7007,
+    "seconds": 3370725398,
+    "expected_floor": "515271657762356880883"
+  },
+  {
+    "principal": "628206335683321645",
+    "rate_bps": 8267,
+    "seconds": 2756638247,
+    "expected_floor": "45365537423664043384"
+  },
+  {
+    "principal": "13881873112340438826",
+    "rate_bps": 891,
+    "seconds": 907881580,
+    "expected_floor": "35583692464194739756"
+  },
+  {
+    "principal": "190356957199983691",
+    "rate_bps": 8645,
+    "seconds": 183166069,
+    "expected_floor": "955157102857384382"
+  },
+  {
+    "principal": "10022697126529643744",
+    "rate_bps": 1776,
+    "seconds": 4091178258,
+    "expected_floor": "230766096450126196468"
+  },
+  {
+    "principal": "15452351308041984889",
+    "rate_bps": 5608,
+    "seconds": 1998697299,
+    "expected_floor": "548839849636992043895"
+  },
+  {
+    "principal": "10243285334831477734",
+    "rate_bps": 1876,
+    "seconds": 3602323336,
+    "expected_floor": "219356662099994077526"
+  },
+  {
+    "principal": "769695967844441143",
+    "rate_bps": 2682,
+    "seconds": 1040270913,
+    "expected_floor": "6804880033829075920"
+  },
+  {
+    "principal": "13330059222353713596",
+    "rate_bps": 7159,
+    "seconds": 1376380238,
+    "expected_floor": "416216126000199144596"
+  },
+  {
+    "principal": "9669931167919145477",
+    "rate_bps": 1029,
+    "seconds": 503653567,
+    "expected_floor": "15880592598304672221"
+  },
+  {
+    "principal": "10187110612517304290",
+    "rate_bps": 2523,
+    "seconds": 2495054820,
+    "expected_floor": "203209682536396061204"
+  },
+  {
+    "principal": "110347148457659491",
+    "rate_bps": 7984,
+    "seconds": 3332594253,
+    "expected_floor": "9303794667258954188"
+  },
+  {
+    "principal": "17982546148706718680",
+    "rate_bps": 5565,
+    "seconds": 2785342666,
+    "expected_floor": "883264990427733305791"
+  },
+  {
+    "principal": "6352654426582859473",
+    "rate_bps": 1913,
+    "seconds": 748836459,
+    "expected_floor": "28837208335549466091"
+  },
+  {
+    "principal": "14452140833372555038",
+    "rate_bps": 3132,
+    "seconds": 3871796608,
+    "expected_floor": "555344539990662013037"
+  },
+  {
+    "principal": "4318664655442657487",
+    "rate_bps": 2059,
+    "seconds": 1936706713,
+    "expected_floor": "54571478444867035075"
+  },
+  {
+    "principal": "7385556141748215604",
+    "rate_bps": 7387,
+    "seconds": 1418082182,
+    "expected_floor": "245159505084455538311"
+  },
+  {
+    "principal": "10271825417711697373",
+    "rate_bps": 582,
+    "seconds": 3186660439,
+    "expected_floor": "60367395056826413507"
+  },
+  {
+    "principal": "5416649746266439066",
+    "rate_bps": 3331,
+    "seconds": 997265500,
+    "expected_floor": "57018030849335804971"
+  },
+  {
+    "principal": "12088590952502986107",
+    "rate_bps": 4267,
+    "seconds": 293701925,
+    "expected_floor": "48006622375715076807"
+  },
+  {
+    "principal": "10742457426826426320",
+    "rate_bps": 642,
+    "seconds": 4180773250,
+    "expected_floor": "91367410363513458134"
+  },
+  {
+    "principal": "15510881146475785001",
+    "rate_bps": 1976,
+    "seconds": 740387459,
+    "expected_floor": "71908213148931038499"
+  },
+  {
+    "principal": "15114261765373638486",
+    "rate_bps": 3098,
+    "seconds": 3724601464,
+    "expected_floor": "552642391825206743606"
+  },
+  {
+    "principal": "2721861020631688807",
+    "rate_bps": 5413,
+    "seconds": 3539713009,
+    "expected_floor": "165260117853361769993"
+  },
+  {
+    "principal": "1440751430341826988",
+    "rate_bps": 6488,
+    "seconds": 1787823806,
+    "expected_floor": "52956667714086383360"
+  },
+  {
+    "principal": "3108073791845495477",
+    "rate_bps": 21,
+    "seconds": 1087153391,
+    "expected_floor": "224852372195427502"
+  },
+  {
+    "principal": "14457277908115132498",
+    "rate_bps": 7998,
+    "seconds": 4036800980,
+    "expected_floor": "1479112818191614417865"
+  },
+  {
+    "principal": "6006643444729966483",
+    "rate_bps": 2522,
+    "seconds": 198562045,
+    "expected_floor": "9531674543881467315"
+  },
+  {
+    "principal": "10415596262629556424",
+    "rate_bps": 4711,
+    "seconds": 1229720378,
+    "expected_floor": "191205175788504523911"
+  },
+  {
+    "principal": "17388295238092144769",
+    "rate_bps": 8755,
+    "seconds": 2841399195,
+    "expected_floor": "1370696935904224433223"
+  },
+  {
+    "principal": "17989974374279963790",
+    "rate_bps": 9582,
+    "seconds": 3080841328,
+    "expected_floor": "1682875840320222380798"
+  },
+  {
+    "principal": "17966915060896689407",
+    "rate_bps": 3121,
+    "seconds": 2967958601,
+    "expected_floor": "527376963191033859462"
+  },
+  {
+    "principal": "7616110067863267620",
+    "rate_bps": 5404,
+    "seconds": 1991062262,
+    "expected_floor": "259674572939342102597"
+  },
+  {
+    "principal": "6788892740392288397",
+    "rate_bps": 8937,
+    "seconds": 3149444743,
+    "expected_floor": "605509179048460556540"
+  },
+  {
+    "principal": "13342275111055495178",
+    "rate_bps": 7978,
+    "seconds": 2990622796,
+    "expected_floor": "1008745465798603797824"
+  },
+  {
+    "principal": "12782539074849925803",
+    "rate_bps": 5458,
+    "seconds": 1161073109,
+    "expected_floor": "256688410065638164423"
+  },
+  {
+    "principal": "2537920559127645888",
+    "rate_bps": 1725,
+    "seconds": 240409074,
+    "expected_floor": "3335139560191153011"
+  },
+  {
+    "principal": "16170356665436364505",
+    "rate_bps": 7137,
+    "seconds": 3610535347,
+    "expected_floor": "1320392138407624699093"
+  },
+  {
+    "principal": "1740720000433401542",
+    "rate_bps": 2164,
+    "seconds": 1012583784,
+    "expected_floor": "12086851232077527277"
+  },
+  {
+    "principal": "14985073662540657815",
+    "rate_bps": 6812,
+    "seconds": 561599905,
+    "expected_floor": "181658858149508490319"
+  },
+  {
+    "principal": "11532667395238489500",
+    "rate_bps": 8698,
+    "seconds": 3208092718,
+    "expected_floor": "1019746244925190398765"
+  },
+  {
+    "principal": "15181176628017284965",
+    "rate_bps": 1973,
+    "seconds": 3988269343,
+    "expected_floor": "378541092783677433589"
+  },
+  {
+    "principal": "8558898764259531970",
+    "rate_bps": 7560,
+    "seconds": 3046749124,
+    "expected_floor": "624701304541022863681"
+  },
+  {
+    "principal": "12661132871917786819",
+    "rate_bps": 9797,
+    "seconds": 1106652077,
+    "expected_floor": "434983527561861917358"
+  },
+  {
+    "principal": "7844233159360709048",
+    "rate_bps": 8843,
+    "seconds": 2682148266,
+    "expected_floor": "589561253291676298787"
+  },
+  {
+    "principal": "15425223953914652209",
+    "rate_bps": 4845,
+    "seconds": 19860683,
+    "expected_floor": "4703438524713090437"
+  },
+  {
+    "principal": "12886115908726846974",
+    "rate_bps": 9683,
+    "seconds": 1775269728,
+    "expected_floor": "701927642666453646983"
+  },
+  {
+    "principal": "2806292207553027375",
+    "rate_bps": 8819,
+    "seconds": 108773369,
+    "expected_floor": "8530428473843315421"
+  },
+  {
+    "principal": "18314223777574143764",
+    "rate_bps": 4327,
+    "seconds": 3655148134,
+    "expected_floor": "917859964472269122116"
+  },
+  {
+    "principal": "5993869154710791997",
+    "rate_bps": 9164,
+    "seconds": 2704432311,
+    "expected_floor": "470721990545477849794"
+  },
+  {
+    "principal": "2511616496866924154",
+    "rate_bps": 3641,
+    "seconds": 3063206972,
+    "expected_floor": "88765944935060440959"
+  },
+  {
+    "principal": "2696329818882347995",
+    "rate_bps": 2628,
+    "seconds": 2427911813,
+    "expected_floor": "54516418479081454512"
+  },
+  {
+    "principal": "3717074532062673328",
+    "rate_bps": 1665,
+    "seconds": 3365002850,
+    "expected_floor": "65992863988702451048"
+  },
+  {
+    "principal": "13885601063411136137",
+    "rate_bps": 8096,
+    "seconds": 3035997411,
+    "expected_floor": "1081515163770106644717"
+  },
+  {
+    "principal": "14042468859290655286",
+    "rate_bps": 3426,
+    "seconds": 706463320,
+    "expected_floor": "107700192349799450924"
+  },
+  {
+    "principal": "10135972274434934471",
+    "rate_bps": 992,
+    "seconds": 2898072401,
+    "expected_floor": "92338401062800570413"
+  },
+  {
+    "principal": "14658112943642514828",
+    "rate_bps": 5066,
+    "seconds": 1730127262,
+    "expected_floor": "407115213197552435568"
+  },
+  {
+    "principal": "1487845021848109077",
+    "rate_bps": 7555,
+    "seconds": 494055759,
+    "expected_floor": "17598034462891468289"
+  },
+  {
+    "principal": "6487808288409902386",
+    "rate_bps": 9302,
+    "seconds": 2538965428,
+    "expected_floor": "485542403275617489999"
+  },
+  {
+    "principal": "17426852006731252211",
+    "rate_bps": 2615,
+    "seconds": 1876388445,
+    "expected_floor": "270962642518052234066"
+  },
+  {
+    "principal": "13123509169827763880",
+    "rate_bps": 8820,
+    "seconds": 699061274,
+    "expected_floor": "256406978633877178843"
+  },
+  {
+    "principal": "11988661713085509601",
+    "rate_bps": 7935,
+    "seconds": 4225076731,
+    "expected_floor": "1273644634261538414245"
+  },
+  {
+    "principal": "12420840147782204270",
+    "rate_bps": 8392,
+    "seconds": 1531550288,
+    "expected_floor": "505875611060642116993"
+  },
+  {
+    "principal": "15737850909947154783",
+    "rate_bps": 5207,
+    "seconds": 4186943401,
+    "expected_floor": "1087241766504372060858"
+  },
+  {
+    "principal": "16252136828489644292",
+    "rate_bps": 793,
+    "seconds": 2647983574,
+    "expected_floor": "108142144370431019527"
+  },
+  {
+    "principal": "1540390558945292781",
+    "rate_bps": 6684,
+    "seconds": 2821228263,
+    "expected_floor": "92045285314162251797"
+  },
+  {
+    "principal": "11086409942513930474",
+    "rate_bps": 9254,
+    "seconds": 1337111596,
+    "expected_floor": "434694471447481672216"
+  },
+  {
+    "principal": "1393819518191468811",
+    "rate_bps": 4974,
+    "seconds": 50057013,
+    "expected_floor": "1099697623467990555"
+  },
+  {
+    "principal": "4106628477859346592",
+    "rate_bps": 128,
+    "seconds": 1853429458,
+    "expected_floor": "3087219284174193730"
+  },
+  {
+    "principal": "2739275144688874041",
+    "rate_bps": 1036,
+    "seconds": 2755667987,
+    "expected_floor": "24780971954333867301"
+  },
+  {
+    "principal": "3505614174415681958",
+    "rate_bps": 6169,
+    "seconds": 651875144,
+    "expected_floor": "44672405735536574182"
+  },
+  {
+    "principal": "12769290227627285751",
+    "rate_bps": 2871,
+    "seconds": 675935489,
+    "expected_floor": "78523786291009025054"
+  },
+  {
+    "principal": "5402580811076079996",
+    "rate_bps": 4581,
+    "seconds": 2795971342,
+    "expected_floor": "219275602053085456534"
+  },
+  {
+    "principal": "1261295588617657541",
+    "rate_bps": 7009,
+    "seconds": 384253311,
+    "expected_floor": "10764319706146494098"
+  },
+  {
+    "principal": "9226880609404211618",
+    "rate_bps": 4085,
+    "seconds": 750203812,
+    "expected_floor": "89602940368372195097"
+  },
+  {
+    "principal": "13080929140854354211",
+    "rate_bps": 5170,
+    "seconds": 411864333,
+    "expected_floor": "88263135867576461189"
+  },
+  {
+    "principal": "10038572845411778456",
+    "rate_bps": 9842,
+    "seconds": 1340114570,
+    "expected_floor": "419559247090235872929"
+  },
+  {
+    "principal": "1504468287209053585",
+    "rate_bps": 6282,
+    "seconds": 2605372203,
+    "expected_floor": "78027335710160366326"
+  },
+  {
+    "principal": "476474055627109598",
+    "rate_bps": 2744,
+    "seconds": 2839826752,
+    "expected_floor": "11765523184087613169"
+  },
+  {
+    "principal": "8093495226099337615",
+    "rate_bps": 7024,
+    "seconds": 398869337,
+    "expected_floor": "71853396499495148629"
+  },
+  {
+    "principal": "6392684518519045876",
+    "rate_bps": 9933,
+    "seconds": 3348356422,
+    "expected_floor": "673738587644555466177"
+  },
+  {
+    "principal": "8298756674163384477",
+    "rate_bps": 7939,
+    "seconds": 1889940759,
+    "expected_floor": "394569087105668035504"
+  },
+  {
+    "principal": "16676650637631962970",
+    "rate_bps": 5227,
+    "seconds": 1612834844,
+    "expected_floor": "445499541286582736390"
+  },
+  {
+    "principal": "10878864750545941051",
+    "rate_bps": 419,
+    "seconds": 2134246373,
+    "expected_floor": "30827491411172218571"
+  },
+  {
+    "principal": "13075258357749500816",
+    "rate_bps": 9121,
+    "seconds": 1742275394,
+    "expected_floor": "658423875617388891203"
+  },
+  {
+    "principal": "17894069530483020265",
+    "rate_bps": 97,
+    "seconds": 1445916483,
+    "expected_floor": "7952800650116379526"
+  },
+  {
+    "principal": "8052790041398267158",
+    "rate_bps": 2812,
+    "seconds": 3916362808,
+    "expected_floor": "281022208728062495636"
+  },
+  {
+    "principal": "14896327357868029735",
+    "rate_bps": 2211,
+    "seconds": 669186737,
+    "expected_floor": "69841138131692634192"
+  },
+  {
+    "principal": "11150009901176086892",
+    "rate_bps": 7752,
+    "seconds": 1600984190,
+    "expected_floor": "438502519670759748955"
+  },
+  {
+    "principal": "9501528495005932917",
+    "rate_bps": 529,
+    "seconds": 2671824303,
+    "expected_floor": "42555243117383593662"
+  },
+  {
+    "principal": "13475328103461976594",
+    "rate_bps": 3953,
+    "seconds": 3756372372,
+    "expected_floor": "634060696335967749697"
+  },
+  {
+    "principal": "8410742223767086163",
+    "rate_bps": 1856,
+    "seconds": 3949499325,
+    "expected_floor": "195366623840595445429"
+  },
+  {
+    "principal": "1273306106413005960",
+    "rate_bps": 4923,
+    "seconds": 3572395258,
+    "expected_floor": "70960749629339192246"
+  },
+  {
+    "principal": "15929536100228575041",
+    "rate_bps": 4235,
+    "seconds": 1271520347,
+    "expected_floor": "271816546433280411764"
+  },
+  {
+    "principal": "5160665872169919054",
+    "rate_bps": 7439,
+    "seconds": 540515376,
+    "expected_floor": "65754334400539027696"
+  },
+  {
+    "principal": "13409364568071325119",
+    "rate_bps": 1031,
+    "seconds": 2801957641,
+    "expected_floor": "122750836975398761584"
+  },
+  {
+    "principal": "3985223131607177444",
+    "rate_bps": 2001,
+    "seconds": 2975377590,
+    "expected_floor": "75186150839937658492"
+  },
+  {
+    "principal": "5585512215837766477",
+    "rate_bps": 1005,
+    "seconds": 821454663,
+    "expected_floor": "14611967577439706133"
+  },
+  {
+    "principal": "15291818925235823050",
+    "rate_bps": 8615,
+    "seconds": 2510909452,
+    "expected_floor": "1048193622512262807369"
+  },
+  {
+    "principal": "8916692680688412523",
+    "rate_bps": 9760,
+    "seconds": 1826135189,
+    "expected_floor": "503596350899148174523"
+  },
+  {
+    "principal": "16776140574244860544",
+    "rate_bps": 1863,
+    "seconds": 2915083186,
+    "expected_floor": "288703398927344015716"
+  },
+  {
+    "principal": "9590517082086413721",
+    "rate_bps": 2337,
+    "seconds": 2115828339,
+    "expected_floor": "150271699539573695973"
+  },
+  {
+    "principal": "13788717726491841670",
+    "rate_bps": 6558,
+    "seconds": 1341073704,
+    "expected_floor": "384276629840300065144"
+  },
+  {
+    "principal": "15807040683029861719",
+    "rate_bps": 1149,
+    "seconds": 3482002529,
+    "expected_floor": "200399076050868665251"
+  },
+  {
+    "principal": "5904738770084562268",
+    "rate_bps": 3000,
+    "seconds": 2152757742,
+    "expected_floor": "120840673262102625837"
+  },
+  {
+    "principal": "2128646394180796965",
+    "rate_bps": 9788,
+    "seconds": 703226335,
+    "expected_floor": "46428926597781953029"
+  },
+  {
+    "principal": "2854560939002517122",
+    "rate_bps": 3692,
+    "seconds": 3729261444,
+    "expected_floor": "124543158384275010229"
+  },
+  {
+    "principal": "15473434082647645059",
+    "rate_bps": 6929,
+    "seconds": 1946058349,
+    "expected_floor": "661163943053915284564"
+  },
+  {
+    "principal": "17432033914683968888",
+    "rate_bps": 4527,
+    "seconds": 1149470570,
+    "expected_floor": "287443469369326656486"
+  },
+  {
+    "principal": "9729770871192937713",
+    "rate_bps": 8710,
+    "seconds": 332245387,
+    "expected_floor": "89222782039877504955"
+  },
+  {
+    "principal": "18436794667808932798",
+    "rate_bps": 269,
+    "seconds": 735738656,
+    "expected_floor": "11562648048417560820"
+  },
+  {
+    "principal": "17521001708388615663",
+    "rate_bps": 1604,
+    "seconds": 1432835769,
+    "expected_floor": "127601489347126722762"
+  },
+  {
+    "principal": "6063361039968536276",
+    "rate_bps": 824,
+    "seconds": 2057463846,
+    "expected_floor": "32573834534260225356"
+  },
+  {
+    "principal": "10308801527686146557",
+    "rate_bps": 9914,
+    "seconds": 3852737911,
+    "expected_floor": "1247735674218317907771"
+  },
+  {
+    "principal": "15962277997015316538",
+    "rate_bps": 8509,
+    "seconds": 1498434556,
+    "expected_floor": "644922021566094014791"
+  },
+  {
+    "principal": "16039553878871695515",
+    "rate_bps": 6149,
+    "seconds": 1737922885,
+    "expected_floor": "543154413398454856168"
+  },
+  {
+    "principal": "14093942232349584752",
+    "rate_bps": 137,
+    "seconds": 981399586,
+    "expected_floor": "6004750370291797743"
+  },
+  {
+    "principal": "17037550008449891657",
+    "rate_bps": 7862,
+    "seconds": 27609507,
+    "expected_floor": "11719116398619224559"
+  },
+  {
+    "principal": "11260284953731813366",
+    "rate_bps": 107,
+    "seconds": 1337094680,
+    "expected_floor": "5104948349812144638"
+  },
+  {
+    "principal": "16648288327523858311",
+    "rate_bps": 4735,
+    "seconds": 2206560785,
+    "expected_floor": "551190216815606235268"
+  },
+  {
+    "principal": "12431998783747259724",
+    "rate_bps": 1434,
+    "seconds": 1970295646,
+    "expected_floor": "111305734748878063241"
+  },
+  {
+    "principal": "4725622604893244117",
+    "rate_bps": 2587,
+    "seconds": 143587855,
+    "expected_floor": "5562489506819457674"
+  },
+  {
+    "principal": "8733393858665244402",
+    "rate_bps": 6012,
+    "seconds": 142944628,
+    "expected_floor": "23782959156152496643"
+  },
+  {
+    "principal": "4996935308133291699",
+    "rate_bps": 4685,
+    "seconds": 3391180061,
+    "expected_floor": "251570785134428058751"
+  },
+  {
+    "principal": "13204336625378947688",
+    "rate_bps": 4220,
+    "seconds": 1670305242,
+    "expected_floor": "294931334195765382925"
+  },
+  {
+    "principal": "9592500529414291105",
+    "rate_bps": 6632,
+    "seconds": 3289463483,
+    "expected_floor": "663128131102390808823"
+  },
+  {
+    "principal": "4914856638796044590",
+    "rate_bps": 5935,
+    "seconds": 3341020688,
+    "expected_floor": "308820964843841762305"
+  },
+  {
+    "principal": "17242034721486162463",
+    "rate_bps": 7680,
+    "seconds": 3914847849,
+    "expected_floor": "1642709073950406381055"
+  },
+  {
+    "principal": "5773573265223272644",
+    "rate_bps": 3004,
+    "seconds": 2016418710,
+    "expected_floor": "110820820440331982969"
+  },
+  {
+    "principal": "15546217631590237357",
+    "rate_bps": 9082,
+    "seconds": 2172278695,
+    "expected_floor": "971891572752821204448"
+  },
+  {
+    "principal": "8531113374264050346",
+    "rate_bps": 4992,
+    "seconds": 3210574828,
+    "expected_floor": "433270499177053086757"
+  },
+  {
+    "principal": "7604960701834878411",
+    "rate_bps": 6051,
+    "seconds": 4016241141,
+    "expected_floor": "585652417917557445097"
+  },
+  {
+    "principal": "993486990091943008",
+    "rate_bps": 6369,
+    "seconds": 2040725650,
+    "expected_floor": "40917970914416919118"
+  },
+  {
+    "principal": "2546224958125705465",
+    "rate_bps": 36,
+    "seconds": 681762003,
+    "expected_floor": "198028682128721433"
+  },
+  {
+    "principal": "7093610656882229094",
+    "rate_bps": 5624,
+    "seconds": 3847212808,
+    "expected_floor": "486356699652906213348"
+  },
+  {
+    "principal": "3286399112820022711",
+    "rate_bps": 5031,
+    "seconds": 2555700161,
+    "expected_floor": "133899993287563129319"
+  },
+  {
+    "principal": "1945191700740000060",
+    "rate_bps": 9116,
+    "seconds": 2552996046,
+    "expected_floor": "143454078339013303148"
+  },
+  {
+    "principal": "4691359002263484293",
+    "rate_bps": 7165,
+    "seconds": 2602145343,
+    "expected_floor": "277167590460873888959"
+  },
+  {
+    "principal": "14751388563700132706",
+    "rate_bps": 9311,
+    "seconds": 3800310628,
+    "expected_floor": "1654033718326177734395"
+  },
+  {
+    "principal": "13425649551824672227",
+    "rate_bps": 5636,
+    "seconds": 1105461197,
+    "expected_floor": "265060996847722583632"
+  },
+  {
+    "principal": "3401404638894959448",
+    "rate_bps": 2887,
+    "seconds": 2688505930,
+    "expected_floor": "83658893314922487021"
+  },
+  {
+    "principal": "12526699184199875665",
+    "rate_bps": 4013,
+    "seconds": 663719915,
+    "expected_floor": "105727190050579966531"
+  },
+  {
+    "principal": "3515886606782325406",
+    "rate_bps": 5034,
+    "seconds": 1816851712,
+    "expected_floor": "101897513499367902320"
+  },
+  {
+    "principal": "505840408020881999",
+    "rate_bps": 6411,
+    "seconds": 4051106329,
+    "expected_floor": "41630245417285630927"
+  },
+  {
+    "principal": "14292192931307642548",
+    "rate_bps": 5667,
+    "seconds": 2751513350,
+    "expected_floor": "706187034957472117529"
+  },
+  {
+    "principal": "8640196019277513565",
+    "rate_bps": 2510,
+    "seconds": 495195607,
+    "expected_floor": "34030641278286153568"
+  },
+  {
+    "principal": "1466111955299729690",
+    "rate_bps": 4152,
+    "seconds": 2002255836,
+    "expected_floor": "38622473255759989191"
+  },
+  {
+    "principal": "17606922338477645563",
+    "rate_bps": 6776,
+    "seconds": 410042021,
+    "expected_floor": "155017684039666606153"
+  },
+  {
+    "principal": "12525953411337019216",
+    "rate_bps": 4144,
+    "seconds": 3086728450,
+    "expected_floor": "507720847738001328660"
+  },
+  {
+    "principal": "10446644555134908585",
+    "rate_bps": 1393,
+    "seconds": 3442521091,
+    "expected_floor": "158745190813770703633"
+  },
+  {
+    "principal": "492129554174026454",
+    "rate_bps": 6124,
+    "seconds": 77479928,
+    "expected_floor": "739945733151568553"
+  },
+  {
+    "principal": "6489206602838362087",
+    "rate_bps": 3297,
+    "seconds": 45906289,
+    "expected_floor": "3112280759620275983"
+  },
+  {
+    "principal": "17478173535557708076",
+    "rate_bps": 4203,
+    "seconds": 2669765182,
+    "expected_floor": "621476247522723372216"
+  },
+  {
+    "principal": "7519798612459030581",
+    "rate_bps": 6491,
+    "seconds": 2142582383,
+    "expected_floor": "331399143495322197947"
+  },
+  {
+    "principal": "3251774242716263378",
+    "rate_bps": 3618,
+    "seconds": 2204889428,
+    "expected_floor": "82199996158542483475"
+  },
+  {
+    "principal": "5441644562470508819",
+    "rate_bps": 5188,
+    "seconds": 463050365,
+    "expected_floor": "41424225981764748019"
+  },
+  {
+    "principal": "8939732124799334472",
+    "rate_bps": 3061,
+    "seconds": 2181303994,
+    "expected_floor": "189147263556419666817"
+  },
+  {
+    "principal": "987705776244940289",
+    "rate_bps": 8051,
+    "seconds": 864266523,
+    "expected_floor": "21778157999163238259"
+  },
+  {
+    "principal": "3808275465218007054",
+    "rate_bps": 1313,
+    "seconds": 80121840,
+    "expected_floor": "1269521406056421082"
+  },
+  {
+    "principal": "8680995669720620671",
+    "rate_bps": 9267,
+    "seconds": 1957151177,
+    "expected_floor": "498917926620005588323"
+  },
+  {
+    "principal": "10511432824085825700",
+    "rate_bps": 1489,
+    "seconds": 223567478,
+    "expected_floor": "11088205789343322743"
+  },
+  {
+    "principal": "7791438842453141005",
+    "rate_bps": 2286,
+    "seconds": 688674823,
+    "expected_floor": "38869068346406639542"
+  },
+  {
+    "principal": "462354859863143306",
+    "rate_bps": 9148,
+    "seconds": 3154565068,
+    "expected_floor": "42280207069011970681"
+  },
+  {
+    "principal": "13637056728219886635",
+    "rate_bps": 4293,
+    "seconds": 993191765,
+    "expected_floor": "184251349945895592736"
+  },
+  {
+    "principal": "5290195938870449728",
+    "rate_bps": 7242,
+    "seconds": 2476223858,
+    "expected_floor": "300618853954143673387"
+  },
+  {
+    "principal": "17783700666373180505",
+    "rate_bps": 56,
+    "seconds": 2343161651,
+    "expected_floor": "7394493824629540210"
+  },
+  {
+    "principal": "9866657276909730374",
+    "rate_bps": 6196,
+    "seconds": 2293548264,
+    "expected_floor": "444309264103568633429"
+  },
+  {
+    "principal": "15008282047060194839",
+    "rate_bps": 9257,
+    "seconds": 129970977,
+    "expected_floor": "57219447880966837462"
+  },
+  {
+    "principal": "5636830346471660828",
+    "rate_bps": 8321,
+    "seconds": 238065582,
+    "expected_floor": "35383690796838608499"
+  },
+  {
+    "principal": "5127077955771006181",
+    "rate_bps": 2330,
+    "seconds": 3268205215,
+    "expected_floor": "123717516499151571315"
+  },
+  {
+    "principal": "17577515433780170818",
+    "rate_bps": 274,
+    "seconds": 2242089796,
+    "expected_floor": "34218194127919814901"
+  },
+  {
+    "principal": "591886443057193027",
+    "rate_bps": 2309,
+    "seconds": 869601581,
+    "expected_floor": "3765985809397414670"
+  },
+  {
+    "principal": "11006433809222719800",
+    "rate_bps": 404,
+    "seconds": 428603690,
+    "expected_floor": "6039207196766990994"
+  },
+  {
+    "principal": "3340622338970362801",
+    "rate_bps": 2083,
+    "seconds": 929597003,
+    "expected_floor": "20497806954976676865"
+  },
+  {
+    "principal": "17258668059872022910",
+    "rate_bps": 3396,
+    "seconds": 3645751008,
+    "expected_floor": "677108077903737182320"
+  },
+  {
+    "principal": "14292531790943039151",
+    "rate_bps": 5762,
+    "seconds": 2718772601,
+    "expected_floor": "709498265903540411219"
+  },
+  {
+    "principal": "2500248937348499092",
+    "rate_bps": 2701,
+    "seconds": 1218899430,
+    "expected_floor": "26083852905175008805"
+  },
+  {
+    "principal": "12236591758647127229",
+    "rate_bps": 9025,
+    "seconds": 2577276471,
+    "expected_floor": "901913159504409745945"
+  },
+  {
+    "principal": "2597921166357371386",
+    "rate_bps": 8023,
+    "seconds": 1131479996,
+    "expected_floor": "74731839719934194688"
+  },
+  {
+    "principal": "5725746091459833179",
+    "rate_bps": 5381,
+    "seconds": 2757522437,
+    "expected_floor": "269221763734043123271"
+  },
+  {
+    "principal": "3192517041871348016",
+    "rate_bps": 5444,
+    "seconds": 1808224738,
+    "expected_floor": "99586341988812315711"
+  },
+  {
+    "principal": "1510802766444495881",
+    "rate_bps": 9905,
+    "seconds": 4071173731,
+    "expected_floor": "193053606750322767929"
+  },
+  {
+    "principal": "17052152648956298678",
+    "rate_bps": 228,
+    "seconds": 602562008,
+    "expected_floor": "7423553406216248470"
+  },
+  {
+    "principal": "15646176736547186759",
+    "rate_bps": 8247,
+    "seconds": 3969913041,
+    "expected_floor": "1623234456769601396252"
+  },
+  {
+    "principal": "12272103409423164684",
+    "rate_bps": 6344,
+    "seconds": 2792898846,
+    "expected_floor": "689022525312071979671"
+  },
+  {
+    "principal": "11003478942837298581",
+    "rate_bps": 9259,
+    "seconds": 252412623,
+    "expected_floor": "81489415662604111970"
+  },
+  {
+    "principal": "18108031501974974642",
+    "rate_bps": 7306,
+    "seconds": 4140960052,
+    "expected_floor": "1735993053406097098566"
+  },
+  {
+    "principal": "292877283136891763",
+    "rate_bps": 2477,
+    "seconds": 3010031581,
+    "expected_floor": "6919564770299447214"
+  },
+  {
+    "principal": "3005553399439543848",
+    "rate_bps": 5930,
+    "seconds": 1892030362,
+    "expected_floor": "106857073535588730800"
+  },
+  {
+    "principal": "15925962537947958625",
+    "rate_bps": 8421,
+    "seconds": 217655163,
+    "expected_floor": "92498430467773036280"
+  },
+  {
+    "principal": "15928097900456867566",
+    "rate_bps": 1968,
+    "seconds": 2178384336,
+    "expected_floor": "216381211911752806985"
+  },
+  {
+    "principal": "11011814792808596191",
+    "rate_bps": 4130,
+    "seconds": 2164931881,
+    "expected_floor": "311996138518503922428"
+  },
+  {
+    "principal": "3795161498635507844",
+    "rate_bps": 5961,
+    "seconds": 3753537878,
+    "expected_floor": "269082974036180744774"
+  },
+  {
+    "principal": "10958425185114724205",
+    "rate_bps": 6493,
+    "seconds": 453273703,
+    "expected_floor": "102199814294642929122"
+  },
+  {
+    "principal": "8415816971063129194",
+    "rate_bps": 5814,
+    "seconds": 786269100,
+    "expected_floor": "121909780852134271101"
+  },
+  {
+    "principal": "14909357674398612107",
+    "rate_bps": 754,
+    "seconds": 1155556533,
+    "expected_floor": "41163994316005311912"
+  },
+  {
+    "principal": "10135176541670735904",
+    "rate_bps": 7428,
+    "seconds": 3508021842,
+    "expected_floor": "836876811976485328306"
+  },
+  {
+    "principal": "9054706084217855929",
+    "rate_bps": 301,
+    "seconds": 3003765139,
+    "expected_floor": "25941964390128219224"
+  },
+  {
+    "principal": "5161899224549836070",
+    "rate_bps": 3038,
+    "seconds": 1339427528,
+    "expected_floor": "66559882155995449166"
+  },
+  {
+    "principal": "11150328226101370487",
+    "rate_bps": 3306,
+    "seconds": 2799833729,
+    "expected_floor": "327053480232898029312"
+  },
+  {
+    "principal": "10559516298791338236",
+    "rate_bps": 2833,
+    "seconds": 3596050062,
+    "expected_floor": "340888508630680788675"
+  },
+  {
+    "principal": "16585922551148024389",
+    "rate_bps": 2715,
+    "seconds": 3713806079,
+    "expected_floor": "529937585525804556156"
+  },
+  {
+    "principal": "6935412286476993826",
+    "rate_bps": 634,
+    "seconds": 1205752612,
+    "expected_floor": "16800251597524141531"
+  },
+  {
+    "principal": "13204390314454743715",
+    "rate_bps": 2169,
+    "seconds": 3211375245,
+    "expected_floor": "291450626729951313114"
+  },
+  {
+    "principal": "3863492514189203224",
+    "rate_bps": 1893,
+    "seconds": 4209076746,
+    "expected_floor": "97546921166872904412"
+  },
+  {
+    "principal": "15497273494394379025",
+    "rate_bps": 3568,
+    "seconds": 1211141291,
+    "expected_floor": "212212512252730922657"
+  },
+  {
+    "principal": "17209531398008868958",
+    "rate_bps": 4222,
+    "seconds": 3583695040,
+    "expected_floor": "825114753277458483679"
+  },
+  {
+    "principal": "5166179492576025359",
+    "rate_bps": 6326,
+    "seconds": 2705453273,
+    "expected_floor": "280178463366494237894"
+  },
+  {
+    "principal": "17621264663629495924",
+    "rate_bps": 3713,
+    "seconds": 3247237318,
+    "expected_floor": "673243370627744639729"
+  },
+  {
+    "principal": "7831090558107166237",
+    "rate_bps": 5737,
+    "seconds": 1061828247,
+    "expected_floor": "151167142354150621083"
+  },
+  {
+    "principal": "13652728105820422874",
+    "rate_bps": 454,
+    "seconds": 4208154524,
+    "expected_floor": "82653834425705294810"
+  },
+  {
+    "principal": "433918987727817659",
+    "rate_bps": 6877,
+    "seconds": 1643231589,
+    "expected_floor": "15538263680449460737"
+  },
+  {
+    "principal": "18200441657888289552",
+    "rate_bps": 4038,
+    "seconds": 4116297410,
+    "expected_floor": "958630009257551629269"
+  },
+  {
+    "principal": "7740650626060705641",
+    "rate_bps": 9604,
+    "seconds": 3488004291,
+    "expected_floor": "821679895299954598109"
+  },
+  {
+    "principal": "2692119832519620758",
+    "rate_bps": 9613,
+    "seconds": 1028574136,
+    "expected_floor": "84349975783728969026"
+  },
+  {
+    "principal": "16259397026178504871",
+    "rate_bps": 864,
+    "seconds": 2353543217,
+    "expected_floor": "104769866073846383491"
+  },
+  {
+    "principal": "12946677861640483052",
+    "rate_bps": 7853,
+    "seconds": 695005182,
+    "expected_floor": "223912333074379452714"
+  },
+  {
+    "principal": "6437665046397104885",
+    "rate_bps": 2479,
+    "seconds": 2766790447,
+    "expected_floor": "139919164655153751102"
+  },
+  {
+    "principal": "10314729303418801554",
+    "rate_bps": 1232,
+    "seconds": 1022325012,
+    "expected_floor": "41167411637633640142"
+  },
+  {
+    "principal": "16961334617476648403",
+    "rate_bps": 3724,
+    "seconds": 690542909,
+    "expected_floor": "138215388018262109448"
+  },
+  {
+    "principal": "6250506682353054728",
+    "rate_bps": 8433,
+    "seconds": 72151162,
+    "expected_floor": "12051377396949689479"
+  },
+  {
+    "principal": "3748965318211161281",
+    "rate_bps": 1594,
+    "seconds": 1732883931,
+    "expected_floor": "32814458900360769955"
+  },
+  {
+    "principal": "6530681707908767182",
+    "rate_bps": 5828,
+    "seconds": 3675177904,
+    "expected_floor": "443253792819143453435"
+  },
+  {
+    "principal": "540553914932803391",
+    "rate_bps": 1483,
+    "seconds": 3398912137,
+    "expected_floor": "8634081406048308397"
+  },
+  {
+    "principal": "879521395056851044",
+    "rate_bps": 6604,
+    "seconds": 2992460854,
+    "expected_floor": "55077977444850955135"
+  },
+  {
+    "principal": "13097944225922947277",
+    "rate_bps": 3508,
+    "seconds": 2931460295,
+    "expected_floor": "426818043460266448934"
+  },
+  {
+    "principal": "1730144480056526154",
+    "rate_bps": 500,
+    "seconds": 1863942028,
+    "expected_floor": "5109528308378277996"
+  },
+  {
+    "principal": "9104955218418032875",
+    "rate_bps": 4289,
+    "seconds": 1157853717,
+    "expected_floor": "143279344992059669415"
+  },
+  {
+    "principal": "3604926809756662272",
+    "rate_bps": 3838,
+    "seconds": 463140658,
+    "expected_floor": "20305344558986532036"
+  },
+  {
+    "principal": "6239337058979070745",
+    "rate_bps": 8694,
+    "seconds": 3466257395,
+    "expected_floor": "595819791840175320727"
+  },
+  {
+    "principal": "12587291723914682374",
+    "rate_bps": 1115,
+    "seconds": 3295387816,
+    "expected_floor": "146558067402210812395"
+  },
+  {
+    "principal": "16857648158649226967",
+    "rate_bps": 8095,
+    "seconds": 47546849,
+    "expected_floor": "20560402492101277911"
+  },
+  {
+    "principal": "10947587799327634652",
+    "rate_bps": 7110,
+    "seconds": 3096966510,
+    "expected_floor": "763871979695522620849"
+  },
+  {
+    "principal": "1549431404916717477",
+    "rate_bps": 881,
+    "seconds": 186618719,
+    "expected_floor": "807234100160407227"
+  },
+  {
+    "principal": "13146002040496556546",
+    "rate_bps": 509,
+    "seconds": 3714867972,
+    "expected_floor": "78768195070298242542"
+  },
+  {
+    "principal": "452027490129929475",
+    "rate_bps": 8219,
+    "seconds": 507110381,
+    "expected_floor": "5970110392769582106"
+  },
+  {
+    "principal": "13217452877864772856",
+    "rate_bps": 3245,
+    "seconds": 582462186,
+    "expected_floor": "79163728488366133513"
+  },
+  {
+    "principal": "10091590532320764529",
+    "rate_bps": 9096,
+    "seconds": 46113547,
+    "expected_floor": "13413268994304961380"
+  },
+  {
+    "principal": "7747849185019338558",
+    "rate_bps": 3508,
+    "seconds": 3085583008,
+    "expected_floor": "265750451025422895830"
+  },
+  {
+    "principal": "3988836337062156143",
+    "rate_bps": 6609,
+    "seconds": 2905424953,
+    "expected_floor": "242709996706737359259"
+  },
+  {
+    "principal": "9532399922379343444",
+    "rate_bps": 491,
+    "seconds": 3148526502,
+    "expected_floor": "46696801301707309535"
+  },
+  {
+    "principal": "193507709182963581",
+    "rate_bps": 4497,
+    "seconds": 1474322167,
+    "expected_floor": "4065459017754346021"
+  },
+  {
+    "principal": "1408977775325854650",
+    "rate_bps": 209,
+    "seconds": 2394356604,
+    "expected_floor": "2234268149096584853"
+  },
+  {
+    "principal": "7244595357135419931",
+    "rate_bps": 3891,
+    "seconds": 3955789509,
+    "expected_floor": "353349573360960947454"
+  },
+  {
+    "principal": "6634137127521441008",
+    "rate_bps": 4774,
+    "seconds": 137030562,
+    "expected_floor": "13752458105304507786"
+  },
+  {
+    "principal": "10889886679622109897",
+    "rate_bps": 5343,
+    "seconds": 3871429411,
+    "expected_floor": "713798962936327191005"
+  },
+  {
+    "principal": "1201047254031432566",
+    "rate_bps": 62,
+    "seconds": 1417906584,
+    "expected_floor": "334576501918871854"
+  },
+  {
+    "principal": "10851455030301628679",
+    "rate_bps": 1317,
+    "seconds": 818737041,
+    "expected_floor": "37077822571313250362"
+  },
+  {
+    "principal": "2188434669499550924",
+    "rate_bps": 3454,
+    "seconds": 2583129822,
+    "expected_floor": "61872574291167563917"
+  },
+  {
+    "principal": "13278415343863996501",
+    "rate_bps": 1383,
+    "seconds": 329796495,
+    "expected_floor": "19191569710980120494"
+  },
+  {
+    "principal": "13274875939171580530",
+    "rate_bps": 6552,
+    "seconds": 1677469940,
+    "expected_floor": "462333261786961699877"
+  },
+  {
+    "principal": "7636766076005498931",
+    "rate_bps": 2260,
+    "seconds": 3631207069,
+    "expected_floor": "198593474942481885005"
+  },
+  {
+    "principal": "5468088807812000232",
+    "rate_bps": 6823,
+    "seconds": 2769328474,
+    "expected_floor": "327402080363692730653"
+  },
+  {
+    "principal": "6771092127092317217",
+    "rate_bps": 8260,
+    "seconds": 4249703483,
+    "expected_floor": "753170726407462858054"
+  },
+  {
+    "principal": "15844487140959294638",
+    "rate_bps": 4808,
+    "seconds": 2703512976,
+    "expected_floor": "652630155063067028649"
+  },
+  {
+    "principal": "576189687757863839",
+    "rate_bps": 6027,
+    "seconds": 2439439337,
+    "expected_floor": "26844339853692042011"
+  },
+  {
+    "principal": "4209971277872179268",
+    "rate_bps": 2366,
+    "seconds": 2620655382,
+    "expected_floor": "82717961054194320723"
+  },
+  {
+    "principal": "14147098939376970285",
+    "rate_bps": 5917,
+    "seconds": 2676406567,
+    "expected_floor": "709932535383361619796"
+  },
+  {
+    "principal": "560709789473269290",
+    "rate_bps": 1977,
+    "seconds": 2280835948,
+    "expected_floor": "8011888376920576463"
+  },
+  {
+    "principal": "4506012951338800971",
+    "rate_bps": 1126,
+    "seconds": 3090419573,
+    "expected_floor": "49687174941237774376"
+  },
+  {
+    "principal": "1438812918464529376",
+    "rate_bps": 4496,
+    "seconds": 1889047570,
+    "expected_floor": "38723050132791729918"
+  },
+  {
+    "principal": "13793402503115077241",
+    "rate_bps": 4394,
+    "seconds": 842335827,
+    "expected_floor": "161775506368151336823"
+  },
+  {
+    "principal": "481699735303604966",
+    "rate_bps": 6901,
+    "seconds": 3828188808,
+    "expected_floor": "40325319518992840431"
+  },
+  {
+    "principal": "15848477719379418935",
+    "rate_bps": 4849,
+    "seconds": 2897314113,
+    "expected_floor": "705555777646480371619"
+  },
+  {
+    "principal": "3134595882462181564",
+    "rate_bps": 7691,
+    "seconds": 1357536334,
+    "expected_floor": "103707905961521898155"
+  },
+  {
+    "principal": "4461707226474245381",
+    "rate_bps": 882,
+    "seconds": 1349453759,
+    "expected_floor": "16827658671448414473"
+  },
+  {
+    "principal": "9082097520383794914",
+    "rate_bps": 7775,
+    "seconds": 780518116,
+    "expected_floor": "174648789189196097310"
+  },
+  {
+    "principal": "11071901748700241763",
+    "rate_bps": 6195,
+    "seconds": 1306371405,
+    "expected_floor": "283939774096591285227"
+  },
+  {
+    "principal": "14903130177481458392",
+    "rate_bps": 3441,
+    "seconds": 59161546,
+    "expected_floor": "9613858260184224200"
+  },
+  {
+    "principal": "13493202721910667729",
+    "rate_bps": 2997,
+    "seconds": 3018705259,
+    "expected_floor": "386828561253398189544"
+  },
+  {
+    "principal": "3500496119264640542",
+    "rate_bps": 6119,
+    "seconds": 3404987520,
+    "expected_floor": "231111529158794823176"
+  },
+  {
+    "principal": "2953972633719169999",
+    "rate_bps": 8190,
+    "seconds": 132589465,
+    "expected_floor": "10164720012771326616"
+  },
+  {
+    "principal": "3187667120837844532",
+    "rate_bps": 8770,
+    "seconds": 939019910,
+    "expected_floor": "83184687589996106601"
+  },
+  {
+    "principal": "9565336381509585117",
+    "rate_bps": 6483,
+    "seconds": 2428016471,
+    "expected_floor": "477115944651687541170"
+  },
+  {
+    "principal": "18154633378829255834",
+    "rate_bps": 5434,
+    "seconds": 2756964188,
+    "expected_floor": "861855137607508221282"
+  },
+  {
+    "principal": "15357543002091501691",
+    "rate_bps": 6172,
+    "seconds": 544797733,
+    "expected_floor": "163636047941538564885"
+  },
+  {
+    "principal": "12417968800795838160",
+    "rate_bps": 7687,
+    "seconds": 1806889090,
+    "expected_floor": "546556387255722907763"
+  },
+  {
+    "principal": "12477410682093323817",
+    "rate_bps": 2541,
+    "seconds": 3708878211,
+    "expected_floor": "372621354546085694327"
+  },
+  {
+    "principal": "11654503746211614294",
+    "rate_bps": 4714,
+    "seconds": 3779106680,
+    "expected_floor": "657913122324195081965"
+  },
+  {
+    "principal": "10812315096856832359",
+    "rate_bps": 9041,
+    "seconds": 759576305,
+    "expected_floor": "235289531080425900444"
+  },
+  {
+    "principal": "18015205595178973356",
+    "rate_bps": 8955,
+    "seconds": 1041219006,
+    "expected_floor": "532283412913084633375"
+  },
+  {
+    "principal": "5892565604751318453",
+    "rate_bps": 2472,
+    "seconds": 295618543,
+    "expected_floor": "13645221753492688398"
+  },
+  {
+    "principal": "6879839861354477394",
+    "rate_bps": 529,
+    "seconds": 2922393812,
+    "expected_floor": "33703016582057748228"
+  },
+  {
+    "principal": "11473753557203501715",
+    "rate_bps": 7521,
+    "seconds": 3772144637,
+    "expected_floor": "1031491077964974601791"
+  },
+  {
+    "principal": "11554710515166556104",
+    "rate_bps": 5962,
+    "seconds": 1334383162,
+    "expected_floor": "291291376072683378383"
+  },
+  {
+    "principal": "7449588492969737089",
+    "rate_bps": 96,
+    "seconds": 769393307,
+    "expected_floor": "1743604388590807595"
+  },
+  {
+    "principal": "11916050993828453262",
+    "rate_bps": 443,
+    "seconds": 1490040688,
+    "expected_floor": "24924717227360901614"
+  },
+  {
+    "principal": "15855549232933097471",
+    "rate_bps": 5175,
+    "seconds": 2576420681,
+    "expected_floor": "669891479796855698233"
+  },
+  {
+    "principal": "6635997677303195684",
+    "rate_bps": 8352,
+    "seconds": 137791990,
+    "expected_floor": "24200075238091325423"
+  },
+  {
+    "principal": "16213319718375574413",
+    "rate_bps": 491,
+    "seconds": 213973383,
+    "expected_floor": "5397705988644578803"
+  },
+  {
+    "principal": "8364120867817412362",
+    "rate_bps": 4762,
+    "seconds": 950101836,
+    "expected_floor": "119915654283129406645"
+  },
+  {
+    "principal": "7100580244645567915",
+    "rate_bps": 8505,
+    "seconds": 1594506453,
+    "expected_floor": "305133908396772602033"
+  },
+  {
+    "principal": "5017739469589765568",
+    "rate_bps": 9694,
+    "seconds": 3783852274,
+    "expected_floor": "583231979755589036234"
+  },
+  {
+    "principal": "12973825303092574681",
+    "rate_bps": 2555,
+    "seconds": 1437612211,
+    "expected_floor": "151006880529943721767"
+  },
+  {
+    "principal": "16008533546527442374",
+    "rate_bps": 3909,
+    "seconds": 550747240,
+    "expected_floor": "109210798676308206086"
+  },
+  {
+    "principal": "10850983928330663831",
+    "rate_bps": 1818,
+    "seconds": 965611681,
+    "expected_floor": "60361711155913468993"
+  },
+  {
+    "principal": "12164301470758685852",
+    "rate_bps": 1484,
+    "seconds": 256283438,
+    "expected_floor": "14660124213067618697"
+  },
+  {
+    "principal": "17785543036761616997",
+    "rate_bps": 151,
+    "seconds": 2510457887,
+    "expected_floor": "21364515601546492704"
+  },
+  {
+    "principal": "5775165036545213378",
+    "rate_bps": 8694,
+    "seconds": 1466069700,
+    "expected_floor": "233257000356795197155"
+  },
+  {
+    "principal": "10698579225054079427",
+    "rate_bps": 4612,
+    "seconds": 267187885,
+    "expected_floor": "41776129506187424672"
+  },
+  {
+    "principal": "6598254581721837752",
+    "rate_bps": 3566,
+    "seconds": 2747702442,
+    "expected_floor": "204868949001073063756"
+  },
+  {
+    "principal": "495921082918461745",
+    "rate_bps": 3346,
+    "seconds": 1284702155,
+    "expected_floor": "6755181058278994206"
+  },
+  {
+    "principal": "7941438006098603262",
+    "rate_bps": 1781,
+    "seconds": 1299187296,
+    "expected_floor": "58227865151565308973"
+  },
+  {
+    "principal": "4842515614224498735",
+    "rate_bps": 8643,
+    "seconds": 2005375737,
+    "expected_floor": "265966741021085819684"
+  },
+  {
+    "principal": "17397251537873159700",
+    "rate_bps": 3382,
+    "seconds": 2339223910,
+    "expected_floor": "436136137733922017062"
+  },
+  {
+    "principal": "11889330947403330109",
+    "rate_bps": 269,
+    "seconds": 4213890999,
+    "expected_floor": "42706012860462343335"
+  },
+  {
+    "principal": "6435892863618227578",
+    "rate_bps": 1139,
+    "seconds": 2497852220,
+    "expected_floor": "58022348551803079510"
+  },
+  {
+    "principal": "7223755290934593243",
+    "rate_bps": 818,
+    "seconds": 580577669,
+    "expected_floor": "10871079945046671466"
+  },
+  {
+    "principal": "13356298125101533360",
+    "rate_bps": 3435,
+    "seconds": 4218013026,
+    "expected_floor": "613220684026220661755"
+  },
+  {
+    "principal": "16585986268844052873",
+    "rate_bps": 3936,
+    "seconds": 2091759587,
+    "expected_floor": "432717233948102878456"
+  },
+  {
+    "principal": "14234863278601367862",
+    "rate_bps": 3049,
+    "seconds": 3476944216,
+    "expected_floor": "478194393990080281699"
+  },
+  {
+    "principal": "7914441209873582535",
+    "rate_bps": 1364,
+    "seconds": 3637251665,
+    "expected_floor": "124423957888326617456"
+  },
+  {
+    "principal": "18145660933559891084",
+    "rate_bps": 8171,
+    "seconds": 799923358,
+    "expected_floor": "375830838908711992382"
+  },
+  {
+    "principal": "5949630513288293141",
+    "rate_bps": 1536,
+    "seconds": 958747727,
+    "expected_floor": "27763971616907722112"
+  },
+  {
+    "principal": "17833702591255905330",
+    "rate_bps": 5170,
+    "seconds": 2445510836,
+    "expected_floor": "714492521177732045130"
+  },
+  {
+    "principal": "17650168440475604211",
+    "rate_bps": 1117,
+    "seconds": 636777821,
+    "expected_floor": "39781942823239660801"
+  },
+  {
+    "principal": "6563192292259808680",
+    "rate_bps": 2669,
+    "seconds": 2486065946,
+    "expected_floor": "137997869019061626442"
+  },
+  {
+    "principal": "6116174857423121121",
+    "rate_bps": 9627,
+    "seconds": 4224565499,
+    "expected_floor": "788222714226022564057"
+  },
+  {
+    "principal": "6042573344554218094",
+    "rate_bps": 3069,
+    "seconds": 2060085584,
+    "expected_floor": "121059845395453287537"
+  },
+  {
+    "principal": "8815536291959190623",
+    "rate_bps": 9506,
+    "seconds": 724421289,
+    "expected_floor": "192368423230958557067"
+  },
+  {
+    "principal": "13782518018420176900",
+    "rate_bps": 8883,
+    "seconds": 3042761942,
+    "expected_floor": "1180462620197075434524"
+  },
+  {
+    "principal": "7613667999883885805",
+    "rate_bps": 2173,
+    "seconds": 2042710503,
+    "expected_floor": "107091873489925770182"
+  },
+  {
+    "principal": "13349302467548813290",
+    "rate_bps": 502,
+    "seconds": 4099756844,
+    "expected_floor": "87059550996551024999"
+  },
+  {
+    "principal": "11067564334533964811",
+    "rate_bps": 4164,
+    "seconds": 1042151989,
+    "expected_floor": "152191315387601771507"
+  },
+  {
+    "principal": "3448564319194040224",
+    "rate_bps": 4734,
+    "seconds": 2481208786,
+    "expected_floor": "128358882449800647627"
+  },
+  {
+    "principal": "8910634330425625913",
+    "rate_bps": 2091,
+    "seconds": 3571743507,
+    "expected_floor": "210881727870232225503"
+  },
+  {
+    "principal": "3522300690924736678",
+    "rate_bps": 6315,
+    "seconds": 1612071496,
+    "expected_floor": "113626626982096922933"
+  },
+  {
+    "principal": "5919735491952566263",
+    "rate_bps": 3551,
+    "seconds": 1115893761,
+    "expected_floor": "74331321928330155833"
+  },
+  {
+    "principal": "10602391387303080060",
+    "rate_bps": 6559,
+    "seconds": 933534222,
+    "expected_floor": "205715842727475071941"
+  },
+  {
+    "principal": "2403884018197694405",
+    "rate_bps": 7537,
+    "seconds": 2802983039,
+    "expected_floor": "160926856564890371961"
+  },
+  {
+    "principal": "16264879521501624482",
+    "rate_bps": 7558,
+    "seconds": 2822402724,
+    "expected_floor": "1099443089265730142344"
+  },
+  {
+    "principal": "4836873799221707811",
+    "rate_bps": 5287,
+    "seconds": 3925858317,
+    "expected_floor": "318130070343205524242"
+  },
+  {
+    "principal": "840540414088834712",
+    "rate_bps": 7741,
+    "seconds": 2649705866,
+    "expected_floor": "54632285238175051864"
+  },
+  {
+    "principal": "4616260620495460497",
+    "rate_bps": 84,
+    "seconds": 1636255275,
+    "expected_floor": "2010558427919358599"
+  },
+  {
+    "principal": "17917080335120935902",
+    "rate_bps": 3328,
+    "seconds": 1914069056,
+    "expected_floor": "361663094329646737798"
+  },
+  {
+    "principal": "10461971310628449423",
+    "rate_bps": 886,
+    "seconds": 1176936025,
+    "expected_floor": "34569741812443428964"
+  },
+  {
+    "principal": "16432695172758535668",
+    "rate_bps": 1125,
+    "seconds": 1594029126,
+    "expected_floor": "93379943546289312471"
+  },
+  {
+    "principal": "9796365492508240797",
+    "rate_bps": 9542,
+    "seconds": 210712599,
+    "expected_floor": "62415280821664749409"
+  },
+  {
+    "principal": "17829204625099245146",
+    "rate_bps": 3607,
+    "seconds": 1838794524,
+    "expected_floor": "374720408084556587022"
+  },
+  {
+    "principal": "519198722400347451",
+    "rate_bps": 9721,
+    "seconds": 1489399525,
+    "expected_floor": "23820550951342103325"
+  },
+  {
+    "principal": "2654316793712450192",
+    "rate_bps": 4881,
+    "seconds": 2798086722,
+    "expected_floor": "114873212353735258274"
+  },
+  {
+    "principal": "15762714989126085865",
+    "rate_bps": 7312,
+    "seconds": 3010429507,
+    "expected_floor": "1099491055713196609899"
+  },
+  {
+    "principal": "3635246448882197526",
+    "rate_bps": 3028,
+    "seconds": 2117313336,
+    "expected_floor": "73853468323316649807"
+  },
+  {
+    "principal": "10752815918477998631",
+    "rate_bps": 9955,
+    "seconds": 2390128049,
+    "expected_floor": "810738275448442406542"
+  },
+  {
+    "principal": "17616252330257285228",
+    "rate_bps": 4821,
+    "seconds": 1556728702,
+    "expected_floor": "418947515762289334047"
+  },
+  {
+    "principal": "15767264702015064181",
+    "rate_bps": 5962,
+    "seconds": 143913135,
+    "expected_floor": "42869142568169261066"
+  },
+  {
+    "principal": "15570515427060261138",
+    "rate_bps": 4362,
+    "seconds": 3102617748,
+    "expected_floor": "667748553300823447481"
+  },
+  {
+    "principal": "6086935210111498067",
+    "rate_bps": 9140,
+    "seconds": 1331830461,
+    "expected_floor": "234795544478711134415"
+  },
+  {
+    "principal": "7626839885548596104",
+    "rate_bps": 6099,
+    "seconds": 2541253626,
+    "expected_floor": "374582347204235673121"
+  },
+  {
+    "principal": "17141771991156451905",
+    "rate_bps": 7289,
+    "seconds": 234524507,
+    "expected_floor": "92855563297106507292"
+  },
+  {
+    "principal": "5770516818976823630",
+    "rate_bps": 8049,
+    "seconds": 1942678320,
+    "expected_floor": "285925944917942996743"
+  },
+  {
+    "principal": "5716784514423826623",
+    "rate_bps": 8091,
+    "seconds": 307566089,
+    "expected_floor": "45080477419194424427"
+  },
+  {
+    "principal": "1356272503227930596",
+    "rate_bps": 7962,
+    "seconds": 3063873462,
+    "expected_floor": "104842166833052808889"
+  },
+  {
+    "principal": "8737278486561144397",
+    "rate_bps": 9886,
+    "seconds": 3453987399,
+    "expected_floor": "945395577182131511183"
+  },
+  {
+    "principal": "17862713683348859082",
+    "rate_bps": 1322,
+    "seconds": 3797847820,
+    "expected_floor": "284192415738024498561"
+  },
+  {
+    "principal": "10173922084799486571",
+    "rate_bps": 3976,
+    "seconds": 2651277205,
+    "expected_floor": "339848966748063300212"
+  },
+  {
+    "principal": "14913873533828006272",
+    "rate_bps": 599,
+    "seconds": 3240250034,
+    "expected_floor": "91725869064218066603"
+  },
+  {
+    "principal": "16630579929172865177",
+    "rate_bps": 6042,
+    "seconds": 1873399155,
+    "expected_floor": "596505521088632449422"
+  },
+  {
+    "principal": "3751217953293183878",
+    "rate_bps": 2364,
+    "seconds": 4222425128,
+    "expected_floor": "118652737032405672737"
+  },
+  {
+    "principal": "5954324131290323031",
+    "rate_bps": 3093,
+    "seconds": 1688788833,
+    "expected_floor": "98556159975245975374"
+  },
+  {
+    "principal": "8698765950492402780",
+    "rate_bps": 8705,
+    "seconds": 3791417582,
+    "expected_floor": "909754209821122598257"
+  },
+  {
+    "principal": "12913019700187983141",
+    "rate_bps": 6626,
+    "seconds": 890619103,
+    "expected_floor": "241472280783204757829"
+  },
+  {
+    "principal": "6072950289943543170",
+    "rate_bps": 8009,
+    "seconds": 2772812420,
+    "expected_floor": "427360662052546592019"
+  },
+  {
+    "principal": "805754895847009923",
+    "rate_bps": 5775,
+    "seconds": 632179053,
+    "expected_floor": "9321613159630504264"
+  },
+  {
+    "principal": "17297567995969174648",
+    "rate_bps": 7228,
+    "seconds": 544788074,
+    "expected_floor": "215837456807975412080"
+  },
+  {
+    "principal": "10979838427171414001",
+    "rate_bps": 2741,
+    "seconds": 732077195,
+    "expected_floor": "69816471527510060196"
+  },
+  {
+    "principal": "18232820092172565182",
+    "rate_bps": 1665,
+    "seconds": 1604258336,
+    "expected_floor": "154325759183389896135"
+  },
+  {
+    "principal": "5836635692536572143",
+    "rate_bps": 324,
+    "seconds": 1104949689,
+    "expected_floor": "6621343730261380914"
+  },
+  {
+    "principal": "11104411477236516308",
+    "rate_bps": 911,
+    "seconds": 2947546918,
+    "expected_floor": "94486700368292722670"
+  },
+  {
+    "principal": "4396192751445161213",
+    "rate_bps": 5119,
+    "seconds": 2654838903,
+    "expected_floor": "189319810598934269046"
+  },
+  {
+    "principal": "8512767310067056442",
+    "rate_bps": 8682,
+    "seconds": 4021463804,
+    "expected_floor": "941826142228882148640"
+  },
+  {
+    "principal": "18365488292101526427",
+    "rate_bps": 9476,
+    "seconds": 1838384197,
+    "expected_floor": "1013817638153637687250"
+  },
+  {
+    "principal": "7283870878270291056",
+    "rate_bps": 8765,
+    "seconds": 1900273442,
+    "expected_floor": "384437983445980342006"
+  },
+  {
+    "principal": "3118454603382888521",
+    "rate_bps": 1429,
+    "seconds": 2469289123,
+    "expected_floor": "34869011143851498859"
+  },
+  {
+    "principal": "6959306785041786614",
+    "rate_bps": 330,
+    "seconds": 3252265240,
+    "expected_floor": "23668019152251416464"
+  },
+  {
+    "principal": "8335031860229552775",
+    "rate_bps": 8019,
+    "seconds": 2908581137,
+    "expected_floor": "616034016440146835585"
+  },
+  {
+    "principal": "6310976851054697548",
+    "rate_bps": 3640,
+    "seconds": 2270923358,
+    "expected_floor": "165308993282128344786"
+  },
+  {
+    "principal": "6320018583121917397",
+    "rate_bps": 8685,
+    "seconds": 3796016399,
+    "expected_floor": "660255900270719229078"
+  },
+  {
+    "principal": "2495015821521358322",
+    "rate_bps": 2096,
+    "seconds": 31991924,
+    "expected_floor": "530152696370272042"
+  },
+  {
+    "principal": "2620199226709911987",
+    "rate_bps": 5552,
+    "seconds": 3367458845,
+    "expected_floor": "155232303211464462155"
+  },
+  {
+    "principal": "2489048932751597928",
+    "rate_bps": 5281,
+    "seconds": 299850970,
+    "expected_floor": "12489673721619099248"
+  },
+  {
+    "principal": "12400588455059192225",
+    "rate_bps": 9247,
+    "seconds": 2939841979,
+    "expected_floor": "1068226068696541875331"
+  },
+  {
+    "principal": "5989606446347817006",
+    "rate_bps": 3005,
+    "seconds": 2760490256,
+    "expected_floor": "157443601377848431357"
+  },
+  {
+    "principal": "545115673000979743",
+    "rate_bps": 5227,
+    "seconds": 2669605225,
+    "expected_floor": "24103729537918479029"
+  },
+  {
+    "principal": "13646297442234664900",
+    "rate_bps": 2598,
+    "seconds": 1928655510,
+    "expected_floor": "216672939464542083877"
+  },
+  {
+    "principal": "8585569137480994733",
+    "rate_bps": 6143,
+    "seconds": 1416895143,
+    "expected_floor": "236800900537010861443"
+  },
+  {
+    "principal": "15854236120175610282",
+    "rate_bps": 6653,
+    "seconds": 3722255084,
+    "expected_floor": "1244127844612338858452"
+  },
+  {
+    "principal": "18092533733012558027",
+    "rate_bps": 105,
+    "seconds": 190719221,
+    "expected_floor": "1148098599529177092"
+  },
+  {
+    "principal": "12224662867594611552",
+    "rate_bps": 3879,
+    "seconds": 3065718674,
+    "expected_floor": "460664772671354977518"
+  },
+  {
+    "principal": "6112094030989419513",
+    "rate_bps": 8078,
+    "seconds": 165162963,
+    "expected_floor": "25840598854302770941"
+  },
+  {
+    "principal": "8335648551085315686",
+    "rate_bps": 6364,
+    "seconds": 3243261448,
+    "expected_floor": "545189595601579234301"
+  },
+  {
+    "principal": "14765523353295937719",
+    "rate_bps": 7467,
+    "seconds": 1092034241,
+    "expected_floor": "381528763520437230418"
+  },
+  {
+    "principal": "8735622528699902012",
+    "rate_bps": 7005,
+    "seconds": 4198897614,
+    "expected_floor": "814204160236841422943"
+  },
+  {
+    "principal": "7131191099622613637",
+    "rate_bps": 6915,
+    "seconds": 3557128511,
+    "expected_floor": "555840065071112612281"
+  },
+  {
+    "principal": "15353985373754561122",
+    "rate_bps": 1568,
+    "seconds": 113009252,
+    "expected_floor": "8621388466858339119"
+  },
+  {
+    "principal": "15180997518588143843",
+    "rate_bps": 1179,
+    "seconds": 3499117261,
+    "expected_floor": "198458015337673467479"
+  },
+  {
+    "principal": "6979663201129552472",
+    "rate_bps": 1415,
+    "seconds": 3990560586,
+    "expected_floor": "124888039510877850742"
+  },
+  {
+    "principal": "2079779427067344721",
+    "rate_bps": 63,
+    "seconds": 2277311211,
+    "expected_floor": "945532028281808889"
+  },
+  {
+    "principal": "10654360998743021982",
+    "rate_bps": 7755,
+    "seconds": 818021376,
+    "expected_floor": "214175552230888426637"
+  },
+  {
+    "principal": "18373021248331330895",
+    "rate_bps": 9323,
+    "seconds": 3166721305,
+    "expected_floor": "1718866463977071588332"
+  },
+  {
+    "principal": "14310977941825838516",
+    "rate_bps": 6507,
+    "seconds": 3463240198,
+    "expected_floor": "1021947923808883848455"
+  },
+  {
+    "principal": "1683477809360588381",
+    "rate_bps": 2051,
+    "seconds": 3985512663,
+    "expected_floor": "43606706095056792095"
+  },
+  {
+    "principal": "3870087031339583514",
+    "rate_bps": 6652,
+    "seconds": 2422529756,
+    "expected_floor": "197623290101233721681"
+  },
+  {
+    "principal": "5142400938396209659",
+    "rate_bps": 5422,
+    "seconds": 1335503269,
+    "expected_floor": "117995769247284204294"
+  },
+  {
+    "principal": "10458594416295849552",
+    "rate_bps": 949,
+    "seconds": 1918313474,
+    "expected_floor": "60333031015982004982"
+  },
+  {
+    "principal": "6359443209923318697",
+    "rate_bps": 810,
+    "seconds": 1371686659,
+    "expected_floor": "22390049819609734778"
+  },
+  {
+    "principal": "18155150944063945174",
+    "rate_bps": 2695,
+    "seconds": 3790073592,
+    "expected_floor": "587627767064958494378"
+  },
+  {
+    "principal": "18356667156765182695",
+    "rate_bps": 7927,
+    "seconds": 2560160881,
+    "expected_floor": "1180499973818036601947"
+  },
+  {
+    "principal": "4447873240556341292",
+    "rate_bps": 5426,
+    "seconds": 1163598142,
+    "expected_floor": "88987958435502619971"
+  },
+  {
+    "principal": "17994735584195031861",
+    "rate_bps": 36,
+    "seconds": 210327919,
+    "expected_floor": "431758531642595293"
+  },
+  {
+    "principal": "15702591694715570898",
+    "rate_bps": 3908,
+    "seconds": 2129227860,
+    "expected_floor": "414041683895472014857"
+  },
+  {
+    "principal": "16419776097350970387",
+    "rate_bps": 849,
+    "seconds": 3247186301,
+    "expected_floor": "143442603795839072368"
+  },
+  {
+    "principal": "5057979326199719752",
+    "rate_bps": 2979,
+    "seconds": 1339758010,
+    "expected_floor": "63969056947996464139"
+  },
+  {
+    "principal": "4344451807032088833",
+    "rate_bps": 7475,
+    "seconds": 3462749211,
+    "expected_floor": "356338914638735127797"
+  },
+  {
+    "principal": "11792280092806289166",
+    "rate_bps": 514,
+    "seconds": 1639898864,
+    "expected_floor": "31497349032485689539"
+  },
+  {
+    "principal": "18261595201212367231",
+    "rate_bps": 7935,
+    "seconds": 2778946761,
+    "expected_floor": "1276032989284788333683"
+  },
+  {
+    "principal": "12210190150174738340",
+    "rate_bps": 7653,
+    "seconds": 2773923190,
+    "expected_floor": "821380909573960632316"
+  },
+  {
+    "principal": "15738477827430347021",
+    "rate_bps": 6544,
+    "seconds": 3168180999,
+    "expected_floor": "1033979754104164028139"
+  },
+  {
+    "principal": "357579954371443338",
+    "rate_bps": 6636,
+    "seconds": 1980823244,
+    "expected_floor": "14894341201600887849"
+  },
+  {
+    "principal": "7700918574135514923",
+    "rate_bps": 5731,
+    "seconds": 1455067733,
+    "expected_floor": "203494269059391346625"
+  },
+  {
+    "principal": "15281370331399611712",
+    "rate_bps": 422,
+    "seconds": 3592868978,
+    "expected_floor": "73419625424355569085"
+  },
+  {
+    "principal": "14683766074407216985",
+    "rate_bps": 1696,
+    "seconds": 2873598515,
+    "expected_floor": "226769910458008952403"
+  },
+  {
+    "principal": "17177542656723865926",
+    "rate_bps": 7272,
+    "seconds": 4072125416,
+    "expected_floor": "1611877689190922014792"
+  },
+  {
+    "principal": "16655265421661452567",
+    "rate_bps": 9738,
+    "seconds": 2095443489,
+    "expected_floor": "1076944479214838336527"
+  },
+  {
+    "principal": "16133988483783572508",
+    "rate_bps": 9751,
+    "seconds": 1081708206,
+    "expected_floor": "539258570731981374406"
+  },
+  {
+    "principal": "12133898201578334181",
+    "rate_bps": 9773,
+    "seconds": 4231609759,
+    "expected_floor": "1590119958872063106981"
+  },
+  {
+    "principal": "1165333456584193858",
+    "rate_bps": 7422,
+    "seconds": 3101053508,
+    "expected_floor": "84991688648696340693"
+  },
+  {
+    "principal": "17237601291932775235",
+    "rate_bps": 7232,
+    "seconds": 3158170669,
+    "expected_floor": "1247575614645096756369"
+  },
+  {
+    "principal": "4490420985164630072",
+    "rate_bps": 2164,
+    "seconds": 1552826410,
+    "expected_floor": "47814900564047759950"
+  },
+  {
+    "principal": "1841760963635682993",
+    "rate_bps": 2953,
+    "seconds": 4138629451,
+    "expected_floor": "71326232944271771166"
+  },
+  {
+    "principal": "15122185187873917054",
+    "rate_bps": 3724,
+    "seconds": 4097265120,
+    "expected_floor": "731163198427928010231"
+  },
+  {
+    "principal": "12203624336411742639",
+    "rate_bps": 4101,
+    "seconds": 2364213369,
+    "expected_floor": "374939591027327235537"
+  },
+  {
+    "principal": "9103761622288631188",
+    "rate_bps": 8044,
+    "seconds": 1613858022,
+    "expected_floor": "374502134699496178925"
+  },
+  {
+    "principal": "4650436828596795325",
+    "rate_bps": 7178,
+    "seconds": 2614665527,
+    "expected_floor": "276572743142255678090"
+  },
+  {
+    "principal": "7795938513525481722",
+    "rate_bps": 9874,
+    "seconds": 2028495548,
+    "expected_floor": "494802197645633965246"
+  },
+  {
+    "principal": "18129225056212492379",
+    "rate_bps": 1273,
+    "seconds": 829579013,
+    "expected_floor": "60668245215707315031"
+  },
+  {
+    "principal": "16076951935718961200",
+    "rate_bps": 2506,
+    "seconds": 3581491426,
+    "expected_floor": "457240539768749385519"
+  },
+  {
+    "principal": "8357584015971622665",
+    "rate_bps": 7458,
+    "seconds": 1224950115,
+    "expected_floor": "241945509398962755117"
+  },
+  {
+    "principal": "10543133302129761462",
+    "rate_bps": 2861,
+    "seconds": 2585169112,
+    "expected_floor": "247099886853748747132"
+  },
+  {
+    "principal": "15841933099764378439",
+    "rate_bps": 9064,
+    "seconds": 3074493393,
+    "expected_floor": "1398935427984406393878"
+  },
+  {
+    "principal": "5846024432230351884",
+    "rate_bps": 7016,
+    "seconds": 12613662,
+    "expected_floor": "1639409429243603070"
+  },
+  {
+    "principal": "6765916593614061717",
+    "rate_bps": 6096,
+    "seconds": 2982159823,
+    "expected_floor": "389761148097665054220"
+  },
+  {
+    "principal": "14237619090732275634",
+    "rate_bps": 129,
+    "seconds": 1982466100,
+    "expected_floor": "11537956111299824194"
+  },
+  {
+    "principal": "5175741916483993203",
+    "rate_bps": 9231,
+    "seconds": 762870493,
+    "expected_floor": "115496337773232110195"
+  },
+  {
+    "principal": "11553896225307213096",
+    "rate_bps": 5384,
+    "seconds": 837000858,
+    "expected_floor": "164989174569024042594"
+  },
+  {
+    "principal": "4171133453250250849",
+    "rate_bps": 3478,
+    "seconds": 4266875515,
+    "expected_floor": "196150612361889890764"
+  },
+  {
+    "principal": "6730666881336241646",
+    "rate_bps": 6041,
+    "seconds": 4095889616,
+    "expected_floor": "527729302419164090566"
+  },
+  {
+    "principal": "16028115556978058719",
+    "rate_bps": 8911,
+    "seconds": 2113558569,
+    "expected_floor": "956575445205292672449"
+  },
+  {
+    "principal": "15244408047360169860",
+    "rate_bps": 9998,
+    "seconds": 1555843158,
+    "expected_floor": "751424835115909040812"
+  },
+  {
+    "principal": "755915937629135469",
+    "rate_bps": 835,
+    "seconds": 442444647,
+    "expected_floor": "884942301554324085"
+  },
+  {
+    "principal": "2592852217306102634",
+    "rate_bps": 462,
+    "seconds": 3996263084,
+    "expected_floor": "15169450320712033977"
+  },
+  {
+    "principal": "14218548834459905419",
+    "rate_bps": 1308,
+    "seconds": 2494861237,
+    "expected_floor": "147029826996346669587"
+  },
+  {
+    "principal": "17146347393999474464",
+    "rate_bps": 9029,
+    "seconds": 2497532242,
+    "expected_floor": "1225232217118664371889"
+  },
+  {
+    "principal": "125001641305864889",
+    "rate_bps": 2951,
+    "seconds": 2144347283,
+    "expected_floor": "2506548312130776784"
+  },
+  {
+    "principal": "13736805093296167974",
+    "rate_bps": 2849,
+    "seconds": 1167817160,
+    "expected_floor": "144826845359404616360"
+  },
+  {
+    "principal": "10802116706454872439",
+    "rate_bps": 2378,
+    "seconds": 3240971649,
+    "expected_floor": "263810441223847769042"
+  },
+  {
+    "principal": "4112947805220642812",
+    "rate_bps": 2806,
+    "seconds": 1217320334,
+    "expected_floor": "44518628281960548785"
+  },
+  {
+    "principal": "2508849302929571141",
+    "rate_bps": 4935,
+    "seconds": 168366591,
+    "expected_floor": "6605621485932192077"
+  },
+  {
+    "principal": "6481625278032915490",
+    "rate_bps": 5183,
+    "seconds": 3687551524,
+    "expected_floor": "392553865732860940036"
+  },
+  {
+    "principal": "16973239764836945315",
+    "rate_bps": 3939,
+    "seconds": 2119105933,
+    "expected_floor": "448951500346123390711"
+  },
+  {
+    "principal": "3363260632280598040",
+    "rate_bps": 2322,
+    "seconds": 1460285706,
+    "expected_floor": "36137375317503562363"
+  },
+  {
+    "principal": "17347422171103237649",
+    "rate_bps": 883,
+    "seconds": 2639200171,
+    "expected_floor": "128104390612149935047"
+  },
+  {
+    "principal": "1243772648809776990",
+    "rate_bps": 9904,
+    "seconds": 2897668032,
+    "expected_floor": "113108774342603554075"
+  },
+  {
+    "principal": "4699146412947308047",
+    "rate_bps": 7150,
+    "seconds": 208948185,
+    "expected_floor": "22246395528644110125"
+  },
+  {
+    "principal": "3093119660347260276",
+    "rate_bps": 4612,
+    "seconds": 1576402886,
+    "expected_floor": "71260567108904596966"
+  },
+  {
+    "principal": "6202568963894194461",
+    "rate_bps": 2623,
+    "seconds": 2926918039,
+    "expected_floor": "150895568810688863871"
+  },
+  {
+    "principal": "11583736469603715546",
+    "rate_bps": 5911,
+    "seconds": 2255828636,
+    "expected_floor": "489453869638048443956"
+  },
+  {
+    "principal": "16855987499143888571",
+    "rate_bps": 2527,
+    "seconds": 2310284389,
+    "expected_floor": "311832171395164321890"
+  },
+  {
+    "principal": "4963719378041897488",
+    "rate_bps": 8292,
+    "seconds": 3659668930,
+    "expected_floor": "477314190557292182838"
+  },
+  {
+    "principal": "11165401909095037545",
+    "rate_bps": 7970,
+    "seconds": 4140387267,
+    "expected_floor": "1167534383241995722124"
+  },
+  {
+    "principal": "10384504209803218838",
+    "rate_bps": 2892,
+    "seconds": 438139576,
+    "expected_floor": "41695825059710577236"
+  },
+  {
+    "principal": "12995372029855095719",
+    "rate_bps": 5880,
+    "seconds": 1953346353,
+    "expected_floor": "472978426290739698348"
+  },
+  {
+    "principal": "18182016762317000684",
+    "rate_bps": 5029,
+    "seconds": 4152600318,
+    "expected_floor": "1203205629561429974402"
+  },
+  {
+    "principal": "15030947101577698805",
+    "rate_bps": 8430,
+    "seconds": 3762225711,
+    "expected_floor": "1510618506786872550902"
+  },
+  {
+    "principal": "9674001237634921618",
+    "rate_bps": 9547,
+    "seconds": 1642197012,
+    "expected_floor": "480611713978776429659"
+  },
+  {
+    "principal": "3072629318470115539",
+    "rate_bps": 696,
+    "seconds": 3289670717,
+    "expected_floor": "22292966925381198837"
+  },
+  {
+    "principal": "16209215328251044616",
+    "rate_bps": 7605,
+    "seconds": 745600890,
+    "expected_floor": "291248475411506096073"
+  },
+  {
+    "principal": "7657785732572547009",
+    "rate_bps": 3907,
+    "seconds": 1977379035,
+    "expected_floor": "187470345548989640146"
+  },
+  {
+    "principal": "11354004673039275214",
+    "rate_bps": 2261,
+    "seconds": 2557219504,
+    "expected_floor": "208024109725041145103"
+  },
+  {
+    "principal": "8514910577869199935",
+    "rate_bps": 2789,
+    "seconds": 71033737,
+    "expected_floor": "5345511911181537523"
+  },
+  {
+    "principal": "5089174165094430564",
+    "rate_bps": 2352,
+    "seconds": 4229802806,
+    "expected_floor": "160435615639701475864"
+  },
+  {
+    "principal": "7986037290897793997",
+    "rate_bps": 4743,
+    "seconds": 3831876551,
+    "expected_floor": "459930277749894121787"
+  },
+  {
+    "principal": "7879909373206006858",
+    "rate_bps": 2011,
+    "seconds": 1031315084,
+    "expected_floor": "51786993173274343953"
+  },
+  {
+    "principal": "11078207408500036587",
+    "rate_bps": 3902,
+    "seconds": 501488917,
+    "expected_floor": "68693260308998193447"
+  },
+  {
+    "principal": "9607765178337134848",
+    "rate_bps": 2000,
+    "seconds": 2086051378,
+    "expected_floor": "127020380445728419767"
+  },
+  {
+    "principal": "3105033973906415129",
+    "rate_bps": 4478,
+    "seconds": 3611932403,
+    "expected_floor": "159142469327062457862"
+  },
+  {
+    "principal": "11610757779036190470",
+    "rate_bps": 9408,
+    "seconds": 3820195752,
+    "expected_floor": "1322329004306806884112"
+  },
+  {
+    "principal": "732443010431982039",
+    "rate_bps": 9971,
+    "seconds": 3137682657,
+    "expected_floor": "72613539282239066074"
+  },
+  {
+    "principal": "2460619885248238556",
+    "rate_bps": 6570,
+    "seconds": 2055072878,
+    "expected_floor": "105276917298255275159"
+  },
+  {
+    "principal": "8686384783784845989",
+    "rate_bps": 3536,
+    "seconds": 1036842591,
+    "expected_floor": "100916035640073133312"
+  },
+  {
+    "principal": "12614667000085672194",
+    "rate_bps": 8787,
+    "seconds": 3285459460,
+    "expected_floor": "1154007317299804222676"
+  },
+  {
+    "principal": "1188281423231285251",
+    "rate_bps": 4893,
+    "seconds": 1885056749,
+    "expected_floor": "34730815859868741821"
+  },
+  {
+    "principal": "17067730007565915128",
+    "rate_bps": 6826,
+    "seconds": 1539764714,
+    "expected_floor": "568450226608214207834"
+  },
+  {
+    "principal": "4423184499699162481",
+    "rate_bps": 3281,
+    "seconds": 1148622347,
+    "expected_floor": "52821968240579287608"
+  },
+  {
+    "principal": "2789676192244323902",
+    "rate_bps": 1811,
+    "seconds": 1358483872,
+    "expected_floor": "21748172353877490837"
+  },
+  {
+    "principal": "2891249448875375215",
+    "rate_bps": 3686,
+    "seconds": 427040569,
+    "expected_floor": "14421354807739948861"
+  },
+  {
+    "principal": "8925308222021780820",
+    "rate_bps": 8531,
+    "seconds": 347228838,
+    "expected_floor": "83778963798395457002"
+  },
+  {
+    "principal": "13556424340238826109",
+    "rate_bps": 8626,
+    "seconds": 2394677751,
+    "expected_floor": "887355653210024950775"
+  },
+  {
+    "principal": "13776846603057545914",
+    "rate_bps": 5275,
+    "seconds": 1245928060,
+    "expected_floor": "286920306802856642341"
+  },
+  {
+    "principal": "5577389679177493787",
+    "rate_bps": 7543,
+    "seconds": 318208453,
+    "expected_floor": "42421189447890878115"
+  },
+  {
+    "principal": "1637211685057569776",
+    "rate_bps": 3827,
+    "seconds": 3553219234,
+    "expected_floor": "70547452383403879681"
+  },
+  {
+    "principal": "14155052815582094793",
+    "rate_bps": 1754,
+    "seconds": 4243351075,
+    "expected_floor": "333845926028184433998"
+  },
+  {
+    "principal": "15072542881237422710",
+    "rate_bps": 7694,
+    "seconds": 95729816,
+    "expected_floor": "35178876644110510045"
+  },
+  {
+    "principal": "10176033695592832007",
+    "rate_bps": 9120,
+    "seconds": 1060563601,
+    "expected_floor": "311893357459594133575"
+  },
+  {
+    "principal": "17973912330522700748",
+    "rate_bps": 3802,
+    "seconds": 1000121822,
+    "expected_floor": "216572678556307621809"
+  },
+  {
+    "principal": "4666636459668654933",
+    "rate_bps": 6302,
+    "seconds": 2321411727,
+    "expected_floor": "216336886736842735694"
+  },
+  {
+    "principal": "17075720067586351474",
+    "rate_bps": 8277,
+    "seconds": 4031326196,
+    "expected_floor": "1805493608303687771056"
+  },
+  {
+    "principal": "8030250841755194163",
+    "rate_bps": 7504,
+    "seconds": 16244125,
+    "expected_floor": "3101803578234779440"
+  },
+  {
+    "principal": "12825333262986205416",
+    "rate_bps": 9083,
+    "seconds": 1207640154,
+    "expected_floor": "445791261339840206845"
+  },
+  {
+    "principal": "13386441255487723297",
+    "rate_bps": 3562,
+    "seconds": 265848635,
+    "expected_floor": "40168861180394406694"
+  },
+  {
+    "principal": "15558587982857669550",
+    "rate_bps": 3161,
+    "seconds": 2136220816,
+    "expected_floor": "332917673878267813002"
+  },
+  {
+    "principal": "5160391640319614623",
+    "rate_bps": 280,
+    "seconds": 2558525161,
+    "expected_floor": "11714571826324254400"
+  },
+  {
+    "principal": "8213407761958561604",
+    "rate_bps": 8136,
+    "seconds": 980606486,
+    "expected_floor": "207646740670760205714"
+  },
+  {
+    "principal": "5146749157294437677",
+    "rate_bps": 3206,
+    "seconds": 4131552295,
+    "expected_floor": "216025892070705423797"
+  },
+  {
+    "principal": "6675317280770993450",
+    "rate_bps": 6271,
+    "seconds": 253520492,
+    "expected_floor": "33629299066244257943"
+  },
+  {
+    "principal": "14121579475641420363",
+    "rate_bps": 3451,
+    "seconds": 2397125237,
+    "expected_floor": "370181738734706574014"
+  },
+  {
+    "principal": "11755325998425952992",
+    "rate_bps": 6140,
+    "seconds": 705346322,
+    "expected_floor": "161324930841922211182"
+  },
+  {
+    "principal": "13075690115904459129",
+    "rate_bps": 4746,
+    "seconds": 629954899,
+    "expected_floor": "123879043684672493132"
+  },
+  {
+    "principal": "5310758207846769126",
+    "rate_bps": 2073,
+    "seconds": 1790440840,
+    "expected_floor": "62461418028040137639"
+  },
+  {
+    "principal": "13104890242902794807",
+    "rate_bps": 9057,
+    "seconds": 461749313,
+    "expected_floor": "173668097451020234311"
+  },
+  {
+    "principal": "14565157076392400828",
+    "rate_bps": 8324,
+    "seconds": 306107214,
+    "expected_floor": "117602577892336576653"
+  },
+  {
+    "principal": "2459315391209166853",
+    "rate_bps": 6858,
+    "seconds": 3151817407,
+    "expected_floor": "168449137325999399706"
+  },
+  {
+    "principal": "14398643371450861026",
+    "rate_bps": 2199,
+    "seconds": 4180148708,
+    "expected_floor": "419405932640583107354"
+  },
+  {
+    "principal": "11267633427577565795",
+    "rate_bps": 8120,
+    "seconds": 2952523853,
+    "expected_floor": "856008715712466212454"
+  },
+  {
+    "principal": "1058075637047620056",
+    "rate_bps": 6043,
+    "seconds": 2101117642,
+    "expected_floor": "42571182235317067597"
+  },
+  {
+    "principal": "14160194411492717777",
+    "rate_bps": 9156,
+    "seconds": 1492991083,
+    "expected_floor": "613378073020669292533"
+  },
+  {
+    "principal": "1044541265496716574",
+    "rate_bps": 2621,
+    "seconds": 3417639808,
+    "expected_floor": "29649334195781624622"
+  },
+  {
+    "principal": "2616715758380451535",
+    "rate_bps": 3069,
+    "seconds": 369263257,
+    "expected_floor": "9396920813419221635"
+  },
+  {
+    "principal": "15324883479765671220",
+    "rate_bps": 7325,
+    "seconds": 626943366,
+    "expected_floor": "223012473340977313082"
+  },
+  {
+    "principal": "9724382116134441949",
+    "rate_bps": 3053,
+    "seconds": 168073815,
+    "expected_floor": "15811931022544870444"
+  },
+  {
+    "principal": "14626135706312559514",
+    "rate_bps": 1363,
+    "seconds": 160091740,
+    "expected_floor": "10113242295154574953"
+  },
+  {
+    "principal": "13060224754801798011",
+    "rate_bps": 1804,
+    "seconds": 3419692837,
+    "expected_floor": "255311463820648101196"
+  },
+  {
+    "principal": "14583297422659196368",
+    "rate_bps": 1089,
+    "seconds": 703092610,
+    "expected_floor": "35382798492007501406"
+  },
+  {
+    "principal": "9308404933777842473",
+    "rate_bps": 1287,
+    "seconds": 558141571,
+    "expected_floor": "21188207526629505552"
+  },
+  {
+    "principal": "1939401226330629462",
+    "rate_bps": 2576,
+    "seconds": 1955874424,
+    "expected_floor": "30963534174418560536"
+  },
+  {
+    "principal": "8459661845824105575",
+    "rate_bps": 9699,
+    "seconds": 2327097841,
+    "expected_floor": "605049127513354300889"
+  },
+  {
+    "principal": "570560953745561516",
+    "rate_bps": 9741,
+    "seconds": 3003348158,
+    "expected_floor": "52894108736135871720"
+  },
+  {
+    "principal": "758283818363996341",
+    "rate_bps": 3129,
+    "seconds": 2255809263,
+    "expected_floor": "16960387091136193694"
+  },
+  {
+    "principal": "3869156770594971218",
+    "rate_bps": 2646,
+    "seconds": 60272596,
+    "expected_floor": "1955339155003770296"
+  },
+  {
+    "principal": "2786085924703802771",
+    "rate_bps": 394,
+    "seconds": 599451389,
+    "expected_floor": "2085166465479616098"
+  },
+  {
+    "principal": "5569917525323062984",
+    "rate_bps": 1449,
+    "seconds": 553261370,
+    "expected_floor": "14149579407266907671"
+  },
+  {
+    "principal": "10948861274148288129",
+    "rate_bps": 2993,
+    "seconds": 1260369307,
+    "expected_floor": "130878865404011974512"
+  },
+  {
+    "principal": "16282414235190383246",
+    "rate_bps": 2501,
+    "seconds": 3448931952,
+    "expected_floor": "445054451914375100470"
+  },
+  {
+    "principal": "13227994932092515071",
+    "rate_bps": 800,
+    "seconds": 517909065,
+    "expected_floor": "17367349829149930220"
+  },
+  {
+    "principal": "16407135623082845988",
+    "rate_bps": 9668,
+    "seconds": 582213878,
+    "expected_floor": "292649641216754168357"
+  },
+  {
+    "principal": "15012960104449185421",
+    "rate_bps": 6041,
+    "seconds": 2404203655,
+    "expected_floor": "690943367330501693896"
+  },
+  {
+    "principal": "1313872246276955658",
+    "rate_bps": 5397,
+    "seconds": 3260384844,
+    "expected_floor": "73260597350804294577"
+  },
+  {
+    "principal": "7774342530158284971",
+    "rate_bps": 1716,
+    "seconds": 3359893461,
+    "expected_floor": "142037328168810610182"
+  },
+  {
+    "principal": "9357563028789456064",
+    "rate_bps": 619,
+    "seconds": 1332848626,
+    "expected_floor": "24464157923496188078"
+  },
+  {
+    "principal": "14632851021849498841",
+    "rate_bps": 9226,
+    "seconds": 40897459,
+    "expected_floor": "17495838449246205640"
+  },
+  {
+    "principal": "17951616682998258886",
+    "rate_bps": 5898,
+    "seconds": 3965758312,
+    "expected_floor": "1330548196291975903420"
+  },
+  {
+    "principal": "11519143064777407127",
+    "rate_bps": 5630,
+    "seconds": 2546387873,
+    "expected_floor": "523298099184450014649"
+  },
+  {
+    "principal": "12708316908581235612",
+    "rate_bps": 3624,
+    "seconds": 533301806,
+    "expected_floor": "77829692154808212585"
+  },
+  {
+    "principal": "6102903111543135589",
+    "rate_bps": 103,
+    "seconds": 2358308639,
+    "expected_floor": "4697538787759564098"
+  },
+  {
+    "principal": "8752202751218084546",
+    "rate_bps": 7442,
+    "seconds": 939471300,
+    "expected_floor": "193903918589906404708"
+  },
+  {
+    "principal": "17465044749898972355",
+    "rate_bps": 2047,
+    "seconds": 516407725,
+    "expected_floor": "58502753700769434732"
+  },
+  {
+    "principal": "15905821933238378424",
+    "rate_bps": 7501,
+    "seconds": 1642259370,
+    "expected_floor": "620887709428788066328"
+  },
+  {
+    "principal": "14231018137086385201",
+    "rate_bps": 9851,
+    "seconds": 3954897611,
+    "expected_floor": "1756902126902456212247"
+  },
+  {
+    "principal": "6316312559408243710",
+    "rate_bps": 7314,
+    "seconds": 4221801824,
+    "expected_floor": "618034109797657821660"
+  },
+  {
+    "principal": "3396253639057302319",
+    "rate_bps": 5888,
+    "seconds": 3895948793,
+    "expected_floor": "246875044379396805989"
+  },
+  {
+    "principal": "14296256573655926036",
+    "rate_bps": 5655,
+    "seconds": 2230472806,
+    "expected_floor": "571410094931512434028"
+  },
+  {
+    "principal": "8469854305577352509",
+    "rate_bps": 3820,
+    "seconds": 1369924279,
+    "expected_floor": "140453284095456698867"
+  },
+  {
+    "principal": "17196731466731463802",
+    "rate_bps": 5345,
+    "seconds": 3179516476,
+    "expected_floor": "926084748412679325152"
+  },
+  {
+    "principal": "11138412825641220571",
+    "rate_bps": 4909,
+    "seconds": 4142060677,
+    "expected_floor": "717676675366314986236"
+  },
+  {
+    "principal": "3515357305319053232",
+    "rate_bps": 2808,
+    "seconds": 1475718242,
+    "expected_floor": "46160027196368772279"
+  },
+  {
+    "principal": "11675264364136721545",
+    "rate_bps": 9055,
+    "seconds": 1302973155,
+    "expected_floor": "436502443083138586002"
+  },
+  {
+    "principal": "14354618390768109622",
+    "rate_bps": 3644,
+    "seconds": 4067697752,
+    "expected_floor": "674240332618439496338"
+  },
+  {
+    "principal": "13856292354183498951",
+    "rate_bps": 5147,
+    "seconds": 3456043345,
+    "expected_floor": "781045653316087760689"
+  },
+  {
+    "principal": "1575218499645625228",
+    "rate_bps": 5747,
+    "seconds": 397415326,
+    "expected_floor": "11400467082532367027"
+  },
+  {
+    "principal": "3502585441533318677",
+    "rate_bps": 1024,
+    "seconds": 2396780367,
+    "expected_floor": "27240367748140716059"
+  },
+  {
+    "principal": "3584486030272441138",
+    "rate_bps": 8424,
+    "seconds": 2986706868,
+    "expected_floor": "285781350273597178960"
+  },
+  {
+    "principal": "15029014688572024819",
+    "rate_bps": 3431,
+    "seconds": 804618333,
+    "expected_floor": "131473184834399436029"
+  },
+  {
+    "principal": "18044872434210714792",
+    "rate_bps": 3851,
+    "seconds": 3890602522,
+    "expected_floor": "856722616113961073641"
+  },
+  {
+    "principal": "963326379940455905",
+    "rate_bps": 5074,
+    "seconds": 1250554875,
+    "expected_floor": "19369691447706238813"
+  },
+  {
+    "principal": "7667446471008446830",
+    "rate_bps": 3340,
+    "seconds": 2615097424,
+    "expected_floor": "212217466410859974008"
+  },
+  {
+    "principal": "378888544244209503",
+    "rate_bps": 2288,
+    "seconds": 4285523369,
+    "expected_floor": "11772464654676294183"
+  },
+  {
+    "principal": "8150606777694467844",
+    "rate_bps": 7366,
+    "seconds": 332968918,
+    "expected_floor": "63346319017092841237"
+  },
+  {
+    "principal": "8837064360909359085",
+    "rate_bps": 4912,
+    "seconds": 1390284007,
+    "expected_floor": "191234364067695950472"
+  },
+  {
+    "principal": "13080711138290261738",
+    "rate_bps": 787,
+    "seconds": 1784410668,
+    "expected_floor": "58209910492720494265"
+  },
+  {
+    "principal": "18258613241692350219",
+    "rate_bps": 9387,
+    "seconds": 4003734837,
+    "expected_floor": "2174482651301885393416"
+  },
+  {
+    "principal": "9941985515350808224",
+    "rate_bps": 1793,
+    "seconds": 2986566866,
+    "expected_floor": "168702567079438215096"
+  },
+  {
+    "principal": "10291180530892171321",
+    "rate_bps": 6747,
+    "seconds": 701287955,
+    "expected_floor": "154300850391689685575"
+  },
+  {
+    "principal": "2855198272299083686",
+    "rate_bps": 6378,
+    "seconds": 3999641928,
+    "expected_floor": "230801130849626062033"
+  },
+  {
+    "principal": "15096832988637455095",
+    "rate_bps": 1447,
+    "seconds": 3907021569,
+    "expected_floor": "270455752666411413448"
+  },
+  {
+    "principal": "11962615900127154044",
+    "rate_bps": 8453,
+    "seconds": 2266370318,
+    "expected_floor": "726212858034282357879"
+  },
+  {
+    "principal": "6832598651003761349",
+    "rate_bps": 5073,
+    "seconds": 2621506431,
+    "expected_floor": "287937171126565232183"
+  },
+  {
+    "principal": "9000108355749683106",
+    "rate_bps": 7846,
+    "seconds": 1888596388,
+    "expected_floor": "422601690083685178546"
+  },
+  {
+    "principal": "14515969672514901795",
+    "rate_bps": 1274,
+    "seconds": 1649877773,
+    "expected_floor": "96685931320727552365"
+  },
+  {
+    "principal": "16821031588793752984",
+    "rate_bps": 7736,
+    "seconds": 1144132746,
+    "expected_floor": "471782183466054230437"
+  },
+  {
+    "principal": "11920341434298241937",
+    "rate_bps": 6492,
+    "seconds": 2978461995,
+    "expected_floor": "730390813212003832216"
+  },
+  {
+    "principal": "3186444539261248222",
+    "rate_bps": 8532,
+    "seconds": 3011276608,
+    "expected_floor": "259420262285274474801"
+  },
+  {
+    "principal": "4328995608916905871",
+    "rate_bps": 4227,
+    "seconds": 4197120345,
+    "expected_floor": "243369891255357250981"
+  },
+  {
+    "principal": "1297147197081877748",
+    "rate_bps": 4756,
+    "seconds": 2087062342,
+    "expected_floor": "40800225400345556993"
+  },
+  {
+    "principal": "8069747277736785565",
+    "rate_bps": 6679,
+    "seconds": 4210834199,
+    "expected_floor": "719176606054491114917"
+  },
+  {
+    "principal": "4134582206740909402",
+    "rate_bps": 7680,
+    "seconds": 325428764,
+    "expected_floor": "32744986896550894880"
+  },
+  {
+    "principal": "18055339090357360699",
+    "rate_bps": 1352,
+    "seconds": 448453093,
+    "expected_floor": "34689288908653166650"
+  },
+  {
+    "principal": "9463247344031066512",
+    "rate_bps": 7565,
+    "seconds": 3983135042,
+    "expected_floor": "903587444198512596936"
+  },
+  {
+    "principal": "9584167898020775913",
+    "rate_bps": 1849,
+    "seconds": 2415138115,
+    "expected_floor": "135621745361774460619"
+  },
+  {
+    "principal": "13274668068259920662",
+    "rate_bps": 2276,
+    "seconds": 2131513912,
+    "expected_floor": "204070454904072402611"
+  },
+  {
+    "principal": "4917967926905257255",
+    "rate_bps": 6385,
+    "seconds": 2217603249,
+    "expected_floor": "220661454152320746285"
+  },
+  {
+    "principal": "10465873118708080492",
+    "rate_bps": 2011,
+    "seconds": 4154098302,
+    "expected_floor": "277051393090762487352"
+  },
+  {
+    "principal": "7788663519714669429",
+    "rate_bps": 2774,
+    "seconds": 1105925039,
+    "expected_floor": "75716603261523525744"
+  },
+  {
+    "principal": "13587575518136944658",
+    "rate_bps": 2579,
+    "seconds": 1170911124,
+    "expected_floor": "130020932923952654849"
+  },
+  {
+    "principal": "9834694926666222163",
+    "rate_bps": 2615,
+    "seconds": 3980372413,
+    "expected_floor": "324378698013208070633"
+  },
+  {
+    "principal": "16102408460155361928",
+    "rate_bps": 5002,
+    "seconds": 1630960378,
+    "expected_floor": "416268904241148585184"
+  },
+  {
+    "principal": "91125414352594241",
+    "rate_bps": 4474,
+    "seconds": 3572449883,
+    "expected_floor": "4615275958622438427"
+  },
+  {
+    "principal": "11286616321151225934",
+    "rate_bps": 8953,
+    "seconds": 4143069744,
+    "expected_floor": "1326632472421369387610"
+  },
+  {
+    "principal": "2907119093247740863",
+    "rate_bps": 8323,
+    "seconds": 642494729,
+    "expected_floor": "49261578066941856550"
+  },
+  {
+    "principal": "13174797912427075300",
+    "rate_bps": 983,
+    "seconds": 3235468982,
+    "expected_floor": "132779415861630668505"
+  },
+  {
+    "principal": "12484544390587353421",
+    "rate_bps": 5711,
+    "seconds": 1213001031,
+    "expected_floor": "274057733022387207655"
+  },
+  {
+    "principal": "5491132386852106186",
+    "rate_bps": 8262,
+    "seconds": 3462901260,
+    "expected_floor": "497832501193072517044"
+  },
+  {
+    "principal": "13714926946187808107",
+    "rate_bps": 8583,
+    "seconds": 1788474005,
+    "expected_floor": "667131237320273279906"
+  },
+  {
+    "principal": "12308683743375659136",
+    "rate_bps": 1259,
+    "seconds": 725086642,
+    "expected_floor": "35606007627708147172"
+  },
+  {
+    "principal": "8460834145025543065",
+    "rate_bps": 1920,
+    "seconds": 2071634035,
+    "expected_floor": "106640821229447355435"
+  },
+  {
+    "principal": "6407396043842765446",
+    "rate_bps": 8286,
+    "seconds": 1786709800,
+    "expected_floor": "300591399285969489678"
+  },
+  {
+    "principal": "1945284588130573143",
+    "rate_bps": 3377,
+    "seconds": 3421149793,
+    "expected_floor": "71216779334335928297"
+  },
+  {
+    "principal": "7959168092157756252",
+    "rate_bps": 9575,
+    "seconds": 1861614,
+    "expected_floor": "449564623161894981"
+  },
+  {
+    "principal": "5448298927998294053",
+    "rate_bps": 9088,
+    "seconds": 3141871583,
+    "expected_floor": "492962302231255679444"
+  },
+  {
+    "principal": "8059854953593840770",
+    "rate_bps": 124,
+    "seconds": 3340206468,
+    "expected_floor": "10578357911390163895"
+  },
+  {
+    "principal": "9268327808266781059",
+    "rate_bps": 7432,
+    "seconds": 3829535853,
+    "expected_floor": "835890249974330492982"
+  },
+  {
+    "principal": "560502217712872312",
+    "rate_bps": 4329,
+    "seconds": 4070708586,
+    "expected_floor": "31299036403311502399"
+  },
+  {
+    "principal": "13700046449641183985",
+    "rate_bps": 6697,
+    "seconds": 54235019,
+    "expected_floor": "15768056524553711095"
+  },
+  {
+    "principal": "5669982594116923838",
+    "rate_bps": 5252,
+    "seconds": 3120011552,
+    "expected_floor": "294414149324175944713"
+  },
+  {
+    "principal": "2362558585411750895",
+    "rate_bps": 9241,
+    "seconds": 972360889,
+    "expected_floor": "67270564470487397463"
+  },
+  {
+    "principal": "9257825332704543956",
+    "rate_bps": 989,
+    "seconds": 2830210598,
+    "expected_floor": "82114539198074917825"
+  },
+  {
+    "principal": "6068232927672123389",
+    "rate_bps": 8657,
+    "seconds": 4284162935,
+    "expected_floor": "713167712027704804647"
+  },
+  {
+    "principal": "15126112275289065018",
+    "rate_bps": 459,
+    "seconds": 1818823164,
+    "expected_floor": "40015340313871358338"
+  },
+  {
+    "principal": "9333005894989792923",
+    "rate_bps": 6085,
+    "seconds": 32796485,
+    "expected_floor": "5902084946276209786"
+  },
+  {
+    "principal": "10190065979228900208",
+    "rate_bps": 6348,
+    "seconds": 2377958946,
+    "expected_floor": "487432294316385181579"
+  },
+  {
+    "principal": "16950158690498589513",
+    "rate_bps": 2701,
+    "seconds": 435908515,
+    "expected_floor": "63239690847008861409"
+  },
+  {
+    "principal": "6831848435727662582",
+    "rate_bps": 8166,
+    "seconds": 2383728664,
+    "expected_floor": "421405743350389218636"
+  },
+  {
+    "principal": "13183315741170204039",
+    "rate_bps": 5380,
+    "seconds": 744056849,
+    "expected_floor": "167228032769411946896"
+  },
+  {
+    "principal": "15903433721712491340",
+    "rate_bps": 2851,
+    "seconds": 3032138078,
+    "expected_floor": "435645395210144623568"
+  },
+  {
+    "principal": "12269673673549357269",
+    "rate_bps": 9644,
+    "seconds": 570048527,
+    "expected_floor": "213746038658885698847"
+  },
+  {
+    "principal": "160703154175292658",
+    "rate_bps": 4707,
+    "seconds": 1025451892,
+    "expected_floor": "2457988931103053664"
+  },
+  {
+    "principal": "3587195810908470451",
+    "rate_bps": 8270,
+    "seconds": 3878773533,
+    "expected_floor": "364628868475304997502"
+  },
+  {
+    "principal": "8303123854593773672",
+    "rate_bps": 171,
+    "seconds": 3848528858,
+    "expected_floor": "17315235670576498489"
+  },
+  {
+    "principal": "11640398611826717857",
+    "rate_bps": 8517,
+    "seconds": 1428660411,
+    "expected_floor": "448827587191681860633"
+  },
+  {
+    "principal": "11032451911607551790",
+    "rate_bps": 3380,
+    "seconds": 3749940240,
+    "expected_floor": "443107522586961732269"
+  },
+  {
+    "principal": "16578810225362145311",
+    "rate_bps": 8622,
+    "seconds": 59378793,
+    "expected_floor": "26896066947713425879"
+  },
+  {
+    "principal": "10988314954245916356",
+    "rate_bps": 8584,
+    "seconds": 816695702,
+    "expected_floor": "244105244906225545576"
+  },
+  {
+    "principal": "9864077062866950829",
+    "rate_bps": 9694,
+    "seconds": 3673284007,
+    "expected_floor": "1113038053887749895591"
+  },
+  {
+    "principal": "6662590523667402922",
+    "rate_bps": 8859,
+    "seconds": 1773189612,
+    "expected_floor": "331649262399877681760"
+  },
+  {
+    "principal": "1003345284908991435",
+    "rate_bps": 2123,
+    "seconds": 3904720885,
+    "expected_floor": "26356421027674567474"
+  },
+  {
+    "principal": "154540650240547424",
+    "rate_bps": 8980,
+    "seconds": 2827439762,
+    "expected_floor": "12433931371309664512"
+  },
+  {
+    "principal": "17602571033915997945",
+    "rate_bps": 1493,
+    "seconds": 4216423123,
+    "expected_floor": "351136626628002675886"
+  },
+  {
+    "principal": "5779397162881330534",
+    "rate_bps": 7814,
+    "seconds": 3462704392,
+    "expected_floor": "495527085518271914571"
+  },
+  {
+    "principal": "4421636860679873463",
+    "rate_bps": 5053,
+    "seconds": 33380801,
+    "expected_floor": "2363334293642579732"
+  },
+  {
+    "principal": "10496351275699668796",
+    "rate_bps": 495,
+    "seconds": 383028942,
+    "expected_floor": "6306249937814787094"
+  },
+  {
+    "principal": "9217225306010733957",
+    "rate_bps": 7492,
+    "seconds": 2650102847,
+    "expected_floor": "579904840439535947289"
+  },
+  {
+    "principal": "9397147632766744930",
+    "rate_bps": 6136,
+    "seconds": 2479399268,
+    "expected_floor": "453026808067301360025"
+  },
+  {
+    "principal": "4392881744629496803",
+    "rate_bps": 4921,
+    "seconds": 3525350861,
+    "expected_floor": "241491170740767776657"
+  },
+  {
+    "principal": "1564724051778439512",
+    "rate_bps": 4776,
+    "seconds": 3484083786,
+    "expected_floor": "82506221763992062366"
+  },
+  {
+    "principal": "5003628899419206225",
+    "rate_bps": 9128,
+    "seconds": 3719198187,
+    "expected_floor": "538277315715556525526"
+  },
+  {
+    "principal": "13716919924114903198",
+    "rate_bps": 5550,
+    "seconds": 3385660160,
+    "expected_floor": "816749697830863510404"
+  },
+  {
+    "principal": "3507910644477253711",
+    "rate_bps": 6861,
+    "seconds": 430813209,
+    "expected_floor": "32856476258779528744"
+  },
+  {
+    "principal": "10140451061380996276",
+    "rate_bps": 9332,
+    "seconds": 4207735046,
+    "expected_floor": "1261759030518720416454"
+  },
+  {
+    "principal": "10674820254682437981",
+    "rate_bps": 8001,
+    "seconds": 3155958743,
+    "expected_floor": "854146157483651903834"
+  },
+  {
+    "principal": "13505320930536787738",
+    "rate_bps": 8536,
+    "seconds": 3720723932,
+    "expected_floor": "1359198216312854742768"
+  },
+  {
+    "principal": "7603926051489973499",
+    "rate_bps": 8207,
+    "seconds": 3139933349,
+    "expected_floor": "620924477414801968550"
+  },
+  {
+    "principal": "418434233877626192",
+    "rate_bps": 8789,
+    "seconds": 4033252098,
+    "expected_floor": "47002187924167089324"
+  },
+  {
+    "principal": "13725207732306177705",
+    "rate_bps": 159,
+    "seconds": 1100470787,
+    "expected_floor": "7610104173418146145"
+  },
+  {
+    "principal": "3339754189596086486",
+    "rate_bps": 3309,
+    "seconds": 122002936,
+    "expected_floor": "4272455868924182405"
+  },
+  {
+    "principal": "4899262105055284711",
+    "rate_bps": 3997,
+    "seconds": 1234792305,
+    "expected_floor": "76622226901155244826"
+  },
+  {
+    "principal": "772081920190064428",
+    "rate_bps": 2203,
+    "seconds": 2231947326,
+    "expected_floor": "12029784674430928984"
+  },
+  {
+    "principal": "2365476647275650613",
+    "rate_bps": 3702,
+    "seconds": 2506194031,
+    "expected_floor": "69544982718060365092"
+  },
+  {
+    "principal": "3203774435607736786",
+    "rate_bps": 3959,
+    "seconds": 1245376340,
+    "expected_floor": "50054609422446585834"
+  },
+  {
+    "principal": "7917542418627575571",
+    "rate_bps": 3895,
+    "seconds": 1835183229,
+    "expected_floor": "179338414311550136992"
+  },
+  {
+    "principal": "11683442385241691720",
+    "rate_bps": 894,
+    "seconds": 1625693370,
+    "expected_floor": "53807523934238273013"
+  },
+  {
+    "principal": "13555908301259854849",
+    "rate_bps": 3833,
+    "seconds": 3658157851,
+    "expected_floor": "602318102680023342574"
+  },
+  {
+    "principal": "3807199493490642446",
+    "rate_bps": 4429,
+    "seconds": 1246440944,
+    "expected_floor": "66600739870920264345"
+  },
+  {
+    "principal": "661439962936812671",
+    "rate_bps": 2804,
+    "seconds": 2336421833,
+    "expected_floor": "13731428780485464378"
+  },
+  {
+    "principal": "576446284959237796",
+    "rate_bps": 7251,
+    "seconds": 3192786038,
+    "expected_floor": "42288530921688428846"
+  },
+  {
+    "principal": "10506784077179010061",
+    "rate_bps": 6811,
+    "seconds": 3659849223,
+    "expected_floor": "829927039383160144361"
+  },
+  {
+    "principal": "8453668469141602698",
+    "rate_bps": 2832,
+    "seconds": 1802442188,
+    "expected_floor": "136740082566982409320"
+  },
+  {
+    "principal": "2262430726223465003",
+    "rate_bps": 2494,
+    "seconds": 1504066901,
+    "expected_floor": "26892732162041972338"
+  },
+  {
+    "principal": "9191005159562835008",
+    "rate_bps": 1378,
+    "seconds": 728333170,
+    "expected_floor": "29230641703986808218"
+  },
+  {
+    "principal": "17515725682062770777",
+    "rate_bps": 1444,
+    "seconds": 3509155123,
+    "expected_floor": "281250904532773596242"
+  },
+  {
+    "principal": "15805856140333705286",
+    "rate_bps": 3689,
+    "seconds": 4224623336,
+    "expected_floor": "780567934504594173120"
+  },
+  {
+    "principal": "13525775718395624471",
+    "rate_bps": 3520,
+    "seconds": 1345366305,
+    "expected_floor": "202974474008855487159"
+  },
+  {
+    "principal": "806413320391334684",
+    "rate_bps": 2982,
+    "seconds": 724993454,
+    "expected_floor": "5524531449455373317"
+  },
+  {
+    "principal": "5038152597372162789",
+    "rate_bps": 4385,
+    "seconds": 3702104223,
+    "expected_floor": "259170513410515447126"
+  },
+  {
+    "principal": "13871679959777582658",
+    "rate_bps": 7773,
+    "seconds": 1658655044,
+    "expected_floor": "566721690253009189886"
+  },
+  {
+    "principal": "6016033320484750915",
+    "rate_bps": 2747,
+    "seconds": 495626029,
+    "expected_floor": "25954880379163334239"
+  },
+  {
+    "principal": "13930813516226705208",
+    "rate_bps": 3411,
+    "seconds": 3519317802,
+    "expected_floor": "529922936388192098816"
+  },
+  {
+    "principal": "14833787835113478577",
+    "rate_bps": 6912,
+    "seconds": 3786959947,
+    "expected_floor": "1230389276251785540225"
+  },
+  {
+    "principal": "17099669944430411646",
+    "rate_bps": 9712,
+    "seconds": 2444549344,
+    "expected_floor": "1286445056697910852557"
+  },
+  {
+    "principal": "16801705170628342959",
+    "rate_bps": 1473,
+    "seconds": 2406278009,
+    "expected_floor": "188711315213136227258"
+  },
+  {
+    "principal": "7670418629129766036",
+    "rate_bps": 4040,
+    "seconds": 3081772006,
+    "expected_floor": "302619542926059512791"
+  },
+  {
+    "principal": "4653858814013047485",
+    "rate_bps": 1659,
+    "seconds": 4069991479,
+    "expected_floor": "99574726612087311102"
+  },
+  {
+    "principal": "9062990532006062074",
+    "rate_bps": 1863,
+    "seconds": 817086908,
+    "expected_floor": "43716830326923123931"
+  },
+  {
+    "principal": "2716104389659513691",
+    "rate_bps": 963,
+    "seconds": 2565622277,
+    "expected_floor": "21264809444962617911"
+  },
+  {
+    "principal": "15477865731421503280",
+    "rate_bps": 8535,
+    "seconds": 3772719074,
+    "expected_floor": "1579301693307705389745"
+  },
+  {
+    "principal": "1259203570607798793",
+    "rate_bps": 1549,
+    "seconds": 2158056547,
+    "expected_floor": "13338476174684216615"
+  },
+  {
+    "principal": "5335879339684623286",
+    "rate_bps": 4913,
+    "seconds": 1180089304,
+    "expected_floor": "98031053854326520346"
+  },
+  {
+    "principal": "15856323866471083591",
+    "rate_bps": 5527,
+    "seconds": 1661339345,
+    "expected_floor": "461366817256203866649"
+  },
+  {
+    "principal": "666411383578780428",
+    "rate_bps": 4191,
+    "seconds": 1920773918,
+    "expected_floor": "16999351368148449285"
+  },
+  {
+    "principal": "1182417028341312405",
+    "rate_bps": 4318,
+    "seconds": 3866675407,
+    "expected_floor": "62558605983061474452"
+  },
+  {
+    "principal": "17881992994525839026",
+    "rate_bps": 9133,
+    "seconds": 1398146868,
+    "expected_floor": "723566089539132003478"
+  },
+  {
+    "principal": "3512456256140710259",
+    "rate_bps": 5866,
+    "seconds": 2473297373,
+    "expected_floor": "161482458245162216018"
+  },
+  {
+    "principal": "6538266904448445480",
+    "rate_bps": 6976,
+    "seconds": 1412769178,
+    "expected_floor": "204190889782341592555"
+  },
+  {
+    "principal": "1488036459897717601",
+    "rate_bps": 8649,
+    "seconds": 376540539,
+    "expected_floor": "15356323142988206422"
+  },
+  {
+    "principal": "1968429833434457326",
+    "rate_bps": 7153,
+    "seconds": 536944592,
+    "expected_floor": "23957068195582505350"
+  },
+  {
+    "principal": "11720243433559967967",
+    "rate_bps": 1092,
+    "seconds": 898528041,
+    "expected_floor": "36440719099869853307"
+  },
+  {
+    "principal": "15798385605616866948",
+    "rate_bps": 8077,
+    "seconds": 414326614,
+    "expected_floor": "167533498020952189812"
+  },
+  {
+    "principal": "16942757927118220653",
+    "rate_bps": 9800,
+    "seconds": 2034101863,
+    "expected_floor": "1070234414360756427436"
+  },
+  {
+    "principal": "6715600282677576298",
+    "rate_bps": 1752,
+    "seconds": 3067789740,
+    "expected_floor": "114377490614888880184"
+  },
+  {
+    "principal": "2889399298394153099",
+    "rate_bps": 6526,
+    "seconds": 4058823349,
+    "expected_floor": "242521818150465215347"
+  },
+  {
+    "principal": "14730674534554082848",
+    "rate_bps": 4234,
+    "seconds": 3377887314,
+    "expected_floor": "667597463903385262864"
+  },
+  {
+    "principal": "76498352405304761",
+    "rate_bps": 7019,
+    "seconds": 1222277011,
+    "expected_floor": "2079663168440018180"
+  },
+  {
+    "principal": "5632406305326986022",
+    "rate_bps": 953,
+    "seconds": 1215621320,
+    "expected_floor": "20676699583738914974"
+  },
+  {
+    "principal": "2818467437376676983",
+    "rate_bps": 9005,
+    "seconds": 2140964993,
+    "expected_floor": "172187784421475764960"
+  },
+  {
+    "principal": "8601508540159917820",
+    "rate_bps": 470,
+    "seconds": 1899646094,
+    "expected_floor": "24335552727034191796"
+  },
+  {
+    "principal": "15817180533932648517",
+    "rate_bps": 6097,
+    "seconds": 4089050367,
+    "expected_floor": "1249579119597852884282"
+  },
+  {
+    "principal": "4887972083483349794",
+    "rate_bps": 108,
+    "seconds": 4102869284,
+    "expected_floor": "6863350623673278437"
+  },
+  {
+    "principal": "13816448478355464355",
+    "rate_bps": 8103,
+    "seconds": 2081966221,
+    "expected_floor": "738604539789699066988"
+  },
+  {
+    "principal": "226094525561124120",
+    "rate_bps": 2124,
+    "seconds": 2204563466,
+    "expected_floor": "3354773456988910073"
+  },
+  {
+    "principal": "14819233522419503377",
+    "rate_bps": 8286,
+    "seconds": 1412526763,
+    "expected_floor": "549621089539058308137"
+  },
+  {
+    "principal": "10083507496946925150",
+    "rate_bps": 5990,
+    "seconds": 3026646720,
+    "expected_floor": "579290241341108410987"
+  },
+  {
+    "principal": "3863176557252714767",
+    "rate_bps": 5954,
+    "seconds": 357213913,
+    "expected_floor": "26036211209609930841"
+  },
+  {
+    "principal": "7251975714098478196",
+    "rate_bps": 4827,
+    "seconds": 2018711238,
+    "expected_floor": "223925665437026197938"
+  },
+  {
+    "principal": "10684971927800167453",
+    "rate_bps": 8370,
+    "seconds": 3357818007,
+    "expected_floor": "951594734297710550402"
+  },
+  {
+    "principal": "1753434121947320538",
+    "rate_bps": 3538,
+    "seconds": 3798668700,
+    "expected_floor": "74674914410365388248"
+  },
+  {
+    "principal": "5272464571309666747",
+    "rate_bps": 1448,
+    "seconds": 836407141,
+    "expected_floor": "20234663986575316934"
+  },
+  {
+    "principal": "11486264130147373328",
+    "rate_bps": 1170,
+    "seconds": 1050576066,
+    "expected_floor": "44739198145543238970"
+  },
+  {
+    "principal": "16875737973382649193",
+    "rate_bps": 8709,
+    "seconds": 1961877187,
+    "expected_floor": "913690089293496671332"
+  },
+  {
+    "principal": "9882161900841821846",
+    "rate_bps": 9452,
+    "seconds": 452995512,
+    "expected_floor": "134080496631242289575"
+  },
+  {
+    "principal": "9046923960024374951",
+    "rate_bps": 2954,
+    "seconds": 62336561,
+    "expected_floor": "5278983484275190969"
+  },
+  {
+    "principal": "5715159787575570156",
+    "rate_bps": 8494,
+    "seconds": 1527668222,
+    "expected_floor": "234998836149360842613"
+  },
+  {
+    "principal": "11417712645095360757",
+    "rate_bps": 9625,
+    "seconds": 1134044463,
+    "expected_floor": "394917120997696198362"
+  },
+  {
+    "principal": "9418545374902311826",
+    "rate_bps": 2186,
+    "seconds": 1923641108,
+    "expected_floor": "125502990464248338621"
+  },
+  {
+    "principal": "4016974108695851987",
+    "rate_bps": 4948,
+    "seconds": 820244285,
+    "expected_floor": "51661613922984854441"
+  },
+  {
+    "principal": "13382267695067091464",
+    "rate_bps": 8887,
+    "seconds": 3553164922,
+    "expected_floor": "1339048453270467265861"
+  },
+  {
+    "principal": "6766098965822489281",
+    "rate_bps": 3847,
+    "seconds": 1630739419,
+    "expected_floor": "134505837922829754017"
+  },
+  {
+    "principal": "17841465918940253134",
+    "rate_bps": 2368,
+    "seconds": 1029530032,
+    "expected_floor": "137831120075600846494"
+  },
+  {
+    "principal": "10646639468434947391",
+    "rate_bps": 9374,
+    "seconds": 4270096009,
+    "expected_floor": "1350427177357957697662"
+  },
+  {
+    "principal": "15446080890885944932",
+    "rate_bps": 84,
+    "seconds": 1121059382,
+    "expected_floor": "4609164852270524298"
+  },
+  {
+    "principal": "17804938397099798221",
+    "rate_bps": 2071,
+    "seconds": 1335168711,
+    "expected_floor": "156010113761077165763"
+  },
+  {
+    "principal": "3201269286912054090",
+    "rate_bps": 4526,
+    "seconds": 3811294604,
+    "expected_floor": "174986808583520001267"
+  },
+  {
+    "principal": "9171983008635045611",
+    "rate_bps": 2199,
+    "seconds": 707315733,
+    "expected_floor": "45206181264452675463"
+  },
+  {
+    "principal": "4341585946048600064",
+    "rate_bps": 5645,
+    "seconds": 2881897778,
+    "expected_floor": "223813848008741609131"
+  },
+  {
+    "principal": "4876650147165993241",
+    "rate_bps": 9214,
+    "seconds": 3527182835,
+    "expected_floor": "502219779940214838780"
+  },
+  {
+    "principal": "9773553938927865350",
+    "rate_bps": 2144,
+    "seconds": 2114944680,
+    "expected_floor": "140434023963750019988"
+  },
+  {
+    "principal": "12335409503376645335",
+    "rate_bps": 6709,
+    "seconds": 1566111713,
+    "expected_floor": "410705136089664122339"
+  },
+  {
+    "principal": "4022217083994026716",
+    "rate_bps": 5610,
+    "seconds": 4040680302,
+    "expected_floor": "288920854712420676982"
+  },
+  {
+    "principal": "10961860472390028709",
+    "rate_bps": 607,
+    "seconds": 1132353887,
+    "expected_floor": "23875428188455841539"
+  },
+  {
+    "principal": "15573045119102638082",
+    "rate_bps": 771,
+    "seconds": 1024450820,
+    "expected_floor": "38977597559087722246"
+  },
+  {
+    "principal": "423523038821550851",
+    "rate_bps": 90,
+    "seconds": 1734441453,
+    "expected_floor": "209495754857582154"
+  },
+  {
+    "principal": "8877684463618196216",
+    "rate_bps": 2095,
+    "seconds": 51001578,
+    "expected_floor": "3005822829813202825"
+  },
+  {
+    "principal": "16573704941103847537",
+    "rate_bps": 2645,
+    "seconds": 502368523,
+    "expected_floor": "69785265014373321368"
+  },
+  {
+    "principal": "16683931548365360446",
+    "rate_bps": 8657,
+    "seconds": 3365626016,
+    "expected_floor": "1540379413547397137493"
+  },
+  {
+    "principal": "6662326950209969519",
+    "rate_bps": 835,
+    "seconds": 2841573945,
+    "expected_floor": "50091889286409448087"
+  },
+  {
+    "principal": "15959555005739484244",
+    "rate_bps": 9163,
+    "seconds": 699261350,
+    "expected_floor": "324036566484599612693"
+  },
+  {
+    "principal": "16928002630226511229",
+    "rate_bps": 4359,
+    "seconds": 3323684087,
+    "expected_floor": "777156274248311989874"
+  },
+  {
+    "principal": "11195868140742494650",
+    "rate_bps": 3930,
+    "seconds": 606321020,
+    "expected_floor": "84537418720562834785"
+  },
+  {
+    "principal": "14942996571294244891",
+    "rate_bps": 9608,
+    "seconds": 1619682501,
+    "expected_floor": "736879736884756081165"
+  },
+  {
+    "principal": "2522108402539295472",
+    "rate_bps": 7698,
+    "seconds": 4246518178,
+    "expected_floor": "261258648675183915937"
+  },
+  {
+    "principal": "695863200412172489",
+    "rate_bps": 2465,
+    "seconds": 3764091171,
+    "expected_floor": "20459591615733835576"
+  },
+  {
+    "principal": "2339862202543188342",
+    "rate_bps": 2576,
+    "seconds": 3371820952,
+    "expected_floor": "64401603178533546883"
+  },
+  {
+    "principal": "15682051425405345543",
+    "rate_bps": 130,
+    "seconds": 3133466001,
+    "expected_floor": "20242644389203744667"
+  },
+  {
+    "principal": "16497648204109302476",
+    "rate_bps": 882,
+    "seconds": 4038450398,
+    "expected_floor": "186209318037959770315"
+  },
+  {
+    "principal": "16057502570476172885",
+    "rate_bps": 9614,
+    "seconds": 3205992847,
+    "expected_floor": "1568341736383621622690"
+  },
+  {
+    "principal": "5439725491223070834",
+    "rate_bps": 3601,
+    "seconds": 4134151924,
+    "expected_floor": "256615314319414987036"
+  },
+  {
+    "principal": "8415345211024565811",
+    "rate_bps": 4147,
+    "seconds": 3781421213,
+    "expected_floor": "418174032316814009673"
+  },
+  {
+    "principal": "8129827051294050280",
+    "rate_bps": 5767,
+    "seconds": 2283382618,
+    "expected_floor": "339239162077455266505"
+  },
+  {
+    "principal": "8830850417594307105",
+    "rate_bps": 6758,
+    "seconds": 3039279675,
+    "expected_floor": "574761162625880443964"
+  },
+  {
+    "principal": "12853798084565369518",
+    "rate_bps": 8313,
+    "seconds": 1930949520,
+    "expected_floor": "653816998007320812719"
+  },
+  {
+    "principal": "6608950868505117087",
+    "rate_bps": 3162,
+    "seconds": 1715280361,
+    "expected_floor": "113586191228087684317"
+  },
+  {
+    "principal": "5760922391712409156",
+    "rate_bps": 6208,
+    "seconds": 2477110550,
+    "expected_floor": "280727627149639365176"
+  },
+  {
+    "principal": "13281053256255815725",
+    "rate_bps": 9915,
+    "seconds": 1484930855,
+    "expected_floor": "619622958592922986590"
+  },
+  {
+    "principal": "18333366757425935402",
+    "rate_bps": 4372,
+    "seconds": 999950700,
+    "expected_floor": "253978527825083785504"
+  },
+  {
+    "principal": "1458912976726900043",
+    "rate_bps": 6949,
+    "seconds": 3203556725,
+    "expected_floor": "102915348791149070787"
+  },
+  {
+    "principal": "16447562547914170848",
+    "rate_bps": 6116,
+    "seconds": 271639058,
+    "expected_floor": "86587912982960186107"
+  },
+  {
+    "principal": "7496564449573088377",
+    "rate_bps": 4985,
+    "seconds": 19377235,
+    "expected_floor": "2294643809398168951"
+  },
+  {
+    "principal": "18184547301617105126",
+    "rate_bps": 1432,
+    "seconds": 3663094920,
+    "expected_floor": "302266291198482654635"
+  },
+  {
+    "principal": "17533723516914804023",
+    "rate_bps": 4359,
+    "seconds": 3128817473,
+    "expected_floor": "757769784735595810279"
+  },
+  {
+    "principal": "13792429248357217980",
+    "rate_bps": 6934,
+    "seconds": 2248624718,
+    "expected_floor": "681455679393025272589"
+  },
+  {
+    "principal": "2238355739467989765",
+    "rate_bps": 7375,
+    "seconds": 273599935,
+    "expected_floor": "14312093245642023285"
+  },
+  {
+    "principal": "13322255372845477090",
+    "rate_bps": 3173,
+    "seconds": 1688092900,
+    "expected_floor": "226120638245473075837"
+  },
+  {
+    "principal": "15956809470237869411",
+    "rate_bps": 1347,
+    "seconds": 486423373,
+    "expected_floor": "33130204987920373702"
+  },
+  {
+    "principal": "3597122820331806936",
+    "rate_bps": 562,
+    "seconds": 52840906,
+    "expected_floor": "338499374466434834"
+  },
+  {
+    "principal": "5752346037499965393",
+    "rate_bps": 2928,
+    "seconds": 3419451243,
+    "expected_floor": "182502376651276638194"
+  },
+  {
+    "principal": "12842205842243808286",
+    "rate_bps": 1393,
+    "seconds": 1493834368,
+    "expected_floor": "84681632722917276867"
+  },
+  {
+    "principal": "10466094203977050575",
+    "rate_bps": 9312,
+    "seconds": 3452034457,
+    "expected_floor": "1066102008903085012441"
+  },
+  {
+    "principal": "7540047642176740404",
+    "rate_bps": 1310,
+    "seconds": 213417094,
+    "expected_floor": "6679910144952513564"
+  },
+  {
+    "principal": "5194640902942482141",
+    "rate_bps": 7140,
+    "seconds": 3654589783,
+    "expected_floor": "429524965179757261850"
+  },
+  {
+    "principal": "11065176107009987226",
+    "rate_bps": 1699,
+    "seconds": 3675630940,
+    "expected_floor": "218967490273821352804"
+  },
+  {
+    "principal": "85830950474456699",
+    "rate_bps": 2245,
+    "seconds": 1133759013,
+    "expected_floor": "692272456539036349"
+  },
+  {
+    "principal": "12115992948914742480",
+    "rate_bps": 5401,
+    "seconds": 600948354,
+    "expected_floor": "124613866683587145571"
+  },
+  {
+    "principal": "16791795750919109673",
+    "rate_bps": 1361,
+    "seconds": 2830902147,
+    "expected_floor": "205010525532613714947"
+  },
+  {
+    "principal": "5865136328665381974",
+    "rate_bps": 8237,
+    "seconds": 133952888,
+    "expected_floor": "20506677028657351310"
+  },
+  {
+    "principal": "4235699358056591207",
+    "rate_bps": 5952,
+    "seconds": 457649393,
+    "expected_floor": "36560908020076201926"
+  },
+  {
+    "principal": "5011609101205698220",
+    "rate_bps": 4023,
+    "seconds": 3110808510,
+    "expected_floor": "198745147149452126557"
+  },
+  {
+    "principal": "3934352751924310965",
+    "rate_bps": 6535,
+    "seconds": 1330580975,
+    "expected_floor": "108406726450819189873"
+  },
+  {
+    "principal": "17543874578043995474",
+    "rate_bps": 7016,
+    "seconds": 1624452820,
+    "expected_floor": "633604465703100450538"
+  },
+  {
+    "principal": "12542151931199875219",
+    "rate_bps": 6890,
+    "seconds": 75723261,
+    "expected_floor": "20735600674495671785"
+  },
+  {
+    "principal": "5122089183398071752",
+    "rate_bps": 5118,
+    "seconds": 2912886842,
+    "expected_floor": "241973086480868605037"
+  },
+  {
+    "principal": "369759766376804737",
+    "rate_bps": 3286,
+    "seconds": 2972149915,
+    "expected_floor": "11443370445372876351"
+  },
+  {
+    "principal": "2039056238929561998",
+    "rate_bps": 8931,
+    "seconds": 2246628720,
+    "expected_floor": "129645256969515727395"
+  },
+  {
+    "principal": "4468835189223036415",
+    "rate_bps": 7141,
+    "seconds": 1892697417,
+    "expected_floor": "191395002424320710638"
+  },
+  {
+    "principal": "17586519509880006180",
+    "rate_bps": 5472,
+    "seconds": 3055892470,
+    "expected_floor": "931880208378971141493"
+  },
+  {
+    "principal": "4035992661031870861",
+    "rate_bps": 9903,
+    "seconds": 4082990983,
+    "expected_floor": "517120316580334542244"
+  },
+  {
+    "principal": "3002688093203326218",
+    "rate_bps": 8577,
+    "seconds": 3210585420,
+    "expected_floor": "262014842631828337874"
+  },
+  {
+    "principal": "16539838061683033003",
+    "rate_bps": 8639,
+    "seconds": 2967573205,
+    "expected_floor": "1343668701526352351383"
+  },
+  {
+    "principal": "3809348094137400256",
+    "rate_bps": 3682,
+    "seconds": 1208897266,
+    "expected_floor": "53730375082940847224"
+  },
+  {
+    "principal": "10750363771893411801",
+    "rate_bps": 2637,
+    "seconds": 2373181107,
+    "expected_floor": "213186748165428012595"
+  },
+  {
+    "principal": "14027507912263300038",
+    "rate_bps": 3306,
+    "seconds": 251763304,
+    "expected_floor": "36997453572924373432"
+  },
+  {
+    "principal": "3681211685425724823",
+    "rate_bps": 389,
+    "seconds": 1814267553,
+    "expected_floor": "8232614123236299732"
+  },
+  {
+    "principal": "14786216241674914460",
+    "rate_bps": 5954,
+    "seconds": 3770712366,
+    "expected_floor": "1051926320205831620245"
+  },
+  {
+    "principal": "6006599822383646821",
+    "rate_bps": 5079,
+    "seconds": 2189644319,
+    "expected_floor": "211678387915980044880"
+  },
+  {
+    "principal": "939240237555864002",
+    "rate_bps": 3441,
+    "seconds": 3346002116,
+    "expected_floor": "34267593506840067408"
+  },
+  {
+    "principal": "6934630753663324099",
+    "rate_bps": 2418,
+    "seconds": 2659617965,
+    "expected_floor": "141317168964047454808"
+  },
+  {
+    "principal": "8116212132401974968",
+    "rate_bps": 7104,
+    "seconds": 3392350890,
+    "expected_floor": "619802241800263193828"
+  },
+  {
+    "principal": "16166082041971103537",
+    "rate_bps": 8902,
+    "seconds": 2393302475,
+    "expected_floor": "1091405131223655852019"
+  },
+  {
+    "principal": "14133884742179003134",
+    "rate_bps": 9338,
+    "seconds": 3832226912,
+    "expected_floor": "1602738481370666959341"
+  },
+  {
+    "principal": "8169927188664583727",
+    "rate_bps": 3547,
+    "seconds": 2290831609,
+    "expected_floor": "210362621538344724860"
+  },
+  {
+    "principal": "9821055245340197908",
+    "rate_bps": 3328,
+    "seconds": 3060459366,
+    "expected_floor": "316974351712313027663"
+  },
+  {
+    "principal": "3058276122310199357",
+    "rate_bps": 3210,
+    "seconds": 1420289463,
+    "expected_floor": "44182941345957797547"
+  },
+  {
+    "principal": "6355637634062330746",
+    "rate_bps": 8255,
+    "seconds": 2692280636,
+    "expected_floor": "447602564474211434907"
+  },
+  {
+    "principal": "12181000614368685275",
+    "rate_bps": 8819,
+    "seconds": 1032765317,
+    "expected_floor": "351560428676333224819"
+  },
+  {
+    "principal": "8249234909188269744",
+    "rate_bps": 4447,
+    "seconds": 3459617634,
+    "expected_floor": "402165614594089078807"
+  },
+  {
+    "principal": "9810741953123977097",
+    "rate_bps": 2278,
+    "seconds": 3622428131,
+    "expected_floor": "256537810216988267194"
+  },
+  {
+    "principal": "8001143729366114102",
+    "rate_bps": 3190,
+    "seconds": 62804824,
+    "expected_floor": "5079626624558649404"
+  },
+  {
+    "principal": "8400701179116179399",
+    "rate_bps": 2114,
+    "seconds": 3159753809,
+    "expected_floor": "177815575070824004605"
+  },
+  {
+    "principal": "2565475557383828108",
+    "rate_bps": 8644,
+    "seconds": 254167710,
+    "expected_floor": "17860723548139515966"
+  },
+  {
+    "principal": "12745227292215410965",
+    "rate_bps": 6499,
+    "seconds": 3465976399,
+    "expected_floor": "909736785460921239562"
+  },
+  {
+    "principal": "12806406431157310002",
+    "rate_bps": 607,
+    "seconds": 1746634420,
+    "expected_floor": "43024320396308375405"
+  },
+  {
+    "principal": "2371374880455490291",
+    "rate_bps": 9953,
+    "seconds": 3185216349,
+    "expected_floor": "238226016276656809293"
+  },
+  {
+    "principal": "12980296218970563496",
+    "rate_bps": 867,
+    "seconds": 349268250,
+    "expected_floor": "12455433347314848405"
+  },
+  {
+    "principal": "15794877240778219745",
+    "rate_bps": 9200,
+    "seconds": 2550802171,
+    "expected_floor": "1174564560801173943603"
+  },
+  {
+    "principal": "9568394636420833390",
+    "rate_bps": 4745,
+    "seconds": 780666704,
+    "expected_floor": "112314799305290134724"
+  },
+  {
+    "principal": "5779134861797325407",
+    "rate_bps": 459,
+    "seconds": 2790654121,
+    "expected_floor": "23457275051687287597"
+  },
+  {
+    "principal": "3003630941579408900",
+    "rate_bps": 2751,
+    "seconds": 2840103638,
+    "expected_floor": "74364794297520286467"
+  },
+  {
+    "principal": "9060356463151944429",
+    "rate_bps": 231,
+    "seconds": 3816738791,
+    "expected_floor": "25313123392809037845"
+  },
+  {
+    "principal": "1420290603765769706",
+    "rate_bps": 1939,
+    "seconds": 565088556,
+    "expected_floor": "4931369764542961270"
+  },
+  {
+    "principal": "14589258410055162379",
+    "rate_bps": 159,
+    "seconds": 1150177333,
+    "expected_floor": "8454563269182338519"
+  },
+  {
+    "principal": "9974132075534411168",
+    "rate_bps": 7607,
+    "seconds": 3101068242,
+    "expected_floor": "745582811521762780766"
+  },
+  {
+    "principal": "8170406587219133241",
+    "rate_bps": 3492,
+    "seconds": 1392058643,
+    "expected_floor": "125855288083112616132"
+  },
+  {
+    "principal": "18310878392673222310",
+    "rate_bps": 4496,
+    "seconds": 1103700040,
+    "expected_floor": "287927119286862296190"
+  },
+  {
+    "principal": "3330962867690006007",
+    "rate_bps": 331,
+    "seconds": 1264690689,
+    "expected_floor": "4418533369777891335"
+  },
+  {
+    "principal": "15355404410989653628",
+    "rate_bps": 4562,
+    "seconds": 2231076878,
+    "expected_floor": "495252992119588637440"
+  },
+  {
+    "principal": "16340875860506795461",
+    "rate_bps": 916,
+    "seconds": 2792613503,
+    "expected_floor": "132457840679489529076"
+  },
+  {
+    "principal": "11668907322273105570",
+    "rate_bps": 9835,
+    "seconds": 4122800292,
+    "expected_floor": "1499314999749071144032"
+  },
+  {
+    "principal": "3953476910070311459",
+    "rate_bps": 8948,
+    "seconds": 2979163661,
+    "expected_floor": "333960864764785540617"
+  },
+  {
+    "principal": "8752472916602277016",
+    "rate_bps": 2028,
+    "seconds": 849927050,
+    "expected_floor": "47805339918242494347"
+  },
+  {
+    "principal": "9478829138439671441",
+    "rate_bps": 601,
+    "seconds": 994847787,
+    "expected_floor": "17958987081490424124"
+  },
+  {
+    "principal": "18372147430947527134",
+    "rate_bps": 6340,
+    "seconds": 3715530304,
+    "expected_floor": "1371405921728489313926"
+  },
+  {
+    "principal": "6620237022803882639",
+    "rate_bps": 71,
+    "seconds": 1674794073,
+    "expected_floor": "2494533471059094172"
+  },
+  {
+    "principal": "9544590750569888756",
+    "rate_bps": 6159,
+    "seconds": 264053318,
+    "expected_floor": "49187548470245872102"
+  },
+  {
+    "principal": "6888195991395451293",
+    "rate_bps": 5279,
+    "seconds": 3958193687,
+    "expected_floor": "456089666243763146806"
+  },
+  {
+    "principal": "4193703074370147418",
+    "rate_bps": 3556,
+    "seconds": 3246753052,
+    "expected_floor": "153428034191306430732"
+  },
+  {
+    "principal": "2169923988870187835",
+    "rate_bps": 9267,
+    "seconds": 4111680741,
+    "expected_floor": "261998679647143395232"
+  },
+  {
+    "principal": "10304653043244808336",
+    "rate_bps": 3696,
+    "seconds": 734017602,
+    "expected_floor": "88586561282353160173"
+  },
+  {
+    "principal": "7897522445916316393",
+    "rate_bps": 2739,
+    "seconds": 2612832323,
+    "expected_floor": "179097891963413186962"
+  },
+  {
+    "principal": "6648949221045654038",
+    "rate_bps": 4114,
+    "seconds": 1543045432,
+    "expected_floor": "133749463821631387513"
+  },
+  {
+    "principal": "16595733088904904743",
+    "rate_bps": 1327,
+    "seconds": 956918705,
+    "expected_floor": "66778773927610544067"
+  },
+  {
+    "principal": "8952572742062915180",
+    "rate_bps": 7760,
+    "seconds": 534722942,
+    "expected_floor": "117715711056651772746"
+  },
+  {
+    "principal": "12669486627211452021",
+    "rate_bps": 7076,
+    "seconds": 4215682735,
+    "expected_floor": "1197597260210694721762"
+  },
+  {
+    "principal": "13925684290806017810",
+    "rate_bps": 6,
+    "seconds": 4135267988,
+    "expected_floor": "1094882433241398740"
+  },
+  {
+    "principal": "16472797730835406163",
+    "rate_bps": 5400,
+    "seconds": 4110496957,
+    "expected_floor": "1158647928574186209802"
+  },
+  {
+    "principal": "11220636022981822856",
+    "rate_bps": 7612,
+    "seconds": 573080058,
+    "expected_floor": "155105637686496253835"
+  },
+  {
+    "principal": "9525716371049242689",
+    "rate_bps": 6410,
+    "seconds": 1353184603,
+    "expected_floor": "261823579653367992926"
+  },
+  {
+    "principal": "14355535151362787150",
+    "rate_bps": 6992,
+    "seconds": 430803248,
+    "expected_floor": "137023737231402071866"
+  },
+  {
+    "principal": "15610776114466090687",
+    "rate_bps": 7439,
+    "seconds": 317082633,
+    "expected_floor": "116682988205714874448"
+  },
+  {
+    "principal": "9081331461710697956",
+    "rate_bps": 9499,
+    "seconds": 3221728694,
+    "expected_floor": "880668399491957886633"
+  },
+  {
+    "principal": "5557163079405163597",
+    "rate_bps": 1471,
+    "seconds": 1346252871,
+    "expected_floor": "34872934157346997317"
+  },
+  {
+    "principal": "13535079805839226570",
+    "rate_bps": 2963,
+    "seconds": 3385117964,
+    "expected_floor": "430191983035300383899"
+  },
+  {
+    "principal": "16582896634136133739",
+    "rate_bps": 2841,
+    "seconds": 43031957,
+    "expected_floor": "6424195629573774856"
+  },
+  {
+    "principal": "2740661212365266816",
+    "rate_bps": 4435,
+    "seconds": 3691092146,
+    "expected_floor": "142167359657292370417"
+  },
+  {
+    "principal": "13884018093229450905",
+    "rate_bps": 8002,
+    "seconds": 1368355699,
+    "expected_floor": "481735616186537756194"
+  },
+  {
+    "principal": "5282999202770835846",
+    "rate_bps": 5298,
+    "seconds": 207943208,
+    "expected_floor": "18443072424549275868"
+  },
+  {
+    "principal": "10330426844298124887",
+    "rate_bps": 19,
+    "seconds": 894457185,
+    "expected_floor": "556323566383335068"
+  },
+  {
+    "principal": "3183832072306729564",
+    "rate_bps": 4841,
+    "seconds": 3400556270,
+    "expected_floor": "166085314986207011432"
+  },
+  {
+    "principal": "13657418813510402853",
+    "rate_bps": 8043,
+    "seconds": 1819839199,
+    "expected_floor": "633454965126599697794"
+  },
+  {
+    "principal": "2653947303358335874",
+    "rate_bps": 3136,
+    "seconds": 3015524484,
+    "expected_floor": "79529314889065130514"
+  },
+  {
+    "principal": "6553948669463319683",
+    "rate_bps": 4282,
+    "seconds": 3753500525,
+    "expected_floor": "333796833479798238677"
+  },
+  {
+    "principal": "15634571793373321848",
+    "rate_bps": 7296,
+    "seconds": 2868862058,
+    "expected_floor": "1036994650739224626911"
+  },
+  {
+    "principal": "15493385451130410481",
+    "rate_bps": 9657,
+    "seconds": 1251508875,
+    "expected_floor": "593360351978816888741"
+  },
+  {
+    "principal": "17713580971390953662",
+    "rate_bps": 7609,
+    "seconds": 2867079200,
+    "expected_floor": "1224530689331683601920"
+  },
+  {
+    "principal": "11419688325045972719",
+    "rate_bps": 9163,
+    "seconds": 1840375737,
+    "expected_floor": "610231285587009890370"
+  },
+  {
+    "principal": "11768933097877210068",
+    "rate_bps": 1936,
+    "seconds": 1437019430,
+    "expected_floor": "103753109203456625713"
+  },
+  {
+    "principal": "16534961451380394749",
+    "rate_bps": 4845,
+    "seconds": 3103565431,
+    "expected_floor": "787868807921953906230"
+  },
+  {
+    "principal": "6259528458824109370",
+    "rate_bps": 6215,
+    "seconds": 1064528124,
+    "expected_floor": "131230844560961923740"
+  },
+  {
+    "principal": "16507412443546384795",
+    "rate_bps": 76,
+    "seconds": 1421433413,
+    "expected_floor": "5650867804638468624"
+  },
+  {
+    "principal": "1517105262831180400",
+    "rate_bps": 9141,
+    "seconds": 2146020642,
+    "expected_floor": "94306005905804674104"
+  },
+  {
+    "principal": "6703049679143751241",
+    "rate_bps": 4173,
+    "seconds": 1175224995,
+    "expected_floor": "104168851359306269670"
+  },
+  {
+    "principal": "6196574438268884214",
+    "rate_bps": 2753,
+    "seconds": 610533144,
+    "expected_floor": "33003740288373965218"
+  },
+  {
+    "principal": "4351566665230598279",
+    "rate_bps": 5716,
+    "seconds": 813261585,
+    "expected_floor": "64100903780472538688"
+  },
+  {
+    "principal": "12694566647366179404",
+    "rate_bps": 21,
+    "seconds": 3985504350,
+    "expected_floor": "3366793617015550311"
+  },
+  {
+    "principal": "10605574970145295317",
+    "rate_bps": 4796,
+    "seconds": 2008408847,
+    "expected_floor": "323714051594244490279"
+  },
+  {
+    "principal": "4146752225990925298",
+    "rate_bps": 550,
+    "seconds": 707405428,
+    "expected_floor": "5112522081148074565"
+  },
+  {
+    "principal": "1728772281819713459",
+    "rate_bps": 9593,
+    "seconds": 1435463197,
+    "expected_floor": "75436291568227377477"
+  },
+  {
+    "principal": "1260451361789525864",
+    "rate_bps": 6867,
+    "seconds": 3457968858,
+    "expected_floor": "94844084739279546596"
+  },
+  {
+    "principal": "14448309116068327329",
+    "rate_bps": 9171,
+    "seconds": 1708708795,
+    "expected_floor": "717460186055076849071"
+  },
+  {
+    "principal": "4695660674333113902",
+    "rate_bps": 1073,
+    "seconds": 3893451536,
+    "expected_floor": "62162322722143963224"
+  },
+  {
+    "principal": "11653701010055066399",
+    "rate_bps": 3299,
+    "seconds": 1184442217,
+    "expected_floor": "144296600136053154524"
+  },
+  {
+    "principal": "4035333600080397764",
+    "rate_bps": 7872,
+    "seconds": 2707071126,
+    "expected_floor": "272496060825776146436"
+  },
+  {
+    "principal": "16614577057293018541",
+    "rate_bps": 2416,
+    "seconds": 3304300711,
+    "expected_floor": "420302348786473949550"
+  },
+  {
+    "principal": "18171774535922128810",
+    "rate_bps": 1849,
+    "seconds": 3537393900,
+    "expected_floor": "376628955964221144784"
+  },
+  {
+    "principal": "9338638338378708683",
+    "rate_bps": 3998,
+    "seconds": 3078650613,
+    "expected_floor": "364235929762876713775"
+  },
+  {
+    "principal": "15757845791614806368",
+    "rate_bps": 3673,
+    "seconds": 1057453458,
+    "expected_floor": "193943428666574318114"
+  },
+  {
+    "principal": "17841395790216731129",
+    "rate_bps": 1970,
+    "seconds": 2903430611,
+    "expected_floor": "323372093315572569599"
+  },
+  {
+    "principal": "16025143435956962406",
+    "rate_bps": 9398,
+    "seconds": 2089622536,
+    "expected_floor": "997243564600931986565"
+  },
+  {
+    "principal": "12558833887436170935",
+    "rate_bps": 5779,
+    "seconds": 185046209,
+    "expected_floor": "42557708524449486064"
+  },
+  {
+    "principal": "14264516441743910460",
+    "rate_bps": 1344,
+    "seconds": 3721856462,
+    "expected_floor": "226105941970990181983"
+  },
+  {
+    "principal": "12736068996898142341",
+    "rate_bps": 4679,
+    "seconds": 2833858367,
+    "expected_floor": "535134095151089525917"
+  },
+  {
+    "principal": "13164545047778222178",
+    "rate_bps": 2768,
+    "seconds": 4188594276,
+    "expected_floor": "483655653395967519571"
+  },
+  {
+    "principal": "9590928431396982499",
+    "rate_bps": 1606,
+    "seconds": 1989468365,
+    "expected_floor": "97104478859675169587"
+  },
+  {
+    "principal": "16110718011608512600",
+    "rate_bps": 2423,
+    "seconds": 900640074,
+    "expected_floor": "111407803094131384823"
+  },
+  {
+    "principal": "13542963943246769489",
+    "rate_bps": 2263,
+    "seconds": 3647203563,
+    "expected_floor": "354204694223083833121"
+  },
+  {
+    "principal": "6157287823361378206",
+    "rate_bps": 6127,
+    "seconds": 2808881664,
+    "expected_floor": "335789267866288240502"
+  },
+  {
+    "principal": "15916669870734277455",
+    "rate_bps": 805,
+    "seconds": 943655705,
+    "expected_floor": "38314017365505015701"
+  },
+  {
+    "principal": "13313623848492129204",
+    "rate_bps": 864,
+    "seconds": 421595142,
+    "expected_floor": "15367444591210474189"
+  },
+  {
+    "principal": "11395285073238352989",
+    "rate_bps": 6155,
+    "seconds": 959323863,
+    "expected_floor": "213213417869611576085"
+  },
+  {
+    "principal": "9445942699643541018",
+    "rate_bps": 1123,
+    "seconds": 3480919260,
+    "expected_floor": "117007862538048538238"
+  },
+  {
+    "principal": "4266876474177501179",
+    "rate_bps": 9645,
+    "seconds": 2333671333,
+    "expected_floor": "304332284766969730158"
+  },
+  {
+    "principal": "14540096760755801168",
+    "rate_bps": 8381,
+    "seconds": 573174274,
+    "expected_floor": "221332841601047177902"
+  },
+  {
+    "principal": "14727182309077813673",
+    "rate_bps": 423,
+    "seconds": 1286696195,
+    "expected_floor": "25399904280390190228"
+  },
+  {
+    "principal": "7966104146340947926",
+    "rate_bps": 6904,
+    "seconds": 3837218040,
+    "expected_floor": "668743036961865294606"
+  },
+  {
+    "principal": "11451439237919346919",
+    "rate_bps": 854,
+    "seconds": 1170074225,
+    "expected_floor": "36259965723921914758"
+  },
+  {
+    "principal": "9141416001086998060",
+    "rate_bps": 8259,
+    "seconds": 1311409982,
+    "expected_floor": "313744020120734973464"
+  },
+  {
+    "principal": "9122860309932869941",
+    "rate_bps": 3225,
+    "seconds": 3393036143,
+    "expected_floor": "316333555461233652127"
+  },
+  {
+    "principal": "15030961800880298194",
+    "rate_bps": 9305,
+    "seconds": 1432383060,
+    "expected_floor": "634831338646836704359"
+  },
+  {
+    "principal": "10617139321401676307",
+    "rate_bps": 8060,
+    "seconds": 1327314813,
+    "expected_floor": "359925430075254695717"
+  },
+  {
+    "principal": "15047464435055740232",
+    "rate_bps": 7713,
+    "seconds": 2770674618,
+    "expected_floor": "1018985997135949067041"
+  },
+  {
+    "principal": "12221353129373470465",
+    "rate_bps": 7529,
+    "seconds": 108315163,
+    "expected_floor": "31582163726003331490"
+  },
+  {
+    "principal": "17145524018522096910",
+    "rate_bps": 2926,
+    "seconds": 778796272,
+    "expected_floor": "123806937686922184943"
+  },
+  {
+    "principal": "9172397459814975359",
+    "rate_bps": 1264,
+    "seconds": 1434882761,
+    "expected_floor": "52715992819639879990"
+  },
+  {
+    "principal": "15384895397153342884",
+    "rate_bps": 597,
+    "seconds": 1211720566,
+    "expected_floor": "35266908486761343469"
+  },
+  {
+    "principal": "8075450364033468173",
+    "rate_bps": 1881,
+    "seconds": 821502215,
+    "expected_floor": "39542153647210658840"
+  },
+  {
+    "principal": "5068263102979360906",
+    "rate_bps": 1861,
+    "seconds": 203502796,
+    "expected_floor": "6082357437281037413"
+  },
+  {
+    "principal": "15063307268427283755",
+    "rate_bps": 10,
+    "seconds": 1945495637,
+    "expected_floor": "928638380913493687"
+  },
+  {
+    "principal": "8488956809055077184",
+    "rate_bps": 9508,
+    "seconds": 2204115570,
+    "expected_floor": "563733563249478370612"
+  },
+  {
+    "principal": "5819801149791673689",
+    "rate_bps": 8,
+    "seconds": 2907654195,
+    "expected_floor": "428979877487707135"
+  },
+  {
+    "principal": "4569415667238272838",
+    "rate_bps": 2654,
+    "seconds": 335122920,
+    "expected_floor": "12878395234732001564"
+  },
+  {
+    "principal": "1826105255787511575",
+    "rate_bps": 8681,
+    "seconds": 2980013089,
+    "expected_floor": "149695852264703662968"
+  },
+  {
+    "principal": "7422230940984637980",
+    "rate_bps": 6967,
+    "seconds": 3194453166,
+    "expected_floor": "523447140835328957150"
+  },
+  {
+    "principal": "11078753503055232485",
+    "rate_bps": 8851,
+    "seconds": 337511327,
+    "expected_floor": "104873950022329461658"
+  },
+  {
+    "principal": "3745485379491661122",
+    "rate_bps": 5936,
+    "seconds": 4088909892,
+    "expected_floor": "288075000536422584814"
+  },
+  {
+    "principal": "4251160435188619587",
+    "rate_bps": 9182,
+    "seconds": 2277208621,
+    "expected_floor": "281671972974443786489"
+  },
+  {
+    "principal": "9501205085866157624",
+    "rate_bps": 8504,
+    "seconds": 1764675114,
+    "expected_floor": "451817177443776477501"
+  },
+  {
+    "principal": "4842097219015972017",
+    "rate_bps": 5507,
+    "seconds": 2827378507,
+    "expected_floor": "238906830441533012507"
+  },
+  {
+    "principal": "4687211038262916734",
+    "rate_bps": 8094,
+    "seconds": 566651872,
+    "expected_floor": "68122420158057942401"
+  },
+  {
+    "principal": "16207188359773984687",
+    "rate_bps": 2343,
+    "seconds": 3650272889,
+    "expected_floor": "439239444786904858177"
+  },
+  {
+    "principal": "10532981536739689364",
+    "rate_bps": 7463,
+    "seconds": 1059238630,
+    "expected_floor": "263848487151819342455"
+  },
+  {
+    "principal": "12926786338994195901",
+    "rate_bps": 5672,
+    "seconds": 1306109751,
+    "expected_floor": "303460729477420913029"
+  },
+  {
+    "principal": "5220585908299968250",
+    "rate_bps": 1773,
+    "seconds": 3671269564,
+    "expected_floor": "107681299789631153845"
+  },
+  {
+    "principal": "15463345805924861531",
+    "rate_bps": 5314,
+    "seconds": 181024005,
+    "expected_floor": "47136487863550256554"
+  },
+  {
+    "principal": "13768126640090074672",
+    "rate_bps": 2855,
+    "seconds": 2113472226,
+    "expected_floor": "263253129361074535401"
+  },
+  {
+    "principal": "375119182680937737",
+    "rate_bps": 2684,
+    "seconds": 1233348451,
+    "expected_floor": "3934899191394107443"
+  },
+  {
+    "principal": "10405787200605768374",
+    "rate_bps": 8152,
+    "seconds": 2561338072,
+    "expected_floor": "688496995098148180168"
+  },
+  {
+    "principal": "6759371621823934791",
+    "rate_bps": 3544,
+    "seconds": 535757265,
+    "expected_floor": "40669060429932909664"
+  },
+  {
+    "principal": "14417955289614942732",
+    "rate_bps": 5486,
+    "seconds": 3953976862,
+    "expected_floor": "991036464135768013380"
+  },
+  {
+    "principal": "6492505356196566677",
+    "rate_bps": 2731,
+    "seconds": 1563782095,
+    "expected_floor": "87863052219690007368"
+  },
+  {
+    "principal": "17471947894029428146",
+    "rate_bps": 8157,
+    "seconds": 4267050548,
+    "expected_floor": "1927061649827596255748"
+  },
+  {
+    "principal": "16567580456172545139",
+    "rate_bps": 7168,
+    "seconds": 356683997,
+    "expected_floor": "134226029170358435946"
+  },
+  {
+    "principal": "13200561173639568168",
+    "rate_bps": 7485,
+    "seconds": 3350899866,
+    "expected_floor": "1049159896915589694155"
+  },
+  {
+    "principal": "2906252442729070177",
+    "rate_bps": 2781,
+    "seconds": 89374843,
+    "expected_floor": "2288999242478571635"
+  },
+  {
+    "principal": "10154397367520222190",
+    "rate_bps": 1226,
+    "seconds": 1970532048,
+    "expected_floor": "77736352670836754921"
+  },
+  {
+    "principal": "4494123507333049311",
+    "rate_bps": 2800,
+    "seconds": 3620113961,
+    "expected_floor": "144351502978024442685"
+  },
+  {
+    "principal": "12937221329806022020",
+    "rate_bps": 4326,
+    "seconds": 60552790,
+    "expected_floor": "10738848471952200074"
+  },
+  {
+    "principal": "8313768580895504493",
+    "rate_bps": 7312,
+    "seconds": 3886068071,
+    "expected_floor": "748584017987616664037"
+  },
+  {
+    "principal": "5026088636221475178",
+    "rate_bps": 2956,
+    "seconds": 4174864556,
+    "expected_floor": "196549976483346405374"
+  },
+  {
+    "principal": "5619724454437639051",
+    "rate_bps": 4395,
+    "seconds": 2357781941,
+    "expected_floor": "184532799823002642828"
+  },
+  {
+    "principal": "9658583920585059616",
+    "rate_bps": 6331,
+    "seconds": 1585684306,
+    "expected_floor": "307254697891549123186"
+  },
+  {
+    "principal": "9844246229709369529",
+    "rate_bps": 1199,
+    "seconds": 3190344339,
+    "expected_floor": "119326044254251848840"
+  },
+  {
+    "principal": "115562031492434470",
+    "rate_bps": 6146,
+    "seconds": 3361888200,
+    "expected_floor": "7566360395723565174"
+  },
+  {
+    "principal": "14372264105486919543",
+    "rate_bps": 7882,
+    "seconds": 305120129,
+    "expected_floor": "109528846008299413920"
+  },
+  {
+    "principal": "2936740298503413244",
+    "rate_bps": 2879,
+    "seconds": 1079624590,
+    "expected_floor": "28925175869517897970"
+  },
+  {
+    "principal": "5242706649899619141",
+    "rate_bps": 3936,
+    "seconds": 1248778239,
+    "expected_floor": "81656733467811901323"
+  },
+  {
+    "principal": "16629329368752454178",
+    "rate_bps": 9303,
+    "seconds": 35786788,
+    "expected_floor": "17543510845501817767"
+  },
+  {
+    "principal": "12707936171495928739",
+    "rate_bps": 9626,
+    "seconds": 3905262477,
+    "expected_floor": "1513795269202462309921"
+  },
+  {
+    "principal": "9372105726264501272",
+    "rate_bps": 366,
+    "seconds": 1878507274,
+    "expected_floor": "20418657227708951778"
+  },
+  {
+    "principal": "4804487863616670737",
+    "rate_bps": 6058,
+    "seconds": 483911083,
+    "expected_floor": "44631139116182778051"
+  },
+  {
+    "principal": "17446560159925122398",
+    "rate_bps": 9828,
+    "seconds": 1554712000,
+    "expected_floor": "844735885003946997714"
+  },
+  {
+    "principal": "3234886055485359119",
+    "rate_bps": 3967,
+    "seconds": 3955556825,
+    "expected_floor": "160851401450677406556"
+  },
+  {
+    "principal": "3699220240622713716",
+    "rate_bps": 2010,
+    "seconds": 10759622,
+    "expected_floor": "253512450511247315"
+  },
+  {
+    "principal": "18413041430763587357",
+    "rate_bps": 5203,
+    "seconds": 1012350871,
+    "expected_floor": "307331057281263840920"
+  },
+  {
+    "principal": "6581669700548990938",
+    "rate_bps": 2021,
+    "seconds": 2125788316,
+    "expected_floor": "89602153097604668863"
+  },
+  {
+    "principal": "9000639798978536635",
+    "rate_bps": 7697,
+    "seconds": 2321873509,
+    "expected_floor": "509717398443053631736"
+  },
+  {
+    "principal": "1298456085357174800",
+    "rate_bps": 9923,
+    "seconds": 315550658,
+    "expected_floor": "12883545052324883894"
+  },
+  {
+    "principal": "2533260461255045225",
+    "rate_bps": 2414,
+    "seconds": 4200231363,
+    "expected_floor": "81392868965280146565"
+  },
+  {
+    "principal": "3415263306699259286",
+    "rate_bps": 5560,
+    "seconds": 2952190136,
+    "expected_floor": "177639417924983033131"
+  },
+  {
+    "principal": "17090469307099832743",
+    "rate_bps": 72,
+    "seconds": 1780787505,
+    "expected_floor": "6943758657693221523"
+  },
+  {
+    "principal": "16083579146051882476",
+    "rate_bps": 559,
+    "seconds": 1141708030,
+    "expected_floor": "32527118879011962740"
+  },
+  {
+    "principal": "8582940860712498165",
+    "rate_bps": 7286,
+    "seconds": 2130004015,
+    "expected_floor": "422086772207044384061"
+  },
+  {
+    "principal": "7464735739493712530",
+    "rate_bps": 9877,
+    "seconds": 3745705492,
+    "expected_floor": "875123109025545411410"
+  },
+  {
+    "principal": "15348831355868497619",
+    "rate_bps": 5680,
+    "seconds": 2677504573,
+    "expected_floor": "739690267025021468316"
+  },
+  {
+    "principal": "1389864466911150344",
+    "rate_bps": 725,
+    "seconds": 3931440506,
+    "expected_floor": "12553308428783652891"
+  },
+  {
+    "principal": "16340344892051094977",
+    "rate_bps": 2022,
+    "seconds": 3645755099,
+    "expected_floor": "381703282647727563603"
+  },
+  {
+    "principal": "4694458362625688270",
+    "rate_bps": 9721,
+    "seconds": 971157680,
+    "expected_floor": "140437217597310188522"
+  },
+  {
+    "principal": "10486233733556330559",
+    "rate_bps": 1377,
+    "seconds": 3916503433,
+    "expected_floor": "179204131695106311823"
+  },
+  {
+    "principal": "9309417457375573348",
+    "rate_bps": 1500,
+    "seconds": 1987729718,
+    "expected_floor": "87956335735100698870"
+  },
+  {
+    "principal": "531439880515418573",
+    "rate_bps": 4664,
+    "seconds": 2689094087,
+    "expected_floor": "21121011557002286157"
+  },
+  {
+    "principal": "6309011746225035850",
+    "rate_bps": 8022,
+    "seconds": 3492994188,
+    "expected_floor": "560193273261138934832"
+  },
+  {
+    "principal": "15485019373495499243",
+    "rate_bps": 9754,
+    "seconds": 2580640533,
+    "expected_floor": "1235145303849286560418"
+  },
+  {
+    "principal": "11375978249944901376",
+    "rate_bps": 7833,
+    "seconds": 2582244402,
+    "expected_floor": "729138880485107969878"
+  },
+  {
+    "principal": "6244254770636051481",
+    "rate_bps": 4810,
+    "seconds": 1869831411,
+    "expected_floor": "177960728437870080533"
+  },
+  {
+    "principal": "2254248039654515974",
+    "rate_bps": 9918,
+    "seconds": 58682792,
+    "expected_floor": "4157503332416552346"
+  },
+  {
+    "principal": "14607891431818010583",
+    "rate_bps": 5849,
+    "seconds": 433107681,
+    "expected_floor": "117263019388908866235"
+  },
+  {
+    "principal": "101646151799378396",
+    "rate_bps": 8964,
+    "seconds": 195418734,
+    "expected_floor": "564228497929612215"
+  },
+  {
+    "principal": "2996682039495850149",
+    "rate_bps": 3508,
+    "seconds": 3425942623,
+    "expected_floor": "114123837773529697503"
+  },
+  {
+    "principal": "10905779499295424258",
+    "rate_bps": 9078,
+    "seconds": 3105857540,
+    "expected_floor": "974371237328565113589"
+  },
+  {
+    "principal": "5444766438917971459",
+    "rate_bps": 9530,
+    "seconds": 860570861,
+    "expected_floor": "141499473888895736821"
+  },
+  {
+    "principal": "45486322735198712",
+    "rate_bps": 3992,
+    "seconds": 142704618,
+    "expected_floor": "82111771408864360"
+  },
+  {
+    "principal": "3424418753957466993",
+    "rate_bps": 8115,
+    "seconds": 1060142091,
+    "expected_floor": "93354552529162161495"
+  },
+  {
+    "principal": "16314272837883774014",
+    "rate_bps": 8783,
+    "seconds": 2396123040,
+    "expected_floor": "1087967073409526298687"
+  },
+  {
+    "principal": "3717309872129114223",
+    "rate_bps": 6599,
+    "seconds": 2364396857,
+    "expected_floor": "183790601756974643169"
+  },
+  {
+    "principal": "2880311329412498260",
+    "rate_bps": 9891,
+    "seconds": 3936188582,
+    "expected_floor": "355346109274901589795"
+  },
+  {
+    "principal": "12190169478076436605",
+    "rate_bps": 2363,
+    "seconds": 2919163895,
+    "expected_floor": "266457517294299543571"
+  },
+  {
+    "principal": "1595982708789268666",
+    "rate_bps": 7923,
+    "seconds": 2354583676,
+    "expected_floor": "94346979187847593995"
+  },
+  {
+    "principal": "14414535096129639195",
+    "rate_bps": 574,
+    "seconds": 75583429,
+    "expected_floor": "1981687435874810706"
+  },
+  {
+    "principal": "6380906982460506608",
+    "rate_bps": 5551,
+    "seconds": 1948491938,
+    "expected_floor": "218699750313465495921"
+  },
+  {
+    "principal": "14223136601237953481",
+    "rate_bps": 6523,
+    "seconds": 1091472419,
+    "expected_floor": "320886582749189586836"
+  },
+  {
+    "principal": "81115463485653110",
+    "rate_bps": 9421,
+    "seconds": 240326296,
+    "expected_floor": "581966497142523162"
+  },
+  {
+    "principal": "2821035821022306823",
+    "rate_bps": 6730,
+    "seconds": 3547783313,
+    "expected_floor": "213440477886036487724"
+  },
+  {
+    "principal": "196414707901000140",
+    "rate_bps": 3728,
+    "seconds": 2839745502,
+    "expected_floor": "6589088828363251910"
+  },
+  {
+    "principal": "17658919620469530965",
+    "rate_bps": 1376,
+    "seconds": 1641362575,
+    "expected_floor": "126381388753394819206"
+  },
+  {
+    "principal": "8089208698736455538",
+    "rate_bps": 9188,
+    "seconds": 3864995316,
+    "expected_floor": "910273776454005117121"
+  },
+  {
+    "principal": "6948165279293192499",
+    "rate_bps": 9265,
+    "seconds": 2847142813,
+    "expected_floor": "580792298965947444156"
+  },
+  {
+    "principal": "18306010963943700200",
+    "rate_bps": 3687,
+    "seconds": 1433153114,
+    "expected_floor": "306517645100309856348"
+  },
+  {
+    "principal": "10316578443676634401",
+    "rate_bps": 4647,
+    "seconds": 2637884731,
+    "expected_floor": "400737702695943461611"
+  },
+  {
+    "principal": "9386067014776945070",
+    "rate_bps": 4157,
+    "seconds": 3966747280,
+    "expected_floor": "490449437421656402320"
+  },
+  {
+    "principal": "5071372901918319775",
+    "rate_bps": 9350,
+    "seconds": 715011305,
+    "expected_floor": "107435076639351796779"
+  },
+  {
+    "principal": "6705477270558172484",
+    "rate_bps": 8094,
+    "seconds": 2546764822,
+    "expected_floor": "438003690838335564534"
+  },
+  {
+    "principal": "14003683316862618413",
+    "rate_bps": 8903,
+    "seconds": 1984299559,
+    "expected_floor": "783938372737859730078"
+  },
+  {
+    "principal": "3208567414471670570",
+    "rate_bps": 3750,
+    "seconds": 2104207468,
+    "expected_floor": "80228196002461457238"
+  },
+  {
+    "principal": "12305682939957325899",
+    "rate_bps": 4427,
+    "seconds": 2020053109,
+    "expected_floor": "348717757847875101934"
+  },
+  {
+    "principal": "10040863241340383456",
+    "rate_bps": 8692,
+    "seconds": 319490322,
+    "expected_floor": "88357721794822844983"
+  },
+  {
+    "principal": "1145963672239212409",
+    "rate_bps": 9603,
+    "seconds": 1963392851,
+    "expected_floor": "68466955642426666999"
+  },
+  {
+    "principal": "15401083585831866342",
+    "rate_bps": 2738,
+    "seconds": 2735264648,
+    "expected_floor": "365493878107566991406"
+  },
+  {
+    "principal": "12511975050960513079",
+    "rate_bps": 7594,
+    "seconds": 3113890369,
+    "expected_floor": "937552969528234058681"
+  },
+  {
+    "principal": "13415089206544668092",
+    "rate_bps": 1361,
+    "seconds": 2621686094,
+    "expected_floor": "151680032675217924754"
+  },
+  {
+    "principal": "2977440382563659269",
+    "rate_bps": 8165,
+    "seconds": 4257525951,
+    "expected_floor": "327983956227514140093"
+  },
+  {
+    "principal": "870377779941888994",
+    "rate_bps": 4987,
+    "seconds": 3773333476,
+    "expected_floor": "51900122747378693546"
+  },
+  {
+    "principal": "11322422502450010211",
+    "rate_bps": 9425,
+    "seconds": 3303310925,
+    "expected_floor": "1117033511347343996741"
+  },
+  {
+    "principal": "6080998612354224088",
+    "rate_bps": 1024,
+    "seconds": 2235830474,
+    "expected_floor": "44117385283068946906"
+  },
+  {
+    "principal": "9570490567436315345",
+    "rate_bps": 3671,
+    "seconds": 3160941163,
+    "expected_floor": "351909530805511938910"
+  },
+  {
+    "principal": "11567727242755679006",
+    "rate_bps": 3852,
+    "seconds": 3807586688,
+    "expected_floor": "537625860804547918857"
+  },
+  {
+    "principal": "251633860242853071",
+    "rate_bps": 9620,
+    "seconds": 1596274841,
+    "expected_floor": "12244691669832312977"
+  },
+  {
+    "principal": "6708960517422275380",
+    "rate_bps": 1419,
+    "seconds": 3724972934,
+    "expected_floor": "112371657256104505248"
+  },
+  {
+    "principal": "6345019846689614301",
+    "rate_bps": 2925,
+    "seconds": 2955452503,
+    "expected_floor": "173811646016773228275"
+  },
+  {
+    "principal": "6128463482489264538",
+    "rate_bps": 5719,
+    "seconds": 2297728092,
+    "expected_floor": "255191594820590292893"
+  },
+  {
+    "principal": "9681253390840091003",
+    "rate_bps": 4310,
+    "seconds": 3082237221,
+    "expected_floor": "407540666110049212766"
+  },
+  {
+    "principal": "11008259393358803920",
+    "rate_bps": 5674,
+    "seconds": 1232020866,
+    "expected_floor": "243849619449574120955"
+  },
+  {
+    "principal": "5514757706666645289",
+    "rate_bps": 4421,
+    "seconds": 595048067,
+    "expected_floor": "45972173051218500245"
+  },
+  {
+    "principal": "2768988877883216726",
+    "rate_bps": 5390,
+    "seconds": 192390264,
+    "expected_floor": "9098904357823140251"
+  },
+  {
+    "principal": "5339496726793220711",
+    "rate_bps": 5364,
+    "seconds": 251504625,
+    "expected_floor": "22826067781447365696"
+  },
+  {
+    "principal": "3610816340749948332",
+    "rate_bps": 6614,
+    "seconds": 1095164606,
+    "expected_floor": "82879099233149294330"
+  },
+  {
+    "principal": "1187553518063427253",
+    "rate_bps": 9264,
+    "seconds": 472723695,
+    "expected_floor": "16479921606868076211"
+  },
+  {
+    "principal": "14495206609442745426",
+    "rate_bps": 1398,
+    "seconds": 904048084,
+    "expected_floor": "58052261705282685418"
+  },
+  {
+    "principal": "9139541684070136723",
+    "rate_bps": 4071,
+    "seconds": 3006266621,
+    "expected_floor": "354445158123725658967"
+  },
+  {
+    "principal": "3902556692572372168",
+    "rate_bps": 7117,
+    "seconds": 3849856826,
+    "expected_floor": "338833856000795579819"
+  },
+  {
+    "principal": "13108581250572889217",
+    "rate_bps": 4345,
+    "seconds": 267590555,
+    "expected_floor": "48296124711604319496"
+  },
+  {
+    "principal": "9208113411585228942",
+    "rate_bps": 9604,
+    "seconds": 4057146480,
+    "expected_floor": "1136945198133246895526"
+  },
+  {
+    "principal": "3102439353956727039",
+    "rate_bps": 9616,
+    "seconds": 3211124809,
+    "expected_floor": "303564494472225288763"
+  },
+  {
+    "principal": "11213384898101454116",
+    "rate_bps": 649,
+    "seconds": 2995425014,
+    "expected_floor": "69077388636599506816"
+  },
+  {
+    "principal": "8886421782192237709",
+    "rate_bps": 8372,
+    "seconds": 3908158087,
+    "expected_floor": "921349274118740013137"
+  },
+  {
+    "principal": "3410407718190230538",
+    "rate_bps": 4490,
+    "seconds": 2679751756,
+    "expected_floor": "130029903608062853904"
+  },
+  {
+    "principal": "11354101799178778283",
+    "rate_bps": 2455,
+    "seconds": 1222852053,
+    "expected_floor": "108012552717768627906"
+  },
+  {
+    "principal": "4111398833554918080",
+    "rate_bps": 5236,
+    "seconds": 3143562738,
+    "expected_floor": "214440796360355097469"
+  },
+  {
+    "principal": "10551169491485969113",
+    "rate_bps": 1517,
+    "seconds": 2797318579,
+    "expected_floor": "141880968054274165968"
+  },
+  {
+    "principal": "10769820121632115398",
+    "rate_bps": 6051,
+    "seconds": 4172712296,
+    "expected_floor": "861688064005705854619"
+  },
+  {
+    "principal": "6291026525134274711",
+    "rate_bps": 5694,
+    "seconds": 3869524385,
+    "expected_floor": "439230611412631339501"
+  },
+  {
+    "principal": "6148198821794605468",
+    "rate_bps": 6628,
+    "seconds": 1110145070,
+    "expected_floor": "143352796880392220193"
+  },
+  {
+    "principal": "1163845993443128165",
+    "rate_bps": 7578,
+    "seconds": 662287647,
+    "expected_floor": "18509419752507134079"
+  },
+  {
+    "principal": "526133987273455810",
+    "rate_bps": 7367,
+    "seconds": 1974775748,
+    "expected_floor": "24254975771626515946"
+  },
+  {
+    "principal": "17832138174024950467",
+    "rate_bps": 8337,
+    "seconds": 3207157677,
+    "expected_floor": "1510878590599396748269"
+  },
+  {
+    "principal": "12881544157593320888",
+    "rate_bps": 2219,
+    "seconds": 3434574250,
+    "expected_floor": "311095816785851165622"
+  },
+  {
+    "principal": "775254063422624305",
+    "rate_bps": 893,
+    "seconds": 3847674059,
+    "expected_floor": "8440920663885263951"
+  },
+  {
+    "principal": "2963428563277009406",
+    "rate_bps": 7268,
+    "seconds": 2009510752,
+    "expected_floor": "137149979919537949998"
+  },
+  {
+    "principal": "9025171165272975663",
+    "rate_bps": 8226,
+    "seconds": 2290297849,
+    "expected_floor": "538805661576172398133"
+  },
+  {
+    "principal": "324926957054837524",
+    "rate_bps": 7484,
+    "seconds": 265780838,
+    "expected_floor": "2048043711398294776"
+  },
+  {
+    "principal": "78817449530315581",
+    "rate_bps": 2993,
+    "seconds": 3022809271,
+    "expected_floor": "2259622406806410860"
+  },
+  {
+    "principal": "14051476328896246394",
+    "rate_bps": 9759,
+    "seconds": 2915192892,
+    "expected_floor": "1266749097070958217147"
+  },
+  {
+    "principal": "11132791185650311131",
+    "rate_bps": 5733,
+    "seconds": 647932549,
+    "expected_floor": "131042399034531117552"
+  },
+  {
+    "principal": "14990259823311615408",
+    "rate_bps": 2239,
+    "seconds": 1311341154,
+    "expected_floor": "139468130003605559281"
+  },
+  {
+    "principal": "16382651801099477641",
+    "rate_bps": 5115,
+    "seconds": 3412979939,
+    "expected_floor": "906274180696639703981"
+  },
+  {
+    "principal": "2369852439531255350",
+    "rate_bps": 5612,
+    "seconds": 1931248216,
+    "expected_floor": "81390383734216323593"
+  },
+  {
+    "principal": "937518953294205639",
+    "rate_bps": 6654,
+    "seconds": 3553689425,
+    "expected_floor": "70248710353925858046"
+  },
+  {
+    "principal": "2508854128322711948",
+    "rate_bps": 6597,
+    "seconds": 101745054,
+    "expected_floor": "5336189384960202745"
+  },
+  {
+    "principal": "17863897549292809237",
+    "rate_bps": 406,
+    "seconds": 2824158543,
+    "expected_floor": "64906375717087144240"
+  },
+  {
+    "principal": "8782537074542147890",
+    "rate_bps": 8215,
+    "seconds": 604341684,
+    "expected_floor": "138167577417596544234"
+  },
+  {
+    "principal": "5932590442640592371",
+    "rate_bps": 4322,
+    "seconds": 4288910941,
+    "expected_floor": "348475453121597177853"
+  },
+  {
+    "principal": "1857324699174965928",
+    "rate_bps": 5509,
+    "seconds": 183562266,
+    "expected_floor": "5951686535747626070"
+  },
+  {
+    "principal": "14447940881371667425",
+    "rate_bps": 5341,
+    "seconds": 2488162811,
+    "expected_floor": "608419831478956475822"
+  },
+  {
+    "principal": "4708086764653762414",
+    "rate_bps": 2930,
+    "seconds": 2730808912,
+    "expected_floor": "119371162304738703557"
+  },
+  {
+    "principal": "9559659694207982943",
+    "rate_bps": 293,
+    "seconds": 1340087209,
+    "expected_floor": "11894307107733427171"
+  },
+  {
+    "principal": "3791985803935233284",
+    "rate_bps": 9310,
+    "seconds": 1705796054,
+    "expected_floor": "190826867889685642872"
+  },
+  {
+    "principal": "2955473545201442285",
+    "rate_bps": 6149,
+    "seconds": 3684930279,
+    "expected_floor": "212205618020212447041"
+  },
+  {
+    "principal": "7946808112394792170",
+    "rate_bps": 1446,
+    "seconds": 2320838700,
+    "expected_floor": "84508814622812909470"
+  },
+  {
+    "principal": "9833684723424218379",
+    "rate_bps": 5304,
+    "seconds": 1876720437,
+    "expected_floor": "310181157290573278487"
+  },
+  {
+    "principal": "585226627884086432",
+    "rate_bps": 9085,
+    "seconds": 2556277458,
+    "expected_floor": "43067834275264665944"
+  },
+  {
+    "principal": "12548972359493623353",
+    "rate_bps": 8119,
+    "seconds": 6910995,
+    "expected_floor": "2231245285431557867"
+  },
+  {
+    "principal": "17049115615787570598",
+    "rate_bps": 8098,
+    "seconds": 3393228616,
+    "expected_floor": "1484529328860214611831"
+  },
+  {
+    "principal": "7301178679222954231",
+    "rate_bps": 8051,
+    "seconds": 2584142081,
+    "expected_floor": "481343625508277477161"
+  },
+  {
+    "principal": "6692138969587617148",
+    "rate_bps": 8512,
+    "seconds": 559218446,
+    "expected_floor": "100942507123687822845"
+  },
+  {
+    "principal": "12022785972963264709",
+    "rate_bps": 4649,
+    "seconds": 1974126975,
+    "expected_floor": "349651807732307554401"
+  },
+  {
+    "principal": "12577442781587172770",
+    "rate_bps": 3563,
+    "seconds": 2814128036,
+    "expected_floor": "399620775658496128526"
+  },
+  {
+    "principal": "10556484849471995171",
+    "rate_bps": 5316,
+    "seconds": 129087757,
+    "expected_floor": "22955427686634358638"
+  },
+  {
+    "principal": "12918394086142213016",
+    "rate_bps": 6755,
+    "seconds": 1498653322,
+    "expected_floor": "414410829412725420783"
+  },
+  {
+    "principal": "13732908888419699089",
+    "rate_bps": 2985,
+    "seconds": 2933169963,
+    "expected_floor": "381013300221002909021"
+  },
+  {
+    "principal": "3991844698787729630",
+    "rate_bps": 1291,
+    "seconds": 1610911040,
+    "expected_floor": "26306766495418641171"
+  },
+  {
+    "principal": "15528006561238029711",
+    "rate_bps": 9912,
+    "seconds": 3005198169,
+    "expected_floor": "1465703576997466573629"
+  },
+  {
+    "principal": "17565946404080417524",
+    "rate_bps": 1600,
+    "seconds": 151533894,
+    "expected_floor": "13495760186607869579"
+  },
+  {
+    "principal": "4626093738551233693",
+    "rate_bps": 7235,
+    "seconds": 2405581079,
+    "expected_floor": "255134386671522109917"
+  },
+  {
+    "principal": "4464658956884269914",
+    "rate_bps": 5002,
+    "seconds": 3891880988,
+    "expected_floor": "275414982139432062566"
+  },
+  {
+    "principal": "1515237395332857403",
+    "rate_bps": 9469,
+    "seconds": 399486949,
+    "expected_floor": "18162826115420520827"
+  },
+  {
+    "principal": "1943042382416381840",
+    "rate_bps": 9213,
+    "seconds": 1372233538,
+    "expected_floor": "77840820891778383811"
+  },
+  {
+    "principal": "6074746364799041001",
+    "rate_bps": 7165,
+    "seconds": 2261334851,
+    "expected_floor": "311892731211438278918"
+  },
+  {
+    "principal": "13895565953429416214",
+    "rate_bps": 1505,
+    "seconds": 2230956088,
+    "expected_floor": "147842669205875495203"
+  },
+  {
+    "principal": "7319170177328694055",
+    "rate_bps": 9654,
+    "seconds": 3708348081,
+    "expected_floor": "830320316501432643526"
+  },
+  {
+    "principal": "9008736324977352044",
+    "rate_bps": 9251,
+    "seconds": 3315069054,
+    "expected_floor": "875469799331552678173"
+  },
+  {
+    "principal": "10545108018968742261",
+    "rate_bps": 7893,
+    "seconds": 3836041647,
+    "expected_floor": "1011748297066330044032"
+  },
+  {
+    "principal": "11214934530786924050",
+    "rate_bps": 4139,
+    "seconds": 989834644,
+    "expected_floor": "145596472121952977179"
+  },
+  {
+    "principal": "9516740998392803411",
+    "rate_bps": 333,
+    "seconds": 2527510461,
+    "expected_floor": "25381745090075850100"
+  },
+  {
+    "principal": "6734562522660534408",
+    "rate_bps": 3846,
+    "seconds": 3394144506,
+    "expected_floor": "278576854624148678726"
+  },
+  {
+    "principal": "14986594808454945601",
+    "rate_bps": 641,
+    "seconds": 824485979,
+    "expected_floor": "25098068625334984302"
+  },
+  {
+    "principal": "15506072792382914126",
+    "rate_bps": 1449,
+    "seconds": 1274861616,
+    "expected_floor": "90767271842449726709"
+  },
+  {
+    "principal": "15140311749842522559",
+    "rate_bps": 6569,
+    "seconds": 136636169,
+    "expected_floor": "43062157916697162548"
+  },
+  {
+    "principal": "13011805934576375012",
+    "rate_bps": 3991,
+    "seconds": 2754217142,
+    "expected_floor": "453224642441027967975"
+  },
+  {
+    "principal": "15327310943429238605",
+    "rate_bps": 708,
+    "seconds": 2511565639,
+    "expected_floor": "86365400514234822495"
+  },
+  {
+    "principal": "14792505507129458122",
+    "rate_bps": 6364,
+    "seconds": 1148578828,
+    "expected_floor": "342632653864078601143"
+  },
+  {
+    "principal": "18406326672450646891",
+    "rate_bps": 6464,
+    "seconds": 2515224725,
+    "expected_floor": "948290281591088637138"
+  },
+  {
+    "principal": "7915273855709359744",
+    "rate_bps": 7046,
+    "seconds": 3279896498,
+    "expected_floor": "579648553230812863723"
+  },
+  {
+    "principal": "12922597241314148761",
+    "rate_bps": 7273,
+    "seconds": 2716354163,
+    "expected_floor": "808994972572438949796"
+  },
+  {
+    "principal": "10693442790557085830",
+    "rate_bps": 9492,
+    "seconds": 1365173544,
+    "expected_floor": "439095691947271225116"
+  },
+  {
+    "principal": "6639186854183477591",
+    "rate_bps": 1423,
+    "seconds": 3503951969,
+    "expected_floor": "104899633061264115932"
+  },
+  {
+    "principal": "16842093869818544476",
+    "rate_bps": 9136,
+    "seconds": 834164206,
+    "expected_floor": "406723960363436872672"
+  },
+  {
+    "principal": "9188792163477335589",
+    "rate_bps": 5602,
+    "seconds": 4172279263,
+    "expected_floor": "680567076044675098797"
+  },
+  {
+    "principal": "297898856960553602",
+    "rate_bps": 4959,
+    "seconds": 3677814660,
+    "expected_floor": "17216656616844873962"
+  },
+  {
+    "principal": "4977083765712545667",
+    "rate_bps": 8341,
+    "seconds": 1209379437,
+    "expected_floor": "159093224522269313855"
+  },
+  {
+    "principal": "8430554449938975096",
+    "rate_bps": 3698,
+    "seconds": 965780330,
+    "expected_floor": "95410777150477627494"
+  },
+  {
+    "principal": "16692449805696749809",
+    "rate_bps": 3487,
+    "seconds": 2981721483,
+    "expected_floor": "549965103787816640491"
+  },
+  {
+    "principal": "8758156211271507902",
+    "rate_bps": 1900,
+    "seconds": 2724509472,
+    "expected_floor": "143664889453707592596"
+  },
+  {
+    "principal": "4359249137625240047",
+    "rate_bps": 6773,
+    "seconds": 219333305,
+    "expected_floor": "20520757188516447464"
+  },
+  {
+    "principal": "13821807599399109332",
+    "rate_bps": 84,
+    "seconds": 2794505254,
+    "expected_floor": "10281230424141971552"
+  },
+  {
+    "principal": "10276652604482573821",
+    "rate_bps": 3116,
+    "seconds": 2065836407,
+    "expected_floor": "209624038951049724907"
+  },
+  {
+    "principal": "7884267024358954042",
+    "rate_bps": 2363,
+    "seconds": 3637626876,
+    "expected_floor": "214752994843543824196"
+  },
+  {
+    "principal": "8664879853011053723",
+    "rate_bps": 5615,
+    "seconds": 2514634053,
+    "expected_floor": "387688689611853620068"
+  },
+  {
+    "principal": "8852427635900541296",
+    "rate_bps": 7613,
+    "seconds": 936023074,
+    "expected_floor": "199894480596001231762"
+  },
+  {
+    "principal": "15173306731201194313",
+    "rate_bps": 7374,
+    "seconds": 3345061283,
+    "expected_floor": "1185996703998714569700"
+  },
+  {
+    "principal": "16817172282226617334",
+    "rate_bps": 5558,
+    "seconds": 4106694168,
+    "expected_floor": "1216353782824248619661"
+  },
+  {
+    "principal": "4473127632233333639",
+    "rate_bps": 5470,
+    "seconds": 3921501713,
+    "expected_floor": "304051435683703658672"
+  },
+  {
+    "principal": "14957446593547106636",
+    "rate_bps": 758,
+    "seconds": 567619422,
+    "expected_floor": "20392944932564608270"
+  },
+  {
+    "principal": "15190833936819713749",
+    "rate_bps": 2221,
+    "seconds": 2473952783,
+    "expected_floor": "264495089901529124248"
+  },
+  {
+    "principal": "8340399550481859314",
+    "rate_bps": 2876,
+    "seconds": 956900724,
+    "expected_floor": "72734197921407939226"
+  },
+  {
+    "principal": "14124942907666047667",
+    "rate_bps": 6028,
+    "seconds": 1137801501,
+    "expected_floor": "306988763803530969369"
+  },
+  {
+    "principal": "189974426101493352",
+    "rate_bps": 9664,
+    "seconds": 3154702810,
+    "expected_floor": "18352978169884306910"
+  },
+  {
+    "principal": "7594347720695294625",
+    "rate_bps": 9127,
+    "seconds": 2437809851,
+    "expected_floor": "535444410477739534226"
+  },
+  {
+    "principal": "15587808390226408750",
+    "rate_bps": 6566,
+    "seconds": 775105040,
+    "expected_floor": "251386835379262314902"
+  },
+  {
+    "principal": "15041546906118641183",
+    "rate_bps": 3821,
+    "seconds": 2555134569,
+    "expected_floor": "465349606104125271754"
+  },
+  {
+    "principal": "5673157367368139972",
+    "rate_bps": 5423,
+    "seconds": 3036379030,
+    "expected_floor": "296016862613049203727"
+  },
+  {
+    "principal": "11548184386167697581",
+    "rate_bps": 442,
+    "seconds": 3262735271,
+    "expected_floor": "52773251079423934288"
+  },
+  {
+    "principal": "2999775368868585130",
+    "rate_bps": 2675,
+    "seconds": 2303981548,
+    "expected_floor": "58585150604603817628"
+  },
+  {
+    "principal": "13515243228898798027",
+    "rate_bps": 3204,
+    "seconds": 2812782069,
+    "expected_floor": "385965504141615098315"
+  },
+  {
+    "principal": "8880621444343347296",
+    "rate_bps": 7979,
+    "seconds": 1782291602,
+    "expected_floor": "400190354047574552240"
+  },
+  {
+    "principal": "11773315323393504505",
+    "rate_bps": 4530,
+    "seconds": 3473942739,
+    "expected_floor": "587104847852565363720"
+  },
+  {
+    "principal": "17004394076529646438",
+    "rate_bps": 3092,
+    "seconds": 1003064072,
+    "expected_floor": "167118817638872407846"
+  },
+  {
+    "principal": "16212783220955408823",
+    "rate_bps": 255,
+    "seconds": 2352336833,
+    "expected_floor": "30817208595409458686"
+  },
+  {
+    "principal": "7687249399117956412",
+    "rate_bps": 9295,
+    "seconds": 1062042830,
+    "expected_floor": "240468630226278425464"
+  },
+  {
+    "principal": "1846066602686456709",
+    "rate_bps": 8774,
+    "seconds": 2766217791,
+    "expected_floor": "141980074157358690684"
+  },
+  {
+    "principal": "13345604833233782626",
+    "rate_bps": 8798,
+    "seconds": 2824675172,
+    "expected_floor": "1050961397340167648091"
+  },
+  {
+    "principal": "6652567284139991523",
+    "rate_bps": 9090,
+    "seconds": 3991743437,
+    "expected_floor": "764912594502150142729"
+  },
+  {
+    "principal": "1142775038653753176",
+    "rate_bps": 2415,
+    "seconds": 266761290,
+    "expected_floor": "2332903219924665599"
+  },
+  {
+    "principal": "1332184955868719185",
+    "rate_bps": 9926,
+    "seconds": 719150059,
+    "expected_floor": "30133831059040412605"
+  },
+  {
+    "principal": "17179498827169742494",
+    "rate_bps": 2403,
+    "seconds": 966734080,
+    "expected_floor": "126464118961799005922"
+  },
+  {
+    "principal": "13279874831189417551",
+    "rate_bps": 9014,
+    "seconds": 1215587865,
+    "expected_floor": "461098728063364116205"
+  },
+  {
+    "principal": "9570499167651945140",
+    "rate_bps": 4725,
+    "seconds": 426319622,
+    "expected_floor": "61089666992926170340"
+  },
+  {
+    "principal": "6685860997468778333",
+    "rate_bps": 1280,
+    "seconds": 348398039,
+    "expected_floor": "9447981790431541399"
+  },
+  {
+    "principal": "18142921696855596314",
+    "rate_bps": 8823,
+    "seconds": 3582163932,
+    "expected_floor": "1817042122091395351778"
+  },
+  {
+    "principal": "12467512701826001659",
+    "rate_bps": 6551,
+    "seconds": 4016990885,
+    "expected_floor": "1039643153665182745927"
+  },
+  {
+    "principal": "6435861973506896",
+    "rate_bps": 1270,
+    "seconds": 4154546434,
+    "expected_floor": "107604415459102029"
+  },
+  {
+    "principal": "7018396957090915497",
+    "rate_bps": 9008,
+    "seconds": 588185603,
+    "expected_floor": "117835657265030821098"
+  },
+  {
+    "principal": "11047092410617888470",
+    "rate_bps": 8906,
+    "seconds": 3929865208,
+    "expected_floor": "1225192600577079013284"
+  },
+  {
+    "principal": "6578326399125804007",
+    "rate_bps": 3672,
+    "seconds": 3171313009,
+    "expected_floor": "242746643038280906279"
+  },
+  {
+    "principal": "15138947776116647212",
+    "rate_bps": 2830,
+    "seconds": 2428517950,
+    "expected_floor": "329700402324972624997"
+  },
+  {
+    "principal": "14222050467452105781",
+    "rate_bps": 4637,
+    "seconds": 1528676975,
+    "expected_floor": "319456014018404224282"
+  },
+  {
+    "principal": "5373483572574470098",
+    "rate_bps": 7334,
+    "seconds": 274328916,
+    "expected_floor": "34258192979638052292"
+  },
+  {
+    "principal": "1732341448672994579",
+    "rate_bps": 5878,
+    "seconds": 2528887421,
+    "expected_floor": "81599708525833207585"
+  },
+  {
+    "principal": "15206919670677746760",
+    "rate_bps": 9948,
+    "seconds": 211299002,
+    "expected_floor": "101290917996579365855"
+  },
+  {
+    "principal": "11753609640080525825",
+    "rate_bps": 2763,
+    "seconds": 60978459,
+    "expected_floor": "6275157428892143392"
+  },
+  {
+    "principal": "3744442225011293198",
+    "rate_bps": 2402,
+    "seconds": 2116013040,
+    "expected_floor": "60307942171497599156"
+  },
+  {
+    "principal": "5958158651664001663",
+    "rate_bps": 6460,
+    "seconds": 879635913,
+    "expected_floor": "107286126643963173516"
+  },
+  {
+    "principal": "5429571087907767460",
+    "rate_bps": 6171,
+    "seconds": 857258614,
+    "expected_floor": "91018350504204920755"
+  },
+  {
+    "principal": "5056925855187390989",
+    "rate_bps": 269,
+    "seconds": 1900897287,
+    "expected_floor": "8193954533318433796"
+  },
+  {
+    "principal": "16055968088678764426",
+    "rate_bps": 743,
+    "seconds": 3358020556,
+    "expected_floor": "126941812019860978384"
+  },
+  {
+    "principal": "17296507610834366507",
+    "rate_bps": 7369,
+    "seconds": 3584660309,
+    "expected_floor": "1447808156231929066849"
+  },
+  {
+    "principal": "12659246331928678976",
+    "rate_bps": 7547,
+    "seconds": 3456813426,
+    "expected_floor": "1046536003373213372557"
+  },
+  {
+    "principal": "13036535002409891929",
+    "rate_bps": 9111,
+    "seconds": 4021885747,
+    "expected_floor": "1513749398804907657789"
+  },
+  {
+    "principal": "3165225403071501894",
+    "rate_bps": 5775,
+    "seconds": 2872606952,
+    "expected_floor": "166390631965426383190"
+  },
+  {
+    "principal": "7127078325927887383",
+    "rate_bps": 5809,
+    "seconds": 3509722913,
+    "expected_floor": "460449252255580479602"
+  },
+  {
+    "principal": "5303260254499068188",
+    "rate_bps": 9138,
+    "seconds": 3926684590,
+    "expected_floor": "602998379619510535533"
+  },
+  {
+    "principal": "6442709777071024357",
+    "rate_bps": 5294,
+    "seconds": 1385588383,
+    "expected_floor": "149755496598165874853"
+  },
+  {
+    "principal": "1988737671132572738",
+    "rate_bps": 2982,
+    "seconds": 3680931652,
+    "expected_floor": "69173368664437160215"
+  },
+  {
+    "principal": "17825697944445480003",
+    "rate_bps": 3950,
+    "seconds": 718290221,
+    "expected_floor": "160265346028152358663"
+  },
+  {
+    "principal": "12462923214169609528",
+    "rate_bps": 388,
+    "seconds": 315430186,
+    "expected_floor": "4833379879233858894"
+  },
+  {
+    "principal": "3937865370339512241",
+    "rate_bps": 4205,
+    "seconds": 4212675147,
+    "expected_floor": "221045087601422179075"
+  },
+  {
+    "principal": "16953645153345088894",
+    "rate_bps": 7363,
+    "seconds": 342620896,
+    "expected_floor": "135527606608425965108"
+  },
+  {
+    "principal": "8664824298817960623",
+    "rate_bps": 1984,
+    "seconds": 2606537081,
+    "expected_floor": "141991180245247345311"
+  },
+  {
+    "principal": "15706902846081237652",
+    "rate_bps": 2751,
+    "seconds": 3867757030,
+    "expected_floor": "529585840544468443841"
+  },
+  {
+    "principal": "3385254073611622589",
+    "rate_bps": 4795,
+    "seconds": 1570777655,
+    "expected_floor": "80796142857163735086"
+  },
+  {
+    "principal": "1746335050225628666",
+    "rate_bps": 8742,
+    "seconds": 3880157116,
+    "expected_floor": "187708404062694853611"
+  },
+  {
+    "principal": "2699837692699883867",
+    "rate_bps": 3421,
+    "seconds": 3071025157,
+    "expected_floor": "89881463960788745066"
+  },
+  {
+    "principal": "14748721437130136880",
+    "rate_bps": 7691,
+    "seconds": 2630282722,
+    "expected_floor": "945443650425203039022"
+  },
+  {
+    "principal": "7543327558602616841",
+    "rate_bps": 7306,
+    "seconds": 1403615843,
+    "expected_floor": "245124617578114652636"
+  },
+  {
+    "principal": "1798554347492614582",
+    "rate_bps": 8534,
+    "seconds": 18029016,
+    "expected_floor": "876888271066506617"
+  },
+  {
+    "principal": "1503797345157723207",
+    "rate_bps": 2660,
+    "seconds": 503053521,
+    "expected_floor": "6376482562921260148"
+  },
+  {
+    "principal": "10610328175328338188",
+    "rate_bps": 774,
+    "seconds": 1548819742,
+    "expected_floor": "40305720232890531785"
+  },
+  {
+    "principal": "8187953563026162069",
+    "rate_bps": 7086,
+    "seconds": 3321237199,
+    "expected_floor": "610621997213886265866"
+  },
+  {
+    "principal": "6122146602073967794",
+    "rate_bps": 1628,
+    "seconds": 3878290740,
+    "expected_floor": "122488275935161041078"
+  },
+  {
+    "principal": "12958140103747909491",
+    "rate_bps": 6277,
+    "seconds": 3808271325,
+    "expected_floor": "981564211795411622688"
+  },
+  {
+    "principal": "5328494048454871592",
+    "rate_bps": 4159,
+    "seconds": 2087990170,
+    "expected_floor": "146628329924225508615"
+  },
+  {
+    "principal": "9953757756593797473",
+    "rate_bps": 2596,
+    "seconds": 2063201147,
+    "expected_floor": "168938782021656157297"
+  },
+  {
+    "principal": "437283985533981422",
+    "rate_bps": 9570,
+    "seconds": 1685765584,
+    "expected_floor": "22354693849909230572"
+  },
+  {
+    "principal": "8136533370423545567",
+    "rate_bps": 5685,
+    "seconds": 2493688105,
+    "expected_floor": "365517391369463738435"
+  },
+  {
+    "principal": "10163698975703012484",
+    "rate_bps": 6703,
+    "seconds": 226086230,
+    "expected_floor": "48808016426382987947"
+  },
+  {
+    "principal": "4840933380226564973",
+    "rate_bps": 8039,
+    "seconds": 361198695,
+    "expected_floor": "44542371948815701350"
+  },
+  {
+    "principal": "13885640431777681514",
+    "rate_bps": 1563,
+    "seconds": 606601132,
+    "expected_floor": "41718063650508999803"
+  },
+  {
+    "principal": "16566735445575190155",
+    "rate_bps": 2086,
+    "seconds": 2492010677,
+    "expected_floor": "272896001741477542666"
+  },
+  {
+    "principal": "1388484477208116256",
+    "rate_bps": 1559,
+    "seconds": 1147455058,
+    "expected_floor": "7870799722202250675"
+  },
+  {
+    "principal": "8086741380803267513",
+    "rate_bps": 2816,
+    "seconds": 2411404691,
+    "expected_floor": "174009251588248319350"
+  },
+  {
+    "principal": "9172681389341319462",
+    "rate_bps": 3138,
+    "seconds": 895731400,
+    "expected_floor": "81700192455600833113"
+  },
+  {
+    "principal": "3037240862388431479",
+    "rate_bps": 9502,
+    "seconds": 2833710721,
+    "expected_floor": "259146773731453489105"
+  },
+  {
+    "principal": "9558771872768277756",
+    "rate_bps": 2410,
+    "seconds": 2783787662,
+    "expected_floor": "203212902121570609359"
+  },
+  {
+    "principal": "16955573747099450949",
+    "rate_bps": 5575,
+    "seconds": 3190274815,
+    "expected_floor": "955611770027820743563"
+  },
+  {
+    "principal": "4621642605784129826",
+    "rate_bps": 1701,
+    "seconds": 1955286820,
+    "expected_floor": "48708771650575837036"
+  },
+  {
+    "principal": "10089954451207702179",
+    "rate_bps": 8559,
+    "seconds": 4099333773,
+    "expected_floor": "1121815782238874939689"
+  },
+  {
+    "principal": "3762484317593637656",
+    "rate_bps": 1350,
+    "seconds": 213681674,
+    "expected_floor": "3439313601053029372"
+  },
+  {
+    "principal": "4091200435499304721",
+    "rate_bps": 1434,
+    "seconds": 2806143147,
+    "expected_floor": "52168189245457253068"
+  },
+  {
+    "principal": "7040967258123070558",
+    "rate_bps": 5764,
+    "seconds": 360912064,
+    "expected_floor": "46414505627968866709"
+  },
+  {
+    "principal": "9740753481852872463",
+    "rate_bps": 9230,
+    "seconds": 3219348697,
+    "expected_floor": "917187875925988073714"
+  },
+  {
+    "principal": "16107423215851895412",
+    "rate_bps": 1027,
+    "seconds": 3874047174,
+    "expected_floor": "203075462517166828795"
+  },
+  {
+    "principal": "6070370355502174749",
+    "rate_bps": 2562,
+    "seconds": 3138273943,
+    "expected_floor": "154661136634168301079"
+  },
+  {
+    "principal": "18157139065388211930",
+    "rate_bps": 3915,
+    "seconds": 3411202972,
+    "expected_floor": "768391904322047208766"
+  },
+  {
+    "principal": "57985830647306171",
+    "rate_bps": 9162,
+    "seconds": 3277022565,
+    "expected_floor": "5516805020538378811"
+  },
+  {
+    "principal": "17074242837134339856",
+    "rate_bps": 7396,
+    "seconds": 1186157250,
+    "expected_floor": "474653466457478204365"
+  },
+  {
+    "principal": "5344608654549404521",
+    "rate_bps": 4360,
+    "seconds": 923337923,
+    "expected_floor": "68180331092732325927"
+  },
+  {
+    "principal": "9111427402702591126",
+    "rate_bps": 4227,
+    "seconds": 1224837048,
+    "expected_floor": "149483416084649987183"
+  },
+  {
+    "principal": "4969466578876277927",
+    "rate_bps": 1426,
+    "seconds": 3619038257,
+    "expected_floor": "81267800667612116091"
+  },
+  {
+    "principal": "1775305313631939820",
+    "rate_bps": 1337,
+    "seconds": 2726284286,
+    "expected_floor": "20505559964849158497"
+  },
+  {
+    "principal": "18416185364502241013",
+    "rate_bps": 1664,
+    "seconds": 1112959791,
+    "expected_floor": "108075811934319060490"
+  },
+  {
+    "principal": "15232797698695342482",
+    "rate_bps": 620,
+    "seconds": 397503764,
+    "expected_floor": "11896210552509698602"
+  },
+  {
+    "principal": "9335326284656974291",
+    "rate_bps": 3488,
+    "seconds": 1076823357,
+    "expected_floor": "111108293695366239338"
+  },
+  {
+    "principal": "6284045908959408136",
+    "rate_bps": 2123,
+    "seconds": 1611992186,
+    "expected_floor": "68147245830879820105"
+  },
+  {
+    "principal": "15181405438337693889",
+    "rate_bps": 3566,
+    "seconds": 2385281499,
+    "expected_floor": "409193748597724495618"
+  },
+  {
+    "principal": "12063402761574480334",
+    "rate_bps": 5243,
+    "seconds": 4261150640,
+    "expected_floor": "854028976395648311136"
+  },
+  {
+    "principal": "18255264689359143743",
+    "rate_bps": 3632,
+    "seconds": 4110529673,
+    "expected_floor": "863630148455199863617"
+  },
+  {
+    "principal": "5149331783883502692",
+    "rate_bps": 4778,
+    "seconds": 2266411062,
+    "expected_floor": "176698041124029164239"
+  },
+  {
+    "principal": "67246116378068173",
+    "rate_bps": 8060,
+    "seconds": 2256508103,
+    "expected_floor": "3875566381503277376"
+  },
+  {
+    "principal": "2624575605608702282",
+    "rate_bps": 1297,
+    "seconds": 1955462028,
+    "expected_floor": "21093297790353666682"
+  },
+  {
+    "principal": "13897160773528136939",
+    "rate_bps": 4273,
+    "seconds": 2631802389,
+    "expected_floor": "495231526759417379012"
+  },
+  {
+    "principal": "1208529096768239104",
+    "rate_bps": 5676,
+    "seconds": 918655794,
+    "expected_floor": "19968633643008748451"
+  },
+  {
+    "principal": "11355239034039185177",
+    "rate_bps": 9955,
+    "seconds": 1592668147,
+    "expected_floor": "570504234710034201454"
+  },
+  {
+    "principal": "17304582715730721798",
+    "rate_bps": 1764,
+    "seconds": 3825425576,
+    "expected_floor": "370028778443466597542"
+  },
+  {
+    "principal": "13277828459360297687",
+    "rate_bps": 4141,
+    "seconds": 543976929,
+    "expected_floor": "94778274512862835015"
+  },
+  {
+    "principal": "2920053213517213916",
+    "rate_bps": 6294,
+    "seconds": 3135754606,
+    "expected_floor": "182623056115298474071"
+  },
+  {
+    "principal": "3155200320054944677",
+    "rate_bps": 8869,
+    "seconds": 2280464223,
+    "expected_floor": "202218501746292254561"
+  },
+  {
+    "principal": "14359445700485391874",
+    "rate_bps": 6177,
+    "seconds": 2818793220,
+    "expected_floor": "792272402367085355093"
+  },
+  {
+    "principal": "15509936896581447939",
+    "rate_bps": 481,
+    "seconds": 68751341,
+    "expected_floor": "1625295427991465530"
+  },
+  {
+    "principal": "17370445682231927032",
+    "rate_bps": 7162,
+    "seconds": 1546438378,
+    "expected_floor": "609640667810041649076"
+  },
+  {
+    "principal": "5058062951440092785",
+    "rate_bps": 1226,
+    "seconds": 1479765771,
+    "expected_floor": "29077944985442025845"
+  },
+  {
+    "principal": "17787924492617481022",
+    "rate_bps": 9692,
+    "seconds": 329023136,
+    "expected_floor": "179746794038451983379"
+  },
+  {
+    "principal": "13514081049945777007",
+    "rate_bps": 7318,
+    "seconds": 4095782969,
+    "expected_floor": "1283547346180634434671"
+  },
+  {
+    "principal": "11883347329907933780",
+    "rate_bps": 1650,
+    "seconds": 1199640486,
+    "expected_floor": "74536652135016501333"
+  },
+  {
+    "principal": "12058907474073787261",
+    "rate_bps": 141,
+    "seconds": 4133907191,
+    "expected_floor": "22273262255360026765"
+  },
+  {
+    "principal": "2532722984477251514",
+    "rate_bps": 6699,
+    "seconds": 4074796924,
+    "expected_floor": "219078456237704819920"
+  },
+  {
+    "principal": "13384634915175204379",
+    "rate_bps": 3543,
+    "seconds": 786184901,
+    "expected_floor": "118140393672630415575"
+  },
+  {
+    "principal": "8068048198761877744",
+    "rate_bps": 184,
+    "seconds": 685672354,
+    "expected_floor": "3225514356338932789"
+  },
+  {
+    "principal": "7981590564793005769",
+    "rate_bps": 4233,
+    "seconds": 3473252131,
+    "expected_floor": "371851945527500437437"
+  },
+  {
+    "principal": "16915029144590735222",
+    "rate_bps": 2369,
+    "seconds": 1170228632,
+    "expected_floor": "148595125753464649194"
+  },
+  {
+    "principal": "17734059045858452743",
+    "rate_bps": 8074,
+    "seconds": 3108821905,
+    "expected_floor": "1410550929479344256165"
+  },
+  {
+    "principal": "13608721823657887948",
+    "rate_bps": 8443,
+    "seconds": 1430538974,
+    "expected_floor": "520846623702785942682"
+  },
+  {
+    "principal": "4276227938430667861",
+    "rate_bps": 4082,
+    "seconds": 580310927,
+    "expected_floor": "32098935354954581937"
+  },
+  {
+    "principal": "3990409579309979250",
+    "rate_bps": 168,
+    "seconds": 807937268,
+    "expected_floor": "1716328564602717904"
+  },
+  {
+    "principal": "5844578389411695667",
+    "rate_bps": 348,
+    "seconds": 2313682589,
+    "expected_floor": "14911874611346777865"
+  },
+  {
+    "principal": "14649237847624656360",
+    "rate_bps": 9242,
+    "seconds": 2683483482,
+    "expected_floor": "1151266728574427599326"
+  },
+  {
+    "principal": "270555906090666017",
+    "rate_bps": 1388,
+    "seconds": 2014453819,
+    "expected_floor": "2397175517304732791"
+  },
+  {
+    "principal": "11181996795962814638",
+    "rate_bps": 5305,
+    "seconds": 1532727696,
+    "expected_floor": "288114947161484879516"
+  },
+  {
+    "principal": "15237824391355467679",
+    "rate_bps": 4477,
+    "seconds": 363024361,
+    "expected_floor": "78476903974056962037"
+  },
+  {
+    "principal": "4655941247500690500",
+    "rate_bps": 5811,
+    "seconds": 921133846,
+    "expected_floor": "78972727933995892020"
+  },
+  {
+    "principal": "16267770174789768749",
+    "rate_bps": 4476,
+    "seconds": 4287481127,
+    "expected_floor": "989273465124293292820"
+  },
+  {
+    "principal": "17804869120703103530",
+    "rate_bps": 7141,
+    "seconds": 1150371692,
+    "expected_floor": "463481109365857166720"
+  },
+  {
+    "principal": "3866773714124907339",
+    "rate_bps": 1680,
+    "seconds": 3946888053,
+    "expected_floor": "81247289399603193309"
+  },
+  {
+    "principal": "16297444128162086880",
+    "rate_bps": 6436,
+    "seconds": 580464658,
+    "expected_floor": "192933370654213143107"
+  },
+  {
+    "principal": "10594576227830850169",
+    "rate_bps": 1171,
+    "seconds": 824857171,
+    "expected_floor": "32427634728867683393"
+  },
+  {
+    "principal": "13164891253390583526",
+    "rate_bps": 5001,
+    "seconds": 885998216,
+    "expected_floor": "184843001026233436120"
+  },
+  {
+    "principal": "13014713452722105143",
+    "rate_bps": 6585,
+    "seconds": 1222274369,
+    "expected_floor": "331936589546221011666"
+  },
+  {
+    "principal": "5747701367902106812",
+    "rate_bps": 4170,
+    "seconds": 1156855886,
+    "expected_floor": "87862902123874887774"
+  },
+  {
+    "principal": "10149336019890739461",
+    "rate_bps": 7745,
+    "seconds": 876516287,
+    "expected_floor": "218330835414683200130"
+  },
+  {
+    "principal": "13198481465603406562",
+    "rate_bps": 9369,
+    "seconds": 3724984036,
+    "expected_floor": "1459612770988078086505"
+  },
+  {
+    "principal": "8848496816404966243",
+    "rate_bps": 7888,
+    "seconds": 3618558285,
+    "expected_floor": "800327990577005554555"
+  },
+  {
+    "principal": "16359388598980083416",
+    "rate_bps": 144,
+    "seconds": 4086683594,
+    "expected_floor": "30506796712444696339"
+  },
+  {
+    "principal": "3735053569571530193",
+    "rate_bps": 1251,
+    "seconds": 3670250859,
+    "expected_floor": "54343289884958891411"
+  },
+  {
+    "principal": "6241112863737371166",
+    "rate_bps": 7229,
+    "seconds": 3648010368,
+    "expected_floor": "521545686677591197945"
+  },
+  {
+    "principal": "8596487190579048399",
+    "rate_bps": 8223,
+    "seconds": 4197225369,
+    "expected_floor": "940177021869676800591"
+  },
+  {
+    "principal": "6053240433763637812",
+    "rate_bps": 2601,
+    "seconds": 2303240838,
+    "expected_floor": "114911544447898805135"
+  },
+  {
+    "principal": "131808355193976029",
+    "rate_bps": 8700,
+    "seconds": 1023451991,
+    "expected_floor": "3718995915143346247"
+  },
+  {
+    "principal": "13742118664842207386",
+    "rate_bps": 2581,
+    "seconds": 2200398684,
+    "expected_floor": "247308537054754850006"
+  },
+  {
+    "principal": "18389944429913048187",
+    "rate_bps": 9359,
+    "seconds": 1480499237,
+    "expected_floor": "807447111012358899603"
+  },
+  {
+    "principal": "8379698505838822096",
+    "rate_bps": 9600,
+    "seconds": 2327874690,
+    "expected_floor": "593410542598616204325"
+  },
+  {
+    "principal": "5171176106192974377",
+    "rate_bps": 7929,
+    "seconds": 1098336643,
+    "expected_floor": "142705020318905556465"
+  },
+  {
+    "principal": "17549138799799724630",
+    "rate_bps": 5788,
+    "seconds": 4010234744,
+    "expected_floor": "1290773853624033541001"
+  },
+  {
+    "principal": "15603143837993776487",
+    "rate_bps": 1563,
+    "seconds": 2513969905,
+    "expected_floor": "194279598550511715489"
+  },
+  {
+    "principal": "4583115914932663468",
+    "rate_bps": 1811,
+    "seconds": 982948286,
+    "expected_floor": "25852705227535161949"
+  },
+  {
+    "principal": "11898132146146757045",
+    "rate_bps": 395,
+    "seconds": 2635027439,
+    "expected_floor": "39242535388585132770"
+  },
+  {
+    "principal": "12449662701156160338",
+    "rate_bps": 2262,
+    "seconds": 4073073876,
+    "expected_floor": "363469945608700535768"
+  },
+  {
+    "principal": "15157388244093406867",
+    "rate_bps": 398,
+    "seconds": 1606453245,
+    "expected_floor": "30709416879352627597"
+  },
+  {
+    "principal": "9148818403546819528",
+    "rate_bps": 8783,
+    "seconds": 3095735866,
+    "expected_floor": "788256973877205917049"
+  },
+  {
+    "principal": "16819741470188726145",
+    "rate_bps": 7519,
+    "seconds": 394448539,
+    "expected_floor": "158075944609503297344"
+  },
+  {
+    "principal": "4986419691319441294",
+    "rate_bps": 3672,
+    "seconds": 2169598832,
+    "expected_floor": "125882967658127191167"
+  },
+  {
+    "principal": "13866986230315310079",
+    "rate_bps": 2215,
+    "seconds": 983530313,
+    "expected_floor": "95728134889989055025"
+  },
+  {
+    "principal": "1563722047506768932",
+    "rate_bps": 7938,
+    "seconds": 132376054,
+    "expected_floor": "5206862605690751471"
+  },
+  {
+    "principal": "17691930467759683469",
+    "rate_bps": 5090,
+    "seconds": 537527687,
+    "expected_floor": "153387467792732735696"
+  },
+  {
+    "principal": "2748847848467165962",
+    "rate_bps": 4892,
+    "seconds": 3546932044,
+    "expected_floor": "151142308430045067626"
+  },
+  {
+    "principal": "4690629533882329515",
+    "rate_bps": 5588,
+    "seconds": 3226003669,
+    "expected_floor": "267946705154449569004"
+  },
+  {
+    "principal": "11397443133092600256",
+    "rate_bps": 2003,
+    "seconds": 2573442290,
+    "expected_floor": "186165349391623265893"
+  },
+  {
+    "principal": "2559815268232603097",
+    "rate_bps": 4231,
+    "seconds": 4266099891,
+    "expected_floor": "146412684523686302712"
+  },
+  {
+    "principal": "18131881831652237766",
+    "rate_bps": 6698,
+    "seconds": 427784296,
+    "expected_floor": "164629967968407677852"
+  },
+  {
+    "principal": "6042373003668571031",
+    "rate_bps": 6988,
+    "seconds": 927530145,
+    "expected_floor": "124103632596771379951"
+  },
+  {
+    "principal": "16350881537686030492",
+    "rate_bps": 7920,
+    "seconds": 873099054,
+    "expected_floor": "358282754343639343571"
+  },
+  {
+    "principal": "3614730288286588517",
+    "rate_bps": 9054,
+    "seconds": 729028639,
+    "expected_floor": "75606130328433126971"
+  },
+  {
+    "principal": "16395631024049102786",
+    "rate_bps": 1246,
+    "seconds": 2999807684,
+    "expected_floor": "194193918272442213647"
+  },
+  {
+    "principal": "16661432937212491203",
+    "rate_bps": 3299,
+    "seconds": 2964333229,
+    "expected_floor": "516318540211752029161"
+  },
+  {
+    "principal": "11700208697597914296",
+    "rate_bps": 6042,
+    "seconds": 1500493994,
+    "expected_floor": "336127947552043468257"
+  },
+  {
+    "principal": "1617657689512955185",
+    "rate_bps": 3979,
+    "seconds": 2680867787,
+    "expected_floor": "54680439281308294622"
+  },
+  {
+    "principal": "16611671555957459198",
+    "rate_bps": 3476,
+    "seconds": 632701536,
+    "expected_floor": "115767865296539398696"
+  },
+  {
+    "principal": "2550413093511285807",
+    "rate_bps": 3254,
+    "seconds": 404686585,
+    "expected_floor": "10642481869995833606"
+  },
+  {
+    "principal": "11377747095512302100",
+    "rate_bps": 5305,
+    "seconds": 2167936358,
+    "expected_floor": "414652440745175638812"
+  },
+  {
+    "principal": "11621120848944881213",
+    "rate_bps": 8087,
+    "seconds": 540339127,
+    "expected_floor": "160915511578337391299"
+  },
+  {
+    "principal": "11106725484328106362",
+    "rate_bps": 3200,
+    "seconds": 1432334140,
+    "expected_floor": "161315609245936894606"
+  },
+  {
+    "principal": "14788851584180949723",
+    "rate_bps": 8954,
+    "seconds": 3792868741,
+    "expected_floor": "1591532043144800583476"
+  },
+  {
+    "principal": "657687321700844720",
+    "rate_bps": 3382,
+    "seconds": 3352387938,
+    "expected_floor": "23628892994518181262"
+  },
+  {
+    "principal": "2595132252586196361",
+    "rate_bps": 6979,
+    "seconds": 3627418595,
+    "expected_floor": "208183545883806167533"
+  },
+  {
+    "principal": "11453696165467573558",
+    "rate_bps": 4758,
+    "seconds": 2962141528,
+    "expected_floor": "511530971276045827146"
+  },
+  {
+    "principal": "7672924998615389639",
+    "rate_bps": 3971,
+    "seconds": 1148189265,
+    "expected_floor": "110858846442438814776"
+  },
+  {
+    "principal": "209584372232859788",
+    "rate_bps": 4814,
+    "seconds": 3966679198,
+    "expected_floor": "12682010068799089763"
+  },
+  {
+    "principal": "12280241908641060629",
+    "rate_bps": 4803,
+    "seconds": 3424116815,
+    "expected_floor": "639976628274436504184"
+  },
+  {
+    "principal": "15143044130119884850",
+    "rate_bps": 2298,
+    "seconds": 1438876852,
+    "expected_floor": "158665633901962957015"
+  },
+  {
+    "principal": "919668314926424307",
+    "rate_bps": 4014,
+    "seconds": 626041181,
+    "expected_floor": "7323311834079086703"
+  },
+  {
+    "principal": "7795720166251299240",
+    "rate_bps": 632,
+    "seconds": 3125049114,
+    "expected_floor": "48789481164202825966"
+  },
+  {
+    "principal": "14844607988335400673",
+    "rate_bps": 4834,
+    "seconds": 4015426811,
+    "expected_floor": "913068009125596864956"
+  },
+  {
+    "principal": "9024706875222249070",
+    "rate_bps": 2886,
+    "seconds": 1754637648,
+    "expected_floor": "144814786376369681299"
+  },
+  {
+    "principal": "3859043193178308703",
+    "rate_bps": 2342,
+    "seconds": 739129001,
+    "expected_floor": "21168145212323989944"
+  },
+  {
+    "principal": "18097715415036851204",
+    "rate_bps": 251,
+    "seconds": 956578006,
+    "expected_floor": "13769364614998367426"
+  },
+  {
+    "principal": "7495251283543435501",
+    "rate_bps": 1110,
+    "seconds": 3947648487,
+    "expected_floor": "104074344379715842717"
+  },
+  {
+    "principal": "14035360605844747242",
+    "rate_bps": 6101,
+    "seconds": 340774700,
+    "expected_floor": "92467257569891489494"
+  },
+  {
+    "principal": "10697852759774969867",
+    "rate_bps": 12,
+    "seconds": 2693703221,
+    "expected_floor": "1095780684340618129"
+  },
+  {
+    "principal": "1168544776405386144",
+    "rate_bps": 9065,
+    "seconds": 1083759058,
+    "expected_floor": "36378261461797830463"
+  },
+  {
+    "principal": "9634818841142819129",
+    "rate_bps": 9476,
+    "seconds": 3793602323,
+    "expected_floor": "1097530102727758883169"
+  },
+  {
+    "principal": "9169859059308096678",
+    "rate_bps": 7525,
+    "seconds": 4157341256,
+    "expected_floor": "909035560932155585454"
+  },
+  {
+    "principal": "4250179209958321143",
+    "rate_bps": 7501,
+    "seconds": 80747521,
+    "expected_floor": "8157397755244559044"
+  },
+  {
+    "principal": "14698827344814402684",
+    "rate_bps": 7972,
+    "seconds": 1277326862,
+    "expected_floor": "474294465558992127346"
+  },
+  {
+    "principal": "11341240370570539973",
+    "rate_bps": 4923,
+    "seconds": 3118836863,
+    "expected_floor": "551796679252621254963"
+  },
+  {
+    "principal": "4109153059366818978",
+    "rate_bps": 711,
+    "seconds": 4136595108,
+    "expected_floor": "38296665897461822381"
+  },
+  {
+    "principal": "17285835199295606819",
+    "rate_bps": 5604,
+    "seconds": 2494891021,
+    "expected_floor": "765836582197897245968"
+  },
+  {
+    "principal": "15284581691122559640",
+    "rate_bps": 9400,
+    "seconds": 2821876106,
+    "expected_floor": "1284740414750196274866"
+  },
+  {
+    "principal": "13139277639438140561",
+    "rate_bps": 4678,
+    "seconds": 3156283947,
+    "expected_floor": "614757458463777746590"
+  },
+  {
+    "principal": "10768488504930469854",
+    "rate_bps": 3935,
+    "seconds": 2871434304,
+    "expected_floor": "385562158424450656946"
+  },
+  {
+    "principal": "18091659938072148111",
+    "rate_bps": 2853,
+    "seconds": 403704409,
+    "expected_floor": "66029759124791827211"
+  },
+  {
+    "principal": "15319249771523766772",
+    "rate_bps": 3740,
+    "seconds": 1481068614,
+    "expected_floor": "268893504257605622686"
+  },
+  {
+    "principal": "13221657824137926557",
+    "rate_bps": 1419,
+    "seconds": 2505786391,
+    "expected_floor": "148973282802425941797"
+  },
+  {
+    "principal": "4951693337537864282",
+    "rate_bps": 4265,
+    "seconds": 4139860764,
+    "expected_floor": "277047696621551233897"
+  },
+  {
+    "principal": "12854682947314725179",
+    "rate_bps": 3764,
+    "seconds": 3002079973,
+    "expected_floor": "460287599152149209105"
+  },
+  {
+    "principal": "14912584291672970896",
+    "rate_bps": 2349,
+    "seconds": 1334380098,
+    "expected_floor": "148119254355266772370"
+  },
+  {
+    "principal": "9030926475838249193",
+    "rate_bps": 8487,
+    "seconds": 18468419,
+    "expected_floor": "4485514455552065795"
+  },
+  {
+    "principal": "2836413319739539478",
+    "rate_bps": 226,
+    "seconds": 1779326776,
+    "expected_floor": "3614345811725632805"
+  },
+  {
+    "principal": "85012399886894631",
+    "rate_bps": 6505,
+    "seconds": 2687263153,
+    "expected_floor": "4709077169733494556"
+  },
+  {
+    "principal": "6335107455779896428",
+    "rate_bps": 9620,
+    "seconds": 3636766590,
+    "expected_floor": "702328867466128634418"
+  },
+  {
+    "principal": "8530212511346488437",
+    "rate_bps": 6844,
+    "seconds": 2919791791,
+    "expected_floor": "540154213013951832658"
+  },
+  {
+    "principal": "13281758954756193554",
+    "rate_bps": 6513,
+    "seconds": 2203593876,
+    "expected_floor": "604038001476334149446"
+  },
+  {
+    "principal": "17681346707954647891",
+    "rate_bps": 2947,
+    "seconds": 36719293,
+    "expected_floor": "6062975587625503574"
+  },
+  {
+    "principal": "17400799724373108616",
+    "rate_bps": 1,
+    "seconds": 1235783674,
+    "expected_floor": "68140873241070257"
+  },
+  {
+    "principal": "1621419730797057601",
+    "rate_bps": 7746,
+    "seconds": 644176731,
+    "expected_floor": "25637401941915724189"
+  },
+  {
+    "principal": "2092395904337294670",
+    "rate_bps": 9792,
+    "seconds": 4259325744,
+    "expected_floor": "276536304109017581753"
+  },
+  {
+    "principal": "15164054200275383487",
+    "rate_bps": 5132,
+    "seconds": 906461705,
+    "expected_floor": "223535997254488904805"
+  },
+  {
+    "principal": "5707852186847335396",
+    "rate_bps": 1627,
+    "seconds": 1564498870,
+    "expected_floor": "46039601675424105891"
+  },
+  {
+    "principal": "7026527775819622989",
+    "rate_bps": 1017,
+    "seconds": 3366762055,
+    "expected_floor": "76237768697973277778"
+  },
+  {
+    "principal": "5688660248093770954",
+    "rate_bps": 7413,
+    "seconds": 2927299340,
+    "expected_floor": "391171463077236720494"
+  },
+  {
+    "principal": "8285381049488205419",
+    "rate_bps": 24,
+    "seconds": 1420424085,
+    "expected_floor": "895030405057086006"
+  },
+  {
+    "principal": "9215537265606344064",
+    "rate_bps": 2659,
+    "seconds": 3518031538,
+    "expected_floor": "273171104322591925721"
+  },
+  {
+    "principal": "18201905652082433177",
+    "rate_bps": 3680,
+    "seconds": 478484851,
+    "expected_floor": "101561452388578386292"
+  },
+  {
+    "principal": "15601497100882020230",
+    "rate_bps": 9340,
+    "seconds": 2842481704,
+    "expected_floor": "1312522816691529665492"
+  },
+  {
+    "principal": "5821577932452176983",
+    "rate_bps": 2303,
+    "seconds": 3465005921,
+    "expected_floor": "147209103413088800077"
+  },
+  {
+    "principal": "12062166700798271580",
+    "rate_bps": 2519,
+    "seconds": 624184558,
+    "expected_floor": "60098349754964763301"
+  },
+  {
+    "principal": "14149008352961173797",
+    "rate_bps": 2895,
+    "seconds": 267079903,
+    "expected_floor": "34666645051041267000"
+  },
+  {
+    "principal": "18362115002060396930",
+    "rate_bps": 5347,
+    "seconds": 2911157892,
+    "expected_floor": "905721507855519199904"
+  },
+  {
+    "principal": "9584641103824714371",
+    "rate_bps": 7095,
+    "seconds": 1297446253,
+    "expected_floor": "279584869225696179592"
+  },
+  {
+    "principal": "2031599686525073528",
+    "rate_bps": 1989,
+    "seconds": 2387995242,
+    "expected_floor": "30577530661093866323"
+  },
+  {
+    "principal": "5554698398876978161",
+    "rate_bps": 6281,
+    "seconds": 3902695563,
+    "expected_floor": "431469383508332477172"
+  },
+  {
+    "principal": "18307483141658629822",
+    "rate_bps": 8526,
+    "seconds": 276383264,
+    "expected_floor": "136704164683927853709"
+  },
+  {
+    "principal": "14224776530120324335",
+    "rate_bps": 4708,
+    "seconds": 1209507257,
+    "expected_floor": "256676682772907267703"
+  },
+  {
+    "principal": "17043469862048498132",
+    "rate_bps": 8837,
+    "seconds": 2339265318,
+    "expected_floor": "1116447709124609389690"
+  },
+  {
+    "principal": "13125818520256602365",
+    "rate_bps": 4226,
+    "seconds": 4123765879,
+    "expected_floor": "724846292388902101828"
+  },
+  {
+    "principal": "14104241488091601722",
+    "rate_bps": 323,
+    "seconds": 2827233020,
+    "expected_floor": "40814069048569104605"
+  },
+  {
+    "principal": "7212345403929616283",
+    "rate_bps": 7463,
+    "seconds": 4117704773,
+    "expected_floor": "702329964162843142251"
+  },
+  {
+    "principal": "3326856425305421936",
+    "rate_bps": 2529,
+    "seconds": 2774498082,
+    "expected_floor": "73971316811513082038"
+  },
+  {
+    "principal": "9703053458559468617",
+    "rate_bps": 2558,
+    "seconds": 1308272803,
+    "expected_floor": "102897141543028083297"
+  },
+  {
+    "principal": "8006246812329378550",
+    "rate_bps": 1571,
+    "seconds": 1866358040,
+    "expected_floor": "74386847552793770626"
+  },
+  {
+    "principal": "9406657080859084423",
+    "rate_bps": 4238,
+    "seconds": 2284149009,
+    "expected_floor": "288547110464386564648"
+  },
+  {
+    "principal": "342371597061757004",
+    "rate_bps": 504,
+    "seconds": 1099982430,
+    "expected_floor": "601464565159207461"
+  },
+  {
+    "principal": "17782964598807732693",
+    "rate_bps": 1819,
+    "seconds": 624503055,
+    "expected_floor": "64012894176684647926"
+  },
+  {
+    "principal": "7969178893717154290",
+    "rate_bps": 9158,
+    "seconds": 3652985972,
+    "expected_floor": "844808456789135220980"
+  },
+  {
+    "principal": "1292940832471741875",
+    "rate_bps": 6037,
+    "seconds": 3791094813,
+    "expected_floor": "93769263722484022499"
+  },
+  {
+    "principal": "6617040166208216424",
+    "rate_bps": 137,
+    "seconds": 2670295258,
+    "expected_floor": "7670782264689084422"
+  },
+  {
+    "principal": "6538495181241968033",
+    "rate_bps": 3989,
+    "seconds": 2273786299,
+    "expected_floor": "187926282380127114460"
+  },
+  {
+    "principal": "10369100218525772846",
+    "rate_bps": 6474,
+    "seconds": 568916240,
+    "expected_floor": "121020273778973744240"
+  },
+  {
+    "principal": "1053388876853950751",
+    "rate_bps": 4119,
+    "seconds": 681794921,
+    "expected_floor": "9374115811883113972"
+  },
+  {
+    "principal": "1538810562351399876",
+    "rate_bps": 6691,
+    "seconds": 1536183958,
+    "expected_floor": "50120506017593652086"
+  },
+  {
+    "principal": "1899095325181721517",
+    "rate_bps": 979,
+    "seconds": 2206410407,
+    "expected_floor": "12999055162272522407"
+  },
+  {
+    "principal": "9785802875712382378",
+    "rate_bps": 9615,
+    "seconds": 4246968044,
+    "expected_floor": "1266253847005459563282"
+  },
+  {
+    "principal": "2427197709692968139",
+    "rate_bps": 7916,
+    "seconds": 3912421621,
+    "expected_floor": "238205959375036963408"
+  },
+  {
+    "principal": "7474204955207321440",
+    "rate_bps": 6620,
+    "seconds": 438551442,
+    "expected_floor": "68760585878591278865"
+  },
+  {
+    "principal": "16208381896180125689",
+    "rate_bps": 630,
+    "seconds": 290814931,
+    "expected_floor": "9410071936834048286"
+  },
+  {
+    "principal": "2304264583527461478",
+    "rate_bps": 3684,
+    "seconds": 2082077192,
+    "expected_floor": "56007324406595303058"
+  },
+  {
+    "principal": "14039921984791014583",
+    "rate_bps": 7966,
+    "seconds": 3045591745,
+    "expected_floor": "1079375897982353653345"
+  },
+  {
+    "principal": "3710612019808576572",
+    "rate_bps": 3760,
+    "seconds": 725087182,
+    "expected_floor": "32056761986488569828"
+  },
+  {
+    "principal": "14629083113487502981",
+    "rate_bps": 2706,
+    "seconds": 1105003839,
+    "expected_floor": "138613241380630605485"
+  },
+  {
+    "principal": "13744313771277856354",
+    "rate_bps": 2562,
+    "seconds": 266690148,
+    "expected_floor": "29758099523183629266"
+  },
+  {
+    "principal": "10217941173205513443",
+    "rate_bps": 3852,
+    "seconds": 1747547853,
+    "expected_floor": "217958989738394796660"
+  },
+  {
+    "principal": "5730193710389532248",
+    "rate_bps": 6907,
+    "seconds": 1314011978,
+    "expected_floor": "164798827182724709276"
+  },
+  {
+    "principal": "2877998838509445969",
+    "rate_bps": 235,
+    "seconds": 2182794987,
+    "expected_floor": "4678077983633757589"
+  },
+  {
+    "principal": "7796787681577104798",
+    "rate_bps": 3758,
+    "seconds": 4033232896,
+    "expected_floor": "374474127266411373763"
+  },
+  {
+    "principal": "9637693355070636367",
+    "rate_bps": 3793,
+    "seconds": 2051916057,
+    "expected_floor": "237690360727907872615"
+  },
+  {
+    "principal": "5753772634159110580",
+    "rate_bps": 6557,
+    "seconds": 3953473030,
+    "expected_floor": "472642415726655253781"
+  },
+  {
+    "principal": "11467084038741490269",
+    "rate_bps": 9883,
+    "seconds": 4275971287,
+    "expected_floor": "1535580554502240192288"
+  },
+  {
+    "principal": "7487863882013058074",
+    "rate_bps": 3101,
+    "seconds": 1608538844,
+    "expected_floor": "118355186229627654832"
+  },
+  {
+    "principal": "6521013662503050747",
+    "rate_bps": 2718,
+    "seconds": 405263781,
+    "expected_floor": "22761369414534296414"
+  },
+  {
+    "principal": "14225254546949401168",
+    "rate_bps": 2956,
+    "seconds": 1624031234,
+    "expected_floor": "216398819139991005269"
+  },
+  {
+    "principal": "5174922828013649833",
+    "rate_bps": 7988,
+    "seconds": 1957729027,
+    "expected_floor": "256442821708568969851"
+  },
+  {
+    "principal": "11293323182324241878",
+    "rate_bps": 613,
+    "seconds": 2278992632,
+    "expected_floor": "49994379795010065858"
+  },
+  {
+    "principal": "11658647989262259943",
+    "rate_bps": 2319,
+    "seconds": 3748847729,
+    "expected_floor": "321175768472750524656"
+  },
+  {
+    "principal": "6078481170703975468",
+    "rate_bps": 3711,
+    "seconds": 1019868478,
+    "expected_floor": "72899782376277419194"
+  },
+  {
+    "principal": "4902125291908325173",
+    "rate_bps": 8630,
+    "seconds": 4160873839,
+    "expected_floor": "557796498266191692670"
+  },
+  {
+    "principal": "7963405855413102290",
+    "rate_bps": 7584,
+    "seconds": 3945229396,
+    "expected_floor": "755032190119792973873"
+  },
+  {
+    "principal": "14311709672551692307",
+    "rate_bps": 4511,
+    "seconds": 1950240125,
+    "expected_floor": "398977555481064836261"
+  },
+  {
+    "principal": "10857793930578961224",
+    "rate_bps": 2579,
+    "seconds": 2269065658,
+    "expected_floor": "201342767076158451299"
+  },
+  {
+    "principal": "17172800115588498689",
+    "rate_bps": 306,
+    "seconds": 2173970459,
+    "expected_floor": "36200303590190513709"
+  },
+  {
+    "principal": "3756540839624373006",
+    "rate_bps": 7710,
+    "seconds": 2842172144,
+    "expected_floor": "260848836714763712634"
+  },
+  {
+    "principal": "16433974004760530303",
+    "rate_bps": 2265,
+    "seconds": 1475987657,
+    "expected_floor": "174096307740098852439"
+  },
+  {
+    "principal": "1178063830335914916",
+    "rate_bps": 6274,
+    "seconds": 1860964726,
+    "expected_floor": "43586049805102330368"
+  },
+  {
+    "principal": "5383940129607785741",
+    "rate_bps": 5851,
+    "seconds": 1260889863,
+    "expected_floor": "125864572781825601827"
+  },
+  {
+    "principal": "14312092067639023242",
+    "rate_bps": 1007,
+    "seconds": 260141772,
+    "expected_floor": "11880609433047122335"
+  },
+  {
+    "principal": "15104219771502584619",
+    "rate_bps": 530,
+    "seconds": 2931899989,
+    "expected_floor": "74373693640893684848"
+  },
+  {
+    "principal": "15475787024933626176",
+    "rate_bps": 3499,
+    "seconds": 4217991282,
+    "expected_floor": "723766366585711120885"
+  },
+  {
+    "principal": "16000559197424112473",
+    "rate_bps": 7091,
+    "seconds": 1214705203,
+    "expected_floor": "436726525922040609962"
+  },
+  {
+    "principal": "15881440267087752518",
+    "rate_bps": 6162,
+    "seconds": 831221736,
+    "expected_floor": "257765330147001443375"
+  },
+  {
+    "principal": "13068409918501307671",
+    "rate_bps": 7462,
+    "seconds": 3739802145,
+    "expected_floor": "1155640231431478865333"
+  },
+  {
+    "principal": "15510285947538323484",
+    "rate_bps": 7151,
+    "seconds": 2653252270,
+    "expected_floor": "932526452270714606571"
+  },
+  {
+    "principal": "15811285564917650405",
+    "rate_bps": 2616,
+    "seconds": 1209190815,
+    "expected_floor": "158487784572972506808"
+  },
+  {
+    "principal": "77736801414271810",
+    "rate_bps": 675,
+    "seconds": 2313768516,
+    "expected_floor": "384721431482902094"
+  },
+  {
+    "principal": "13480787620708613955",
+    "rate_bps": 1652,
+    "seconds": 919144493,
+    "expected_floor": "64864209867520441964"
+  },
+  {
+    "principal": "6569935913243984952",
+    "rate_bps": 191,
+    "seconds": 3198114858,
+    "expected_floor": "12716997633243329548"
+  },
+  {
+    "principal": "6195187656600947377",
+    "rate_bps": 8370,
+    "seconds": 2305705291,
+    "expected_floor": "378860870735321319922"
+  },
+  {
+    "principal": "10174334087856186494",
+    "rate_bps": 3476,
+    "seconds": 3651504608,
+    "expected_floor": "409216981806794167429"
+  },
+  {
+    "principal": "17726178480313785775",
+    "rate_bps": 6527,
+    "seconds": 80376953,
+    "expected_floor": "29468382743223059418"
+  },
+  {
+    "principal": "18225604767327125908",
+    "rate_bps": 5045,
+    "seconds": 2648957158,
+    "expected_floor": "771816548520098577424"
+  },
+  {
+    "principal": "13441139090785706941",
+    "rate_bps": 1715,
+    "seconds": 3521817911,
+    "expected_floor": "257254588866085756114"
+  },
+  {
+    "principal": "10798438409892871418",
+    "rate_bps": 4608,
+    "seconds": 3322797756,
+    "expected_floor": "523930121530586230043"
+  },
+  {
+    "principal": "2526229270691507291",
+    "rate_bps": 811,
+    "seconds": 3450997509,
+    "expected_floor": "22404450453706665769"
+  },
+  {
+    "principal": "6667894564840533040",
+    "rate_bps": 2731,
+    "seconds": 759747810,
+    "expected_floor": "43840541923474370590"
+  },
+  {
+    "principal": "8634339589099293449",
+    "rate_bps": 2966,
+    "seconds": 1326681443,
+    "expected_floor": "107662127983974103441"
+  },
+  {
+    "principal": "14550617986027911350",
+    "rate_bps": 150,
+    "seconds": 4019144920,
+    "expected_floor": "27797286087062091642"
+  },
+  {
+    "principal": "15240630863679092551",
+    "rate_bps": 7565,
+    "seconds": 2368534481,
+    "expected_floor": "865341677527627726358"
+  },
+  {
+    "principal": "606951147653349388",
+    "rate_bps": 5967,
+    "seconds": 3026801694,
+    "expected_floor": "34736797431401510401"
+  },
+  {
+    "principal": "9957297417619254421",
+    "rate_bps": 96,
+    "seconds": 3501896143,
+    "expected_floor": "10607474765066462027"
+  },
+  {
+    "principal": "2813519436007961522",
+    "rate_bps": 8827,
+    "seconds": 2110915636,
+    "expected_floor": "166123072893949289539"
+  },
+  {
+    "principal": "17992862397369158259",
+    "rate_bps": 6516,
+    "seconds": 748463837,
+    "expected_floor": "278066191645810739239"
+  },
+  {
+    "principal": "9576700116700068136",
+    "rate_bps": 4848,
+    "seconds": 1650571930,
+    "expected_floor": "242833716915345429482"
+  },
+  {
+    "principal": "810162120884335713",
+    "rate_bps": 7112,
+    "seconds": 660874875,
+    "expected_floor": "12066434396486231034"
+  },
+  {
+    "principal": "547763101478439406",
+    "rate_bps": 455,
+    "seconds": 1561693392,
+    "expected_floor": "1233377371099001299"
+  },
+  {
+    "principal": "6269437453847523807",
+    "rate_bps": 510,
+    "seconds": 2619524137,
+    "expected_floor": "26540994230360864534"
+  },
+  {
+    "principal": "12664002155086173060",
+    "rate_bps": 8245,
+    "seconds": 642491478,
+    "expected_floor": "212581291018094047099"
+  },
+  {
+    "principal": "16710302039053700717",
+    "rate_bps": 8905,
+    "seconds": 3002218343,
+    "expected_floor": "1415652077582191796078"
+  },
+  {
+    "principal": "13146490111320020842",
+    "rate_bps": 1471,
+    "seconds": 2831982252,
+    "expected_floor": "173543779734702584097"
+  },
+  {
+    "principal": "1329467430513326475",
+    "rate_bps": 132,
+    "seconds": 971848629,
+    "expected_floor": "540438516088288847"
+  },
+  {
+    "principal": "15240001477638540064",
+    "rate_bps": 7678,
+    "seconds": 1794764114,
+    "expected_floor": "665482327869302532692"
+  },
+  {
+    "principal": "14518640193491953337",
+    "rate_bps": 793,
+    "seconds": 1838248083,
+    "expected_floor": "67065518180211716074"
+  },
+  {
+    "principal": "16678041891742169126",
+    "rate_bps": 930,
+    "seconds": 4286133704,
+    "expected_floor": "210663723623138731219"
+  },
+  {
+    "principal": "12077445500958944631",
+    "rate_bps": 8683,
+    "seconds": 1942108545,
+    "expected_floor": "645378390238947721039"
+  },
+  {
+    "principal": "10358336134738058236",
+    "rate_bps": 9927,
+    "seconds": 2448732558,
+    "expected_floor": "797894387937616263935"
+  },
+  {
+    "principal": "3898482413086845253",
+    "rate_bps": 5468,
+    "seconds": 4276395519,
+    "expected_floor": "288867035151994161291"
+  },
+  {
+    "principal": "7419060673203914786",
+    "rate_bps": 6672,
+    "seconds": 3150482980,
+    "expected_floor": "494171996138681619707"
+  },
+  {
+    "principal": "7573077775400065443",
+    "rate_bps": 4559,
+    "seconds": 3469486477,
+    "expected_floor": "379579929888581935527"
+  },
+  {
+    "principal": "16793058586639516184",
+    "rate_bps": 675,
+    "seconds": 1236618506,
+    "expected_floor": "44418649513562264852"
+  },
+  {
+    "principal": "8438004215603790353",
+    "rate_bps": 1665,
+    "seconds": 2742078379,
+    "expected_floor": "122075882685399026697"
+  },
+  {
+    "principal": "12522884033661379422",
+    "rate_bps": 2704,
+    "seconds": 1324295104,
+    "expected_floor": "142099271849400135759"
+  },
+  {
+    "principal": "14405678520869915151",
+    "rate_bps": 9175,
+    "seconds": 3248863193,
+    "expected_floor": "1360715238881338927133"
+  },
+  {
+    "principal": "15596530992042113396",
+    "rate_bps": 1747,
+    "seconds": 455236550,
+    "expected_floor": "39305567750690705368"
+  },
+  {
+    "principal": "10097104475097849117",
+    "rate_bps": 643,
+    "seconds": 4098442647,
+    "expected_floor": "84318470066251661365"
+  },
+  {
+    "principal": "7377159267497911770",
+    "rate_bps": 6263,
+    "seconds": 944026268,
+    "expected_floor": "138213887751517892958"
+  },
+  {
+    "principal": "7983966534792006331",
+    "rate_bps": 5191,
+    "seconds": 212193381,
+    "expected_floor": "27867473860268995225"
+  },
+  {
+    "principal": "3774500559436398096",
+    "rate_bps": 1939,
+    "seconds": 3393960386,
+    "expected_floor": "78711847299568303222"
+  },
+  {
+    "principal": "10024004169629197929",
+    "rate_bps": 7484,
+    "seconds": 3673921475,
+    "expected_floor": "873375329287487812409"
+  },
+  {
+    "principal": "45974706446789526",
+    "rate_bps": 9083,
+    "seconds": 1444951736,
+    "expected_floor": "1912042992111179890"
+  },
+  {
+    "principal": "17278939865581250471",
+    "rate_bps": 3933,
+    "seconds": 2087427889,
+    "expected_floor": "449519518677695336194"
+  },
+  {
+    "principal": "7836501414914345964",
+    "rate_bps": 9129,
+    "seconds": 1717994238,
+    "expected_floor": "389460268790514998432"
+  },
+  {
+    "principal": "16275844961813826037",
+    "rate_bps": 9111,
+    "seconds": 1035701807,
+    "expected_floor": "486676479462232552099"
+  },
+  {
+    "principal": "13004595181520146578",
+    "rate_bps": 9307,
+    "seconds": 2348018708,
+    "expected_floor": "900542341774626904865"
+  },
+  {
+    "principal": "2826337786087992531",
+    "rate_bps": 8071,
+    "seconds": 1118474301,
+    "expected_floor": "80848777018007865831"
+  },
+  {
+    "principal": "617720675011010312",
+    "rate_bps": 6960,
+    "seconds": 621351802,
+    "expected_floor": "8465156119835486492"
+  },
+  {
+    "principal": "7759361268698018753",
+    "rate_bps": 7572,
+    "seconds": 802108635,
+    "expected_floor": "149336442937533878889"
+  },
+  {
+    "principal": "11683919183711793358",
+    "rate_bps": 6812,
+    "seconds": 4188622512,
+    "expected_floor": "1056404978159891119588"
+  },
+  {
+    "principal": "1231069151358068287",
+    "rate_bps": 3210,
+    "seconds": 1362513801,
+    "expected_floor": "17061783389615909471"
+  },
+  {
+    "principal": "7282991321665860452",
+    "rate_bps": 7763,
+    "seconds": 1688667958,
+    "expected_floor": "302537820837370823880"
+  },
+  {
+    "principal": "5247876209823813581",
+    "rate_bps": 3427,
+    "seconds": 2990200775,
+    "expected_floor": "170409604747534036659"
+  },
+  {
+    "principal": "11684317804829222986",
+    "rate_bps": 6614,
+    "seconds": 1077746316,
+    "expected_floor": "263924757658414912326"
+  },
+  {
+    "principal": "7051754132613144555",
+    "rate_bps": 6106,
+    "seconds": 1666107669,
+    "expected_floor": "227328066441559670107"
+  },
+  {
+    "principal": "10510852821488452864",
+    "rate_bps": 3401,
+    "seconds": 1917663794,
+    "expected_floor": "217226641890783029726"
+  },
+  {
+    "principal": "8119872875910105625",
+    "rate_bps": 3331,
+    "seconds": 1353515763,
+    "expected_floor": "116006737605190726425"
+  },
+  {
+    "principal": "14028741382902289158",
+    "rate_bps": 9138,
+    "seconds": 2409319336,
+    "expected_floor": "978724053567702952640"
+  },
+  {
+    "principal": "9847524033686676951",
+    "rate_bps": 6520,
+    "seconds": 2704025825,
+    "expected_floor": "550150501407166824185"
+  },
+  {
+    "principal": "7751955985990111196",
+    "rate_bps": 3154,
+    "seconds": 4003317870,
+    "expected_floor": "310162361976616942920"
+  },
+  {
+    "principal": "10777703978815213221",
+    "rate_bps": 4450,
+    "seconds": 648708703,
+    "expected_floor": "98589807665657230529"
+  },
+  {
+    "principal": "16928766736111013122",
+    "rate_bps": 3820,
+    "seconds": 2042306052,
+    "expected_floor": "418509712195392522067"
+  },
+  {
+    "principal": "4996245475226272771",
+    "rate_bps": 8107,
+    "seconds": 164289261,
+    "expected_floor": "21086725762492691883"
+  },
+  {
+    "principal": "4441913744143716344",
+    "rate_bps": 1371,
+    "seconds": 3993767402,
+    "expected_floor": "77070180559668252634"
+  },
+  {
+    "principal": "18264834553650547057",
+    "rate_bps": 7662,
+    "seconds": 419062283,
+    "expected_floor": "185837133461436184628"
+  },
+  {
+    "principal": "6958121892703449662",
+    "rate_bps": 3899,
+    "seconds": 3338341792,
+    "expected_floor": "286993525911462895860"
+  },
+  {
+    "principal": "3809373594474727023",
+    "rate_bps": 1153,
+    "seconds": 251104057,
+    "expected_floor": "3494882964243390120"
+  },
+  {
+    "principal": "7707431346639552852",
+    "rate_bps": 5247,
+    "seconds": 811116198,
+    "expected_floor": "103944098367711256852"
+  },
+  {
+    "principal": "13394516133177403005",
+    "rate_bps": 9764,
+    "seconds": 1330769399,
+    "expected_floor": "551510314374078230239"
+  },
+  {
+    "principal": "17937099450679746234",
+    "rate_bps": 1656,
+    "seconds": 3351041660,
+    "expected_floor": "315419405186445752637"
+  },
+  {
+    "principal": "10943812074818287899",
+    "rate_bps": 1128,
+    "seconds": 261825989,
+    "expected_floor": "10242041047700486010"
+  },
+  {
+    "principal": "17791112566363316208",
+    "rate_bps": 8600,
+    "seconds": 189623970,
+    "expected_floor": "91937105488807843888"
+  },
+  {
+    "principal": "1090895106702070217",
+    "rate_bps": 333,
+    "seconds": 977318435,
+    "expected_floor": "1125017688853391946"
+  },
+  {
+    "principal": "17483511970291592822",
+    "rate_bps": 7177,
+    "seconds": 3745608856,
+    "expected_floor": "1489327050238664505709"
+  },
+  {
+    "principal": "11218374788122175495",
+    "rate_bps": 9994,
+    "seconds": 2621888145,
+    "expected_floor": "931492758284106905807"
+  },
+  {
+    "principal": "10567886210753243084",
+    "rate_bps": 3572,
+    "seconds": 3837362654,
+    "expected_floor": "459016668010766331031"
+  },
+  {
+    "principal": "4011749342936725333",
+    "rate_bps": 7131,
+    "seconds": 2975627919,
+    "expected_floor": "269748404348902531181"
+  },
+  {
+    "principal": "9189165280099630450",
+    "rate_bps": 5480,
+    "seconds": 1136993268,
+    "expected_floor": "181430604544797848272"
+  },
+  {
+    "principal": "14722718480040779571",
+    "rate_bps": 9252,
+    "seconds": 2986346909,
+    "expected_floor": "1289020787133398219063"
+  },
+  {
+    "principal": "2519181308241843432",
+    "rate_bps": 246,
+    "seconds": 1470970970,
+    "expected_floor": "2888648290292138385"
+  },
+  {
+    "principal": "2051998279380353825",
+    "rate_bps": 9826,
+    "seconds": 4121776955,
+    "expected_floor": "263350575494577887377"
+  },
+  {
+    "principal": "16841381205495539630",
+    "rate_bps": 2089,
+    "seconds": 802906256,
+    "expected_floor": "89511126126443058531"
+  },
+  {
+    "principal": "42487419214162591",
+    "rate_bps": 2046,
+    "seconds": 1464625897,
+    "expected_floor": "403449074015427992"
+  },
+  {
+    "principal": "3750708226866078532",
+    "rate_bps": 8408,
+    "seconds": 1626749462,
+    "expected_floor": "162563368121079142268"
+  },
+  {
+    "principal": "6022335120911802669",
+    "rate_bps": 790,
+    "seconds": 2757330983,
+    "expected_floor": "41569705119940490153"
+  },
+  {
+    "principal": "261324687079033130",
+    "rate_bps": 6486,
+    "seconds": 17491564,
+    "expected_floor": "93946814689663366"
+  },
+  {
+    "principal": "5921938002207938123",
+    "rate_bps": 6725,
+    "seconds": 1199433333,
+    "expected_floor": "151365985201049199601"
+  },
+  {
+    "principal": "12222375045656612576",
+    "rate_bps": 153,
+    "seconds": 786126610,
+    "expected_floor": "4658387018977888351"
+  },
+  {
+    "principal": "900786355894861177",
+    "rate_bps": 4671,
+    "seconds": 3851527507,
+    "expected_floor": "51352395019256284240"
+  },
+  {
+    "principal": "8492738135356390886",
+    "rate_bps": 6955,
+    "seconds": 4289311112,
+    "expected_floor": "802838975601896937076"
+  },
+  {
+    "principal": "14603649873723403831",
+    "rate_bps": 5434,
+    "seconds": 2554243137,
+    "expected_floor": "642302059013999404315"
+  },
+  {
+    "principal": "8230231325936210876",
+    "rate_bps": 2772,
+    "seconds": 1880665934,
+    "expected_floor": "135960564412428353726"
+  },
+  {
+    "principal": "6912691730984469509",
+    "rate_bps": 7680,
+    "seconds": 1673295551,
+    "expected_floor": "281499157505898284085"
+  },
+  {
+    "principal": "3244137734437872098",
+    "rate_bps": 6329,
+    "seconds": 3422092772,
+    "expected_floor": "222649739874232677531"
+  },
+  {
+    "principal": "7751904704121290339",
+    "rate_bps": 5294,
+    "seconds": 2237471821,
+    "expected_floor": "290968496219931094348"
+  },
+  {
+    "principal": "2151166522035318232",
+    "rate_bps": 8456,
+    "seconds": 1041997514,
+    "expected_floor": "60062267035414480278"
+  },
+  {
+    "principal": "1659869344988569809",
+    "rate_bps": 1415,
+    "seconds": 3605203051,
+    "expected_floor": "26832189165025354467"
+  },
+  {
+    "principal": "4724132733444690206",
+    "rate_bps": 6411,
+    "seconds": 2894153600,
+    "expected_floor": "277757297356397838504"
+  },
+  {
+    "principal": "5596349563747799759",
+    "rate_bps": 3189,
+    "seconds": 3470257817,
+    "expected_floor": "196253371900303668262"
+  },
+  {
+    "principal": "8144914505156483380",
+    "rate_bps": 4515,
+    "seconds": 4269719942,
+    "expected_floor": "497553410452033489921"
+  },
+  {
+    "principal": "14813997409766408157",
+    "rate_bps": 7142,
+    "seconds": 811378263,
+    "expected_floor": "272026686706312917922"
+  },
+  {
+    "principal": "2849985326931830682",
+    "rate_bps": 74,
+    "seconds": 967723612,
+    "expected_floor": "646728075042731173"
+  },
+  {
+    "principal": "8076335467068012411",
+    "rate_bps": 1346,
+    "seconds": 1428818725,
+    "expected_floor": "49218976214935300329"
+  },
+  {
+    "principal": "15436379197611430352",
+    "rate_bps": 649,
+    "seconds": 3620074370,
+    "expected_floor": "114922128468481200881"
+  },
+  {
+    "principal": "8160689587944607017",
+    "rate_bps": 2367,
+    "seconds": 2998590595,
+    "expected_floor": "183543210512032500778"
+  },
+  {
+    "principal": "16840650636816302422",
+    "rate_bps": 106,
+    "seconds": 581632632,
+    "expected_floor": "3290103262527244975"
+  },
+  {
+    "principal": "1503929407503890535",
+    "rate_bps": 401,
+    "seconds": 3755384305,
+    "expected_floor": "7176657889066316691"
+  },
+  {
+    "principal": "7081155454381904812",
+    "rate_bps": 7138,
+    "seconds": 2505724094,
+    "expected_floor": "401337696976688926879"
+  },
+  {
+    "principal": "8155728501306815669",
+    "rate_bps": 9776,
+    "seconds": 2180347631,
+    "expected_floor": "550865695572694299909"
+  },
+  {
+    "principal": "823018498566978130",
+    "rate_bps": 6231,
+    "seconds": 125676500,
+    "expected_floor": "2042290223249984994"
+  },
+  {
+    "principal": "4666133347076989331",
+    "rate_bps": 1309,
+    "seconds": 976556797,
+    "expected_floor": "18901241554039216428"
+  },
+  {
+    "principal": "15649481290383121096",
+    "rate_bps": 2904,
+    "seconds": 382088506,
+    "expected_floor": "55024558372196372938"
+  },
+  {
+    "principal": "12551302322739257985",
+    "rate_bps": 8739,
+    "seconds": 2010546587,
+    "expected_floor": "698812562286513763156"
+  },
+  {
+    "principal": "3849471735470435982",
+    "rate_bps": 7846,
+    "seconds": 2758001264,
+    "expected_floor": "263961101981156010687"
+  },
+  {
+    "principal": "465031570040176383",
+    "rate_bps": 152,
+    "seconds": 310187593,
+    "expected_floor": "69477867625312223"
+  },
+  {
+    "principal": "8116058652155028260",
+    "rate_bps": 6658,
+    "seconds": 2788244726,
+    "expected_floor": "477436799328324815077"
+  },
+  {
+    "principal": "4476155014493717133",
+    "rate_bps": 461,
+    "seconds": 1218857095,
+    "expected_floor": "7969936592947699371"
+  },
+  {
+    "principal": "4766920307836467722",
+    "rate_bps": 6258,
+    "seconds": 3396207180,
+    "expected_floor": "321043335651539829775"
+  },
+  {
+    "principal": "665953860671347883",
+    "rate_bps": 524,
+    "seconds": 1192399829,
+    "expected_floor": "1318540171823193910"
+  },
+  {
+    "principal": "13052035051153991872",
+    "rate_bps": 7259,
+    "seconds": 3525067762,
+    "expected_floor": "1058323721322070739059"
+  },
+  {
+    "principal": "13717934272691470553",
+    "rate_bps": 4600,
+    "seconds": 1142380467,
+    "expected_floor": "228430111096147686754"
+  },
+  {
+    "principal": "10460513150153439430",
+    "rate_bps": 1301,
+    "seconds": 3780929384,
+    "expected_floor": "163051532641945964736"
+  },
+  {
+    "principal": "8427138626130429591",
+    "rate_bps": 2574,
+    "seconds": 2383525793,
+    "expected_floor": "163834201776710595930"
+  },
+  {
+    "principal": "7855474750663075740",
+    "rate_bps": 2397,
+    "seconds": 2791138862,
+    "expected_floor": "166539765038903541164"
+  },
+  {
+    "principal": "16264832138259024229",
+    "rate_bps": 3397,
+    "seconds": 1047690015,
+    "expected_floor": "183431522247561772552"
+  },
+  {
+    "principal": "12434312181450180290",
+    "rate_bps": 1590,
+    "seconds": 4005178820,
+    "expected_floor": "250920899012458145684"
+  },
+  {
+    "principal": "829714650465159363",
+    "rate_bps": 8777,
+    "seconds": 2736450989,
+    "expected_floor": "63147849321758669523"
+  },
+  {
+    "principal": "13757204401548499896",
+    "rate_bps": 1338,
+    "seconds": 1616641962,
+    "expected_floor": "94296632502928584005"
+  },
+  {
+    "principal": "1232473510851037233",
+    "rate_bps": 7149,
+    "seconds": 1845673675,
+    "expected_floor": "51531625478461224001"
+  },
+  {
+    "principal": "4959953251239772158",
+    "rate_bps": 4607,
+    "seconds": 1580847456,
+    "expected_floor": "114467393306904813749"
+  },
+  {
+    "principal": "14304996104923508527",
+    "rate_bps": 7659,
+    "seconds": 1734271481,
+    "expected_floor": "602105963674360334549"
+  },
+  {
+    "principal": "12976435370527605012",
+    "rate_bps": 4428,
+    "seconds": 4203523174,
+    "expected_floor": "765371874959948198241"
+  },
+  {
+    "principal": "6034756870349416765",
+    "rate_bps": 8002,
+    "seconds": 1220636343,
+    "expected_floor": "186784422592509356136"
+  },
+  {
+    "principal": "76711167411077242",
+    "rate_bps": 1024,
+    "seconds": 122752572,
+    "expected_floor": "30555203612607702"
+  },
+  {
+    "principal": "11549377815399024091",
+    "rate_bps": 473,
+    "seconds": 2682945669,
+    "expected_floor": "46443788686779318705"
+  },
+  {
+    "principal": "10713605449662010288",
+    "rate_bps": 1957,
+    "seconds": 724387938,
+    "expected_floor": "48127545942539119332"
+  },
+  {
+    "principal": "12880174568866568329",
+    "rate_bps": 9834,
+    "seconds": 2923566819,
+    "expected_floor": "1173440329619204095799"
+  },
+  {
+    "principal": "6874834643653174326",
+    "rate_bps": 4814,
+    "seconds": 739565656,
+    "expected_floor": "77560591202446325825"
+  },
+  {
+    "principal": "15948251267526465735",
+    "rate_bps": 2387,
+    "seconds": 1043526993,
+    "expected_floor": "125882456378781215618"
+  },
+  {
+    "principal": "13175956205185847180",
+    "rate_bps": 4442,
+    "seconds": 2990600094,
+    "expected_floor": "554644961834057301796"
+  },
+  {
+    "principal": "7999275729590616597",
+    "rate_bps": 8768,
+    "seconds": 3923673935,
+    "expected_floor": "872047518144948928339"
+  },
+  {
+    "principal": "12099717967238121266",
+    "rate_bps": 5880,
+    "seconds": 1834320820,
+    "expected_floor": "413546073689335775747"
+  },
+  {
+    "principal": "11751260279848694771",
+    "rate_bps": 5891,
+    "seconds": 1591848029,
+    "expected_floor": "349197483497958645838"
+  },
+  {
+    "principal": "12485654748486561960",
+    "rate_bps": 7192,
+    "seconds": 315358746,
+    "expected_floor": "89735009546987835633"
+  },
+  {
+    "principal": "12019517887190667745",
+    "rate_bps": 5273,
+    "seconds": 1495449595,
+    "expected_floor": "300339623368683639413"
+  },
+  {
+    "principal": "13677753959494174062",
+    "rate_bps": 1859,
+    "seconds": 4026168400,
+    "expected_floor": "324400971240364639765"
+  },
+  {
+    "principal": "4043899944056234847",
+    "rate_bps": 7689,
+    "seconds": 1793085865,
+    "expected_floor": "176671860427988723265"
+  },
+  {
+    "principal": "11287285575879865092",
+    "rate_bps": 6527,
+    "seconds": 324014038,
+    "expected_floor": "75641996876005900122"
+  },
+  {
+    "principal": "13015910866667926509",
+    "rate_bps": 9284,
+    "seconds": 3262716135,
+    "expected_floor": "1249352589322923455470"
+  },
+  {
+    "principal": "12923853274108295914",
+    "rate_bps": 716,
+    "seconds": 798912044,
+    "expected_floor": "23426102674065673218"
+  },
+  {
+    "principal": "9110984185023345419",
+    "rate_bps": 9634,
+    "seconds": 111464757,
+    "expected_floor": "31003129992642679601"
+  },
+  {
+    "principal": "15883091135959306912",
+    "rate_bps": 1119,
+    "seconds": 2710044882,
+    "expected_floor": "152629200999772701581"
+  },
+  {
+    "principal": "10332017971948540985",
+    "rate_bps": 9155,
+    "seconds": 2820020755,
+    "expected_floor": "845262961667711941970"
+  },
+  {
+    "principal": "5696618196296565670",
+    "rate_bps": 3127,
+    "seconds": 980118856,
+    "expected_floor": "55324789649374596810"
+  },
+  {
+    "principal": "5160125598825737975",
+    "rate_bps": 4702,
+    "seconds": 3149747969,
+    "expected_floor": "242166873514699705683"
+  },
+  {
+    "principal": "9111951973072915324",
+    "rate_bps": 6259,
+    "seconds": 4116966670,
+    "expected_floor": "744028818721268724642"
+  },
+  {
+    "principal": "17109807537730363077",
+    "rate_bps": 9548,
+    "seconds": 589598591,
+    "expected_floor": "305217903265773726280"
+  },
+  {
+    "principal": "12644131095905811362",
+    "rate_bps": 9391,
+    "seconds": 1379315108,
+    "expected_floor": "518991633339837302865"
+  },
+  {
+    "principal": "7393716335099536163",
+    "rate_bps": 2274,
+    "seconds": 2291945229,
+    "expected_floor": "122110641513979640456"
+  },
+  {
+    "principal": "15413883666998876568",
+    "rate_bps": 9502,
+    "seconds": 256192650,
+    "expected_floor": "118902175799453690400"
+  },
+  {
+    "principal": "22696935902642065",
+    "rate_bps": 3335,
+    "seconds": 322012459,
+    "expected_floor": "77238134816399678"
+  },
+  {
+    "principal": "10877430227549765342",
+    "rate_bps": 4466,
+    "seconds": 786213696,
+    "expected_floor": "121026831326443843642"
+  },
+  {
+    "principal": "11901288601291742095",
+    "rate_bps": 9646,
+    "seconds": 3265553753,
+    "expected_floor": "1187938928195091590678"
+  },
+  {
+    "principal": "10495199690203691252",
+    "rate_bps": 6262,
+    "seconds": 3984222022,
+    "expected_floor": "829742497171850814674"
+  },
+  {
+    "principal": "15166156936684331677",
+    "rate_bps": 5248,
+    "seconds": 2916632343,
+    "expected_floor": "735609098775548081413"
+  },
+  {
+    "principal": "242513747922610522",
+    "rate_bps": 1980,
+    "seconds": 1574773276,
+    "expected_floor": "2396158944902123675"
+  },
+  {
+    "principal": "13183300909896983611",
+    "rate_bps": 9246,
+    "seconds": 4134831589,
+    "expected_floor": "1597099274951187352065"
+  },
+  {
+    "principal": "4250492505966552464",
+    "rate_bps": 8539,
+    "seconds": 352021826,
+    "expected_floor": "40486654601974678679"
+  },
+  {
+    "principal": "5800041417996202985",
+    "rate_bps": 3684,
+    "seconds": 3131990339,
+    "expected_floor": "212064104566808819139"
+  },
+  {
+    "principal": "8980682550956381974",
+    "rate_bps": 5711,
+    "seconds": 2067205688,
+    "expected_floor": "335970564909513189696"
+  },
+  {
+    "principal": "473964350684186919",
+    "rate_bps": 8105,
+    "seconds": 2993937585,
+    "expected_floor": "36444959485105742395"
+  },
+  {
+    "principal": "2484869808072825708",
+    "rate_bps": 1028,
+    "seconds": 1231380094,
+    "expected_floor": "9967469503200710654"
+  },
+  {
+    "principal": "6580103192249343861",
+    "rate_bps": 8599,
+    "seconds": 124755887,
+    "expected_floor": "22368544952641664135"
+  },
+  {
+    "principal": "686057883260511250",
+    "rate_bps": 7978,
+    "seconds": 1065659284,
+    "expected_floor": "18482860972650458492"
+  },
+  {
+    "principal": "7650898738218276435",
+    "rate_bps": 5392,
+    "seconds": 1738397117,
+    "expected_floor": "227251816570357576080"
+  },
+  {
+    "principal": "9133409059136853640",
+    "rate_bps": 5430,
+    "seconds": 2419496698,
+    "expected_floor": "380236501242656061705"
+  },
+  {
+    "principal": "3640293456173601089",
+    "rate_bps": 6114,
+    "seconds": 3765046875,
+    "expected_floor": "265538959916592596321"
+  },
+  {
+    "principal": "4771147976768891982",
+    "rate_bps": 1627,
+    "seconds": 2673309232,
+    "expected_floor": "65759071190015937707"
+  },
+  {
+    "principal": "1482319131139708863",
+    "rate_bps": 8083,
+    "seconds": 3431865609,
+    "expected_floor": "130298854620534756061"
+  },
+  {
+    "principal": "3912317119005922020",
+    "rate_bps": 2514,
+    "seconds": 3679105718,
+    "expected_floor": "114666781706702129083"
+  },
+  {
+    "principal": "16141131243036030285",
+    "rate_bps": 5098,
+    "seconds": 2569664839,
+    "expected_floor": "670048616597674823591"
+  },
+  {
+    "principal": "17811784947187682250",
+    "rate_bps": 229,
+    "seconds": 2010393100,
+    "expected_floor": "25984833791038563145"
+  },
+  {
+    "principal": "16530089162318731627",
+    "rate_bps": 2592,
+    "seconds": 1858903701,
+    "expected_floor": "252384755003649116739"
+  },
+  {
+    "principal": "14634230898544102528",
+    "rate_bps": 5309,
+    "seconds": 4137061810,
+    "expected_floor": "1018522601959884124007"
+  },
+  {
+    "principal": "15965094289055397785",
+    "rate_bps": 7046,
+    "seconds": 1902505075,
+    "expected_floor": "678165954661405885149"
+  },
+  {
+    "principal": "1338829212224462470",
+    "rate_bps": 4889,
+    "seconds": 2223948584,
+    "expected_floor": "46128145232874212249"
+  },
+  {
+    "principal": "8462544829289113431",
+    "rate_bps": 3213,
+    "seconds": 1582925409,
+    "expected_floor": "136385497174445012130"
+  },
+  {
+    "principal": "14673905845713190748",
+    "rate_bps": 4867,
+    "seconds": 2502181870,
+    "expected_floor": "566267947976541785984"
+  },
+  {
+    "principal": "13515420397348095013",
+    "rate_bps": 3615,
+    "seconds": 1646965727,
+    "expected_floor": "254987244157511846728"
+  },
+  {
+    "principal": "6040174335433359490",
+    "rate_bps": 6233,
+    "seconds": 2594602372,
+    "expected_floor": "309537623746322873159"
+  },
+  {
+    "principal": "1448460218530008451",
+    "rate_bps": 3333,
+    "seconds": 528040045,
+    "expected_floor": "8078017281345837101"
+  },
+  {
+    "principal": "14943606863367694200",
+    "rate_bps": 9039,
+    "seconds": 2572104042,
+    "expected_floor": "1100931720064075355501"
+  },
+  {
+    "principal": "15227078939412842225",
+    "rate_bps": 8983,
+    "seconds": 2672253835,
+    "expected_floor": "1158275154903048741511"
+  },
+  {
+    "principal": "10360163645371157950",
+    "rate_bps": 3480,
+    "seconds": 1696716064,
+    "expected_floor": "193843420184170372326"
+  },
+  {
+    "principal": "4729737756127057903",
+    "rate_bps": 2482,
+    "seconds": 1321236665,
+    "expected_floor": "49149090853450848919"
+  },
+  {
+    "principal": "7332386668215632084",
+    "rate_bps": 8913,
+    "seconds": 4097831462,
+    "expected_floor": "848631974703910752319"
+  },
+  {
+    "principal": "7699216832936537085",
+    "rate_bps": 9503,
+    "seconds": 3640209271,
+    "expected_floor": "843975159648024782651"
+  },
+  {
+    "principal": "9590427787500708410",
+    "rate_bps": 5546,
+    "seconds": 512394748,
+    "expected_floor": "86361175956946356361"
+  },
+  {
+    "principal": "4204828550431576731",
+    "rate_bps": 9240,
+    "seconds": 2740984645,
+    "expected_floor": "337460463857507458968"
+  },
+  {
+    "principal": "3242145328777693040",
+    "rate_bps": 5535,
+    "seconds": 3098042914,
+    "expected_floor": "176170653593897681535"
+  },
+  {
+    "principal": "14454175203728138057",
+    "rate_bps": 2835,
+    "seconds": 2312616867,
+    "expected_floor": "300293616045949657946"
+  },
+  {
+    "principal": "8273534143062104566",
+    "rate_bps": 5466,
+    "seconds": 63540248,
+    "expected_floor": "9105538380905833386"
+  },
+  {
+    "principal": "9120164785693723015",
+    "rate_bps": 8961,
+    "seconds": 1001477137,
+    "expected_floor": "259355961298323283748"
+  },
+  {
+    "principal": "4374812741235160908",
+    "rate_bps": 3602,
+    "seconds": 1019190622,
+    "expected_floor": "50892598816705025971"
+  },
+  {
+    "principal": "16477211414258109653",
+    "rate_bps": 4183,
+    "seconds": 3707816975,
+    "expected_floor": "809815154939501893742"
+  },
+  {
+    "principal": "17828959291126698226",
+    "rate_bps": 1586,
+    "seconds": 2084774772,
+    "expected_floor": "186803217488888023971"
+  },
+  {
+    "principal": "9024429165399460019",
+    "rate_bps": 6224,
+    "seconds": 1610714909,
+    "expected_floor": "286684383205221089975"
+  },
+  {
+    "principal": "9861193150910827624",
+    "rate_bps": 6379,
+    "seconds": 1736310746,
+    "expected_floor": "346103151266285067815"
+  },
+  {
+    "principal": "10235655620319289505",
+    "rate_bps": 3724,
+    "seconds": 4169428155,
+    "expected_floor": "503614082287556119411"
+  },
+  {
+    "principal": "12954616084085236526",
+    "rate_bps": 6891,
+    "seconds": 858966032,
+    "expected_floor": "242984639271880750491"
+  },
+  {
+    "principal": "5048617196190997535",
+    "rate_bps": 6088,
+    "seconds": 664696937,
+    "expected_floor": "64739120694744685826"
+  },
+  {
+    "principal": "573162152141767364",
+    "rate_bps": 8730,
+    "seconds": 2233017750,
+    "expected_floor": "35406252041408396902"
+  },
+  {
+    "principal": "14946601755818231469",
+    "rate_bps": 7487,
+    "seconds": 3088116135,
+    "expected_floor": "1095065139285369544927"
+  },
+  {
+    "principal": "12456294402530045098",
+    "rate_bps": 8160,
+    "seconds": 2655466988,
+    "expected_floor": "855295057933487281785"
+  },
+  {
+    "principal": "1785249059314339787",
+    "rate_bps": 6856,
+    "seconds": 2887908341,
+    "expected_floor": "112008004444620294808"
+  },
+  {
+    "principal": "7734137080090482272",
+    "rate_bps": 7223,
+    "seconds": 1052764818,
+    "expected_floor": "186361791207880045474"
+  },
+  {
+    "principal": "17878522305957341945",
+    "rate_bps": 6207,
+    "seconds": 601804499,
+    "expected_floor": "211623956236011841092"
+  },
+  {
+    "principal": "11568747058176952678",
+    "rate_bps": 8963,
+    "seconds": 2910742792,
+    "expected_floor": "956400040134204488092"
+  },
+  {
+    "principal": "5426101392217665463",
+    "rate_bps": 3615,
+    "seconds": 3070117313,
+    "expected_floor": "190830245938291259163"
+  },
+  {
+    "principal": "12922709888845054780",
+    "rate_bps": 3906,
+    "seconds": 2442554062,
+    "expected_floor": "390684383084473783824"
+  },
+  {
+    "principal": "14322176158462540165",
+    "rate_bps": 3435,
+    "seconds": 803006527,
+    "expected_floor": "125184586963097392510"
+  },
+  {
+    "principal": "16559724885612336482",
+    "rate_bps": 7663,
+    "seconds": 2688654692,
+    "expected_floor": "1081142660903951834470"
+  },
+  {
+    "principal": "17819093581809895395",
+    "rate_bps": 8523,
+    "seconds": 357155277,
+    "expected_floor": "171882317732800675266"
+  },
+  {
+    "principal": "800939167756600664",
+    "rate_bps": 4909,
+    "seconds": 3773956682,
+    "expected_floor": "47020312176039783770"
+  },
+  {
+    "principal": "6556988074719878737",
+    "rate_bps": 943,
+    "seconds": 2400993771,
+    "expected_floor": "47043882091984371012"
+  },
+  {
+    "principal": "10445148521292737694",
+    "rate_bps": 2471,
+    "seconds": 1002524416,
+    "expected_floor": "81993298213858905167"
+  },
+  {
+    "principal": "8390677965286106191",
+    "rate_bps": 2631,
+    "seconds": 4257946649,
+    "expected_floor": "297861347371828239198"
+  },
+  {
+    "principal": "13582081681725642932",
+    "rate_bps": 2802,
+    "seconds": 2144685318,
+    "expected_floor": "258639040548799041472"
+  },
+  {
+    "principal": "12682615026634851677",
+    "rate_bps": 7527,
+    "seconds": 2809931735,
+    "expected_floor": "850007050510856455057"
+  },
+  {
+    "principal": "1373045862860663578",
+    "rate_bps": 5032,
+    "seconds": 3734059484,
+    "expected_floor": "81752857468714158853"
+  },
+  {
+    "principal": "12171812527120765179",
+    "rate_bps": 9333,
+    "seconds": 893730981,
+    "expected_floor": "321720967675592191419"
+  },
+  {
+    "principal": "1783748349349771600",
+    "rate_bps": 6551,
+    "seconds": 1303127810,
+    "expected_floor": "48252990013814046541"
+  },
+  {
+    "principal": "12461398769460468393",
+    "rate_bps": 2281,
+    "seconds": 4053149187,
+    "expected_floor": "365073829481660001711"
+  },
+  {
+    "principal": "3561257538624597206",
+    "rate_bps": 9529,
+    "seconds": 763648504,
+    "expected_floor": "82118356092318215843"
+  },
+  {
+    "principal": "14006628979061381607",
+    "rate_bps": 3830,
+    "seconds": 3707984753,
+    "expected_floor": "630327668906860318677"
+  },
+  {
+    "principal": "9730723463611589420",
+    "rate_bps": 8181,
+    "seconds": 1111993406,
+    "expected_floor": "280510917105159755236"
+  },
+  {
+    "principal": "10759507286138915381",
+    "rate_bps": 215,
+    "seconds": 1357514863,
+    "expected_floor": "9951108695814732030"
+  },
+  {
+    "principal": "5468608608265899474",
+    "rate_bps": 2826,
+    "seconds": 1439230804,
+    "expected_floor": "70481555119417561754"
+  },
+  {
+    "principal": "7022355893397981971",
+    "rate_bps": 4552,
+    "seconds": 396679293,
+    "expected_floor": "40180991819197520039"
+  },
+  {
+    "principal": "17871719287946252872",
+    "rate_bps": 7196,
+    "seconds": 85604538,
+    "expected_floor": "34885930374498440625"
+  },
+  {
+    "principal": "9329230667489853441",
+    "rate_bps": 2950,
+    "seconds": 810146587,
+    "expected_floor": "70652492377676940058"
+  },
+  {
+    "principal": "9272850359188744718",
+    "rate_bps": 3281,
+    "seconds": 541354480,
+    "expected_floor": "52191196084753678687"
+  },
+  {
+    "principal": "2621772795485106303",
+    "rate_bps": 110,
+    "seconds": 4029244361,
+    "expected_floor": "3682200033346872992"
+  },
+  {
+    "principal": "2942357147300381348",
+    "rate_bps": 5332,
+    "seconds": 3954403446,
+    "expected_floor": "196590504150492149977"
+  },
+  {
+    "principal": "3473640396040529933",
+    "rate_bps": 6037,
+    "seconds": 1854269959,
+    "expected_floor": "123218247549771007439"
+  },
+  {
+    "principal": "4879140573121748362",
+    "rate_bps": 5879,
+    "seconds": 1378849228,
+    "expected_floor": "125331317244009561056"
+  },
+  {
+    "principal": "11460237555326539307",
+    "rate_bps": 269,
+    "seconds": 792521045,
+    "expected_floor": "7741992325926323968"
+  },
+  {
+    "principal": "8884205833334206528",
+    "rate_bps": 5587,
+    "seconds": 4219213682,
+    "expected_floor": "663628206820195497054"
+  },
+  {
+    "principal": "16107563834246639193",
+    "rate_bps": 7432,
+    "seconds": 1733869875,
+    "expected_floor": "657730673909780703337"
+  },
+  {
+    "principal": "8279697386474357830",
+    "rate_bps": 2502,
+    "seconds": 384982760,
+    "expected_floor": "25271969227786117247"
+  },
+  {
+    "principal": "5643445281650329623",
+    "rate_bps": 207,
+    "seconds": 180589857,
+    "expected_floor": "668504062777002859"
+  },
+  {
+    "principal": "2661810360330819356",
+    "rate_bps": 4005,
+    "seconds": 3400688046,
+    "expected_floor": "114879479509688188605"
+  },
+  {
+    "principal": "11586047662222081765",
+    "rate_bps": 3634,
+    "seconds": 2761108639,
+    "expected_floor": "368383153615061477821"
+  },
+  {
+    "principal": "1263726812177119810",
+    "rate_bps": 4511,
+    "seconds": 1866468676,
+    "expected_floor": "33716521745583098607"
+  },
+  {
+    "principal": "3637637507309539907",
+    "rate_bps": 142,
+    "seconds": 3685077805,
+    "expected_floor": "6031848962521583802"
+  },
+  {
+    "principal": "12323920868324537144",
+    "rate_bps": 3066,
+    "seconds": 1554359082,
+    "expected_floor": "186109455954209645056"
+  },
+  {
+    "principal": "5704555637588428209",
+    "rate_bps": 4920,
+    "seconds": 59258955,
+    "expected_floor": "5270319506706520650"
+  },
+  {
+    "principal": "16359841962459503486",
+    "rate_bps": 8262,
+    "seconds": 3782416608,
+    "expected_floor": "1620054740809121696179"
+  },
+  {
+    "principal": "10874934252371837103",
+    "rate_bps": 3847,
+    "seconds": 1172066169,
+    "expected_floor": "155380669957600670998"
+  },
+  {
+    "principal": "13693537850878558356",
+    "rate_bps": 8346,
+    "seconds": 1429370854,
+    "expected_floor": "517648550346766464449"
+  },
+  {
+    "principal": "6271669687157763773",
+    "rate_bps": 7969,
+    "seconds": 1522085943,
+    "expected_floor": "241058367972619893977"
+  },
+  {
+    "principal": "13481995530802512890",
+    "rate_bps": 8848,
+    "seconds": 3878239676,
+    "expected_floor": "1465986499277754001196"
+  },
+  {
+    "principal": "5258229765595438939",
+    "rate_bps": 1391,
+    "seconds": 2126247429,
+    "expected_floor": "49280660920292758020"
+  },
+  {
+    "principal": "16633357355327109936",
+    "rate_bps": 8723,
+    "seconds": 528399330,
+    "expected_floor": "242942827520083437681"
+  },
+  {
+    "principal": "1557659056945866249",
+    "rate_bps": 6922,
+    "seconds": 3955335267,
+    "expected_floor": "135139819367605352742"
+  },
+  {
+    "principal": "7772287753049395126",
+    "rate_bps": 3118,
+    "seconds": 3558832088,
+    "expected_floor": "273293002859488590141"
+  },
+  {
+    "principal": "13641249553320229447",
+    "rate_bps": 5692,
+    "seconds": 2642539217,
+    "expected_floor": "650184361649259265805"
+  },
+  {
+    "principal": "17967705843362815756",
+    "rate_bps": 9663,
+    "seconds": 3824519966,
+    "expected_floor": "2104154251428467363647"
+  },
+  {
+    "principal": "7437450468509013909",
+    "rate_bps": 7261,
+    "seconds": 763581647,
+    "expected_floor": "130668840547417976407"
+  },
+  {
+    "principal": "8147368203619343026",
+    "rate_bps": 5949,
+    "seconds": 843973428,
+    "expected_floor": "129624208926057703623"
+  },
+  {
+    "principal": "1938713816740715891",
+    "rate_bps": 1177,
+    "seconds": 572502493,
+    "expected_floor": "4139649614074837959"
+  },
+  {
+    "principal": "3703114883371853864",
+    "rate_bps": 8936,
+    "seconds": 1770209690,
+    "expected_floor": "185622702921546896508"
+  },
+  {
+    "principal": "9122798323263565665",
+    "rate_bps": 8728,
+    "seconds": 3130153339,
+    "expected_floor": "789776955843346087780"
+  },
+  {
+    "principal": "14024276215185817838",
+    "rate_bps": 9393,
+    "seconds": 3477363664,
+    "expected_floor": "1451546402677776537345"
+  },
+  {
+    "principal": "2714586085325264095",
+    "rate_bps": 7582,
+    "seconds": 507961129,
+    "expected_floor": "33129426003435736735"
+  },
+  {
+    "principal": "6739493362559029892",
+    "rate_bps": 7929,
+    "seconds": 1041333078,
+    "expected_floor": "176332093904695955173"
+  },
+  {
+    "principal": "516562326069434733",
+    "rate_bps": 7149,
+    "seconds": 1877015143,
+    "expected_floor": "21965031749218691883"
+  },
+  {
+    "principal": "5785916395805974122",
+    "rate_bps": 5737,
+    "seconds": 4140121516,
+    "expected_floor": "435477905036589750246"
+  },
+  {
+    "principal": "676530626207657099",
+    "rate_bps": 3831,
+    "seconds": 2897569461,
+    "expected_floor": "23797399549635577622"
+  },
+  {
+    "principal": "12492839306644642336",
+    "rate_bps": 534,
+    "seconds": 3259176018,
+    "expected_floor": "68897943599893775289"
+  },
+  {
+    "principal": "12875280334744240569",
+    "rate_bps": 538,
+    "seconds": 128697235,
+    "expected_floor": "2824907415852677352"
+  },
+  {
+    "principal": "7425962969750425382",
+    "rate_bps": 3106,
+    "seconds": 2527241416,
+    "expected_floor": "184712800835980769859"
+  },
+  {
+    "principal": "17041969773160018039",
+    "rate_bps": 5693,
+    "seconds": 2730587265,
+    "expected_floor": "839485246055690734970"
+  },
+  {
+    "principal": "11613891587541170940",
+    "rate_bps": 8319,
+    "seconds": 4100991118,
+    "expected_floor": "1255549251843673074909"
+  },
+  {
+    "principal": "6649841387017802821",
+    "rate_bps": 3624,
+    "seconds": 3164963071,
+    "expected_floor": "241693046247298918317"
+  },
+  {
+    "principal": "16515334333446795042",
+    "rate_bps": 3223,
+    "seconds": 1205456164,
+    "expected_floor": "203327036273517230899"
+  },
+  {
+    "principal": "11477680715880557731",
+    "rate_bps": 1392,
+    "seconds": 2821026957,
+    "expected_floor": "142822504281208491777"
+  },
+  {
+    "principal": "1709647581407080728",
+    "rate_bps": 6550,
+    "seconds": 383915018,
+    "expected_floor": "13623196795800665775"
+  },
+  {
+    "principal": "4971152317465754897",
+    "rate_bps": 2762,
+    "seconds": 3244506795,
+    "expected_floor": "141164490647005725279"
+  },
+  {
+    "principal": "13627532869566421598",
+    "rate_bps": 2344,
+    "seconds": 2028942016,
+    "expected_floor": "205371660353155312736"
+  },
+  {
+    "principal": "2671573138594114831",
+    "rate_bps": 3074,
+    "seconds": 554439385,
+    "expected_floor": "14428495136074434662"
+  },
+  {
+    "principal": "13242024768614266996",
+    "rate_bps": 5969,
+    "seconds": 2370794182,
+    "expected_floor": "593807748695478597122"
+  },
+  {
+    "principal": "15800905052996823069",
+    "rate_bps": 6477,
+    "seconds": 2550679703,
+    "expected_floor": "827194845775762647951"
+  },
+  {
+    "principal": "6009727684119243994",
+    "rate_bps": 1774,
+    "seconds": 898273692,
+    "expected_floor": "30346815370523065909"
+  },
+  {
+    "principal": "18365774620886007227",
+    "rate_bps": 9420,
+    "seconds": 2522626917,
+    "expected_floor": "1382958702829453650174"
+  },
+  {
+    "principal": "6778114538276261136",
+    "rate_bps": 3294,
+    "seconds": 2375557314,
+    "expected_floor": "168071487604114683563"
+  },
+  {
+    "principal": "9982251719583564137",
+    "rate_bps": 6272,
+    "seconds": 2519870147,
+    "expected_floor": "499929496202148255023"
+  },
+  {
+    "principal": "3836499762302861974",
+    "rate_bps": 1188,
+    "seconds": 1196615096,
+    "expected_floor": "17282323355609917858"
+  },
+  {
+    "principal": "6702013620152707751",
+    "rate_bps": 3855,
+    "seconds": 2286230065,
+    "expected_floor": "187174056670145108959"
+  },
+  {
+    "principal": "3432052084949674732",
+    "rate_bps": 4195,
+    "seconds": 2143369726,
+    "expected_floor": "97786513145637923232"
+  },
+  {
+    "principal": "381228158151144693",
+    "rate_bps": 9422,
+    "seconds": 556052783,
+    "expected_floor": "6329073255009539718"
+  },
+  {
+    "principal": "5873819174368442258",
+    "rate_bps": 4137,
+    "seconds": 2886363924,
+    "expected_floor": "222255856818144201298"
+  },
+  {
+    "principal": "14732355160843960275",
+    "rate_bps": 2887,
+    "seconds": 3607763773,
+    "expected_floor": "486242695428795692941"
+  },
+  {
+    "principal": "8810601214471474696",
+    "rate_bps": 6054,
+    "seconds": 691083898,
+    "expected_floor": "116808586445730950441"
+  },
+  {
+    "principal": "10543659540131196609",
+    "rate_bps": 2711,
+    "seconds": 1849026523,
+    "expected_floor": "167478886681272837224"
+  },
+  {
+    "principal": "2120922251877279694",
+    "rate_bps": 5556,
+    "seconds": 2632621488,
+    "expected_floor": "98304056735567984669"
+  },
+  {
+    "principal": "14275421859465890111",
+    "rate_bps": 7344,
+    "seconds": 772729481,
+    "expected_floor": "256711387428965431136"
+  },
+  {
+    "principal": "16615386690216637028",
+    "rate_bps": 3793,
+    "seconds": 4281032246,
+    "expected_floor": "854944312998412996396"
+  },
+  {
+    "principal": "5136452845862771405",
+    "rate_bps": 4883,
+    "seconds": 3547994823,
+    "expected_floor": "281986969478528773312"
+  },
+  {
+    "principal": "6009136406712676170",
+    "rate_bps": 4387,
+    "seconds": 2738895244,
+    "expected_floor": "228797435207062100226"
+  },
+  {
+    "principal": "17509414957601133291",
+    "rate_bps": 5005,
+    "seconds": 488862741,
+    "expected_floor": "135755892242578144316"
+  },
+  {
+    "principal": "9173041413094528000",
+    "rate_bps": 3925,
+    "seconds": 1015865650,
+    "expected_floor": "115900503791611213947"
+  },
+  {
+    "principal": "5062853359484855577",
+    "rate_bps": 4239,
+    "seconds": 4105164275,
+    "expected_floor": "279180666009975270222"
+  },
+  {
+    "principal": "14493910032269355526",
+    "rate_bps": 6344,
+    "seconds": 1984379560,
+    "expected_floor": "578188585147762817691"
+  },
+  {
+    "principal": "14821561917076547799",
+    "rate_bps": 6187,
+    "seconds": 3423593441,
+    "expected_floor": "994837865974810626001"
+  },
+  {
+    "principal": "5008120103308635868",
+    "rate_bps": 4823,
+    "seconds": 2529673070,
+    "expected_floor": "193620986142157772964"
+  },
+  {
+    "principal": "2900391606710548901",
+    "rate_bps": 9342,
+    "seconds": 1483466079,
+    "expected_floor": "127370881867942093674"
+  },
+  {
+    "principal": "15388485272009438210",
+    "rate_bps": 6283,
+    "seconds": 2655444228,
+    "expected_floor": "813572293782176812239"
+  },
+  {
+    "principal": "17517258466338887427",
+    "rate_bps": 1268,
+    "seconds": 1952490989,
+    "expected_floor": "137426492641783558880"
+  },
+  {
+    "principal": "15005554941029138168",
+    "rate_bps": 5168,
+    "seconds": 2921288938,
+    "expected_floor": "717868857731276465336"
+  },
+  {
+    "principal": "15604720435382158449",
+    "rate_bps": 4442,
+    "seconds": 830821643,
+    "expected_floor": "182489710018379179396"
+  },
+  {
+    "principal": "11267502947248826686",
+    "rate_bps": 1389,
+    "seconds": 418225312,
+    "expected_floor": "20741314312597819398"
+  },
+  {
+    "principal": "6505708531813935471",
+    "rate_bps": 928,
+    "seconds": 225601081,
+    "expected_floor": "4315983618120136411"
+  },
+  {
+    "principal": "17592414066383962196",
+    "rate_bps": 9419,
+    "seconds": 2502180262,
+    "expected_floor": "1313847206597420968325"
+  },
+  {
+    "principal": "776062624268398973",
+    "rate_bps": 2134,
+    "seconds": 1757507831,
+    "expected_floor": "9223260709588156287"
+  },
+  {
+    "principal": "14000794716131943866",
+    "rate_bps": 452,
+    "seconds": 2062366076,
+    "expected_floor": "41357369872661222900"
+  },
+  {
+    "principal": "1663935352815905819",
+    "rate_bps": 1572,
+    "seconds": 3602780357,
+    "expected_floor": "29862269457070283898"
+  },
+  {
+    "principal": "10967460615044148976",
+    "rate_bps": 9604,
+    "seconds": 191911330,
+    "expected_floor": "64055272492295146316"
+  },
+  {
+    "principal": "2284812846332898505",
+    "rate_bps": 3554,
+    "seconds": 851428643,
+    "expected_floor": "21908484897095513174"
+  },
+  {
+    "principal": "12138308213221655926",
+    "rate_bps": 4335,
+    "seconds": 1255580568,
+    "expected_floor": "209357190335039666838"
+  },
+  {
+    "principal": "9635364944828607239",
+    "rate_bps": 9002,
+    "seconds": 2892288401,
+    "expected_floor": "794959137996890544351"
+  },
+  {
+    "principal": "17984157379779643084",
+    "rate_bps": 9867,
+    "seconds": 1201846494,
+    "expected_floor": "675803219543198460560"
+  },
+  {
+    "principal": "15771431338083492437",
+    "rate_bps": 100,
+    "seconds": 3190168975,
+    "expected_floor": "15943395868537751138"
+  },
+  {
+    "principal": "6984568308691346546",
+    "rate_bps": 4023,
+    "seconds": 2436244212,
+    "expected_floor": "216923426008711535357"
+  },
+  {
+    "principal": "17340243662822879795",
+    "rate_bps": 118,
+    "seconds": 1375474845,
+    "expected_floor": "8918378260061781872"
+  },
+  {
+    "principal": "15628989908433109992",
+    "rate_bps": 6549,
+    "seconds": 1822147418,
+    "expected_floor": "590997228262506602614"
+  },
+  {
+    "principal": "6078453877635841569",
+    "rate_bps": 3006,
+    "seconds": 3322709563,
+    "expected_floor": "192384693713685381950"
+  },
+  {
+    "principal": "9486739966748352174",
+    "rate_bps": 3252,
+    "seconds": 3656331152,
+    "expected_floor": "357444886992722464741"
+  },
+  {
+    "principal": "2957642978431815071",
+    "rate_bps": 3702,
+    "seconds": 530154985,
+    "expected_floor": "18394205969850262522"
+  },
+  {
+    "principal": "755607174527296068",
+    "rate_bps": 113,
+    "seconds": 100208918,
+    "expected_floor": "27112959304076284"
+  },
+  {
+    "principal": "12206631465906564141",
+    "rate_bps": 5786,
+    "seconds": 346639143,
+    "expected_floor": "77579664549004842122"
+  },
+  {
+    "principal": "5014118775698821162",
+    "rate_bps": 4468,
+    "seconds": 584615276,
+    "expected_floor": "41502472843186128126"
+  },
+  {
+    "principal": "14793891659489970507",
+    "rate_bps": 6760,
+    "seconds": 3172929909,
+    "expected_floor": "1005508256972181879118"
+  },
+  {
+    "principal": "5696348520557026784",
+    "rate_bps": 7334,
+    "seconds": 668040722,
+    "expected_floor": "88437494096679225104"
+  },
+  {
+    "principal": "13290819752294324345",
+    "rate_bps": 4228,
+    "seconds": 1111291987,
+    "expected_floor": "197884128531891017545"
+  },
+  {
+    "principal": "6876714937102587110",
+    "rate_bps": 2976,
+    "seconds": 1939349640,
+    "expected_floor": "125766824478584918579"
+  },
+  {
+    "principal": "2655858070742151479",
+    "rate_bps": 5937,
+    "seconds": 3620135745,
+    "expected_floor": "180880937425226766944"
+  },
+  {
+    "principal": "18044990930723779260",
+    "rate_bps": 4447,
+    "seconds": 229713486,
+    "expected_floor": "58412571139807511479"
+  },
+  {
+    "principal": "1884816447783431941",
+    "rate_bps": 124,
+    "seconds": 1010719167,
+    "expected_floor": "748543912231584774"
+  },
+  {
+    "principal": "1430934151096043746",
+    "rate_bps": 8328,
+    "seconds": 448740580,
+    "expected_floor": "16945396809940852405"
+  },
+  {
+    "principal": "13042645388130931043",
+    "rate_bps": 2214,
+    "seconds": 4260325197,
+    "expected_floor": "389836129720429852936"
+  },
+  {
+    "principal": "7921530333848984792",
+    "rate_bps": 196,
+    "seconds": 1423271370,
+    "expected_floor": "7002432114063633431"
+  },
+  {
+    "principal": "17827919984311638993",
+    "rate_bps": 7815,
+    "seconds": 1623620459,
+    "expected_floor": "716820152775804153763"
+  },
+  {
+    "principal": "16856795177171044382",
+    "rate_bps": 4979,
+    "seconds": 3425064576,
+    "expected_floor": "910923556539567014223"
+  },
+  {
+    "principal": "902592901514409423",
+    "rate_bps": 2070,
+    "seconds": 220678553,
+    "expected_floor": "1306527092016952356"
+  },
+  {
+    "principal": "4788557620810045492",
+    "rate_bps": 3610,
+    "seconds": 766040198,
+    "expected_floor": "41962322030214108710"
+  },
+  {
+    "principal": "12018603520765594333",
+    "rate_bps": 1162,
+    "seconds": 977054039,
+    "expected_floor": "43238911645456038147"
+  },
+  {
+    "principal": "2317946427570286234",
+    "rate_bps": 453,
+    "seconds": 478751068,
+    "expected_floor": "1592969222875075444"
+  },
+  {
+    "principal": "568369705703991931",
+    "rate_bps": 8596,
+    "seconds": 3732502053,
+    "expected_floor": "57786104262977939814"
+  },
+  {
+    "principal": "12695768571048272080",
+    "rate_bps": 3737,
+    "seconds": 545217154,
+    "expected_floor": "81968622994318331435"
+  },
+  {
+    "principal": "9520700644652673065",
+    "rate_bps": 9357,
+    "seconds": 658665347,
+    "expected_floor": "185937243298361374551"
+  },
+  {
+    "principal": "2629265727280257110",
+    "rate_bps": 8244,
+    "seconds": 375566712,
+    "expected_floor": "25796191270212877499"
+  },
+  {
+    "principal": "10650388002475555687",
+    "rate_bps": 8735,
+    "seconds": 486086897,
+    "expected_floor": "143297392003487138682"
+  },
+  {
+    "principal": "12971928528396579500",
+    "rate_bps": 3451,
+    "seconds": 1100089278,
+    "expected_floor": "156053484792206588438"
+  },
+  {
+    "principal": "2470075252227448757",
+    "rate_bps": 2071,
+    "seconds": 2061474287,
+    "expected_floor": "33416752220773464577"
+  },
+  {
+    "principal": "17206918252545843538",
+    "rate_bps": 3839,
+    "seconds": 3825806036,
+    "expected_floor": "800829731794035478442"
+  },
+  {
+    "principal": "3739708312441533587",
+    "rate_bps": 1247,
+    "seconds": 1921883645,
+    "expected_floor": "28400586390320116150"
+  },
+  {
+    "principal": "13472156436094896584",
+    "rate_bps": 7214,
+    "seconds": 4030413882,
+    "expected_floor": "1241249064048524913433"
+  },
+  {
+    "principal": "6735678402301517185",
+    "rate_bps": 802,
+    "seconds": 3773707419,
+    "expected_floor": "64598133591046747106"
+  },
+  {
+    "principal": "6934948260982728078",
+    "rate_bps": 6860,
+    "seconds": 3406434672,
+    "expected_floor": "513527184210777797632"
+  },
+  {
+    "principal": "15011316587032683007",
+    "rate_bps": 1366,
+    "seconds": 1996403017,
+    "expected_floor": "129722029337760366748"
+  },
+  {
+    "principal": "14394790198126633508",
+    "rate_bps": 2567,
+    "seconds": 2104660982,
+    "expected_floor": "246438973352047812019"
+  },
+  {
+    "principal": "1241893276892564877",
+    "rate_bps": 8585,
+    "seconds": 315001735,
+    "expected_floor": "10642252387183920404"
+  },
+  {
+    "principal": "9191058567155220746",
+    "rate_bps": 4002,
+    "seconds": 4106625356,
+    "expected_floor": "478656251140021277061"
+  },
+  {
+    "principal": "17018054784562499499",
+    "rate_bps": 4366,
+    "seconds": 222314197,
+    "expected_floor": "52342791381623442962"
+  },
+  {
+    "principal": "8065539245614774208",
+    "rate_bps": 3035,
+    "seconds": 1435036402,
+    "expected_floor": "111314324417329100652"
+  },
+  {
+    "principal": "9686653432389229529",
+    "rate_bps": 9126,
+    "seconds": 673917619,
+    "expected_floor": "188780473051426021676"
+  },
+  {
+    "principal": "11120633095376326598",
+    "rate_bps": 7184,
+    "seconds": 3226293864,
+    "expected_floor": "816762502264515841712"
+  },
+  {
+    "principal": "1459662409418754455",
+    "rate_bps": 8707,
+    "seconds": 452883105,
+    "expected_floor": "18239088079907604709"
+  },
+  {
+    "principal": "8374783069167847068",
+    "rate_bps": 488,
+    "seconds": 2300861742,
+    "expected_floor": "29797507938379496154"
+  },
+  {
+    "principal": "16418654129935332453",
+    "rate_bps": 1200,
+    "seconds": 276094495,
+    "expected_floor": "17237432582645676463"
+  },
+  {
+    "principal": "9329424805225491906",
+    "rate_bps": 2844,
+    "seconds": 2574970052,
+    "expected_floor": "216497395458759343649"
+  },
+  {
+    "principal": "9826295302096444355",
+    "rate_bps": 2262,
+    "seconds": 3328817325,
+    "expected_floor": "234459809679512734842"
+  },
+  {
+    "principal": "17913475548941372088",
+    "rate_bps": 6428,
+    "seconds": 3514582698,
+    "expected_floor": "1282405945941974364094"
+  },
+  {
+    "principal": "5037098131221660465",
+    "rate_bps": 9460,
+    "seconds": 4294881739,
+    "expected_floor": "648513156233137145619"
+  },
+  {
+    "principal": "12036515941736478462",
+    "rate_bps": 68,
+    "seconds": 2438029408,
+    "expected_floor": "6323313017578572949"
+  },
+  {
+    "principal": "6059381837948850735",
+    "rate_bps": 6982,
+    "seconds": 2789391609,
+    "expected_floor": "373950129864532241626"
+  },
+  {
+    "principal": "11440624736536576020",
+    "rate_bps": 1413,
+    "seconds": 1809138534,
+    "expected_floor": "92674394964425080663"
+  },
+  {
+    "principal": "15915128541833983037",
+    "rate_bps": 9632,
+    "seconds": 3721523639,
+    "expected_floor": "1807771100761405354425"
+  },
+  {
+    "principal": "4753687172592945018",
+    "rate_bps": 983,
+    "seconds": 865496380,
+    "expected_floor": "12815790668046972619"
+  },
+  {
+    "principal": "11862863924203714779",
+    "rate_bps": 274,
+    "seconds": 2418436997,
+    "expected_floor": "24909839110958430674"
+  },
+  {
+    "principal": "4464006348642214576",
+    "rate_bps": 2028,
+    "seconds": 1748840290,
+    "expected_floor": "50169403475066479886"
+  },
+  {
+    "principal": "2816168563662156681",
+    "rate_bps": 234,
+    "seconds": 4254214627,
+    "expected_floor": "8883619178826070003"
+  },
+  {
+    "principal": "10813880738840017718",
+    "rate_bps": 8160,
+    "seconds": 1437536088,
+    "expected_floor": "401963411404640183100"
+  },
+  {
+    "principal": "8798955536004537287",
+    "rate_bps": 4255,
+    "seconds": 4045008977,
+    "expected_floor": "479894983550543010762"
+  },
+  {
+    "principal": "6566746503553216140",
+    "rate_bps": 925,
+    "seconds": 1200039582,
+    "expected_floor": "23098489902692745283"
+  },
+  {
+    "principal": "10658034724410731797",
+    "rate_bps": 5622,
+    "seconds": 2980652623,
+    "expected_floor": "565946488524365242202"
+  },
+  {
+    "principal": "7059882037278109234",
+    "rate_bps": 5689,
+    "seconds": 3669721780,
+    "expected_floor": "467049111985739373983"
+  },
+  {
+    "principal": "9691687857478485747",
+    "rate_bps": 3254,
+    "seconds": 3696670557,
+    "expected_floor": "369422844726217059339"
+  },
+  {
+    "principal": "9636149313683709864",
+    "rate_bps": 5035,
+    "seconds": 75990298,
+    "expected_floor": "11683075311886135739"
+  },
+  {
+    "principal": "9810281745287990497",
+    "rate_bps": 1926,
+    "seconds": 2175988475,
+    "expected_floor": "130283790869535829219"
+  },
+  {
+    "principal": "14827813041700977774",
+    "rate_bps": 1491,
+    "seconds": 2834514768,
+    "expected_floor": "198577254513562603678"
+  },
+  {
+    "principal": "4678029833964291679",
+    "rate_bps": 9553,
+    "seconds": 1012296873,
+    "expected_floor": "143352969346276466337"
+  },
+  {
+    "principal": "1956089266066780676",
+    "rate_bps": 9272,
+    "seconds": 3834635990,
+    "expected_floor": "220385120716481066455"
+  },
+  {
+    "principal": "1437215712526810861",
+    "rate_bps": 1379,
+    "seconds": 287955943,
+    "expected_floor": "1808457478361497891"
+  },
+  {
+    "principal": "13574554760996831722",
+    "rate_bps": 9424,
+    "seconds": 1279331628,
+    "expected_floor": "518608990057411872838"
+  },
+  {
+    "principal": "16922137707218183691",
+    "rate_bps": 9196,
+    "seconds": 3525246005,
+    "expected_floor": "1738359716873809430304"
+  },
+  {
+    "principal": "2119113266437366176",
+    "rate_bps": 890,
+    "seconds": 2871732178,
+    "expected_floor": "17162642035163751247"
+  },
+  {
+    "principal": "13701661486306864953",
+    "rate_bps": 2580,
+    "seconds": 38956307,
+    "expected_floor": "4363819234283557813"
+  },
+  {
+    "principal": "7976959657217366694",
+    "rate_bps": 2293,
+    "seconds": 35576904,
+    "expected_floor": "2062080594084600877"
+  },
+  {
+    "principal": "5254422257463456247",
+    "rate_bps": 3979,
+    "seconds": 4006515201,
+    "expected_floor": "265437169532579445477"
+  },
+  {
+    "principal": "3229655598152460924",
+    "rate_bps": 1322,
+    "seconds": 219767822,
+    "expected_floor": "2973362124770100539"
+  },
+  {
+    "principal": "5962090640096823749",
+    "rate_bps": 6358,
+    "seconds": 1634169471,
+    "expected_floor": "196296349703174173574"
+  },
+  {
+    "principal": "7709979488008708770",
+    "rate_bps": 2758,
+    "seconds": 716303524,
+    "expected_floor": "48265921826107815156"
+  },
+  {
+    "principal": "1002743897858209315",
+    "rate_bps": 2518,
+    "seconds": 325556749,
+    "expected_floor": "2604764650823130527"
+  },
+  {
+    "principal": "13423503295131617432",
+    "rate_bps": 9088,
+    "seconds": 2123102090,
+    "expected_floor": "820731501395644176517"
+  },
+  {
+    "principal": "410933067874663057",
+    "rate_bps": 9549,
+    "seconds": 1678112811,
+    "expected_floor": "20866334715078396645"
+  },
+  {
+    "principal": "8088423272654861790",
+    "rate_bps": 2559,
+    "seconds": 1529264704,
+    "expected_floor": "100302753149159736278"
+  },
+  {
+    "principal": "4031211046258343567",
+    "rate_bps": 5530,
+    "seconds": 3806117977,
+    "expected_floor": "268867894017016743993"
+  },
+  {
+    "principal": "6453742171352627188",
+    "rate_bps": 98,
+    "seconds": 3097591366,
+    "expected_floor": "6208087721437799676"
+  },
+  {
+    "principal": "6097549049100856733",
+    "rate_bps": 1264,
+    "seconds": 2295941655,
+    "expected_floor": "56073705557516033375"
+  },
+  {
+    "principal": "15021145154620616794",
+    "rate_bps": 125,
+    "seconds": 2370634012,
+    "expected_floor": "14105016542264237904"
+  },
+  {
+    "principal": "1359887556015658811",
+    "rate_bps": 992,
+    "seconds": 308080869,
+    "expected_floor": "1316968645523086740"
+  },
+  {
+    "principal": "4537664861953881232",
+    "rate_bps": 6315,
+    "seconds": 2451690562,
+    "expected_floor": "222621682193301012991"
+  },
+  {
+    "principal": "6656726001559572201",
+    "rate_bps": 9710,
+    "seconds": 1669788739,
+    "expected_floor": "342008950574451246800"
+  },
+  {
+    "principal": "1796944044409794070",
+    "rate_bps": 4846,
+    "seconds": 678673720,
+    "expected_floor": "18727294016568050001"
+  },
+  {
+    "principal": "14904635724882414631",
+    "rate_bps": 3680,
+    "seconds": 1138710449,
+    "expected_floor": "197914914738577220697"
+  },
+  {
+    "principal": "12388880643091577452",
+    "rate_bps": 2128,
+    "seconds": 125441406,
+    "expected_floor": "10479501847163723025"
+  },
+  {
+    "principal": "2839570403559262837",
+    "rate_bps": 9121,
+    "seconds": 2698691247,
+    "expected_floor": "221485005573691170582"
+  },
+  {
+    "principal": "5297472264286735122",
+    "rate_bps": 3284,
+    "seconds": 3750046356,
+    "expected_floor": "206730478190157962916"
+  },
+  {
+    "principal": "16945183499576633683",
+    "rate_bps": 4354,
+    "seconds": 4142883005,
+    "expected_floor": "968575329102684337517"
+  },
+  {
+    "principal": "12007941998808548744",
+    "rate_bps": 7999,
+    "seconds": 2381880826,
+    "expected_floor": "724970507790994545176"
+  },
+  {
+    "principal": "6626774724376284225",
+    "rate_bps": 6388,
+    "seconds": 254984539,
+    "expected_floor": "34204007678006520348"
+  },
+  {
+    "principal": "10151601280996778830",
+    "rate_bps": 7352,
+    "seconds": 2690827568,
+    "expected_floor": "636387955757446117280"
+  },
+  {
+    "principal": "5054122055029947071",
+    "rate_bps": 7500,
+    "seconds": 4223186953,
+    "expected_floor": "507274847936915841854"
+  },
+  {
+    "principal": "2655352976463974884",
+    "rate_bps": 7586,
+    "seconds": 239667638,
+    "expected_floor": "15298206791929715735"
+  },
+  {
+    "principal": "15923915671969038413",
+    "rate_bps": 6325,
+    "seconds": 3073064007,
+    "expected_floor": "980794536166716694523"
+  },
+  {
+    "principal": "17903644083771626186",
+    "rate_bps": 4346,
+    "seconds": 276908300,
+    "expected_floor": "68275228769125839276"
+  },
+  {
+    "principal": "9889448510508125291",
+    "rate_bps": 3589,
+    "seconds": 341002645,
+    "expected_floor": "38352997533817753170"
+  },
+  {
+    "principal": "2631743645522680704",
+    "rate_bps": 4317,
+    "seconds": 573584562,
+    "expected_floor": "20649955416962288905"
+  },
+  {
+    "principal": "6527559094258045593",
+    "rate_bps": 7906,
+    "seconds": 1351270259,
+    "expected_floor": "220976389445018078783"
+  },
+  {
+    "principal": "11638143987414742406",
+    "rate_bps": 2914,
+    "seconds": 1388622376,
+    "expected_floor": "149229081339148095399"
+  },
+  {
+    "principal": "7236466421350574679",
+    "rate_bps": 9670,
+    "seconds": 2957984097,
+    "expected_floor": "655910967794323003775"
+  },
+  {
+    "principal": "15331796472773090908",
+    "rate_bps": 4169,
+    "seconds": 1904753390,
+    "expected_floor": "385797783912540325426"
+  },
+  {
+    "principal": "17716757999405231909",
+    "rate_bps": 7871,
+    "seconds": 2674792159,
+    "expected_floor": "1181953088269369610187"
+  },
+  {
+    "principal": "17410621868773549954",
+    "rate_bps": 4883,
+    "seconds": 312228996,
+    "expected_floor": "84114384851106476997"
+  },
+  {
+    "principal": "13479752724563599491",
+    "rate_bps": 6944,
+    "seconds": 4001434477,
+    "expected_floor": "1186870622626841420316"
+  },
+  {
+    "principal": "13068557300568069752",
+    "rate_bps": 7424,
+    "seconds": 1249671274,
+    "expected_floor": "384200060949137115721"
+  },
+  {
+    "principal": "12672342974528963057",
+    "rate_bps": 156,
+    "seconds": 2243186315,
+    "expected_floor": "14052153867702750228"
+  },
+  {
+    "principal": "11690119943767409854",
+    "rate_bps": 7900,
+    "seconds": 274621472,
+    "expected_floor": "80366782581154175938"
+  },
+  {
+    "principal": "11612857745074223855",
+    "rate_bps": 8284,
+    "seconds": 1359827897,
+    "expected_floor": "414533063274895979245"
+  },
+  {
+    "principal": "17138468329832644564",
+    "rate_bps": 5746,
+    "seconds": 3506800934,
+    "expected_floor": "1094321103330852306471"
+  },
+  {
+    "principal": "16668000412909467389",
+    "rate_bps": 3131,
+    "seconds": 3567956599,
+    "expected_floor": "590040966888132524666"
+  },
+  {
+    "principal": "9597317295369414970",
+    "rate_bps": 5618,
+    "seconds": 2867127548,
+    "expected_floor": "489862996220887909818"
+  },
+  {
+    "principal": "554814583771547035",
+    "rate_bps": 4896,
+    "seconds": 3484747333,
+    "expected_floor": "29995534473032955870"
+  },
+  {
+    "principal": "17730665601531041392",
+    "rate_bps": 7243,
+    "seconds": 1638222114,
+    "expected_floor": "666672193488326409731"
+  },
+  {
+    "principal": "10080222766021687881",
+    "rate_bps": 1181,
+    "seconds": 720948899,
+    "expected_floor": "27196971319789088036"
+  },
+  {
+    "principal": "17030297689277182198",
+    "rate_bps": 2197,
+    "seconds": 577288984,
+    "expected_floor": "68444979785604855044"
+  },
+  {
+    "principal": "13474964148854541447",
+    "rate_bps": 4745,
+    "seconds": 878792465,
+    "expected_floor": "178051727875225388258"
+  },
+  {
+    "principal": "17480327201107793484",
+    "rate_bps": 9240,
+    "seconds": 56808542,
+    "expected_floor": "29075768671494539134"
+  },
+  {
+    "principal": "9850462383768041429",
+    "rate_bps": 4259,
+    "seconds": 1791782671,
+    "expected_floor": "238202119751312209097"
+  },
+  {
+    "principal": "6636943604158461938",
+    "rate_bps": 4389,
+    "seconds": 2426282612,
+    "expected_floor": "223960344545578009894"
+  },
+  {
+    "principal": "15363037266885680051",
+    "rate_bps": 5993,
+    "seconds": 3991902749,
+    "expected_floor": "1164655138341102189126"
+  },
+  {
+    "principal": "7410178638380465000",
+    "rate_bps": 2458,
+    "seconds": 84313818,
+    "expected_floor": "4866372454277454944"
+  },
+  {
+    "principal": "9263246480134986657",
+    "rate_bps": 9494,
+    "seconds": 2487590843,
+    "expected_floor": "693246091722492332647"
+  },
+  {
+    "principal": "6103621944911419950",
+    "rate_bps": 3937,
+    "seconds": 3524302608,
+    "expected_floor": "268362769279829472477"
+  },
+  {
+    "principal": "13759654148265148191",
+    "rate_bps": 29,
+    "seconds": 3309146985,
+    "expected_floor": "4184249826165032782"
+  },
+  {
+    "principal": "4004353656042848708",
+    "rate_bps": 2897,
+    "seconds": 563477654,
+    "expected_floor": "20713507807561497601"
+  },
+  {
+    "principal": "13120830814535373229",
+    "rate_bps": 7386,
+    "seconds": 270707879,
+    "expected_floor": "83131873475568446644"
+  },
+  {
+    "principal": "15327389617051251626",
+    "rate_bps": 2579,
+    "seconds": 3703493868,
+    "expected_floor": "463903022508894671042"
+  },
+  {
+    "principal": "9734238233686966987",
+    "rate_bps": 373,
+    "seconds": 544548597,
+    "expected_floor": "6265323197377850380"
+  },
+  {
+    "principal": "17865861687788954976",
+    "rate_bps": 8510,
+    "seconds": 3356496274,
+    "expected_floor": "1617095728351344679338"
+  },
+  {
+    "principal": "12486842878798857721",
+    "rate_bps": 7617,
+    "seconds": 3064734163,
+    "expected_floor": "923688305204372729258"
+  },
+  {
+    "principal": "7849648277032018022",
+    "rate_bps": 4360,
+    "seconds": 1073141768,
+    "expected_floor": "116383072463173372346"
+  },
+  {
+    "principal": "11388637041787892407",
+    "rate_bps": 3582,
+    "seconds": 3231219905,
+    "expected_floor": "417695582326535796940"
+  },
+  {
+    "principal": "17337957398398820924",
+    "rate_bps": 8101,
+    "seconds": 1651040718,
+    "expected_floor": "734835925705531145353"
+  },
+  {
+    "principal": "2951014428751062149",
+    "rate_bps": 148,
+    "seconds": 518048575,
+    "expected_floor": "716967656930822251"
+  },
+  {
+    "principal": "12025145023754042466",
+    "rate_bps": 3030,
+    "seconds": 3379682404,
+    "expected_floor": "390215822046857140653"
+  },
+  {
+    "principal": "9637618651090967267",
+    "rate_bps": 356,
+    "seconds": 625872077,
+    "expected_floor": "6804580320706384996"
+  },
+  {
+    "principal": "12880256174578627672",
+    "rate_bps": 3293,
+    "seconds": 3083192650,
+    "expected_floor": "414393492137659904333"
+  },
+  {
+    "principal": "11616263839122299217",
+    "rate_bps": 9531,
+    "seconds": 31569131,
+    "expected_floor": "11075506525354091420"
+  },
+  {
+    "principal": "14089471501058958238",
+    "rate_bps": 2859,
+    "seconds": 2343591424,
+    "expected_floor": "299148473680329254287"
+  },
+  {
+    "principal": "4764079299526002511",
+    "rate_bps": 6768,
+    "seconds": 49051417,
+    "expected_floor": "5011721421893469779"
+  },
+  {
+    "principal": "7194290400278534068",
+    "rate_bps": 600,
+    "seconds": 3321455622,
+    "expected_floor": "45432193125533818819"
+  },
+  {
+    "principal": "14847238865279455325",
+    "rate_bps": 1689,
+    "seconds": 3198036695,
+    "expected_floor": "254129347118263203776"
+  },
+  {
+    "principal": "8919317075757412890",
+    "rate_bps": 1393,
+    "seconds": 3247839452,
+    "expected_floor": "127871366224853228139"
+  },
+  {
+    "principal": "7641350121781396475",
+    "rate_bps": 8604,
+    "seconds": 1992731557,
+    "expected_floor": "415159836488311664714"
+  },
+  {
+    "principal": "1730900301466273872",
+    "rate_bps": 8929,
+    "seconds": 2923400706,
+    "expected_floor": "143172384127130043109"
+  },
+  {
+    "principal": "18249061363625260457",
+    "rate_bps": 5722,
+    "seconds": 1237301507,
+    "expected_floor": "409411426807214217084"
+  },
+  {
+    "principal": "5165212781886211030",
+    "rate_bps": 7634,
+    "seconds": 1262881016,
+    "expected_floor": "157797035680970722547"
+  },
+  {
+    "principal": "14021023833272753383",
+    "rate_bps": 4469,
+    "seconds": 3854030449,
+    "expected_floor": "765246332015040067223"
+  },
+  {
+    "principal": "5363400372513620524",
+    "rate_bps": 6304,
+    "seconds": 2436457278,
+    "expected_floor": "261042521547436125467"
+  },
+  {
+    "principal": "8288258207115097397",
+    "rate_bps": 6173,
+    "seconds": 366357359,
+    "expected_floor": "59396451770238130878"
+  },
+  {
+    "principal": "10158728894819349714",
+    "rate_bps": 9501,
+    "seconds": 3225315924,
+    "expected_floor": "986454327308286663943"
+  },
+  {
+    "principal": "10923099320756723219",
+    "rate_bps": 7803,
+    "seconds": 2968478589,
+    "expected_floor": "801747184009666179699"
+  },
+  {
+    "principal": "10874998209455325512",
+    "rate_bps": 4875,
+    "seconds": 1982414778,
+    "expected_floor": "333038447665840910115"
+  },
+  {
+    "principal": "17342383868132915969",
+    "rate_bps": 6104,
+    "seconds": 3217264155,
+    "expected_floor": "1079210278998434192643"
+  },
+  {
+    "principal": "16260326278366617870",
+    "rate_bps": 6950,
+    "seconds": 1387575536,
+    "expected_floor": "496897403830183989652"
+  },
+  {
+    "principal": "8882987877334193023",
+    "rate_bps": 4155,
+    "seconds": 754777801,
+    "expected_floor": "88276529090273828176"
+  },
+  {
+    "principal": "8841396222779654564",
+    "rate_bps": 8810,
+    "seconds": 2574172022,
+    "expected_floor": "635375348310278912635"
+  },
+  {
+    "principal": "16102662280655188749",
+    "rate_bps": 3491,
+    "seconds": 2338860295,
+    "expected_floor": "416627418387319756000"
+  },
+  {
+    "principal": "16954897016505296010",
+    "rate_bps": 2034,
+    "seconds": 3256524,
+    "expected_floor": "355874132035757578"
+  },
+  {
+    "principal": "14457428293329406251",
+    "rate_bps": 7839,
+    "seconds": 2266797141,
+    "expected_floor": "814067469565766315837"
+  },
+  {
+    "principal": "11383246727621164864",
+    "rate_bps": 7704,
+    "seconds": 3192045170,
+    "expected_floor": "887048742352930550683"
+  },
+  {
+    "principal": "17006560824945772889",
+    "rate_bps": 5691,
+    "seconds": 4237202483,
+    "expected_floor": "1299512116974315408557"
+  },
+  {
+    "principal": "7528278919748508486",
+    "rate_bps": 3069,
+    "seconds": 3412938216,
+    "expected_floor": "249871686962059567271"
+  },
+  {
+    "principal": "3937071803709278999",
+    "rate_bps": 4784,
+    "seconds": 2227327009,
+    "expected_floor": "132936586461197709636"
+  },
+  {
+    "principal": "8001630201669023260",
+    "rate_bps": 7045,
+    "seconds": 1605589166,
+    "expected_floor": "286807124810706359473"
+  },
+  {
+    "principal": "176427000275298789",
+    "rate_bps": 1486,
+    "seconds": 404197279,
+    "expected_floor": "335794267598817146"
+  },
+  {
+    "principal": "6645232497767915842",
+    "rate_bps": 579,
+    "seconds": 4218080324,
+    "expected_floor": "51427998501001619973"
+  },
+  {
+    "principal": "2380183585468917059",
+    "rate_bps": 5067,
+    "seconds": 1231461933,
+    "expected_floor": "47062867462604560950"
+  }
+]

--- a/contracts/credit/tests/snapshot_prorate_interest.rs
+++ b/contracts/credit/tests/snapshot_prorate_interest.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: MIT
+
+//! # Integration test: `prorate_interest` snapshot
+//!
+//! Two modes, selected by whether the string `"regenerate"` appears in
+//! `CARGO_TEST_ARGS` (passed via `-- regenerate` on the CLI):
+//!
+//! ## Verify mode (default, CI)
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snapshot_prorate_interest
+//! ```
+//!
+//! Loads `contracts/credit/test_snapshots/prorate_interest.json`, re-runs
+//! `prorate_interest` for every entry, and fails immediately on any mismatch.
+//!
+//! ## Regenerate mode
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snapshot_prorate_interest \
+//!     -- --nocapture regenerate
+//! ```
+//!
+//! Rewrites the snapshot file with freshly computed values.  Run this after
+//! any intentional change to `prorate_interest` and commit the updated JSON.
+//! See `docs/contributing-tests.md` for the full regeneration workflow.
+
+use std::fs;
+use std::path::PathBuf;
+
+use creditra_credit::math_utils::{prorate_interest, Rounding};
+use serde::{Deserialize, Serialize};
+
+// ─── Snapshot path ────────────────────────────────────────────────────────────
+
+/// Resolves the snapshot path relative to the workspace root.
+///
+/// `CARGO_MANIFEST_DIR` points to `contracts/credit`; the snapshot lives
+/// two levels up in `test_snapshots/` inside that same directory.
+fn snapshot_path() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest.join("test_snapshots").join("prorate_interest.json")
+}
+
+// ─── Snapshot schema ──────────────────────────────────────────────────────────
+
+/// One row in the pinned snapshot JSON array.
+///
+/// `principal` and `expected_floor` are decimal strings to preserve full
+/// u128 precision across JSON serialisers that cap integers at 2^53.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct SnapshotEntry {
+    /// Outstanding principal (u128 as decimal string).
+    principal: String,
+    /// Annual interest rate in basis points (0 ..= 10_000).
+    rate_bps: u32,
+    /// Elapsed seconds since last accrual (stored as u32; cast to u64 on use).
+    seconds: u32,
+    /// Floor-rounded expected output (u128 as decimal string).
+    expected_floor: String,
+}
+
+// ─── Deterministic input generation ──────────────────────────────────────────
+
+/// Minimal 64-bit LCG (Knuth / MMIX parameters).
+///
+/// No external crate required; reproducible on every platform.
+/// State is public only for testing; callers should use [`Lcg::next_u64`].
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    /// Create a new LCG seeded with `seed`.  The same seed always produces
+    /// the same sequence.
+    const fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    /// Advance the state and return the next pseudo-random `u64`.
+    fn next_u64(&mut self) -> u64 {
+        // Knuth multiplicative LCG — period 2^64.
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.state
+    }
+}
+
+/// Upper bound for `principal` such that `principal × 10_000 × u32::MAX`
+/// never overflows `u128`.
+///
+/// Proof:
+///   u128::MAX  ≈ 3.402 × 10^38
+///   10_000 × u32::MAX ≈ 4.295 × 10^13
+///   PRINCIPAL_MAX = floor(u128::MAX / (10_000 × u32::MAX))
+///               ≈ 7.922 × 10^24
+///
+/// We cap at 10^24 for a round number safely below that ceiling.
+const PRINCIPAL_MAX: u128 = 1_000_000_000_000_000_000_000_000_u128; // 10^24
+
+/// Generate the deterministic 4 096-input corpus.
+///
+/// Input ranges:
+/// - `principal` ∈ [0, PRINCIPAL_MAX]  (skewed toward interesting values)
+/// - `rate_bps`  ∈ [0, 10_000]
+/// - `seconds`   ∈ [0, u32::MAX]
+///
+/// The corpus is built to maximise coverage of:
+/// - zero inputs (short-circuit paths)
+/// - exact-year boundaries (`SECONDS_PER_YEAR`, half-year, quarter-year)
+/// - maximum rate (10 000 bps = 100 %)
+/// - very small and very large principals
+/// - arbitrary interior points via the LCG
+fn generate_inputs() -> Vec<(u128, u32, u32)> {
+    const COUNT: usize = 4096;
+
+    // Fixed interesting anchors added first (< COUNT so LCG fills the rest).
+    let anchors: &[(u128, u32, u32)] = &[
+        // Zero-input triples (short-circuit)
+        (0, 500, 86_400),
+        (1_000_000, 0, 86_400),
+        (1_000_000, 500, 0),
+        // Exact year
+        (10_000, 300, 31_557_600),
+        // Half year
+        (10_000, 300, 15_778_800),
+        // Quarter year
+        (10_000, 300, 7_889_400),
+        // Max rate, one year
+        (10_000, 10_000, 31_557_600),
+        // Very small principal
+        (1, 1, 1),
+        (1, 10_000, u32::MAX),
+        // Very large principal (at cap)
+        (PRINCIPAL_MAX, 10_000, u32::MAX),
+        (PRINCIPAL_MAX, 1, 1),
+        // Boundary: principal = BPS_YEAR_DENOM (exact divisibility)
+        (315_576_000_000_u128, 10_000, 31_557_600),
+        // One day
+        (10_000, 300, 86_400),
+        // One hour
+        (1_000_000, 500, 3_600),
+        // One second
+        (1_000_000_000, 9_999, 1),
+    ];
+
+    let mut inputs: Vec<(u128, u32, u32)> = Vec::with_capacity(COUNT);
+    inputs.extend_from_slice(anchors);
+
+    let mut lcg = Lcg::new(0xDEAD_BEEF_CAFE_1234_u64);
+
+    while inputs.len() < COUNT {
+        // principal: map a u64 into [0, PRINCIPAL_MAX] via modulo reduction.
+        // The slight modulo bias is acceptable for a test corpus.
+        let principal = (lcg.next_u64() as u128) % (PRINCIPAL_MAX + 1);
+
+        // rate_bps: [0, 10_000]
+        let rate_bps = (lcg.next_u64() % 10_001) as u32;
+
+        // seconds: full u32 range [0, u32::MAX]
+        let seconds = (lcg.next_u64() % (u32::MAX as u64 + 1)) as u32;
+
+        inputs.push((principal, rate_bps, seconds));
+    }
+
+    inputs
+}
+
+// ─── Snapshot generation ──────────────────────────────────────────────────────
+
+/// Compute every entry and serialise to JSON.
+fn build_snapshot() -> Vec<SnapshotEntry> {
+    generate_inputs()
+        .into_iter()
+        .map(|(principal, rate_bps, seconds)| {
+            let floor =
+                prorate_interest(principal, rate_bps, seconds as u64, Rounding::Floor);
+            SnapshotEntry {
+                principal: principal.to_string(),
+                rate_bps,
+                seconds,
+                expected_floor: floor.to_string(),
+            }
+        })
+        .collect()
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/// Verify mode: load the snapshot from disk and re-run the math.
+///
+/// Fails immediately if:
+/// - the snapshot file is missing (run regenerate first)
+/// - the JSON is malformed
+/// - the entry count is not exactly 4 096
+/// - any live result diverges from the pinned value
+#[test]
+fn verify_prorate_interest_snapshot() {
+    // Allow the test runner to skip straight to regeneration.
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "regenerate") {
+        regenerate_prorate_interest_snapshot();
+        return;
+    }
+
+    let path = snapshot_path();
+    let raw = fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "snapshot not found at '{}': {e}\n\
+             Run: cargo test -p creditra-credit --test snapshot_prorate_interest \
+             -- --nocapture regenerate",
+            path.display()
+        )
+    });
+
+    let entries: Vec<SnapshotEntry> =
+        serde_json::from_str(&raw).expect("prorate_interest.json is malformed");
+
+    assert_eq!(
+        entries.len(),
+        4096,
+        "snapshot must contain exactly 4 096 entries, found {}",
+        entries.len()
+    );
+
+    for (i, entry) in entries.iter().enumerate() {
+        let principal: u128 = entry
+            .principal
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid principal '{}'", entry.principal));
+        let expected_floor: u128 = entry
+            .expected_floor
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid expected_floor"));
+        let time_delta = entry.seconds as u64;
+
+        // ── Primary assertion: exact match ────────────────────────────────
+        let live_floor =
+            prorate_interest(principal, entry.rate_bps, time_delta, Rounding::Floor);
+        assert_eq!(
+            live_floor,
+            expected_floor,
+            "SNAPSHOT MISMATCH at entry {i} (principal={principal}, \
+             rate_bps={}, seconds={}): live={live_floor}, pinned={expected_floor}\n\
+             If this change is intentional, regenerate the snapshot:\n\
+             cargo test -p creditra-credit --test snapshot_prorate_interest \
+             -- --nocapture regenerate",
+            entry.rate_bps,
+            entry.seconds,
+        );
+
+        // ── Secondary: zero-input short-circuit ───────────────────────────
+        if principal == 0 || entry.rate_bps == 0 || entry.seconds == 0 {
+            assert_eq!(
+                live_floor, 0,
+                "entry {i}: zero input must yield 0, got {live_floor}"
+            );
+        }
+
+        // ── Secondary: floor ≤ ceil ───────────────────────────────────────
+        let live_ceil =
+            prorate_interest(principal, entry.rate_bps, time_delta, Rounding::Ceil);
+        assert!(
+            live_floor <= live_ceil,
+            "entry {i}: floor ({live_floor}) > ceil ({live_ceil})"
+        );
+
+        // ── Secondary: ceil − floor ∈ {0, 1} ─────────────────────────────
+        assert!(
+            live_ceil - live_floor <= 1,
+            "entry {i}: ceil − floor = {} (must be 0 or 1)",
+            live_ceil - live_floor
+        );
+    }
+
+    println!(
+        "✓ All {} snapshot entries verified against prorate_interest",
+        entries.len()
+    );
+}
+
+/// Regenerate mode: recompute all entries and overwrite the snapshot file.
+///
+/// Invoked automatically when the test binary receives `regenerate` as an
+/// argument, or can be called directly from other test code.
+#[test]
+fn regenerate_prorate_interest_snapshot() {
+    let entries = build_snapshot();
+    let path = snapshot_path();
+
+    // Ensure the directory exists (it should, but be defensive).
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("could not create test_snapshots dir");
+    }
+
+    let json = serde_json::to_string_pretty(&entries)
+        .expect("failed to serialise snapshot");
+    fs::write(&path, json).unwrap_or_else(|e| {
+        panic!("failed to write snapshot to '{}': {e}", path.display())
+    });
+
+    println!(
+        "✓ Wrote {} entries to '{}'",
+        entries.len(),
+        path.display()
+    );
+
+    // Self-verify immediately after writing.
+    assert_eq!(entries.len(), 4096);
+    for (i, entry) in entries.iter().enumerate() {
+        let principal: u128 = entry.principal.parse().unwrap();
+        let expected_floor: u128 = entry.expected_floor.parse().unwrap();
+        let live = prorate_interest(principal, entry.rate_bps, entry.seconds as u64, Rounding::Floor);
+        assert_eq!(
+            live, expected_floor,
+            "self-check failed at entry {i} immediately after regeneration"
+        );
+    }
+    println!("✓ Self-check passed for all {} entries", entries.len());
+}

--- a/docs/contributing-tests.md
+++ b/docs/contributing-tests.md
@@ -56,3 +56,82 @@ cargo test -p creditra-credit --test token_failure_rollback rollback
 
 `MockLiquidityToken` is test-only (`#[cfg(test)]`) and must not be imported
 into contract runtime logic.
+
+---
+
+## Snapshot fuzzing: `prorate_interest`
+
+`math_utils::prorate_interest` is the single rounding-floor primitive used by
+every interest accrual in the protocol. A dedicated snapshot harness pins 4 096
+deterministic `(principal, rate_bps, seconds)` inputs together with their
+expected floor-rounded outputs, so any rounding-direction regression is caught
+at PR time.
+
+### Files
+
+| File | Role |
+|---|---|
+| `contracts/credit/test_snapshots/prorate_interest.json` | Checked-in pinned snapshot (4 096 entries) |
+| `contracts/credit/fuzz/fuzz_targets/prorate_interest_snapshot.rs` | libFuzzer target that loads and verifies the snapshot |
+| `contracts/credit/tests/snapshot_prorate_interest.rs` | `cargo test` integration test (verify + regenerate) |
+
+### Running the snapshot test (CI / default)
+
+```bash
+cargo test -p creditra-credit --test snapshot_prorate_interest
+```
+
+This loads the checked-in JSON and re-runs `prorate_interest` for every entry.
+It fails immediately if any output diverges from its pinned value.
+
+### Running the fuzz target
+
+```bash
+cargo fuzz run prorate_interest_snapshot -- -max_total_time=60
+```
+
+libFuzzer ignores the mutated corpus bytes; every invocation executes the full
+4 096-entry snapshot verification sweep.
+
+### Regenerating the snapshot
+
+Run regeneration **only after an intentional change** to `prorate_interest`
+(e.g., a constant update or a deliberate rounding-direction change).
+
+```bash
+# 1. Regenerate and self-check
+cargo test -p creditra-credit --test snapshot_prorate_interest \
+    -- --nocapture regenerate
+
+# 2. Verify the freshly written file
+cargo test -p creditra-credit --test snapshot_prorate_interest
+
+# 3. Commit the updated snapshot alongside the implementation change
+git add contracts/credit/test_snapshots/prorate_interest.json
+git commit -m "test: regenerate prorate_interest snapshot after <describe change>"
+```
+
+### Input generation design
+
+Inputs are produced by a seeded 64-bit LCG (Knuth/MMIX parameters,
+seed `0xDEADBEEFCAFE1234`) with no external crate dependency, ensuring full
+reproducibility across platforms and Rust versions.
+
+The corpus begins with 15 hand-chosen anchors covering:
+- zero-input short-circuit paths (`principal=0`, `rate_bps=0`, `seconds=0`)
+- exact Julian-year, half-year, and quarter-year time boundaries
+- maximum rate (10 000 bps = 100 %)
+- minimum and maximum principal values
+- the exact-divisibility boundary where `floor == ceil`
+
+The remaining entries are LCG-generated with:
+- `principal` ∈ [0, 10^24]  (safe ceiling: `10^24 × 10_000 × u32::MAX < u128::MAX`)
+- `rate_bps`  ∈ [0, 10_000]
+- `seconds`   ∈ [0, u32::MAX]
+
+### Properties verified per entry
+
+1. **Exact match** — `live_result == pinned_output` (primary regression gate).
+2. **Zero-input short-circuit** — any zero input produces zero output.
+3. **Floor ≤ ceil** — `prorate_interest(..., Floor) ≤ prorate_interest(..., Ceil)`.
+4. **Ceil − floor ∈ {0, 1}** — rounding never moves by more than 1 ulp.


### PR DESCRIPTION
Closes #455

## Summary

Adds a deterministic snapshot fuzz harness that pins 4 096
`(principal, rate_bps, seconds)` inputs and their floor-rounded outputs
for `math_utils::prorate_interest` — the single rounding primitive hit by
every interest accrual in the protocol. Any rounding-direction regression
now turns the test red at PR time.

## Files Changed

- **`contracts/credit/fuzz/Cargo.toml`** — added `serde` + `serde_json`
  dependencies and registered the new `prorate_interest_snapshot` fuzz
  binary target
- **`contracts/credit/fuzz/fuzz_targets/prorate_interest_snapshot.rs`** —
  libFuzzer target that loads the pinned snapshot and re-runs
  `prorate_interest` for all 4 096 entries on every invocation; verifies
  exact match, zero-input short-circuit, floor ≤ ceil, and ceil − floor ∈ {0, 1}
- **`contracts/credit/tests/snapshot_prorate_interest.rs`** — `cargo test`
  integration test with two modes: verify (default/CI) and regenerate
  (`-- --nocapture regenerate`)
- **`contracts/credit/test_snapshots/prorate_interest.json`** — 4 096
  checked-in deterministic entries; ~575 KB
- **`docs/contributing-tests.md`** — documents snapshot regeneration
  workflow, input design rationale, and properties verified per entry
- **`rust-toolchain.toml`** — pinned to `stable` (no functional change,
  resolves local Windows toolchain override)

## Design Decisions

- **No external RNG crate**: inputs are generated by a seeded 64-bit LCG
  (Knuth/MMIX parameters, seed `0xDEADBEEFCAFE1234`) — fully reproducible
  across platforms and Rust versions with zero new dependencies
- **Principal cap at 10^24**: guarantees `principal × 10_000 × u32::MAX`
  never overflows `u128`, keeping every entry panic-free
- **u128 values as decimal strings**: avoids JSON integer precision loss
  for values > 2^53
- **15 hand-chosen anchors**: cover zero short-circuits, exact calendar
  boundaries, max rate, min/max principal, and the exact-divisibility
  boundary where floor == ceil

## Verification

```bash
# Run the snapshot integration test
cargo test -p creditra-credit --test snapshot_prorate_interest -- --nocapture

# Run the fuzz target (requires cargo-fuzz + nightly)
cargo fuzz run prorate_interest_snapshot -- -max_total_time=60
```