### PR TITLE
feat: proof-of-reserve view for protocol treasury

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -109,6 +109,7 @@ mod freeze;
 pub mod instrument;
 mod lifecycle;
 mod query;
+mod views;
 mod risk;
 pub use crate::risk::compute_rate_from_score;
 pub use crate::types::FreezeReason;
@@ -149,7 +150,8 @@ use crate::storage::{
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
+    ProofOfReserve, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
+    RateFormulaConfig,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -991,6 +993,14 @@ impl Credit {
     /// Get protocol-level dashboard totals requested for GrantFox campaign.
     pub fn get_protocol_summary_view(env: Env) -> ProtocolSummaryView {
         views::get_protocol_summary_view(env)
+    }
+
+    /// Return proof-of-reserve balances for the protocol treasury.
+    ///
+    /// Read-only view exposing accumulated reserves for transparency
+    /// and indexer integration.
+    pub fn get_proof_of_reserve(env: Env) -> ProofOfReserve {
+        views::get_proof_of_reserve(env)
     }
 
     pub fn deposit_collateral(env: Env, borrower: Address, amount: i128) {

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -414,6 +414,20 @@ pub struct ProtocolSummaryView {
     pub active_line_count: u32,
 }
 
+/// Proof-of-reserve view for the protocol treasury.
+///
+/// Exposes the accumulated reserves held by the protocol in a single
+/// read-only call. Indexers and dashboards can use this to verify that
+/// the protocol's accounting balances are consistent.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofOfReserve {
+    /// Accumulated protocol fees held in the contract (treasury share).
+    pub treasury_balance: i128,
+    /// Accumulated bounty pool fees held in the contract.
+    pub bounty_balance: i128,
+}
+
 /// Reason for protocol pause (escape-hatch audit trail).
 ///
 /// Stored alongside the pause flag in instance storage when the admin invokes

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -2,9 +2,10 @@
 
 //! Read-only query views for specialized campaign indexing.
 //!
-//! Provides the protocol summary view requested for the GrantFox campaign.
+//! Provides the protocol summary view requested for the GrantFox campaign
+//! and the proof-of-reserve view for protocol treasury transparency.
 
-use crate::types::ProtocolSummaryView;
+use crate::types::{ProofOfReserve, ProtocolSummaryView};
 use soroban_sdk::Env;
 
 /// Return protocol-level dashboard aggregates including ActiveLineCount.
@@ -16,5 +17,20 @@ pub fn get_protocol_summary_view(env: Env) -> ProtocolSummaryView {
         total_utilized: crate::storage::get_total_utilized(&env),
         total_collateral: crate::storage::get_total_collateral(&env),
         active_line_count: crate::storage::get_active_line_count(&env),
+    }
+}
+
+/// Return proof-of-reserve balances for the protocol treasury.
+///
+/// Exposes the accumulated treasury and bounty pool reserves held in the
+/// contract as a result of protocol fee collection. This is a pure
+/// storage read — no token CPIs or borrower records are touched.
+///
+/// Callers can compare `treasury_balance + bounty_balance` against the
+/// on-chain token balance of the contract to verify reserve integrity.
+pub fn get_proof_of_reserve(env: Env) -> ProofOfReserve {
+    ProofOfReserve {
+        treasury_balance: crate::storage::get_treasury_balance(&env),
+        bounty_balance: crate::storage::get_bounty_balance(&env),
     }
 }

--- a/contracts/credit/src/views_tests.rs
+++ b/contracts/credit/src/views_tests.rs
@@ -55,3 +55,55 @@ fn test_protocol_summary_view_active_lines() {
     client.close_credit_line(&b3, &admin);
     assert_eq!(client.get_protocol_summary_view().active_line_count, 0);
 }
+
+#[test]
+fn test_proof_of_reserve_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    let por = client.get_proof_of_reserve();
+    assert_eq!(por.treasury_balance, 0);
+    assert_eq!(por.bounty_balance, 0);
+}
+
+#[test]
+fn test_proof_of_reserve_reads_existing_balances() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Set balances directly via storage
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&crate::storage::DataKey::TreasuryBalance, &42_i128);
+        env.storage()
+            .instance()
+            .set(&crate::storage::DataKey::BountyBalance, &7_i128);
+    });
+
+    let por = client.get_proof_of_reserve();
+    assert_eq!(por.treasury_balance, 42);
+    assert_eq!(por.bounty_balance, 7);
+}


### PR DESCRIPTION
## Description

Adds a new read-only proof-of-reserve view that exposes the protocol treasury balances for indexers, dashboards, and external verification tools.

### Changes

* [x] Added `ProofOfReserve` contract type to represent protocol reserve balances
* [x] Added `get_proof_of_reserve()` view in `views.rs`
* [x] Exposed the new contract entrypoint from `lib.rs`
* [x] Added the missing `mod views;` declaration required for the existing and new view functions
* [x] Added focused unit tests covering:

  * Empty reserve state
  * Reading existing treasury and bounty balances directly from contract storage

The implementation reuses the existing storage helpers (`get_treasury_balance` and `get_bounty_balance`) and performs only read operations. No storage layout or protocol accounting logic was modified.

## Linked Issue

Closes #634

## API / Visible Changes

New read-only contract entrypoint:

```rust
get_proof_of_reserve() -> ProofOfReserve
```

Returns:

* `treasury_balance`
* `bounty_balance`

This is a non-breaking addition.

## Testing

* [x] Added unit tests for empty reserve state
* [x] Added unit tests verifying stored reserve values are returned correctly
* [x] `cargo test`
* [x] `cargo clippy`
* [x] Repository formatting checks

## Notes

* This change is read-only and introduces no state mutations.
* Existing fee accounting and reserve accumulation logic remain unchanged.
* The added `mod views;` declaration is required to expose the existing `views.rs` module and the new proof-of-reserve view.
