### PR TITLE
Add configurable liquidation auction grace window

### DIFF
--- a/C__Users_ADEBOW_1_AppData_Local_Temp_libtest_a_h.s
+++ b/C__Users_ADEBOW_1_AppData_Local_Temp_libtest_a_h.s
@@ -1,0 +1,16 @@
+# IMAGE_IMPORT_DESCRIPTOR
+	.section	.idata$2
+	.global	_head_C__Users_ADEBOW_1_AppData_Local_Temp_libtest_a
+_head_C__Users_ADEBOW_1_AppData_Local_Temp_libtest_a:
+	.rva	hname	#Ptr to image import by name list
+	#this should be the timestamp, but NT sometimes
+	#doesn't load DLLs when this is set.
+	.long	0	# loaded time
+	.long	0	# Forwarder chain
+	.rva	__C__Users_ADEBOW_1_AppData_Local_Temp_libtest_a_iname	# imported dll's name
+	.rva	fthunk	# pointer to firstthunk
+#Stuff for compatibility
+	.section	.idata$5
+fthunk:
+	.section	.idata$4
+hname:

--- a/C__Users_ADEBOW_1_AppData_Local_Temp_test_lib_h.s
+++ b/C__Users_ADEBOW_1_AppData_Local_Temp_test_lib_h.s
@@ -1,0 +1,16 @@
+# IMAGE_IMPORT_DESCRIPTOR
+	.section	.idata$2
+	.global	_head_C__Users_ADEBOW_1_AppData_Local_Temp_test_lib
+_head_C__Users_ADEBOW_1_AppData_Local_Temp_test_lib:
+	.rva	hname	#Ptr to image import by name list
+	#this should be the timestamp, but NT sometimes
+	#doesn't load DLLs when this is set.
+	.long	0	# loaded time
+	.long	0	# Forwarder chain
+	.rva	__C__Users_ADEBOW_1_AppData_Local_Temp_test_lib_iname	# imported dll's name
+	.rva	fthunk	# pointer to firstthunk
+#Stuff for compatibility
+	.section	.idata$5
+fthunk:
+	.section	.idata$4
+hname:

--- a/gateway-contract/contracts/auction_contract/.cargo/config.toml
+++ b/gateway-contract/contracts/auction_contract/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.x86_64-pc-windows-msvc]
+linker = "C:/Users/ADEBOWALE EDUKPE/.rustup/toolchains/stable-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu/bin/self-contained/x86_64-w64-mingw32-gcc.exe"
+ar = "C:/Users/ADEBOWALE EDUKPE/.rustup/toolchains/stable-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu/bin/self-contained/x86_64-w64-mingw32-gcc.exe"

--- a/gateway-contract/contracts/auction_contract/src/errors.rs
+++ b/gateway-contract/contracts/auction_contract/src/errors.rs
@@ -36,4 +36,6 @@ pub enum AuctionError {
     NotFound = 12,
     /// `settle_default_liquidation` was called a second time for the same auction.
     AlreadySettled = 13,
+    /// The liquidation grace window has not yet elapsed; bidding is blocked.
+    GracePeriodActive = 14,
 }

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -192,6 +192,32 @@ impl Auction {
         storage::set_factory_contract(&env, &factory);
     }
 
+    /// Set the liquidation auction grace window duration in seconds (admin only).
+    ///
+    /// This is the minimum time that must elapse between auction creation
+    /// (`start_time` in `init_auction`) and when the first bid can be placed.
+    /// During the grace period, calls to `place_bid` will fail with
+    /// [`AuctionError::GracePeriodActive`]. After the grace window expires,
+    /// existing auction behavior is preserved.
+    ///
+    /// Pass `0` to disable the grace window (default).
+    ///
+    /// # Authorization
+    /// Requires auth from the configured factory/credit contract.
+    pub fn set_liquidation_grace_window(env: Env, seconds: u64) {
+        let factory = get_factory_contract(&env)
+            .unwrap_or_else(|| env.panic_with_error(AuctionError::NoFactoryContract));
+        factory.require_auth();
+        storage::set_liquidation_grace_window(&env, seconds);
+    }
+
+    /// Return the configured liquidation auction grace window in seconds.
+    ///
+    /// Returns `0` when never configured (no grace period enforced).
+    pub fn get_liquidation_grace_window(env: Env) -> u64 {
+        storage::get_liquidation_grace_window(&env)
+    }
+
     pub fn close_auction(env: Env, auction_id: Symbol) {
         let mut state: AuctionState = env
             .storage()
@@ -232,6 +258,15 @@ impl Auction {
         let now = env.ledger().timestamp();
         if now >= state.config.end_time {
             env.panic_with_error(AuctionError::AuctionNotOpen);
+        }
+
+        // Enforce liquidation grace window: no bids until start_time + grace_window.
+        let grace_window = storage::get_liquidation_grace_window(&env);
+        if grace_window > 0 {
+            let earliest_start = state.config.start_time.saturating_add(grace_window);
+            if now < earliest_start {
+                env.panic_with_error(AuctionError::GracePeriodActive);
+            }
         }
 
         match state.config.mode {

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -142,6 +142,26 @@ pub fn clear_reentrancy_guard(env: &Env) {
     env.storage().instance().set(&reentrancy_key(env), &false);
 }
 
+/// Return the configured liquidation grace window in seconds.
+///
+/// Returns `0` when never configured (no grace period enforced).
+pub fn get_liquidation_grace_window(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::LiquidationGraceWindow)
+        .unwrap_or(0)
+}
+
+/// Set the liquidation grace window (in seconds) for all future auctions.
+///
+/// When non-zero, `place_bid` will reject any bid placed before
+/// `start_time + grace_window` has elapsed.
+pub fn set_liquidation_grace_window(env: &Env, seconds: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LiquidationGraceWindow, &seconds);
+}
+
 pub fn get_end_time(env: &Env) -> u64 {
     env.storage().instance().get(&DataKey::EndTime).unwrap_or(0)
 }

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -1902,3 +1902,356 @@ mod reentrancy_preservation {
         assert!(settlement_found, "LIQ_SETL event must be emitted");
     }
 }
+
+// ── liquidation_grace_window ──────────────────────────────────────────────────
+#[cfg(test)]
+mod liquidation_grace_window {
+    extern crate std;
+    use super::super::*;
+    use crate::errors::AuctionError;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
+    use soroban_sdk::{Address, Env, Symbol};
+
+    fn setup_grace_window_test(
+        env: &Env,
+        start_time: u64,
+        end_time: u64,
+    ) -> (AuctionClient, Address, Address, Symbol) {
+        env.mock_all_auths();
+        let factory = Address::generate(env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(env, &contract_id);
+        let auction_id = Symbol::new(env, "grace_auc");
+
+        client.set_factory_contract(&factory);
+        client.set_liquidation_grace_window(&60_u64);
+        client.init_auction(
+            &auction_id,
+            &AuctionMode::English,
+            &start_time,
+            &end_time,
+            &50_i128,
+            &0_u32,
+            &None,
+            &None,
+            &DutchAuctionDecay::None,
+            &None,
+        );
+
+        (client, factory, contract_id, auction_id)
+    }
+
+    /// 1. Grace window enabled: bid before grace period expires is rejected.
+    #[test]
+    fn bid_rejected_during_grace_window() {
+        let env = Env::default();
+        let start_time = 1000;
+        let end_time = 2000;
+        let (client, _factory, _contract_id, auction_id) =
+            setup_grace_window_test(&env, start_time, end_time);
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1050);
+        let result = client.try_place_bid(&auction_id, &bidder, &100_i128);
+        assert!(
+            result.is_err(),
+            "bid before grace window expires must be rejected"
+        );
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            AuctionError::GracePeriodActive.into(),
+        );
+    }
+
+    /// 2. Grace period elapsed: auction starts successfully.
+    #[test]
+    fn bid_accepted_after_grace_window() {
+        let env = Env::default();
+        let start_time = 1000;
+        let end_time = 2000;
+        let (client, _factory, _contract_id, auction_id) =
+            setup_grace_window_test(&env, start_time, end_time);
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1100);
+        let result = client.try_place_bid(&auction_id, &bidder, &100_i128);
+        assert!(
+            result.is_ok(),
+            "bid after grace window must succeed"
+        );
+    }
+
+    /// 3. Configuration update: authorized user can update grace window.
+    #[test]
+    fn authorized_set_liquidation_grace_window() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let factory = Address::generate(&env);
+        client.set_factory_contract(&factory);
+
+        client.set_liquidation_grace_window(&120_u64);
+        assert_eq!(client.get_liquidation_grace_window(), 120_u64);
+
+        client.set_liquidation_grace_window(&0_u64);
+        assert_eq!(client.get_liquidation_grace_window(), 0_u64);
+    }
+
+    /// 4. Unauthorized update: rejected without auth from factory contract.
+    #[test]
+    fn unauthorized_set_liquidation_grace_window_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let factory = Address::generate(&env);
+        client.set_factory_contract(&factory);
+
+        let intruder = Address::generate(&env);
+        use soroban_sdk::IntoVal;
+        let result = client
+            .mock_auths(&[soroban_sdk::testutils::MockAuth {
+                address: &intruder,
+                invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "set_liquidation_grace_window",
+                    args: (60_u64,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_set_liquidation_grace_window(&60_u64);
+        assert!(
+            result.is_err(),
+            "unauthorized grace window update should be rejected"
+        );
+    }
+
+    /// 5a. Boundary: bid at the exact expiry time succeeds.
+    #[test]
+    fn bid_at_exact_grace_window_expiry() {
+        let env = Env::default();
+        let start_time = 1000;
+        let end_time = 2000;
+        let (client, _factory, _contract_id, auction_id) =
+            setup_grace_window_test(&env, start_time, end_time);
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1060);
+        let result = client.try_place_bid(&auction_id, &bidder, &100_i128);
+        assert!(
+            result.is_ok(),
+            "bid at exact grace window expiry must succeed"
+        );
+    }
+
+    /// 5b. Boundary: bid one second before expiry fails.
+    #[test]
+    fn bid_one_second_before_expiry() {
+        let env = Env::default();
+        let start_time = 1000;
+        let end_time = 2000;
+        let (client, _factory, _contract_id, auction_id) =
+            setup_grace_window_test(&env, start_time, end_time);
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1059);
+        let result = client.try_place_bid(&auction_id, &bidder, &100_i128);
+        assert!(
+            result.is_err(),
+            "bid one second before grace expiry must be rejected"
+        );
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            AuctionError::GracePeriodActive.into(),
+        );
+    }
+
+    /// Grace window disabled (default) preserves existing behavior.
+    #[test]
+    fn no_grace_window_default_behavior() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let factory = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "no_grace");
+
+        client.set_factory_contract(&factory);
+
+        // Never set a grace window — defaults to 0 (disabled).
+        assert_eq!(client.get_liquidation_grace_window(), 0_u64);
+
+        client.init_auction(
+            &auction_id,
+            &AuctionMode::English,
+            &1000,
+            &2000,
+            &50_i128,
+            &0_u32,
+            &None,
+            &None,
+            &DutchAuctionDecay::None,
+            &None,
+        );
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1000);
+        let result = client.try_place_bid(&auction_id, &bidder, &100_i128);
+        assert!(
+            result.is_ok(),
+            "bid at start_time must be accepted when grace window is disabled"
+        );
+    }
+
+    /// Grace window with Dutch auction: bid before expiry is blocked.
+    #[test]
+    fn dutch_auction_bid_during_grace_window_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let factory = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "dutch_grace");
+
+        client.set_factory_contract(&factory);
+        client.set_liquidation_grace_window(&60_u64);
+        client.init_auction(
+            &auction_id,
+            &AuctionMode::Dutch,
+            &1000,
+            &2000,
+            &50_i128,
+            &0_u32,
+            &Some(500_i128),
+            &Some(100_i128),
+            &DutchAuctionDecay::Linear,
+            &None,
+        );
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1050);
+        let result = client.try_place_bid(&auction_id, &bidder, &300_i128);
+        assert!(
+            result.is_err(),
+            "Dutch bid during grace window must be rejected"
+        );
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            AuctionError::GracePeriodActive.into(),
+        );
+    }
+
+    /// Grace window with Dutch auction: bid after expiry is accepted.
+    #[test]
+    fn dutch_auction_bid_after_grace_window_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let factory = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "dutch_grace_ok");
+
+        client.set_factory_contract(&factory);
+        client.set_liquidation_grace_window(&60_u64);
+        client.init_auction(
+            &auction_id,
+            &AuctionMode::Dutch,
+            &1000,
+            &2000,
+            &50_i128,
+            &0_u32,
+            &Some(500_i128),
+            &Some(100_i128),
+            &DutchAuctionDecay::Linear,
+            &None,
+        );
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1100);
+        let result = client.try_place_bid(&auction_id, &bidder, &300_i128);
+        assert!(
+            result.is_ok(),
+            "Dutch bid after grace window must succeed"
+        );
+    }
+
+    /// Grace window does not affect close_auction or other non-bid operations.
+    #[test]
+    fn close_auction_unaffected_by_grace_window() {
+        let env = Env::default();
+        let start_time = 1000;
+        let end_time = 2000;
+        let (client, _factory, _contract_id, auction_id) =
+            setup_grace_window_test(&env, start_time, end_time);
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1100);
+        client.place_bid(&auction_id, &bidder, &100_i128);
+
+        env.ledger().set_timestamp(2000);
+        let result = client.try_close_auction(&auction_id);
+        assert!(
+            result.is_ok(),
+            "close_auction must not be blocked by grace window"
+        );
+    }
+
+    /// Grace window requires factory to be set.
+    #[test]
+    fn set_grace_window_requires_factory() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+
+        let result = client.try_set_liquidation_grace_window(&60_u64);
+        assert!(
+            result.is_err(),
+            "setting grace window without factory must fail"
+        );
+    }
+
+    /// Zero grace window: bid immediately after start_time succeeds.
+    #[test]
+    fn zero_grace_window_allows_immediate_bid() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let factory = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "zero_grace_ok");
+
+        client.set_factory_contract(&factory);
+        client.set_liquidation_grace_window(&0_u64);
+        client.init_auction(
+            &auction_id,
+            &AuctionMode::English,
+            &1000,
+            &2000,
+            &50_i128,
+            &0_u32,
+            &None,
+            &None,
+            &DutchAuctionDecay::None,
+            &None,
+        );
+
+        let bidder = Address::generate(&env);
+        env.ledger().set_timestamp(1000);
+        let result = client.try_place_bid(&auction_id, &bidder, &100_i128);
+        assert!(
+            result.is_ok(),
+            "zero grace window must allow immediate bid at start_time"
+        );
+    }
+}

--- a/gateway-contract/contracts/auction_contract/src/types.rs
+++ b/gateway-contract/contracts/auction_contract/src/types.rs
@@ -82,6 +82,9 @@ pub enum DataKey {
     FactoryContract,
     EndTime,
     HighestBid,
+    /// Contract-level grace window (in seconds) that must elapse after
+    /// auction creation before the first bid can be placed.
+    LiquidationGraceWindow,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #632

Summary:
Adds a configurable grace period between liquidation and auction start.

Changes:

- Added liquidation auction grace window configuration
- Added enforcement preventing auctions before grace expiry
- Preserved existing auction flow after grace period completion

Security:

- Added require_auth checks for state-changing operations
- Used overflow-safe time calculations
- Avoided unwrap() usage in production paths

Documentation:

- Added rustdoc comments for new public APIs
- Documented grace window behavior

Tests added:

- Auction blocked before grace period expires
- Auction succeeds after grace period
- Grace window configuration update
- Authorization failures
- Timestamp boundary cases

Validation:

- cargo test passes
- Contract behavior preserved
- Coverage improved for liquidation timing paths