### PR TITLE
feat: protocol fee skim on repayment

### DIFF
--- a/contracts/credit/src/borrow.rs
+++ b/contracts/credit/src/borrow.rs
@@ -3,7 +3,7 @@ use crate::events::{
     publish_drawn_event, publish_interest_accrued_event, publish_repayment_event, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent,
 };
-use crate::math_utils::{mul_div, Rounding};
+use crate::math_utils::{apply_bps, mul_div, Rounding};
 use crate::storage::{
     clear_reentrancy_guard, get_collateral_balance, persist_credit_line, set_reentrancy_guard,
     DataKey, CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD,
@@ -324,12 +324,39 @@ pub fn repay_and_release_collateral(env: Env, borrower: Address, amount: i128) {
                 panic!("Insufficient balance");
             }
 
-            token_client.transfer_from(
-                &contract_address,
-                &borrower,
-                &reserve_address,
-                &effective_repay,
-            );
+            // Compute protocol fee on the total repayment amount.
+            let fee_bps: u32 =
+                crate::storage::get_protocol_fee_bps(&env).unwrap_or(0);
+            let mut fee: i128 = 0;
+            if fee_bps > 0 && effective_repay > 0 {
+                fee = apply_bps(
+                    effective_repay as u128,
+                    fee_bps,
+                    Rounding::Floor,
+                ) as i128;
+            }
+
+            // Transfer fee portion into contract (treasury accumulator), then
+            // transfer remaining amount into the reserve.
+            if fee > 0 {
+                token_client.transfer_from(
+                    &contract_address,
+                    &borrower,
+                    &contract_address,
+                    &fee,
+                );
+                crate::fees::accrue_protocol_fee(&env, &borrower, fee);
+            }
+
+            let reserve_amount = effective_repay.saturating_sub(fee);
+            if reserve_amount > 0 {
+                token_client.transfer_from(
+                    &contract_address,
+                    &borrower,
+                    &reserve_address,
+                    &reserve_amount,
+                );
+            }
         }
     }
 

--- a/contracts/credit/src/fees.rs
+++ b/contracts/credit/src/fees.rs
@@ -2,9 +2,9 @@
 
 //! Protocol fee skim split between treasury and bounty pools.
 //!
-//! When a borrower repays interest, the protocol fee (`ProtocolFeeBps`) is
-//! skimmed into the contract and allocated between two accumulators by
-//! [`TreasuryFeeShareBps`]:
+//! When a borrower repays, the protocol fee (`ProtocolFeeBps`) is
+//! skimmed from the total repayment amount into the contract and allocated
+//! between two accumulators by [`TreasuryFeeShareBps`]:
 //!
 //! - **Treasury** — withdrawable via `propose_treasury_withdrawal` / `execute_treasury_withdrawal` to `TreasuryAddress`.
 //! - **Bounty pool** — withdrawable via `withdraw_bounty` to `BountyAddress`.

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -25,7 +25,7 @@ mod handshake;
 //!   into the configured `LiquidityToken`.
 //! - **Repay** — `repay_credit` is **not pause-gated**: borrowers must always
 //!   be able to deleverage. Interest-first allocation with optional
-//!   protocol-fee-on-interest split between treasury and bounty accumulators.
+//!   protocol-fee-on-repayment split between treasury and bounty accumulators.
 //! - **Risk update** — `update_risk_parameters` either computes the new rate
 //!   from `risk_score` via the piecewise-linear formula (if configured) or
 //!   accepts an admin-supplied rate; both paths are clamped and gated by the
@@ -562,12 +562,12 @@ impl Credit {
                 let token_client = token::Client::new(&env, &token_address);
                 let contract_address = env.current_contract_address();
 
-                // Compute protocol fee only on the interest component.
+                // Compute protocol fee on the total repayment amount.
                 let fee_bps: u32 = crate::storage::get_protocol_fee_bps(&env).unwrap_or(0);
                 let mut fee: i128 = 0;
-                if fee_bps > 0 && interest_repaid > 0 {
+                if fee_bps > 0 && effective_repay > 0 {
                     fee = crate::math_utils::apply_bps(
-                        interest_repaid as u128,
+                        effective_repay as u128,
                         fee_bps,
                         Rounding::Floor,
                     ) as i128;

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -156,7 +156,7 @@ pub enum DataKey {
     AuctionContract,
     /// Maximum total exposure allowed across all credit lines (admin-configurable).
     MaxTotalExposure,
-    /// Protocol fee in basis points applied to interest portion of repayments.
+    /// Protocol fee in basis points applied to total repayment amount.
     ProtocolFeeBps,
     /// Minimum allowed protocol fee in basis points (governance-configurable).
     MinProtocolFeeBps,

--- a/contracts/credit/tests/fee_split.rs
+++ b/contracts/credit/tests/fee_split.rs
@@ -99,7 +99,7 @@ fn fee_split_default_is_all_treasury() {
     client.repay_credit(&borrower, &1_100);
 
     let summary = client.get_protocol_summary();
-    assert_eq!(summary.treasury_balance, 10);
+    assert_eq!(summary.treasury_balance, 110);
     assert_eq!(summary.bounty_balance, 0);
 }
 
@@ -122,8 +122,8 @@ fn fee_split_even_ratio_splits_fee_between_pools() {
     client.repay_credit(&borrower, &1_100);
 
     let summary = client.get_protocol_summary();
-    assert_eq!(summary.treasury_balance, 5);
-    assert_eq!(summary.bounty_balance, 5);
+    assert_eq!(summary.treasury_balance, 55);
+    assert_eq!(summary.bounty_balance, 55);
 }
 
 #[test]
@@ -145,9 +145,9 @@ fn fee_split_remainder_goes_to_bounty_on_rounding() {
     client.repay_credit(&borrower, &1_100);
 
     let summary = client.get_protocol_summary();
-    assert_eq!(summary.treasury_balance, 3);
-    assert_eq!(summary.bounty_balance, 7);
-    assert_eq!(summary.treasury_balance + summary.bounty_balance, 10);
+    assert_eq!(summary.treasury_balance, 36);
+    assert_eq!(summary.bounty_balance, 74);
+    assert_eq!(summary.treasury_balance + summary.bounty_balance, 110);
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn fee_split_all_bounty_when_share_is_zero() {
 
     let summary = client.get_protocol_summary();
     assert_eq!(summary.treasury_balance, 0);
-    assert_eq!(summary.bounty_balance, 10);
+    assert_eq!(summary.bounty_balance, 110);
 }
 
 #[test]
@@ -193,11 +193,11 @@ fn withdraw_bounty_transfers_accumulated_balance() {
 
     let token_client = token::Client::new(&env, &token_address);
     assert_eq!(token_client.balance(&bounty), 0);
-    assert_eq!(client.get_protocol_summary().bounty_balance, 10);
+    assert_eq!(client.get_protocol_summary().bounty_balance, 110);
 
     client.withdraw_bounty(&admin);
 
-    assert_eq!(token_client.balance(&bounty), 10);
+    assert_eq!(token_client.balance(&bounty), 110);
     assert_eq!(client.get_protocol_summary().bounty_balance, 0);
 }
 

--- a/contracts/credit/tests/protocol_fee.rs
+++ b/contracts/credit/tests/protocol_fee.rs
@@ -91,8 +91,8 @@ fn protocol_fee_zero_fee_keeps_treasury_balance_at_zero() {
 }
 
 #[test]
-fn protocol_fee_max_fee_accrues_expected_fee_amount() {
-    let (env, contract_id, token_address, borrower, reserve, treasury) = setup();
+fn protocol_fee_on_total_repayment_accrues_expected_fee_amount() {
+    let (env, contract_id, token_address, borrower, reserve, _treasury) = setup();
     let client = prepare_repay(
         &env,
         &contract_id,
@@ -110,41 +110,41 @@ fn protocol_fee_max_fee_accrues_expected_fee_amount() {
 
     client.repay_credit(&borrower, &1_100);
 
+    // fee = 10% of 1100 = 110; reserve = 1100 - 110 = 990
     assert_eq!(
         token_client.balance(&contract_id),
-        contract_balance_before + 10
+        contract_balance_before + 110
     );
     assert_eq!(
         token_client.balance(&reserve),
-        reserve_balance_before + 1_090
+        reserve_balance_before + 990
     );
-    assert_eq!(token_client.balance(&treasury), 0);
 }
 
 #[test]
-fn protocol_fee_rounding_edge_floors_small_fee_to_zero() {
-    let (env, contract_id, token_address, borrower, reserve, treasury) = setup();
+fn protocol_fee_rounding_floors_sub_bps_fee_to_zero() {
+    let (env, contract_id, token_address, borrower, reserve, _treasury) = setup();
     let client = prepare_repay(
         &env,
         &contract_id,
         &token_address,
         &borrower,
         10_000,
-        10_001,
-        1,
         5_000,
+        1,
+        1,
     );
 
     let token_client = token::Client::new(&env, &token_address);
     let contract_balance_before = token_client.balance(&contract_id);
     let reserve_balance_before = token_client.balance(&reserve);
 
-    client.repay_credit(&borrower, &10_001);
+    client.repay_credit(&borrower, &5_000);
 
+    // fee = apply_bps(5000, 1, Floor) = 0 — sub-bps rounding
     assert_eq!(token_client.balance(&contract_id), contract_balance_before);
     assert_eq!(
         token_client.balance(&reserve),
-        reserve_balance_before + 10_001
+        reserve_balance_before + 5_000
     );
-    assert_eq!(token_client.balance(&treasury), 0);
 }

--- a/contracts/credit/tests/protocol_fee_total_repayment.rs
+++ b/contracts/credit/tests/protocol_fee_total_repayment.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT
+
+//! Focused tests for protocol fee on total repayment amount.
+//!
+//! The protocol fee (`ProtocolFeeBps`) is now applied to the **total**
+//! repayment amount (principal + interest), not just the interest component.
+//! This file covers:
+//!
+//! - Fee on principal-only repayment (no interest period)
+//! - Fee on mixed principal + interest repayment
+//! - Fee via `repay_and_release_collateral` path
+//! - Rounding edge: sub-bps fee floors to zero
+//! - Zero fee sends everything to reserve
+//! - Fee event emission correctness
+
+use creditra_credit::events::FeeAccruedEvent;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, Events, Ledger};
+use soroban_sdk::{token, Address, Env};
+
+/// Create a minimal environment with a funded credit line ready to repay.
+///
+/// Returns (env, client, borrower, token_address, reserve_address).
+fn setup_minimal() -> (Env, CreditClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let reserve = Address::generate(&env);
+
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+
+    client.set_liquidity_token(&token_address);
+    client.set_liquidity_source(&reserve);
+
+    (env, client, borrower, token_address, reserve)
+}
+
+/// Open a line, mint reserve, draw, and approve `repay_amount` for the borrower.
+fn prepare_repay(
+    env: &Env,
+    client: &CreditClient,
+    borrower: &Address,
+    token_address: &Address,
+    draw_amount: i128,
+    repay_amount: i128,
+    interest_rate_bps: u32,
+    fee_bps: u32,
+) {
+    client.open_credit_line(borrower, &draw_amount, &interest_rate_bps, &50_u32);
+
+    let asset = token::StellarAssetClient::new(env, token_address);
+    asset.mint(&client.contract_id, &draw_amount);
+    client.draw_credit(borrower, &draw_amount);
+
+    // Widen bounds if fee_bps exceeds the default 1000 cap.
+    if fee_bps > 1000 {
+        client.set_protocol_fee_bounds(&0_u32, &fee_bps);
+    }
+    client.set_protocol_fee_bps(&fee_bps);
+
+    asset.mint(borrower, &repay_amount);
+    token::Client::new(env, token_address).approve(borrower, &client.contract_id, &repay_amount, &u32::MAX);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+/// Fee on a principal-only repayment (zero interest elapsed).
+#[test]
+fn fee_on_principal_only_repayment() {
+    let (env, client, borrower, token_address, reserve) = setup_minimal();
+
+    prepare_repay(
+        &env,
+        &client,
+        &borrower,
+        &token_address,
+        1_000_i128,  // draw
+        500_i128,    // repay
+        500_u32,     // interest rate bps (5% APR, but no time elapsed)
+        500_u32,     // fee bps (5%)
+    );
+
+    let token_client = token::Client::new(&env, &token_address);
+    let contract_before = token_client.balance(&client.contract_id);
+    let reserve_before = token_client.balance(&reserve);
+
+    client.repay_credit(&borrower, &500_i128);
+
+    // fee = floor(500 * 500 / 10000) = 25
+    // reserve gets 500 - 25 = 475
+    assert_eq!(
+        token_client.balance(&client.contract_id),
+        contract_before + 25,
+        "contract should hold the skimmed fee"
+    );
+    assert_eq!(
+        token_client.balance(&reserve),
+        reserve_before + 475,
+        "reserve gets repayment minus fee"
+    );
+
+    let summary = client.get_protocol_summary();
+    assert_eq!(summary.treasury_balance, 25, "treasury balance matches fee");
+}
+
+/// Fee on a mixed principal + interest repayment.
+#[test]
+fn fee_on_mixed_principal_and_interest() {
+    let (env, client, borrower, token_address, reserve) = setup_minimal();
+
+    prepare_repay(
+        &env,
+        &client,
+        &borrower,
+        &token_address,
+        10_000_i128, // draw
+        11_000_i128, // repay
+        1_000_u32,   // interest rate bps (10%)
+        1_000_u32,   // fee bps (10%)
+    );
+
+    // Advance one year so interest accrues.
+    env.ledger().with_mut(|l| l.timestamp = 31_536_000);
+
+    let token_client = token::Client::new(&env, &token_address);
+    let contract_before = token_client.balance(&client.contract_id);
+    let reserve_before = token_client.balance(&reserve);
+
+    client.repay_credit(&borrower, &11_000_i128);
+
+    // effective_repay ≈ 10_999 (cap at utilized), fee = floor(10999 * 1000 / 10000) = 1099
+    // reserve gets 10999 - 1099 = 9900
+    let contract_delta = token_client.balance(&client.contract_id) - contract_before;
+    let reserve_delta = token_client.balance(&reserve) - reserve_before;
+    let total = contract_delta + reserve_delta;
+
+    assert_eq!(total, 10_999, "total tokens transferred = effective_repay");
+    assert_eq!(
+        contract_delta, 1_099,
+        "fee = 10% of 10999 = 1099"
+    );
+    assert_eq!(
+        reserve_delta, 9_900,
+        "reserve = 10999 - 1099 = 9900"
+    );
+}
+
+/// Fee via `repay_and_release_collateral` path.
+#[test]
+fn fee_with_repay_and_release_collateral() {
+    let (env, client, borrower, token_address, reserve) = setup_minimal();
+
+    let draw = 5_000_i128;
+    let collateral = 10_000_i128;
+
+    client.open_credit_line(&borrower, &draw, &500_u32, &50_u32);
+    let asset = token::StellarAssetClient::new(&env, &token_address);
+
+    // Fund borrower with collateral + repayment buffer.
+    asset.mint(&borrower, &(collateral + draw + 1_000));
+    asset.mint(&client.contract_id, &draw);
+
+    client.deposit_collateral(&borrower, &collateral);
+    client.draw_credit(&borrower, &draw);
+
+    // Set fee.
+    client.set_protocol_fee_bps(&300_u32); // 3% fee
+
+    let repay = 1_000_i128;
+    token::Client::new(&env, &token_address)
+        .approve(&borrower, &client.contract_id, &repay, &u32::MAX);
+
+    let token_client = token::Client::new(&env, &token_address);
+    let contract_before = token_client.balance(&client.contract_id);
+    let reserve_before = token_client.balance(&reserve);
+
+    client.repay_and_release_collateral(&borrower, &repay);
+
+    // fee = floor(1000 * 300 / 10000) = 30
+    // reserve gets 1000 - 30 = 970
+    assert_eq!(
+        token_client.balance(&client.contract_id),
+        contract_before + 30,
+        "fee skimmed in repay_and_release_collateral"
+    );
+    assert_eq!(
+        token_client.balance(&reserve),
+        reserve_before + 970,
+        "reserve gets remainder"
+    );
+
+    let summary = client.get_protocol_summary();
+    assert_eq!(summary.treasury_balance, 30);
+}
+
+/// Fee event is emitted with correct amounts.
+#[test]
+fn fee_event_emitted_on_repayment() {
+    let (env, client, borrower, token_address, _reserve) = setup_minimal();
+
+    prepare_repay(
+        &env,
+        &client,
+        &borrower,
+        &token_address,
+        1_000_i128,
+        500_i128,
+        500_u32,
+        500_u32,
+    );
+
+    client.repay_credit(&borrower, &500_i128);
+
+    // Locate the FeeAccruedEvent in the event log.
+    let events = env.events().all();
+    let fee_event = events
+        .iter()
+        .find(|e| {
+            let topic_str = format!("{:?}", e.0);
+            topic_str.contains("fee_accrd")
+        })
+        .expect("FeeAccruedEvent must be emitted");
+
+    let (_topics, data) = fee_event;
+    let fee_data: FeeAccruedEvent = data.clone().try_into().expect("valid FeeAccruedEvent");
+
+    assert_eq!(fee_data.borrower, borrower);
+    assert_eq!(fee_data.fee_amount, 25, "total fee = 25");
+    assert_eq!(fee_data.treasury_amount, 25, "default 100% to treasury");
+    assert_eq!(fee_data.bounty_amount, 0);
+    assert!(
+        fee_data.new_treasury_balance >= fee_data.treasury_amount,
+        "new_treasury_balance includes this fee"
+    );
+}
+
+/// Rounding: sub-basis-point fee floors to zero.
+#[test]
+fn fee_rounds_to_zero_when_below_one_unit() {
+    let (env, client, borrower, token_address, reserve) = setup_minimal();
+
+    prepare_repay(
+        &env,
+        &client,
+        &borrower,
+        &token_address,
+        10_000_i128,
+        5_000_i128,
+        500_u32,
+        1_u32, // 0.01% — sub-bps on 5000
+    );
+
+    let token_client = token::Client::new(&env, &token_address);
+    let reserve_before = token_client.balance(&reserve);
+
+    client.repay_credit(&borrower, &5_000_i128);
+
+    // fee = floor(5000 * 1 / 10000) = 0
+    // All 5000 goes to reserve.
+    assert_eq!(
+        token_client.balance(&reserve),
+        reserve_before + 5_000,
+        "entire repayment goes to reserve when fee rounds to zero"
+    );
+}
+
+/// Zero fee sends everything to reserve.
+#[test]
+fn zero_fee_sends_all_to_reserve() {
+    let (env, client, borrower, token_address, reserve) = setup_minimal();
+
+    prepare_repay(
+        &env,
+        &client,
+        &borrower,
+        &token_address,
+        1_000_i128,
+        500_i128,
+        500_u32,
+        0_u32,
+    );
+
+    let token_client = token::Client::new(&env, &token_address);
+    let contract_before = token_client.balance(&client.contract_id);
+    let reserve_before = token_client.balance(&reserve);
+
+    client.repay_credit(&borrower, &500_i128);
+
+    assert_eq!(
+        token_client.balance(&client.contract_id),
+        contract_before,
+        "no fee when fee_bps = 0"
+    );
+    assert_eq!(
+        token_client.balance(&reserve),
+        reserve_before + 500,
+        "all to reserve when fee_bps = 0"
+    );
+}


### PR DESCRIPTION
closes #605 

# feat: protocol fee skim on total repayment

## Description

Changes the protocol fee (`ProtocolFeeBps`) from applying only to the **interest component** of a repayment to applying to the **total repayment amount** (principal + interest). Previously, the fee was computed as `floor(interest_repaid × bps / 10_000)`; it is now computed as `floor(effective_repay × bps / 10_000)`.

Additionally, the `repay_and_release_collateral` path in `borrow.rs` previously had **no protocol fee logic at all** — the full repayment was transferred to the reserve without any skim. This path now also skims the protocol fee, matching the behavior of `repay_credit`.

The fee continues to be accrued into the contract via `accrue_protocol_fee` and split between treasury and bounty accumulators per `TreasuryFeeShareBps`, preserving the existing treasury/bounty mechanics and timelock-withdrawal security.

## Files Changed

### Modified

| File | Change |
|------|--------|
| `contracts/credit/src/lib.rs` | Fee calculation changed from `interest_repaid` to `effective_repay` |
| `contracts/credit/src/borrow.rs` | Added protocol fee skim to `repay_and_release_collateral` (was absent) |
| `contracts/credit/src/storage.rs` | Updated `ProtocolFeeBps` doc comment |
| `contracts/credit/src/fees.rs` | Updated module docstring |
| `contracts/credit/tests/protocol_fee.rs` | Updated 3 tests for new fee-on-total semantics |
| `contracts/credit/tests/fee_split.rs` | Updated 5 tests (fee amount changed from 10 to 110) |

### Added

| File | Content |
|------|---------|
| `contracts/credit/tests/protocol_fee_total_repayment.rs` | 6 focused tests covering principal-only, mixed, repay-and-release, event emission, rounding, zero-fee |

## API Changes

**None.** No new storage keys, entrypoints, or event topics were added. The semantics of the existing `ProtocolFeeBps` parameter changed from *"fee on interest portion"* to *"fee on total repayment"*. Existing integrations will observe a larger fee amount for the same `ProtocolFeeBps` value if interest was being paid. Backward-compatible deployments can set `ProtocolFeeBps = 0` to disable the fee entirely.

## Security Considerations

- Overflow-safe: uses `saturating_sub` and `checked` arithmetic (`apply_bps` wraps `mul_div` with checked multiplication)
- No new storage keys or admin entrypoints
- Reentrancy guard already protects both repayment paths
- The fee cap `MAX_PROTOCOL_FEE_BPS = 1000` (10%) bounds maximum skim per repayment
- Treasury/bounty split and timelock-withdrawal remain unchanged

## Test Plan

All existing fee tests were updated for the new calculation. Six new tests cover:

- **Principal-only** — fee on repayment with zero interest elapsed
- **Mixed principal + interest** — fee on combined repayment after accrual
- **repay_and_release_collateral path** — ensures fee is skimmed in this code path
- **Event emission** — verifies `FeeAccruedEvent` contains correct amounts
- **Rounding to zero** — sub-basis-point fee correctly floors to 0
- **Zero fee** — `ProtocolFeeBps = 0` sends entire repayment to reserve

## Verification

- `cargo check --workspace` — blocked by 142 pre-existing errors (MSVC linker path, doc ordering, missing type imports) unrelated to these changes
- `cargo test` — requires MSVC linker fix (environment issue) to execute; test values are manually verified against the new formula
