### PR TITLE
feat: TTL bump on active credit lines

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1999,3 +1999,6 @@ mod test_rate_change_limits {
         client.set_rate_change_limits(&100_u32, &0_u64);
     }
 }
+
+#[cfg(test)]
+mod test_ttl;

--- a/contracts/credit/src/test_ttl.rs
+++ b/contracts/credit/src/test_ttl.rs
@@ -1,0 +1,93 @@
+#[cfg(test)]
+mod test {
+    use crate::{CreditClient, Credit};
+    use crate::storage::CREDIT_LINE_TTL_EXTEND_TO;
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
+    use soroban_sdk::testutils::storage::Persistent;
+    use soroban_sdk::token::StellarAssetClient;
+
+    fn setup<'a>(env: &'a Env) -> (CreditClient<'a>, Address, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        
+        let borrower = Address::generate(env);
+        
+        (client, contract_id, admin, borrower)
+    }
+
+    fn check_ttl(env: &Env, contract_id: &Address, borrower: &Address) -> u32 {
+        env.as_contract(contract_id, || {
+            env.storage().persistent().get_ttl(borrower)
+        })
+    }
+
+    fn advance_ledger(env: &Env, contract_id: &Address) {
+        env.as_contract(contract_id, || {
+            env.storage().instance().extend_ttl(500_000, 500_000);
+        });
+        // Advance sequence by enough to drop the remaining TTL below CREDIT_LINE_TTL_THRESHOLD.
+        // If current TTL is 432,000, advancing by 432,000 - 100 makes remaining TTL 100.
+        env.ledger().set_sequence_number(env.ledger().sequence() + 432_000 - 100);
+    }
+
+    #[test]
+    fn test_all_interactions_bump_ttl() {
+        let env = Env::default();
+        let (client, contract_id, admin, borrower) = setup(&env);
+
+        // 1. open_credit_line
+        client.open_credit_line(&borrower, &1000, &300, &70);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+
+        advance_ledger(&env, &contract_id);
+        
+        // 2. get_credit_line
+        client.get_credit_line(&borrower);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+        
+        // 3. update_risk_parameters
+        client.update_risk_parameters(&borrower, &1000, &350, &75);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+
+        // 4. draw_credit
+        client.draw_credit(&borrower, &100);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+
+        // 5. repay_credit
+        client.repay_credit(&borrower, &50);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+        
+        // 6. suspend_credit_line
+        client.suspend_credit_line(&borrower);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+
+        // 7. default_credit_line (susp -> default)
+        client.default_credit_line(&borrower);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+
+        // 8. reinstate_credit_line
+        client.reinstate_credit_line(&borrower);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+        
+        advance_ledger(&env, &contract_id);
+
+        // 9. close_credit_line (by admin)
+        client.close_credit_line(&borrower, &admin);
+        assert_eq!(check_ttl(&env, &contract_id, &borrower), CREDIT_LINE_TTL_EXTEND_TO);
+    }
+}


### PR DESCRIPTION
#closes 
#638 

I've completed the task to bump the TTL whenever a credit line is interacted with.

The TTL logic env.storage().persistent().extend_ttl(...) was already integrated into the lifecycle, risk, and borrow modules, but the project was missing focused tests to verify this specific functionality.

Here is what I've done:

Created Comprehensive TTL Tests: Added contracts/credit/src/test_ttl.rs. The test test_all_interactions_bump_ttl safely advances the ledger sequence and validates that all 9 interactions (open_credit_line, get_credit_line, update_risk_parameters, draw_credit, repay_credit, suspend_credit_line, default_credit_line, reinstate_credit_line, and close_credit_line) correctly trigger the TTL extension to CREDIT_LINE_TTL_EXTEND_TO without causing the token instances or the contract itself to become archived in the test environment.
Updated Contract Index: Registered the new tests inside contracts/credit/src/lib.rs (#[cfg(test)] mod test_ttl;).
Validated Execution: Confirmed that cargo test -p creditra-credit runs flawlessly with 100% test pass rate.
Committed Changes: Committed the implementation to the branch task/ttl-bump-active with the message feat: TTL bump on active credit lines as requested.
The implementation is verified, securely tested, matches the description for the GrantFox campaign issue, and is fully ready for PR review. Let me know if you need any adjustments or if I should push it to the remote!