### PR TITLE
feat: cursor pagination for credit lines

### DIFF
--- a/PAGINATION_IMPLEMENTATION_SUMMARY.md
+++ b/PAGINATION_IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,103 @@
+# Credit Lines Pagination Implementation Summary
+
+## Overview
+Implemented cursor-based pagination for credit lines to enable efficient off-chain reporting without loading all credit lines at once.
+
+## Changes Made
+
+### 1. Type Definition (`contracts/credit/src/types.rs`)
+Added `CreditLinesPage` struct for paginated responses:
+```rust
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLinesPage {
+    pub credit_lines: Vec<CreditLineData>,
+    pub next_cursor: Option<u32>,
+}
+```
+
+### 2. Implementation (`contracts/credit/src/views.rs`)
+Added `get_credit_lines_paginated` function with:
+- Cursor-based pagination using stable numeric IDs
+- Limit enforcement (max 100 items per page)
+- Overflow-safe arithmetic using `saturating_add`
+- TTL bump for loaded credit line entries
+- Comprehensive NatSpec-style documentation
+
+### 3. Public API (`contracts/credit/src/lib.rs`)
+- Added `CreditLinesPage` to type imports
+- Exposed `get_credit_lines_paginated` as a public contract function
+- Added comprehensive documentation with usage examples
+
+### 4. Tests (`contracts/credit/src/views_tests.rs`)
+Added 8 comprehensive test cases:
+1. `test_credit_lines_paginated_empty` - Empty result handling
+2. `test_credit_lines_paginated_single_page` - Single page with all results
+3. `test_credit_lines_paginated_multiple_pages` - Multi-page navigation
+4. `test_credit_lines_paginated_limit_enforcement` - Exact limit handling
+5. `test_credit_lines_paginated_limit_exceeds_max` - Overflow protection
+6. `test_credit_lines_paginated_cursor_beyond_end` - Edge case handling
+7. `test_credit_lines_paginated_with_closed_lines` - Closed line inclusion
+8. `test_credit_lines_paginated_cursor_continuation` - Cursor continuity verification
+
+## Security Considerations
+
+### Read-Only Safety
+- No authentication required (pure read operation)
+- No state mutations
+- Only reads storage and bumps TTL (side effect only)
+
+### Overflow Protection
+- Enforces `MAX_ENUMERATION_LIMIT` (100) to prevent unbounded gas consumption
+- Uses `saturating_add` for all arithmetic operations
+- Panics with `ContractError::Overflow` if limit exceeds maximum
+
+### Gas Efficiency
+- Limits iterations to prevent excessive gas consumption
+- Returns early when cursor is beyond valid range
+- Skips gaps in ID sequence efficiently
+
+## API Usage Example
+
+```text
+// First page
+let page1 = client.get_credit_lines_paginated(None, 10);
+
+// Second page
+if let Some(cursor) = page1.next_cursor {
+    let page2 = client.get_credit_lines_paginated(Some(cursor), 10);
+}
+```
+
+## Build Environment Note
+
+The current Windows environment is missing the MSVC linker (`link.exe`) required for Rust compilation. To run `cargo check` and `cargo test`, you need to:
+
+1. Install Visual Studio 2017 or later with the Visual C++ option, OR
+2. Install Build Tools for Visual Studio with the Visual C++ workload
+
+Once the build environment is properly configured, run:
+```bash
+cargo check --workspace
+cargo test --package creditra-credit
+cargo clippy --package creditra-credit
+```
+
+## Acceptance Criteria Status
+
+- ✅ Implementation matches design (cursor-based pagination)
+- ✅ Tests added (8 comprehensive test cases)
+- ✅ Documentation updated (NatSpec-style comments)
+- ⏳ Tests pass (blocked by build environment setup)
+- ⏳ No new clippy warnings (blocked by build environment setup)
+- ✅ Overflow-safe math (saturating operations)
+- ✅ No unwrap() in production paths
+- ✅ Clear NatSpec-style rustdoc
+
+## Next Steps
+
+1. Set up Windows build environment with MSVC linker
+2. Run `cargo check --workspace` to verify compilation
+3. Run `cargo test --package creditra-credit` to verify all tests pass
+4. Run `cargo clippy --package creditra-credit` to verify no new warnings
+5. Commit changes with message: `feat: cursor pagination for credit lines`

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -163,9 +163,9 @@ use crate::storage::{
     set_pending_treasury_withdrawal,
 };
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
-    TreasuryWithdrawalProposal,
+    ContractError, CreditLineData, CreditLinesPage, CreditStatus, GracePeriodConfig, GraceWaiverMode,
+    OracleConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
+    RateFormulaConfig, TreasuryWithdrawalProposal,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -1240,6 +1240,42 @@ impl Credit {
     /// and indexer integration.
     pub fn get_proof_of_reserve(env: Env) -> ProofOfReserve {
         views::get_proof_of_reserve(env)
+    }
+
+    /// Return a paginated view of credit lines for off-chain reporting.
+    ///
+    /// Uses cursor-based pagination where the cursor is the stable numeric ID
+    /// assigned to each borrower. This allows efficient, stateless navigation
+    /// through large sets of credit lines without offset-based limitations.
+    ///
+    /// # Parameters
+    ///
+    /// - `cursor`: Optional starting cursor (numeric ID). Pass `None` for the first page.
+    /// - `limit`: Maximum number of credit lines to return. Must be <= 100.
+    ///
+    /// # Returns
+    ///
+    /// A [`CreditLinesPage`] containing:
+    /// - `credit_lines`: Vector of credit line data for this page.
+    /// - `next_cursor`: Cursor for the next page, or `None` if this is the last page.
+    ///
+    /// # Authentication
+    ///
+    /// No authentication required. This is a pure read-only query.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// // First page
+    /// let page1 = client.get_credit_lines_paginated(None, 10);
+    ///
+    /// // Second page
+    /// if let Some(cursor) = page1.next_cursor {
+    ///     let page2 = client.get_credit_lines_paginated(Some(cursor), 10);
+    /// }
+    /// ```
+    pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> CreditLinesPage {
+        views::get_credit_lines_paginated(env, cursor, limit)
     }
 
     pub fn deposit_collateral(env: Env, borrower: Address, amount: i128) {

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -447,3 +447,19 @@ pub struct TreasuryWithdrawalProposal {
     /// Earliest ledger timestamp at which execution is permitted (`proposed_at + 86_400`).
     pub execute_after: u64,
 }
+
+/// Paginated response for credit lines enumeration.
+///
+/// Uses cursor-based pagination where the cursor is the stable numeric ID
+/// assigned to each borrower. This allows efficient, stateless navigation
+/// through large sets of credit lines without offset-based limitations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLinesPage {
+    /// The credit lines in this page.
+    pub credit_lines: Vec<CreditLineData>,
+    /// The cursor for the next page, if more results exist.
+    /// Pass this value as `cursor` in the next call to continue enumeration.
+    /// When `None`, this is the last page.
+    pub next_cursor: Option<u32>,
+}

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -5,8 +5,9 @@
 //! Provides the protocol summary view requested for the GrantFox campaign
 //! and the proof-of-reserve view for protocol treasury transparency.
 
-use crate::types::{ProofOfReserve, ProtocolSummaryView};
-use soroban_sdk::Env;
+use crate::storage::{get_borrower_by_credit_line_id, get_credit_line, MAX_ENUMERATION_LIMIT};
+use crate::types::{CreditLinesPage, ProofOfReserve, ProtocolSummaryView};
+use soroban_sdk::{Env, Vec};
 
 /// Return protocol-level dashboard aggregates including ActiveLineCount.
 ///
@@ -32,5 +33,103 @@ pub fn get_proof_of_reserve(env: Env) -> ProofOfReserve {
     ProofOfReserve {
         treasury_balance: crate::storage::get_treasury_balance(&env),
         bounty_balance: crate::storage::get_bounty_balance(&env),
+    }
+}
+
+/// Return a paginated view of credit lines for off-chain reporting.
+///
+/// Uses cursor-based pagination where the cursor is the stable numeric ID
+/// assigned to each borrower. This allows efficient, stateless navigation
+/// through large sets of credit lines without offset-based limitations.
+///
+/// # Parameters
+///
+/// - `cursor`: Optional starting cursor (numeric ID). Pass `None` for the first page.
+/// - `limit`: Maximum number of credit lines to return. Must be <= `MAX_ENUMERATION_LIMIT`.
+///
+/// # Returns
+///
+/// A [`CreditLinesPage`] containing:
+/// - `credit_lines`: Vector of credit line data for this page.
+/// - `next_cursor`: Cursor for the next page, or `None` if this is the last page.
+///
+/// # Behavior
+///
+/// - Starts enumeration from `cursor.unwrap_or(0)`.
+/// - Returns at most `limit` credit lines.
+/// - Iterates through stable numeric IDs in ascending order.
+/// - Skips IDs that have no corresponding borrower (gaps in the sequence).
+/// - Bumps TTL for each credit line entry that is loaded.
+///
+/// # Errors
+///
+/// - Panics with [`ContractError::Overflow`] if `limit` exceeds `MAX_ENUMERATION_LIMIT`.
+///
+/// # Example
+///
+/// ```text
+/// // First page
+/// let page1 = get_credit_lines_paginated(env, None, 10);
+///
+/// // Second page
+/// if let Some(cursor) = page1.next_cursor {
+///     let page2 = get_credit_lines_paginated(env, Some(cursor), 10);
+/// }
+/// ```
+///
+/// # Security
+///
+/// This is a read-only function with no authentication requirement. It only
+/// reads storage and does not mutate any state. The TTL bump on loaded entries
+/// is a side effect but does not change the logical state of the contract.
+pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> CreditLinesPage {
+    // Enforce maximum limit to prevent unbounded gas consumption
+    if limit > MAX_ENUMERATION_LIMIT {
+        env.panic_with_error(crate::types::ContractError::Overflow);
+    }
+
+    let total_count = crate::storage::get_credit_line_count(&env);
+    let start_id = cursor.unwrap_or(0);
+
+    // Clamp start_id to valid range
+    if start_id >= total_count {
+        return CreditLinesPage {
+            credit_lines: Vec::new(&env),
+            next_cursor: None,
+        };
+    }
+
+    let mut credit_lines = Vec::new(&env);
+    let mut next_cursor: Option<u32> = None;
+    let mut current_id = start_id;
+    let end_id = total_count.saturating_sub(1);
+
+    // Iterate through IDs until we collect enough results or reach the end
+    while credit_lines.len() < limit as u32 && current_id <= end_id {
+        if let Some(borrower) = get_borrower_by_credit_line_id(&env, current_id) {
+            if let Some(line) = get_credit_line(&env, &borrower) {
+                credit_lines.push_back(line);
+            }
+        }
+
+        // Prepare next cursor if we might have more results
+        if credit_lines.len() < limit as u32 && current_id < end_id {
+            next_cursor = Some(current_id.saturating_add(1));
+        } else if current_id < end_id {
+            // We've filled the page but there are more results
+            next_cursor = Some(current_id.saturating_add(1));
+        }
+
+        current_id = current_id.saturating_add(1);
+    }
+
+    // If we didn't fill the page, there are no more results
+    if credit_lines.len() < limit as u32 {
+        next_cursor = None;
+    }
+
+    CreditLinesPage {
+        credit_lines,
+        next_cursor,
     }
 }

--- a/contracts/credit/src/views_tests.rs
+++ b/contracts/credit/src/views_tests.rs
@@ -107,3 +107,264 @@ fn test_proof_of_reserve_reads_existing_balances() {
     assert_eq!(por.treasury_balance, 42);
     assert_eq!(por.bounty_balance, 7);
 }
+
+#[test]
+fn test_credit_lines_paginated_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Empty result with no credit lines
+    let page = client.get_credit_lines_paginated(None, &10);
+    assert_eq!(page.credit_lines.len(), 0);
+    assert!(page.next_cursor.is_none());
+}
+
+#[test]
+fn test_credit_lines_paginated_single_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Create 3 credit lines
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+
+    client.open_credit_line(&b1, &1000, &500, &10);
+    client.open_credit_line(&b2, &2000, &600, &20);
+    client.open_credit_line(&b3, &3000, &700, &30);
+
+    // Request all 3 in one page
+    let page = client.get_credit_lines_paginated(None, &10);
+    assert_eq!(page.credit_lines.len(), 3);
+    assert!(page.next_cursor.is_none());
+
+    // Verify credit line data
+    assert_eq!(page.credit_lines.get(0).unwrap().credit_limit, 1000);
+    assert_eq!(page.credit_lines.get(1).unwrap().credit_limit, 2000);
+    assert_eq!(page.credit_lines.get(2).unwrap().credit_limit, 3000);
+}
+
+#[test]
+fn test_credit_lines_paginated_multiple_pages() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Create 5 credit lines
+    let borrowers: Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+    for (i, borrower) in borrowers.iter().enumerate() {
+        client.open_credit_line(borrower, &(1000 * (i as i128 + 1)), &500, &(10 * (i as u32 + 1)));
+    }
+
+    // First page with 2 items
+    let page1 = client.get_credit_lines_paginated(None, &2);
+    assert_eq!(page1.credit_lines.len(), 2);
+    assert!(page1.next_cursor.is_some());
+
+    // Second page with 2 items
+    let cursor1 = page1.next_cursor.unwrap();
+    let page2 = client.get_credit_lines_paginated(Some(cursor1), &2);
+    assert_eq!(page2.credit_lines.len(), 2);
+    assert!(page2.next_cursor.is_some());
+
+    // Third page with 1 item (last page)
+    let cursor2 = page2.next_cursor.unwrap();
+    let page3 = client.get_credit_lines_paginated(Some(cursor2), &2);
+    assert_eq!(page3.credit_lines.len(), 1);
+    assert!(page3.next_cursor.is_none());
+}
+
+#[test]
+fn test_credit_lines_paginated_limit_enforcement() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Create 5 credit lines
+    let borrowers: Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+    for (i, borrower) in borrowers.iter().enumerate() {
+        client.open_credit_line(borrower, &(1000 * (i as i128 + 1)), &500, &(10 * (i as u32 + 1)));
+    }
+
+    // Request exactly 3 items
+    let page = client.get_credit_lines_paginated(None, &3);
+    assert_eq!(page.credit_lines.len(), 3);
+    assert!(page.next_cursor.is_some());
+}
+
+#[test]
+fn test_credit_lines_paginated_limit_exceeds_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Request limit > MAX_ENUMERATION_LIMIT (100) should panic
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.get_credit_lines_paginated(None, &101);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_credit_lines_paginated_cursor_beyond_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Create 2 credit lines
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    client.open_credit_line(&b1, &1000, &500, &10);
+    client.open_credit_line(&b2, &2000, &600, &20);
+
+    // Request with cursor beyond the last ID
+    let page = client.get_credit_lines_paginated(Some(100), &10);
+    assert_eq!(page.credit_lines.len(), 0);
+    assert!(page.next_cursor.is_none());
+}
+
+#[test]
+fn test_credit_lines_paginated_with_closed_lines() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Create 3 credit lines
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+
+    client.open_credit_line(&b1, &1000, &500, &10);
+    client.open_credit_line(&b2, &2000, &600, &20);
+    client.open_credit_line(&b3, &3000, &700, &30);
+
+    // Close one line
+    client.close_credit_line(&b2, &admin);
+
+    // Pagination should still return all lines (including closed)
+    let page = client.get_credit_lines_paginated(None, &10);
+    assert_eq!(page.credit_lines.len(), 3);
+}
+
+#[test]
+fn test_credit_lines_paginated_cursor_continuation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Create 4 credit lines with distinct limits for identification
+    let b1 = Address::generate(&env);
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+    let b4 = Address::generate(&env);
+
+    client.open_credit_line(&b1, &1000, &500, &10);
+    client.open_credit_line(&b2, &2000, &600, &20);
+    client.open_credit_line(&b3, &3000, &700, &30);
+    client.open_credit_line(&b4, &4000, &800, &40);
+
+    // First page: 2 items
+    let page1 = client.get_credit_lines_paginated(None, &2);
+    assert_eq!(page1.credit_lines.len(), 2);
+    let cursor1 = page1.next_cursor.unwrap();
+
+    // Second page: continue from cursor
+    let page2 = client.get_credit_lines_paginated(Some(cursor1), &2);
+    assert_eq!(page2.credit_lines.len(), 2);
+    assert!(page2.next_cursor.is_none());
+
+    // Verify we got all 4 distinct lines
+    let all_limits: Vec<i128> = page1
+        .credit_lines
+        .iter()
+        .chain(page2.credit_lines.iter())
+        .map(|line| line.credit_limit)
+        .collect();
+    assert_eq!(all_limits.len(), 4);
+    assert!(all_limits.contains(&1000));
+    assert!(all_limits.contains(&2000));
+    assert!(all_limits.contains(&3000));
+    assert!(all_limits.contains(&4000));
+}


### PR DESCRIPTION
- Add CreditLinesPage type for paginated responses
- Implement get_credit_lines_paginated with cursor-based navigation
- Add comprehensive test coverage (8 test cases)
- Update API documentation with NatSpec-style comments
- Enforce MAX_ENUMERATION_LIMIT to prevent unbounded gas consumption
- Use overflow-safe arithmetic with saturating operations

closes  #610