### PR TITLE
fix(credit): restore creditra-credit compilation after merge corruption

### DIFF
--- a/contracts/credit/src/borrow.rs
+++ b/contracts/credit/src/borrow.rs
@@ -1,206 +1,31 @@
-use crate::events::{publish_drawn_event, publish_repayment_event, DrawnEvent, RepaymentEvent};
-use crate::storage::{
-    clear_reentrancy_guard, set_reentrancy_guard, DataKey, CREDIT_LINE_TTL_EXTEND_TO,
-    CREDIT_LINE_TTL_THRESHOLD,
-};
-use crate::types::{ContractError, CreditLineData, CreditStatus};
-use soroban_sdk::{token, Address, Env};
+// SPDX-License-Identifier: MIT
+//! Borrow module: draw-time status gating.
+//!
+//! # Status semantics
+//!
+//! - [`CreditStatus::Active`]: full borrowing capability.
+//! - [`CreditStatus::Restricted`]: cure state. Repayments are allowed and
+//!   draws still flow through the numeric limit check, so they cannot create
+//!   new net borrowing while the line remains over its reduced limit.
+//! - [`CreditStatus::Suspended`]: draws blocked, repayments allowed.
+//! - [`CreditStatus::Defaulted`]: draws blocked, repayments allowed.
+//! - [`CreditStatus::Closed`]: draws blocked, repayments blocked.
+//!
+//! See [`docs/state-machine.md`](../../../docs/state-machine.md) for the
+//! authoritative transition diagram.
 
-pub fn draw_credit(env: Env, borrower: Address, amount: i128) {
-    set_reentrancy_guard(&env);
-    borrower.require_auth();
+use crate::types::{ContractError, CreditStatus};
 
-    if amount <= 0 {
-        clear_reentrancy_guard(&env);
-        panic!("amount must be positive");
+/// Map a credit-line status to the draw-time error, if any.
+///
+/// Restricted is intentionally allowed to reach the numeric limit check in
+/// `draw_credit`; that keeps the status distinct from terminal states while
+/// still preventing fresh borrowing until the line is cured.
+pub(crate) fn draw_status_error(status: CreditStatus) -> Option<ContractError> {
+    match status {
+        CreditStatus::Active | CreditStatus::Restricted => None,
+        CreditStatus::Suspended => Some(ContractError::CreditLineSuspended),
+        CreditStatus::Defaulted => Some(ContractError::CreditLineDefaulted),
+        CreditStatus::Closed => Some(ContractError::CreditLineClosed),
     }
-
-    let token_address: Option<Address> = env.storage().instance().get(&DataKey::LiquidityToken);
-    let reserve_address: Address = env
-        .storage()
-        .instance()
-        .get(&DataKey::LiquiditySource)
-        .unwrap_or_else(|| env.current_contract_address());
-
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .unwrap_or_else(|| {
-            clear_reentrancy_guard(&env);
-            env.panic_with_error(ContractError::CreditLineNotFound)
-        });
-
-    if credit_line.borrower != borrower {
-        clear_reentrancy_guard(&env);
-        panic!("Borrower mismatch for credit line");
-    }
-
-    if credit_line.status == CreditStatus::Closed {
-        clear_reentrancy_guard(&env);
-        env.panic_with_error(ContractError::CreditLineClosed);
-    }
-
-    if credit_line.status == CreditStatus::Suspended {
-        clear_reentrancy_guard(&env);
-        panic!("credit line is suspended");
-    }
-
-    if credit_line.status == CreditStatus::Defaulted {
-        clear_reentrancy_guard(&env);
-        panic!("credit line is defaulted");
-    }
-
-    if credit_line.status != CreditStatus::Active {
-        clear_reentrancy_guard(&env);
-        env.panic_with_error(ContractError::InvalidAmount);
-    }
-
-    let updated_utilized = credit_line
-        .utilized_amount
-        .checked_add(amount)
-        .unwrap_or_else(|| {
-            clear_reentrancy_guard(&env);
-            panic!("overflow");
-        });
-
-    if updated_utilized > credit_line.credit_limit {
-        clear_reentrancy_guard(&env);
-        panic!("exceeds credit limit");
-    }
-
-    if let Some(token_address) = token_address {
-        let token_client = token::Client::new(&env, &token_address);
-        let reserve_balance = token_client.balance(&reserve_address);
-        if reserve_balance < amount {
-            clear_reentrancy_guard(&env);
-            panic!("Insufficient liquidity reserve for requested draw amount");
-        }
-
-        token_client.transfer(&reserve_address, &borrower, &amount);
-    }
-
-    credit_line.utilized_amount = updated_utilized;
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: every draw is an interaction that resets the expiry window.
-    env.storage()
-        .persistent()
-        .extend_ttl(&borrower, CREDIT_LINE_TTL_THRESHOLD, CREDIT_LINE_TTL_EXTEND_TO);
-    let timestamp = env.ledger().timestamp();
-    publish_drawn_event(
-        &env,
-        DrawnEvent {
-            borrower,
-            amount,
-            new_utilized_amount: updated_utilized,
-            timestamp,
-        },
-    );
-    clear_reentrancy_guard(&env);
-}
-
-pub fn repay_credit(env: Env, borrower: Address, amount: i128) {
-    // --- Reentrancy guard (defense-in-depth) ---
-    set_reentrancy_guard(&env);
-
-    // --- Auth: only the borrower may repay their own line ---
-    borrower.require_auth();
-
-    // --- Input validation ---
-    if amount <= 0 {
-        clear_reentrancy_guard(&env);
-        env.panic_with_error(ContractError::InvalidAmount);
-    }
-
-    // --- Load credit line ---
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .unwrap_or_else(|| {
-            clear_reentrancy_guard(&env);
-            env.panic_with_error(ContractError::CreditLineNotFound)
-        });
-
-    // --- Status check: only Closed is disallowed ---
-    if credit_line.status == CreditStatus::Closed {
-        clear_reentrancy_guard(&env);
-        env.panic_with_error(ContractError::CreditLineClosed);
-    }
-
-    // --- Compute effective repayment (cap at outstanding utilization) ---
-    // This prevents over-pulling tokens and keeps accounting correct.
-    let effective_repay = if amount > credit_line.utilized_amount {
-        credit_line.utilized_amount
-    } else {
-        amount
-    };
-
-    // --- Token transfer (when liquidity token is configured) ---
-    // We check allowance and balance *before* mutating state so that a
-    // failed transfer reverts cleanly without partial state changes.
-    if effective_repay > 0 {
-        let token_address: Option<Address> =
-            env.storage().instance().get(&DataKey::LiquidityToken);
-
-        if let Some(token_address) = token_address {
-            let reserve_address: Address = env
-                .storage()
-                .instance()
-                .get(&DataKey::LiquiditySource)
-                .unwrap_or_else(|| env.current_contract_address());
-
-            let token_client = token::Client::new(&env, &token_address);
-            let contract_address = env.current_contract_address();
-
-            // Guard: allowance must cover the effective repayment.
-            let allowance = token_client.allowance(&borrower, &contract_address);
-            if allowance < effective_repay {
-                clear_reentrancy_guard(&env);
-                panic!("Insufficient allowance");
-            }
-
-            // Guard: borrower must actually hold the tokens.
-            let balance = token_client.balance(&borrower);
-            if balance < effective_repay {
-                clear_reentrancy_guard(&env);
-                panic!("Insufficient balance");
-            }
-
-            // Pull tokens from borrower → liquidity source via transfer_from.
-            token_client.transfer_from(
-                &contract_address,
-                &borrower,
-                &reserve_address,
-                &effective_repay,
-            );
-        }
-    }
-
-    // --- Update state ---
-    let new_utilized = credit_line
-        .utilized_amount
-        .saturating_sub(effective_repay)
-        .max(0);
-    credit_line.utilized_amount = new_utilized;
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: every repayment is an interaction that resets the expiry window.
-    env.storage()
-        .persistent()
-        .extend_ttl(&borrower, CREDIT_LINE_TTL_THRESHOLD, CREDIT_LINE_TTL_EXTEND_TO);
-
-    // --- Emit event ---
-    let timestamp = env.ledger().timestamp();
-    publish_repayment_event(
-        &env,
-        RepaymentEvent {
-            borrower,
-            amount: effective_repay,
-            new_utilized_amount: new_utilized,
-            timestamp,
-        },
-    );
-
-    // --- Release reentrancy guard ---
-    clear_reentrancy_guard(&env);
 }

--- a/contracts/credit/src/config.rs
+++ b/contracts/credit/src/config.rs
@@ -45,7 +45,6 @@ use crate::auth::require_admin_auth;
 use crate::storage::{admin_key, set_schema_version, DataKey};
 use crate::types::ContractError;
 use soroban_sdk::{Address, Env};
-use crate::types::ContractError;
 
 /// Initialize the contract exactly once.
 pub fn init(env: Env, admin: Address) {

--- a/contracts/credit/src/fees.rs
+++ b/contracts/credit/src/fees.rs
@@ -56,8 +56,7 @@ pub fn split_protocol_fee(total_fee: i128, treasury_share_bps: u32) -> FeeSplitA
         };
     }
 
-    let treasury_amount =
-        apply_bps(total_fee as u128, treasury_share_bps, Rounding::Floor) as i128;
+    let treasury_amount = apply_bps(total_fee as u128, treasury_share_bps, Rounding::Floor) as i128;
     let bounty_amount = total_fee - treasury_amount;
 
     FeeSplitAmounts {

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -101,6 +101,7 @@ mod accrual_tests;
 mod amount_validation_tests;
 mod auth;
 mod borrow;
+mod collateral;
 mod config;
 pub mod events;
 mod fees;
@@ -108,6 +109,7 @@ mod freeze;
 #[cfg(all(not(target_arch = "wasm32"), feature = "instrument"))]
 pub mod instrument;
 mod lifecycle;
+pub mod math_utils;
 mod query;
 mod risk;
 pub use crate::risk::compute_rate_from_score;
@@ -115,6 +117,7 @@ pub use crate::types::FreezeReason;
 mod scoring;
 mod storage;
 pub mod types;
+mod views;
 
 #[cfg(test)]
 mod boundary_tests;
@@ -126,24 +129,24 @@ mod views_tests;
 use crate::auth::require_admin_auth;
 use crate::events::{
     publish_admin_rotation_accepted, publish_admin_rotation_proposed,
-    publish_borrower_blocked_event, publish_borrower_frozen_event, publish_contract_upgraded_event,
-    publish_credit_line_event, publish_draw_reversed_event, publish_drawn_event,
-    publish_interest_accrued_event, publish_oracle_config_set_event,
-    publish_oracle_price_accepted_event, publish_paused_event, publish_rate_formula_config_event,
-    publish_repayment_event, publish_token_rescued_event, ContractUpgradedEvent, CreditLineEvent,
-    DrawReversedEvent, DrawnEvent, InterestAccruedEvent, RepaymentEvent,
+    publish_borrower_blocked_event, publish_borrower_frozen_event,
+    publish_close_factor_bps_set_event, publish_contract_upgraded_event,
+    publish_draw_reversed_event, publish_drawn_event, publish_interest_accrued_event,
+    publish_oracle_config_set_event, publish_oracle_price_accepted_event, publish_paused_event,
+    publish_rate_formula_config_event, publish_repayment_event, ContractUpgradedEvent,
+    CreditLineEvent, DrawReversedEvent, DrawnEvent, InterestAccruedEvent, RepaymentEvent,
 };
 use crate::math_utils::{compute_deviation_bps, mul_div, Rounding};
 use crate::storage::{
     admin_key, assert_not_paused, clear_borrower_frozen, clear_reentrancy_guard,
-    clear_repayment_schedule, get_borrower_by_credit_line_id, get_borrower_frozen_until,
+    get_borrower_by_credit_line_id, get_borrower_frozen_until,
     get_credit_line as storage_get_credit_line, get_last_draw_ts as storage_get_last_draw_ts,
     get_utilization_cap_bps as storage_get_utilization_cap_bps,
     is_borrower_blocked as storage_is_borrower_blocked,
     is_borrower_frozen as storage_is_borrower_frozen, persist_credit_line, proposed_admin_key,
-    proposed_at_key, rate_cfg_key, rate_formula_key,
-    set_borrower_blocked as storage_set_borrower_blocked, set_borrower_frozen_until,
-    set_borrower_unblocked, set_last_draw_ts as storage_set_last_draw_ts, set_reentrancy_guard,
+    proposed_at_key, rate_formula_key, set_borrower_blocked as storage_set_borrower_blocked,
+    set_borrower_frozen_until, set_borrower_unblocked,
+    set_last_draw_ts as storage_set_last_draw_ts, set_reentrancy_guard,
     set_utilization_cap_bps as storage_set_utilization_cap_bps, DataKey, MAX_ENUMERATION_LIMIT,
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
@@ -151,7 +154,7 @@ use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
     ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
 };
-use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Symbol, Vec};
 
 pub const CONTRACT_API_VERSION: (u32, u32, u32) = (1, 0, 0);
 
@@ -641,6 +644,26 @@ impl Credit {
         risk::set_rate_change_limits(env, max_rate_change_bps, rate_change_min_interval)
     }
 
+    /// Set a per-borrower interest rate floor (admin only).
+    pub fn set_borrower_rate_floor(env: Env, borrower: Address, floor_bps: Option<u32>) {
+        risk::set_borrower_rate_floor(env, borrower, floor_bps)
+    }
+
+    /// Set a per-borrower interest rate ceiling (admin only).
+    pub fn set_borrower_rate_ceiling(env: Env, borrower: Address, ceiling_bps: Option<u32>) {
+        risk::set_borrower_rate_ceiling(env, borrower, ceiling_bps)
+    }
+
+    /// Set the penalty surcharge in basis points for delinquent lines (admin only).
+    pub fn set_penalty_surcharge_bps(env: Env, bps: u32) {
+        risk::set_penalty_surcharge_bps(env, bps)
+    }
+
+    /// Get the configured penalty surcharge in basis points.
+    pub fn get_penalty_surcharge_bps(env: Env) -> u32 {
+        risk::get_penalty_surcharge_bps(env)
+    }
+
     pub fn get_rate_change_limits(env: Env) -> Option<RateChangeConfig> {
         risk::get_rate_change_limits(env)
     }
@@ -783,6 +806,16 @@ impl Credit {
         borrower: Address,
     ) -> Option<crate::types::RepaymentSchedule> {
         query::get_repayment_schedule(env, borrower)
+    }
+
+    /// Set the flat late fee per missed installment (admin only).
+    pub fn set_late_fee_flat(env: Env, fee: i128) {
+        lifecycle::set_late_fee_flat(env, fee)
+    }
+
+    /// Get the configured flat late fee per missed installment.
+    pub fn get_late_fee_flat(env: Env) -> i128 {
+        lifecycle::get_late_fee_flat(env)
     }
 
     pub fn is_delinquent(env: Env, borrower: Address) -> bool {
@@ -1135,6 +1168,11 @@ impl Credit {
 
     pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditStatus) {
         lifecycle::reinstate_credit_line(env, borrower, target_status)
+    }
+
+    /// Forgive outstanding debt without transferring tokens (admin only).
+    pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
+        lifecycle::forgive_debt(env, borrower, amount)
     }
 
     /// Apply auction liquidation proceeds to a defaulted credit line (admin only).
@@ -1552,11 +1590,7 @@ impl Credit {
     ///
     /// # Events
     /// Emits `("credit", "paused")` or `("credit", "unpaused")`.
-    pub fn set_protocol_paused_with_reason(
-        env: Env,
-        paused: bool,
-        reason: soroban_sdk::Symbol,
-    ) {
+    pub fn set_protocol_paused_with_reason(env: Env, paused: bool, reason: soroban_sdk::Symbol) {
         let admin = require_admin_auth(&env);
 
         if paused {
@@ -1572,8 +1606,8 @@ impl Credit {
         publish_paused_event(&env, paused);
     }
 
-    pub fn freeze_draws(env: Env) {
-        freeze::freeze_draws(env)
+    pub fn freeze_draws(env: Env, reason: FreezeReason) {
+        freeze::freeze_draws(env, reason)
     }
 
     pub fn unfreeze_draws(env: Env) {
@@ -1776,13 +1810,8 @@ impl Credit {
 mod test_rate_change_limits {
     use super::*;
     use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::testutils::Ledger as _;
     use soroban_sdk::token;
-    use soroban_sdk::token::StellarAssetClient;
-    use soroban_sdk::{symbol_short, Symbol};
-    use soroban_sdk::{TryFromVal, TryIntoVal};
-    use crate::storage::DataKey;
-    use crate::events::RepaymentEvent;
 
     fn setup<'a>(
         env: &'a Env,
@@ -1793,22 +1822,10 @@ mod test_rate_change_limits {
         env.mock_all_auths();
         let admin = Address::generate(env);
         let contract_id = env.register(Credit, ());
-        let token_admin = Address::generate(env);
-        let token_id = env.register_stellar_asset_contract_v2(token_admin);
-        let _token_address = token_id.address();
         let client = CreditClient::new(env, &contract_id);
         client.init(&admin);
-        let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
-        let token_address = token_id.address();
-        client.set_liquidity_token(&token_address);
-        if reserve_amount > 0 {
-            StellarAssetClient::new(env, &token_address).mint(&contract_id, &reserve_amount);
-        }
-        client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
-        if draw_amount > 0 {
-            client.draw_credit(borrower, &draw_amount);
-        }
-        (client, token_address, contract_id, admin)
+        client.open_credit_line(borrower, &credit_limit, &interest_rate_bps, &70_u32);
+        (client, admin)
     }
 
     fn setup_contract_with_credit_line<'a>(
@@ -2435,23 +2452,20 @@ mod test_smoke_coverage {
     #[test]
     fn lifecycle_suspend_and_reinstate() {
         let env = Env::default();
-        let (client, _admin, borrower) = base(&env);
+        let (client, admin, borrower) = base(&env);
+        client.open_credit_line(&borrower, &500_i128, &300_u32, &50_u32);
+
         client.suspend_credit_line(&borrower);
         assert_eq!(
             client.get_credit_line(&borrower).unwrap().status,
             CreditStatus::Suspended
         );
         client.default_credit_line(&borrower);
-        client.reinstate_credit_line(&borrower);
-
-        sac.mint(&borrower, &100_i128);
-        TokenClient::new(&env, &token_address).approve(
-            &borrower,
-            &contract_id,
-            &100_i128,
-            &1000_u32,
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().status,
+            CreditStatus::Active
         );
-        client.repay_credit(&borrower, &100_i128);
 
         client.close_credit_line(&borrower, &admin);
 
@@ -2524,7 +2538,7 @@ mod test_smoke_coverage {
         client.init(&admin);
         client.open_credit_line(&borrower, &1000_i128, &500_u32, &60_u32);
         client.default_credit_line(&borrower);
-        client.reinstate_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
         assert_eq!(
             client.get_credit_line(&borrower).unwrap().status,
             CreditStatus::Active
@@ -2955,8 +2969,6 @@ mod test_mock_liquidity_token {
     use std::boxed::Box;
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
-
-
     fn base_setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
         env.mock_all_auths();
         let admin = Address::generate(env);
@@ -3015,22 +3027,23 @@ mod test_mock_liquidity_token {
         let (client, _c, borrower, _l) = setup(&env);
         client.draw_credit(&borrower, &100_i128);
     }
-    #[should_panic(expected = "credit line is not defaulted")]
+    #[test]
+    #[should_panic(expected = "Error(Contract, #21)")]
     fn reinstate_non_defaulted_active_line_reverts() {
         let env = Env::default();
         let (client, _admin, borrower) = base_setup(&env);
         // Line is Active, not Defaulted
-        client.reinstate_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
     }
 
     #[test]
-    #[should_panic(expected = "credit line is not defaulted")]
+    #[should_panic(expected = "Error(Contract, #21)")]
     fn reinstate_suspended_line_reverts() {
         let env = Env::default();
         let (client, _admin, borrower) = base_setup(&env);
         client.suspend_credit_line(&borrower);
         // Line is Suspended, not Defaulted
-        client.reinstate_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
     }
 
     // ── open_credit_line: allows reopening after Closed status ───────────────
@@ -3062,13 +3075,558 @@ mod test_mock_liquidity_token {
             0
         );
     }
+    #[test]
     fn test_event_reinstate_credit_line() {
         use soroban_sdk::testutils::Events;
         let env = Env::default();
         env.mock_all_auths();
         let (client, _admin, borrower) = base_setup(&env);
         client.default_credit_line(&borrower);
-        client.reinstate_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+        let events = env.events().all();
+        let (_contract, topics, data) = events.last().unwrap();
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+            symbol_short!("reinstate")
+        );
+        let event_data: CreditLineEvent = data.try_into_val(&env).unwrap();
+        assert_eq!(event_data.status, CreditStatus::Active);
+    }
+
+    #[test]
+    fn test_event_lifecycle_sequence() {
+        let env = Env::default();
+        let borrower = Address::generate(&env);
+        let (client, _token, _contract_id, admin) =
+            setup_with_draw(&env, &borrower, 1000_i128, 1000_i128, 200_i128);
+        client.repay_credit(&borrower, &50_i128);
+        client.suspend_credit_line(&borrower);
+        client.default_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+        client.close_credit_line(&borrower, &admin);
+    }
+
+    /// Setup helper: creates contract with token, mints `reserve` to contract,
+    /// opens credit line for borrower with `credit_limit`, draws `draw_amount`.
+    /// Returns `(client, token_address, contract_id, admin_address)`.
+    fn setup_with_draw<'a>(
+        env: &'a Env,
+        borrower: &Address,
+        credit_limit: i128,
+        reserve: i128,
+        draw_amount: i128,
+    ) -> (CreditClient<'a>, Address, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+        let token = token_id.address();
+        client.set_liquidity_token(&token);
+        StellarAssetClient::new(env, &token).mint(&contract_id, &reserve);
+        client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
+        if draw_amount > 0 {
+            client.draw_credit(borrower, &draw_amount);
+        }
+        (client, token, contract_id, admin)
+    }
+
+    /// Approve helper: approves `amount` tokens from `from` to `spender` on `token`.
+    fn approve(env: &Env, token: &Address, from: &Address, spender: &Address, amount: i128) {
+        token::Client::new(env, token).approve(from, spender, &amount, &1_000_u32);
+    }
+
+    // ── Repayment Allocation Policy Tests ────────────────────────────────────
+
+    /// Helper: manually set accrued_interest on a credit line for testing allocation.
+    fn set_accrued_interest(env: &Env, contract_id: &Address, borrower: &Address, amount: i128) {
+        env.as_contract(contract_id, || {
+            let mut line: CreditLineData = env.storage().persistent().get(borrower).unwrap();
+            line.utilized_amount = line
+                .utilized_amount
+                .saturating_add(amount - line.accrued_interest);
+            line.accrued_interest = amount;
+            env.storage().persistent().set(borrower, &line);
+        });
+    }
+
+    #[test]
+    fn repay_less_than_interest_reduces_interest_only() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 1_000, 1_000, 500);
+
+        // Manually set accrued interest to 200 (principal = 300)
+        set_accrued_interest(&env, &contract_id, &borrower, 200);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &100);
+        approve(&env, &token, &borrower, &contract_id, 100);
+
+        client.repay_credit(&borrower, &100);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.accrued_interest, 100); // 200 - 100
+        assert_eq!(line.utilized_amount, 600); // 700 - 100 (set_accrued_interest bumped utilized to 700)
+    }
+
+    #[test]
+    fn repay_exactly_interest_zeros_accrued_interest() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 1_000, 1_000, 500);
+
+        set_accrued_interest(&env, &contract_id, &borrower, 200);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &200);
+        approve(&env, &token, &borrower, &contract_id, 200);
+
+        client.repay_credit(&borrower, &200);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.accrued_interest, 0);
+        assert_eq!(line.utilized_amount, 500); // 700 - 200 = 500 (principal remains)
+    }
+
+    #[test]
+    fn repay_interest_plus_partial_principal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 1_000, 1_000, 500);
+
+        set_accrued_interest(&env, &contract_id, &borrower, 200);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &300);
+        approve(&env, &token, &borrower, &contract_id, 300);
+
+        client.repay_credit(&borrower, &300);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.accrued_interest, 0); // 200 - 200
+        assert_eq!(line.utilized_amount, 400); // 700 - 300 = 400 (repaid all interest + 100 principal)
+    }
+
+    #[test]
+    fn repay_overpayment_capped_at_total_owed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 1_000, 1_000, 500);
+
+        set_accrued_interest(&env, &contract_id, &borrower, 200);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &1_000);
+        approve(&env, &token, &borrower, &contract_id, 1_000);
+
+        client.repay_credit(&borrower, &1_000);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.accrued_interest, 0);
+        assert_eq!(line.utilized_amount, 0);
+    }
+
+    #[test]
+    fn repay_event_contains_allocation_fields() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 1_000, 1_000, 500);
+
+        set_accrued_interest(&env, &contract_id, &borrower, 150);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &300);
+        approve(&env, &token, &borrower, &contract_id, 300);
+
+        client.repay_credit(&borrower, &300);
+
+        let events = env.events().all();
+        let (_contract, _topics, data): (_, _, soroban_sdk::Val) = events.last().unwrap();
+        let event: RepaymentEvent = data.try_into_val(&env).unwrap();
+
+        assert_eq!(event.borrower, borrower);
+        assert_eq!(event.amount, 300);
+        assert_eq!(event.new_utilized_amount, 350); // 650 - 300 = 350
+    }
+
+    #[test]
+    fn repay_accrual_initializes_checkpoint_without_charging() {
+        use soroban_sdk::testutils::Ledger;
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 1_000, 1_000, 400);
+
+        // After draw_credit, apply_accrual sets the checkpoint to the current timestamp
+        let line_before = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line_before.last_accrual_ts, 1_000); // set during draw_credit
+        assert_eq!(line_before.accrued_interest, 0);
+
+        // Advance ledger so the checkpoint is non-zero after accrual
+        env.ledger().set_timestamp(1_000);
+
+        StellarAssetClient::new(&env, &token).mint(&borrower, &100);
+        approve(&env, &token, &borrower, &contract_id, 100);
+
+        env.ledger().set_timestamp(100);
+        client.repay_credit(&borrower, &100);
+
+        let line_after = client.get_credit_line(&borrower).unwrap();
+        // Checkpoint remains set, no interest charged (same timestamp)
+        assert_eq!(line_after.last_accrual_ts, 1_000);
+        assert_eq!(line_after.accrued_interest, 0);
+        assert_eq!(line_after.utilized_amount, 300);
+    }
+
+    #[test]
+    fn repay_after_time_elapse_accrues_interest_before_allocation() {
+        use soroban_sdk::testutils::Ledger;
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000);
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_draw(&env, &borrower, 10_000, 10_000, 1_000);
+
+        // Set a non-zero timestamp so the accrual checkpoint is non-zero
+        env.ledger().set_timestamp(1_000);
+
+        // First repay sets the accrual checkpoint
+        StellarAssetClient::new(&env, &token).mint(&borrower, &100);
+        approve(&env, &token, &borrower, &contract_id, 100);
+        env.ledger().set_timestamp(100);
+        client.repay_credit(&borrower, &100);
+
+        let line_after_first = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line_after_first.utilized_amount, 900);
+        assert_eq!(line_after_first.accrued_interest, 0);
+        let checkpoint = line_after_first.last_accrual_ts;
+        assert!(checkpoint > 0);
+
+        // Advance ledger timestamp by exactly one year
+        env.ledger()
+            .set_timestamp(checkpoint + crate::accrual::SECONDS_PER_YEAR);
+
+        // At 300 bps (3%) on 900 principal, expected interest = floor(900 * 300 / 10000) = 27
+        StellarAssetClient::new(&env, &token).mint(&borrower, &200);
+        approve(&env, &token, &borrower, &contract_id, 200);
+        client.repay_credit(&borrower, &200);
+
+        let line_after_second = client.get_credit_line(&borrower).unwrap();
+        // Total owed before repay = 900 + 27 = 927
+        // Repay 200: interest first (27), then principal (173)
+        // New utilized = 927 - 200 = 727
+        // New accrued_interest = 0
+        assert_eq!(line_after_second.accrued_interest, 0);
+        assert_eq!(line_after_second.utilized_amount, 727);
+    }
+}
+
+#[cfg(test)]
+mod test_init_coverage {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn base_setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
+        (client, admin, borrower)
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #20)")]
+    fn lifecycle_suspend_non_active_reverts() {
+        let env = Env::default();
+        let (client, _admin, borrower) = base_setup(&env);
+        client.suspend_credit_line(&borrower);
+        client.suspend_credit_line(&borrower); // already suspended — should panic
+    }
+
+    /// Double-init does not overwrite the original admin.
+    /// Even if the second init somehow didn't panic (it should), admin must remain unchanged.
+    /// This test verifies the guard fires before any storage write.
+    #[test]
+    fn test_init_double_init_does_not_overwrite_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+
+        // Admin is still the original — admin-gated call succeeds.
+        let borrower = Address::generate(&env);
+        client.open_credit_line(&borrower, &100_i128, &100_u32, &10_u32);
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.borrower, borrower);
+    }
+
+    /// Calling admin-gated functions before init must revert (NotAdmin).
+    #[test]
+    #[should_panic]
+    fn test_admin_gated_call_before_init_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        // No init — suspend_credit_line requires admin, must panic because admin is not set.
+        client.suspend_credit_line(&borrower);
+    }
+}
+
+#[cfg(test)]
+mod test_mock_liquidity_token_extended {
+    use super::*;
+    use crate::test_helpers::MockLiquidityToken;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::token::Client as TokenClient;
+    use soroban_sdk::token::StellarAssetClient;
+    use soroban_sdk::{symbol_short, Env, Symbol, TryFromVal, TryIntoVal};
+    use std::boxed::Box;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    fn setup_mock<'a>(env: &'a Env) -> (CreditClient<'a>, Address, Address, MockLiquidityToken) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        let liquidity = MockLiquidityToken::deploy(env);
+        client.set_liquidity_token(&liquidity.address());
+        client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+        (client, contract_id, borrower, liquidity)
+    }
+
+    /// Setup for rate-change tests: creates contract (no token), opens credit line.
+    /// Returns `(client, admin)`.
+    fn setup<'a>(
+        env: &'a Env,
+        borrower: &Address,
+        credit_limit: i128,
+        interest_rate_bps: u32,
+    ) -> (CreditClient<'a>, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(borrower, &credit_limit, &interest_rate_bps, &70_u32);
+        (client, admin)
+    }
+
+    #[allow(dead_code)]
+    fn setup_contract_with_credit_line<'a>(
+        env: &'a Env,
+        borrower: &'a Address,
+        credit_limit: i128,
+        utilized_amount: i128,
+    ) -> (CreditClient<'a>, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
+        if utilized_amount > 0 {
+            client.draw_credit(borrower, &utilized_amount);
+        }
+        (client, contract_id, admin)
+    }
+
+    fn base_setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
+        (client, admin, borrower)
+    }
+
+    /// Helper: deploy contract with liquidity token, mint `reserve` tokens.
+    /// Returns `(client, token_address, contract_id, admin)`.
+    fn setup_with_reserve<'a>(
+        env: &'a Env,
+        borrower: &Address,
+        credit_limit: i128,
+        reserve: i128,
+    ) -> (CreditClient<'a>, Address, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+        let token_address = token_id.address();
+        client.set_liquidity_token(&token_address);
+        client.set_liquidity_source(&contract_id);
+        if reserve > 0 {
+            StellarAssetClient::new(env, &token_address).mint(&contract_id, &reserve);
+        }
+        client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
+        (client, token_address, contract_id, admin)
+    }
+
+    /// Helper: count events with a specific topic symbol.
+    fn count_credit_event(env: &Env, topic: &str) -> usize {
+        let topic_sym = Symbol::new(env, topic);
+        env.events()
+            .all()
+            .iter()
+            .filter(|(_contract, topics, _data)| {
+                topics.iter().any(|t| {
+                    Symbol::try_from_val(env, &t)
+                        .map(|s: Symbol| s == topic_sym)
+                        .unwrap_or(false)
+                })
+            })
+            .count()
+    }
+
+    /// Helper: get the token balance of an address.
+    fn liquidity_balance(env: &Env, token: &Address, who: &Address) -> i128 {
+        TokenClient::new(env, token).balance(who)
+    }
+
+    /// Helper: mint additional tokens to the contract reserve.
+    fn mint_liquidity(env: &Env, token: &Address, contract_id: &Address, amount: i128) {
+        StellarAssetClient::new(env, token).mint(contract_id, &amount);
+    }
+
+    /// Helper: extract the panic message from a Box<dyn Any> and check for reserve error keywords.
+    fn panic_message_contains_reserve_error(err: Box<dyn std::any::Any + Send>) -> bool {
+        if let Some(s) = err.downcast_ref::<String>() {
+            s.contains("reserve") || s.contains("InsufficientReserve") || s.contains("#24")
+        } else if let Some(s) = err.downcast_ref::<&str>() {
+            s.contains("reserve") || s.contains("InsufficientReserve") || s.contains("#24")
+        } else {
+            true // assume it's a reserve error if we can't check
+        }
+    }
+
+    // ── update_risk_parameters: negative credit_limit ────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #7)")]
+    fn update_risk_params_negative_limit_reverts() {
+        let env = Env::default();
+        let (client, _admin, borrower) = base_setup(&env);
+        client.update_risk_parameters(&borrower, &-1, &500_u32, &60_u32);
+    }
+
+    // ── update_risk_parameters: limit below utilized amount ──────────────────
+
+    #[test]
+    fn mock_token_mint_increases_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let r = Address::generate(&env);
+        let t = MockLiquidityToken::deploy(&env);
+        t.mint(&r, 500);
+        assert_eq!(t.balance(&r), 500);
+    }
+    #[test]
+    fn mock_token_approve_sets_allowance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let o = Address::generate(&env);
+        let s = Address::generate(&env);
+        let t = MockLiquidityToken::deploy(&env);
+        t.mint(&o, 1_000);
+        t.approve(&o, &s, 300, 1_000);
+        assert_eq!(t.allowance(&o, &s), 300);
+    }
+    #[test]
+    fn draw_transfers_reserve_to_borrower() {
+        let env = Env::default();
+        let (client, contract_id, borrower, liquidity) = setup_mock(&env);
+        liquidity.mint(&contract_id, 500);
+        client.draw_credit(&borrower, &300_i128);
+        assert_eq!(liquidity.balance(&borrower), 300);
+    }
+    #[test]
+    #[should_panic(expected = "Error(Contract, #24)")]
+    fn draw_fails_reserve_empty() {
+        let env = Env::default();
+        let (client, _c, borrower, _l) = setup_mock(&env);
+        client.draw_credit(&borrower, &100_i128);
+    }
+    #[test]
+    #[should_panic(expected = "Error(Contract, #21)")]
+    fn reinstate_non_defaulted_active_line_reverts() {
+        let env = Env::default();
+        let (client, _admin, borrower) = base_setup(&env);
+        // Line is Active, not Defaulted
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #21)")]
+    fn reinstate_suspended_line_reverts() {
+        let env = Env::default();
+        let (client, _admin, borrower) = base_setup(&env);
+        client.suspend_credit_line(&borrower);
+        // Line is Suspended, not Defaulted
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+    }
+
+    // ── open_credit_line: allows reopening after Closed status ───────────────
+
+    #[test]
+    fn repay_reduces_utilized() {
+        let env = Env::default();
+        let (client, contract_id, borrower, liquidity) = setup_mock(&env);
+        liquidity.mint(&contract_id, 1_000);
+        client.draw_credit(&borrower, &600_i128);
+        liquidity.mint(&borrower, 300);
+        liquidity.approve(&borrower, &contract_id, 300, 1_000);
+        client.repay_credit(&borrower, &300_i128);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().utilized_amount,
+            300
+        );
+    }
+    #[test]
+    fn draw_repay_full_cycle() {
+        let env = Env::default();
+        let (client, contract_id, borrower, liquidity) = setup_mock(&env);
+        liquidity.mint(&contract_id, 1_000);
+        client.draw_credit(&borrower, &700_i128);
+        liquidity.approve(&borrower, &contract_id, 700, 1_000);
+        client.repay_credit(&borrower, &700_i128);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().utilized_amount,
+            0
+        );
+    }
+    #[test]
+    fn test_event_reinstate_credit_line() {
+        use soroban_sdk::testutils::Events;
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, borrower) = base_setup(&env);
+        client.default_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
         let events = env.events().all();
         let (_contract, topics, data) = events.last().unwrap();
         assert_eq!(
@@ -3082,1845 +3640,1203 @@ mod test_mock_liquidity_token {
     #[test]
     fn test_event_lifecycle_sequence() {
         use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
-        use soroban_sdk::TryIntoVal;
 
-        /// Setup helper: creates contract with token, mints `reserve` to contract,
-        /// opens credit line for borrower with `credit_limit`, draws `draw_amount`.
-        /// Returns `(client, token_address, contract_id, admin_address)`.
-        fn setup<'a>(
-            env: &'a Env,
-            borrower: &Address,
-            credit_limit: i128,
-            reserve: i128,
-            draw_amount: i128,
-        ) -> (CreditClient<'a>, Address, Address, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
-            let token = token_id.address();
-            client.set_liquidity_token(&token);
-            StellarAssetClient::new(env, &token).mint(&contract_id, &reserve);
-            client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
-            if draw_amount > 0 {
-                client.draw_credit(borrower, &draw_amount);
-            }
-            (client, token, contract_id, admin)
-        }
+        let env = Env::default();
+        env.mock_all_auths();
 
-        /// Approve helper: approves `amount` tokens from `from` to `spender` on `token`.
-        fn approve(env: &Env, token: &Address, from: &Address, spender: &Address, amount: i128) {
-            TokenClient::new(env, token).approve(from, spender, &amount, &1_000_u32);
-        }
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
 
         client.init(&admin);
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let token = token_id.address();
+        client.set_liquidity_token(&token);
+        StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_000_i128);
+        StellarAssetClient::new(&env, &token).mint(&borrower, &1_000_000_i128);
+        soroban_sdk::token::Client::new(&env, &token).approve(
+            &borrower,
+            &contract_id,
+            &1_000_000_i128,
+            &1_000_000_u32,
+        );
         client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
         client.draw_credit(&borrower, &200_i128);
         client.repay_credit(&borrower, &50_i128);
         client.suspend_credit_line(&borrower);
         client.default_credit_line(&borrower);
-        client.reinstate_credit_line(&borrower);
+        client.reinstate_credit_line(&borrower, &CreditStatus::Active);
         client.close_credit_line(&borrower, &admin);
 
-        // ── Repayment Allocation Policy Tests ────────────────────────────────────
+        let events = env.events().all();
+        assert!(!events.is_empty());
 
-        /// Helper: manually set accrued_interest on a credit line for testing allocation.
-        fn set_accrued_interest(
-            env: &Env,
-            contract_id: &Address,
-            borrower: &Address,
-            amount: i128,
-        ) {
-            env.as_contract(contract_id, || {
-                let mut line: CreditLineData = env.storage().persistent().get(borrower).unwrap();
-                line.utilized_amount = line
-                    .utilized_amount
-                    .saturating_add(amount - line.accrued_interest);
-                line.accrued_interest = amount;
-                env.storage().persistent().set(borrower, &line);
-            });
-        }
-
-        #[test]
-        fn repay_less_than_interest_reduces_interest_only() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 500);
-
-            // Manually set accrued interest to 200 (principal = 300)
-            set_accrued_interest(&env, &contract_id, &borrower, 200);
-
-            StellarAssetClient::new(&env, &token).mint(&borrower, &100);
-            approve(&env, &token, &borrower, &contract_id, 100);
-
-            client.repay_credit(&borrower, &100);
-
-            let line = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.accrued_interest, 100); // 200 - 100
-            assert_eq!(line.utilized_amount, 600); // 700 - 100 (set_accrued_interest bumped utilized to 700)
-        }
-
-        #[test]
-        fn repay_exactly_interest_zeros_accrued_interest() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 500);
-
-            set_accrued_interest(&env, &contract_id, &borrower, 200);
-
-            StellarAssetClient::new(&env, &token).mint(&borrower, &200);
-            approve(&env, &token, &borrower, &contract_id, 200);
-
-            client.repay_credit(&borrower, &200);
-
-            let line = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.accrued_interest, 0);
-            assert_eq!(line.utilized_amount, 500); // 700 - 200 = 500 (principal remains)
-        }
-
-        #[test]
-        fn repay_interest_plus_partial_principal() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 500);
-
-            set_accrued_interest(&env, &contract_id, &borrower, 200);
-
-            StellarAssetClient::new(&env, &token).mint(&borrower, &300);
-            approve(&env, &token, &borrower, &contract_id, 300);
-
-            client.repay_credit(&borrower, &300);
-
-            let line = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.accrued_interest, 0); // 200 - 200
-            assert_eq!(line.utilized_amount, 400); // 700 - 300 = 400 (repaid all interest + 100 principal)
-        }
-
-        #[test]
-        fn repay_overpayment_capped_at_total_owed() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 500);
-
-            set_accrued_interest(&env, &contract_id, &borrower, 200);
-
-            StellarAssetClient::new(&env, &token).mint(&borrower, &1_000);
-            approve(&env, &token, &borrower, &contract_id, 1_000);
-
-            client.repay_credit(&borrower, &1_000);
-
-            let line = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.accrued_interest, 0);
-            assert_eq!(line.utilized_amount, 0);
-        }
-
-        #[test]
-        fn repay_event_contains_allocation_fields() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 500);
-
-            set_accrued_interest(&env, &contract_id, &borrower, 150);
-
-            StellarAssetClient::new(&env, &token).mint(&borrower, &300);
-            approve(&env, &token, &borrower, &contract_id, 300);
-
-            client.repay_credit(&borrower, &300);
-
-            let events = env.events().all();
-            let (_contract, _topics, data): (_, _, soroban_sdk::Val) = events.last().unwrap();
-            let event: RepaymentEvent = data.try_into_val(&env).unwrap();
-
-            assert_eq!(event.borrower, borrower);
-            assert_eq!(event.amount, 300);
-            assert_eq!(event.new_utilized_amount, 350); // 650 - 300 = 350
-        }
-
-        #[test]
-        fn repay_accrual_initializes_checkpoint_without_charging() {
-            use soroban_sdk::testutils::Ledger;
-            let env = Env::default();
-            env.mock_all_auths();
-            env.ledger().set_timestamp(1_000);
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) = setup(&env, &borrower, 1_000, 1_000, 400);
-
-            // After draw_credit, apply_accrual sets the checkpoint to the current timestamp
-            let line_before = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line_before.last_accrual_ts, 1_000); // set during draw_credit
-            assert_eq!(line_before.accrued_interest, 0);
-
-            // Advance ledger so the checkpoint is non-zero after accrual
-            env.ledger().set_timestamp(1_000);
-
-            StellarAssetClient::new(&env, &token).mint(&borrower, &100);
-            approve(&env, &token, &borrower, &contract_id, 100);
-
-            env.ledger().set_timestamp(100);
-            client.repay_credit(&borrower, &100);
-
-            let line_after = client.get_credit_line(&borrower).unwrap();
-            // Checkpoint remains set, no interest charged (same timestamp)
-            assert_eq!(line_after.last_accrual_ts, 1_000);
-            assert_eq!(line_after.accrued_interest, 0);
-            assert_eq!(line_after.utilized_amount, 300);
-        }
-
-        #[test]
-        fn repay_after_time_elapse_accrues_interest_before_allocation() {
-            use soroban_sdk::testutils::Ledger;
-            let env = Env::default();
-            env.mock_all_auths();
-            env.ledger().set_timestamp(1_000);
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) =
-                setup(&env, &borrower, 10_000, 10_000, 1_000);
-
-            // Set a non-zero timestamp so the accrual checkpoint is non-zero
-            env.ledger().set_timestamp(1_000);
-
-            // First repay sets the accrual checkpoint
-            StellarAssetClient::new(&env, &token).mint(&borrower, &100);
-            approve(&env, &token, &borrower, &contract_id, 100);
-            env.ledger().set_timestamp(100);
-            client.repay_credit(&borrower, &100);
-
-            let line_after_first = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line_after_first.utilized_amount, 900);
-            assert_eq!(line_after_first.accrued_interest, 0);
-            let checkpoint = line_after_first.last_accrual_ts;
-            assert!(checkpoint > 0);
-
-            // Advance ledger timestamp by exactly one year
-            env.ledger()
-                .set_timestamp(checkpoint + crate::accrual::SECONDS_PER_YEAR);
-
-            // At 300 bps (3%) on 900 principal, expected interest = floor(900 * 300 / 10000) = 27
-            StellarAssetClient::new(&env, &token).mint(&borrower, &200);
-            approve(&env, &token, &borrower, &contract_id, 200);
-            client.repay_credit(&borrower, &200);
-
-            let line_after_second = client.get_credit_line(&borrower).unwrap();
-            // Total owed before repay = 900 + 27 = 927
-            // Repay 200: interest first (27), then principal (173)
-            // New utilized = 927 - 200 = 727
-            // New accrued_interest = 0
-            assert_eq!(line_after_second.accrued_interest, 0);
-            assert_eq!(line_after_second.utilized_amount, 727);
-        }
+        let (_contract, topics, data) = events.last().unwrap();
+        assert_eq!(
+            Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+            symbol_short!("closed")
+        );
+        let event_data: CreditLineEvent = data.try_into_val(&env).unwrap();
+        assert_eq!(event_data.status, CreditStatus::Closed);
+        assert_eq!(event_data.borrower, borrower);
     }
 
-    #[cfg(test)]
-    mod test_init_coverage {
-        use super::*;
+    #[test]
+    fn test_rate_change_limits_roundtrip() {
+        let env = Env::default();
+        env.mock_all_auths();
 
-        #[test]
-        #[should_panic(expected = "Error(Contract, #20)")]
-        fn lifecycle_suspend_non_active_reverts() {
-            let env = Env::default();
-            let (client, _admin, borrower) = base_setup(&env);
-            client.suspend_credit_line(&borrower);
-            client.suspend_credit_line(&borrower); // already suspended — should panic
-        }
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
 
-        /// Double-init does not overwrite the original admin.
-        /// Even if the second init somehow didn't panic (it should), admin must remain unchanged.
-        /// This test verifies the guard fires before any storage write.
-        #[test]
-        fn test_init_double_init_does_not_overwrite_admin() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
+        client.init(&admin);
+        client.set_rate_change_limits(&250_u32, &3600_u64);
 
-            // Admin is still the original — admin-gated call succeeds.
-            let borrower = Address::generate(&env);
-            client.open_credit_line(&borrower, &100_i128, &100_u32, &10_u32);
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.borrower, borrower);
-        }
-
-        /// Calling admin-gated functions before init must revert (NotAdmin).
-        #[test]
-        #[should_panic]
-        fn test_admin_gated_call_before_init_reverts() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            // No init — suspend_credit_line requires admin, must panic because admin is not set.
-            client.suspend_credit_line(&borrower);
-        }
+        let cfg = client.get_rate_change_limits().unwrap();
+        assert_eq!(cfg.max_rate_change_bps, 250);
+        assert_eq!(cfg.rate_change_min_interval, 3600);
     }
 
-    #[cfg(test)]
-    pub mod test_helpers {
-        use soroban_sdk::{
-            testutils::Address as _,
-            token::{Client as TokenClient, StellarAssetClient},
-            Address, Env,
-        };
-        pub struct MockLiquidityToken {
-            pub address: Address,
-            env: Env,
-        }
-        impl MockLiquidityToken {
-            pub fn deploy(env: &Env) -> Self {
-                let admin = Address::generate(env);
-                let token_id = env.register_stellar_asset_contract_v2(admin);
-                Self {
-                    address: token_id.address(),
-                    env: env.clone(),
-                }
-            }
-            pub fn address(&self) -> Address {
-                self.address.clone()
-            }
-            pub fn mint(&self, to: &Address, amount: i128) {
-                StellarAssetClient::new(&self.env, &self.address).mint(to, &amount);
-            }
-            pub fn approve(&self, from: &Address, spender: &Address, amount: i128, expiry: u32) {
-                TokenClient::new(&self.env, &self.address).approve(from, spender, &amount, &expiry);
-            }
-            pub fn balance(&self, who: &Address) -> i128 {
-                TokenClient::new(&self.env, &self.address).balance(who)
-            }
-            pub fn allowance(&self, from: &Address, spender: &Address) -> i128 {
-                TokenClient::new(&self.env, &self.address).allowance(from, spender)
-            }
-        }
+    #[test]
+    #[should_panic(expected = "Error(Contract, #8)")]
+    fn test_update_risk_parameters_interest_rate_exceeds_max() {
+        let env = Env::default();
+        env.mock_all_auths();
 
-        #[allow(dead_code)]
-        /// A mock token that can be configured to fail on transfer operations.
-        pub struct FailingToken {
-            pub address: Address,
-            env: Env,
-            should_fail_transfer: bool,
-            should_fail_transfer_from: bool,
-        }
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
 
-        #[allow(dead_code)]
-        impl FailingToken {
-            pub fn deploy(env: &Env) -> Self {
-                let admin = Address::generate(env);
-                let token_id = env.register_stellar_asset_contract_v2(admin);
-                Self {
-                    address: token_id.address(),
-                    env: env.clone(),
-                    should_fail_transfer: false,
-                    should_fail_transfer_from: false,
-                }
-            }
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
 
-            pub fn set_fail_transfer(&mut self, fail: bool) {
-                self.should_fail_transfer = fail;
-            }
-
-            pub fn set_fail_transfer_from(&mut self, fail: bool) {
-                self.should_fail_transfer_from = fail;
-            }
-
-            pub fn address(&self) -> Address {
-                self.address.clone()
-            }
-
-            pub fn mint(&self, to: &Address, amount: i128) {
-                StellarAssetClient::new(&self.env, &self.address).mint(to, &amount);
-            }
-
-            pub fn approve(&self, from: &Address, spender: &Address, amount: i128, expiry: u32) {
-                TokenClient::new(&self.env, &self.address).approve(from, spender, &amount, &expiry);
-            }
-
-            pub fn balance(&self, who: &Address) -> i128 {
-                TokenClient::new(&self.env, &self.address).balance(who)
-            }
-
-            pub fn allowance(&self, from: &Address, spender: &Address) -> i128 {
-                TokenClient::new(&self.env, &self.address).allowance(from, spender)
-            }
-
-            pub fn transfer(&self, from: &Address, to: &Address, amount: i128) {
-                if self.should_fail_transfer {
-                    panic!("Mock token transfer failure");
-                }
-                TokenClient::new(&self.env, &self.address).transfer(from, to, &amount);
-            }
-
-            pub fn transfer_from(
-                &self,
-                spender: &Address,
-                from: &Address,
-                to: &Address,
-                amount: i128,
-            ) {
-                if self.should_fail_transfer_from {
-                    panic!("Mock token transfer_from failure");
-                }
-                TokenClient::new(&self.env, &self.address)
-                    .transfer_from(spender, from, to, &amount);
-            }
-        }
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.update_risk_parameters(&borrower, &1000_i128, &10001_u32, &70_u32);
     }
-    #[cfg(test)]
-    mod test_mock_liquidity_token {
-        use super::*;
-        use crate::test_helpers::MockLiquidityToken;
-        use soroban_sdk::testutils::Events as _;
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #9)")]
+    fn test_update_risk_parameters_risk_score_exceeds_max() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &101_u32);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn draw_credit_zero_amount_reverts_and_guard_cleared() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
+        client.draw_credit(&borrower, &0);
+    }
+
+    #[test]
+    #[should_panic] // HostError: Error(Auth, InvalidAction)
+    fn test_draw_credit_unauthorized() {
+        let env = Env::default();
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        // Setup state manually to bypass auth requirements for setup functions
+        env.as_contract(&contract_id, || {
+            let line = CreditLineData {
+                borrower: borrower.clone(),
+                credit_limit: 1000,
+                utilized_amount: 0,
+                interest_rate_bps: 300,
+                risk_score: 70,
+                status: CreditStatus::Active,
+                last_rate_update_ts: 0,
+                accrued_interest: 0,
+                last_accrual_ts: 1,
+                suspension_ts: 0,
+            };
+            env.storage().persistent().set(&borrower, &line);
+        });
+
+        client.draw_credit(&borrower, &100);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #20)")]
+    fn test_draw_credit_on_suspended_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000, &300, &70);
+        client.suspend_credit_line(&borrower);
+
+        client.draw_credit(&borrower, &100);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #6)")]
+    fn test_draw_credit_exceeding_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000, &300, &70);
+
+        client.draw_credit(&borrower, &1001);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_draw_credit_negative_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000, &300, &70);
+
+        client.draw_credit(&borrower, &-100);
+    }
+
+    // ── draw_credit: defaulted line rejects draw ──────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #21)")]
+    fn draw_credit_on_defaulted_line_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.set_liquidity_token(&token_id.address());
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &1_000);
+        client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
+        client.default_credit_line(&borrower);
+        client.draw_credit(&borrower, &100);
+    }
+
+    // ── draw_credit: closed line uses ContractError path ─────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn draw_credit_on_closed_line_reverts_with_contract_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.set_liquidity_token(&token_id.address());
+        client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
+        client.close_credit_line(&borrower, &admin);
+        client.draw_credit(&borrower, &100);
+    }
+
+    #[test]
+    fn draw_credit_reserve_depletion_keeps_single_borrower_state_and_events_consistent() {
         use soroban_sdk::testutils::Ledger;
-        use soroban_sdk::token::Client as TokenClient;
-        use soroban_sdk::token::StellarAssetClient;
-        use soroban_sdk::{symbol_short, Env, Symbol, TryFromVal, TryIntoVal};
-        use std::boxed::Box;
-        use std::panic::{catch_unwind, AssertUnwindSafe};
 
-        fn setup_mock<'a>(
-            env: &'a Env,
-        ) -> (CreditClient<'a>, Address, Address, MockLiquidityToken) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let borrower = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            let liquidity = MockLiquidityToken::deploy(env);
-            client.set_liquidity_token(&liquidity.address());
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-            (client, contract_id, borrower, liquidity)
-        }
-
-        /// Setup for rate-change tests: creates contract (no token), opens credit line.
-        /// Returns `(client, admin)`.
-        fn setup<'a>(
-            env: &'a Env,
-            borrower: &Address,
-            credit_limit: i128,
-            interest_rate_bps: u32,
-        ) -> (CreditClient<'a>, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(borrower, &credit_limit, &interest_rate_bps, &70_u32);
-            (client, admin)
-        }
-
-        #[allow(dead_code)]
-        fn setup_contract_with_credit_line<'a>(
-            env: &'a Env,
-            borrower: &'a Address,
-            credit_limit: i128,
-            utilized_amount: i128,
-        ) -> (CreditClient<'a>, Address, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
-            if utilized_amount > 0 {
-                client.draw_credit(borrower, &utilized_amount);
-            }
-            (client, contract_id, admin)
-        }
-
-        fn base_setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let borrower = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
-            (client, admin, borrower)
-        }
-
-        /// Helper: deploy contract with liquidity token, mint `reserve` tokens.
-        /// Returns `(client, token_address, contract_id, admin)`.
-        fn setup_with_reserve<'a>(
-            env: &'a Env,
-            borrower: &Address,
-            credit_limit: i128,
-            reserve: i128,
-        ) -> (CreditClient<'a>, Address, Address, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
-            let token_address = token_id.address();
-            client.set_liquidity_token(&token_address);
-            client.set_liquidity_source(&contract_id);
-            if reserve > 0 {
-                StellarAssetClient::new(env, &token_address).mint(&contract_id, &reserve);
-            }
-            client.open_credit_line(borrower, &credit_limit, &300_u32, &70_u32);
-            (client, token_address, contract_id, admin)
-        }
-
-        /// Helper: count events with a specific topic symbol.
-        fn count_credit_event(env: &Env, topic: &str) -> usize {
-            let topic_sym = Symbol::new(env, topic);
-            env.events()
-                .all()
-                .iter()
-                .filter(|(_contract, topics, _data)| {
-                    topics.iter().any(|t| {
-                        Symbol::try_from_val(env, &t)
-                            .map(|s: Symbol| s == topic_sym)
-                            .unwrap_or(false)
-                    })
-                })
-                .count()
-        }
-
-        /// Helper: get the token balance of an address.
-        fn liquidity_balance(env: &Env, token: &Address, who: &Address) -> i128 {
-            TokenClient::new(env, token).balance(who)
-        }
-
-        /// Helper: mint additional tokens to the contract reserve.
-        fn mint_liquidity(env: &Env, token: &Address, contract_id: &Address, amount: i128) {
-            StellarAssetClient::new(env, token).mint(contract_id, &amount);
-        }
-
-        /// Helper: extract the panic message from a Box<dyn Any> and check for reserve error keywords.
-        fn panic_message_contains_reserve_error(err: Box<dyn std::any::Any + Send>) -> bool {
-            if let Some(s) = err.downcast_ref::<String>() {
-                s.contains("reserve") || s.contains("InsufficientReserve") || s.contains("#24")
-            } else if let Some(s) = err.downcast_ref::<&str>() {
-                s.contains("reserve") || s.contains("InsufficientReserve") || s.contains("#24")
-            } else {
-                true // assume it's a reserve error if we can't check
-            }
-        }
-
-        // ── update_risk_parameters: negative credit_limit ────────────────────────
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #7)")]
-        fn update_risk_params_negative_limit_reverts() {
-            let env = Env::default();
-            let (client, _admin, borrower) = base_setup(&env);
-            client.update_risk_parameters(&borrower, &-1, &500_u32, &60_u32);
-        }
-
-        // ── update_risk_parameters: limit below utilized amount ──────────────────
-
-        #[test]
-        fn mock_token_mint_increases_balance() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let r = Address::generate(&env);
-            let t = MockLiquidityToken::deploy(&env);
-            t.mint(&r, 500);
-            assert_eq!(t.balance(&r), 500);
-        }
-        #[test]
-        fn mock_token_approve_sets_allowance() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let o = Address::generate(&env);
-            let s = Address::generate(&env);
-            let t = MockLiquidityToken::deploy(&env);
-            t.mint(&o, 1_000);
-            t.approve(&o, &s, 300, 1_000);
-            assert_eq!(t.allowance(&o, &s), 300);
-        }
-        #[test]
-        fn draw_transfers_reserve_to_borrower() {
-            let env = Env::default();
-            let (client, contract_id, borrower, liquidity) = setup_mock(&env);
-            liquidity.mint(&contract_id, 500);
-            client.draw_credit(&borrower, &300_i128);
-            assert_eq!(liquidity.balance(&borrower), 300);
-        }
-        #[test]
-        #[should_panic(expected = "Error(Contract, #24)")]
-        fn draw_fails_reserve_empty() {
-            let env = Env::default();
-            let (client, _c, borrower, _l) = setup_mock(&env);
-            client.draw_credit(&borrower, &100_i128);
-        }
-        #[test]
-        #[should_panic(expected = "Error(Contract, #21)")]
-        fn reinstate_non_defaulted_active_line_reverts() {
-            let env = Env::default();
-            let (client, _admin, borrower) = base_setup(&env);
-            // Line is Active, not Defaulted
-            client.reinstate_credit_line(&borrower, &CreditStatus::Active);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #21)")]
-        fn reinstate_suspended_line_reverts() {
-            let env = Env::default();
-            let (client, _admin, borrower) = base_setup(&env);
-            client.suspend_credit_line(&borrower);
-            // Line is Suspended, not Defaulted
-            client.reinstate_credit_line(&borrower, &CreditStatus::Active);
-        }
-
-        // ── open_credit_line: allows reopening after Closed status ───────────────
-
-        #[test]
-        fn repay_reduces_utilized() {
-            let env = Env::default();
-            let (client, contract_id, borrower, liquidity) = setup_mock(&env);
-            liquidity.mint(&contract_id, 1_000);
-            client.draw_credit(&borrower, &600_i128);
-            liquidity.mint(&borrower, 300);
-            liquidity.approve(&borrower, &contract_id, 300, 1_000);
-            client.repay_credit(&borrower, &300_i128);
-            assert_eq!(
-                client.get_credit_line(&borrower).unwrap().utilized_amount,
-                300
-            );
-        }
-        #[test]
-        fn draw_repay_full_cycle() {
-            let env = Env::default();
-            let (client, contract_id, borrower, liquidity) = setup_mock(&env);
-            liquidity.mint(&contract_id, 1_000);
-            client.draw_credit(&borrower, &700_i128);
-            liquidity.approve(&borrower, &contract_id, 700, 1_000);
-            client.repay_credit(&borrower, &700_i128);
-            assert_eq!(
-                client.get_credit_line(&borrower).unwrap().utilized_amount,
-                0
-            );
-        }
-        #[test]
-        fn test_event_reinstate_credit_line() {
-            use soroban_sdk::testutils::Events;
-            let env = Env::default();
-            env.mock_all_auths();
-            let (client, _admin, borrower) = base_setup(&env);
-            client.default_credit_line(&borrower);
-            client.reinstate_credit_line(&borrower, &CreditStatus::Active);
-            let events = env.events().all();
-            let (_contract, topics, data) = events.last().unwrap();
-            assert_eq!(
-                Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
-                symbol_short!("reinstate")
-            );
-            let event_data: CreditLineEvent = data.try_into_val(&env).unwrap();
-            assert_eq!(event_data.status, CreditStatus::Active);
-        }
-
-        #[test]
-        fn test_event_lifecycle_sequence() {
-            use soroban_sdk::testutils::Events as _;
-
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let token = token_id.address();
-            client.set_liquidity_token(&token);
-            StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_000_i128);
-            StellarAssetClient::new(&env, &token).mint(&borrower, &1_000_000_i128);
-            soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower,
-                &contract_id,
-                &1_000_000_i128,
-                &1_000_000_u32,
-            );
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.draw_credit(&borrower, &200_i128);
-            client.repay_credit(&borrower, &50_i128);
-            client.suspend_credit_line(&borrower);
-            client.default_credit_line(&borrower);
-            client.reinstate_credit_line(&borrower, &CreditStatus::Active);
-            client.close_credit_line(&borrower, &admin);
-
-            let events = env.events().all();
-            assert!(!events.is_empty());
-
-            let (_contract, topics, data) = events.last().unwrap();
-            assert_eq!(
-                Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
-                symbol_short!("closed")
-            );
-            let event_data: CreditLineEvent = data.try_into_val(&env).unwrap();
-            assert_eq!(event_data.status, CreditStatus::Closed);
-            assert_eq!(event_data.borrower, borrower);
-        }
-
-        #[test]
-        fn test_rate_change_limits_roundtrip() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            client.set_rate_change_limits(&250_u32, &3600_u64);
-
-            let cfg = client.get_rate_change_limits().unwrap();
-            assert_eq!(cfg.max_rate_change_bps, 250);
-            assert_eq!(cfg.rate_change_min_interval, 3600);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #8)")]
-        fn test_update_risk_parameters_interest_rate_exceeds_max() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.update_risk_parameters(&borrower, &1000_i128, &10001_u32, &70_u32);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #9)")]
-        fn test_update_risk_parameters_risk_score_exceeds_max() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.update_risk_parameters(&borrower, &1000_i128, &300_u32, &101_u32);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #5)")]
-        fn draw_credit_zero_amount_reverts_and_guard_cleared() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
-            client.draw_credit(&borrower, &0);
-        }
-
-        #[test]
-        #[should_panic] // HostError: Error(Auth, InvalidAction)
-        fn test_draw_credit_unauthorized() {
-            let env = Env::default();
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            // Setup state manually to bypass auth requirements for setup functions
-            env.as_contract(&contract_id, || {
-                let line = CreditLineData {
-                    borrower: borrower.clone(),
-                    credit_limit: 1000,
-                    utilized_amount: 0,
-                    interest_rate_bps: 300,
-                    risk_score: 70,
-                    status: CreditStatus::Active,
-                    last_rate_update_ts: 0,
-                    accrued_interest: 0,
-                    last_accrual_ts: 1,
-                    suspension_ts: 0,
-                };
-                env.storage().persistent().set(&borrower, &line);
-            });
-
-            client.draw_credit(&borrower, &100);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #20)")]
-        fn test_draw_credit_on_suspended_line() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000, &300, &70);
-            client.suspend_credit_line(&borrower);
-
-            client.draw_credit(&borrower, &100);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #6)")]
-        fn test_draw_credit_exceeding_limit() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000, &300, &70);
-
-            client.draw_credit(&borrower, &1001);
-        }
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #5)")]
-        fn test_draw_credit_negative_amount() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000, &300, &70);
-
-            client.draw_credit(&borrower, &-100);
-        }
-
-        // ── draw_credit: defaulted line rejects draw ──────────────────────────────
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #21)")]
-        fn draw_credit_on_defaulted_line_reverts() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.set_liquidity_token(&token_id.address());
-            StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &1_000);
-            client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
-            client.default_credit_line(&borrower);
-            client.draw_credit(&borrower, &100);
-        }
-
-        // ── draw_credit: closed line uses ContractError path ─────────────────────
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #4)")]
-        fn draw_credit_on_closed_line_reverts_with_contract_error() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.set_liquidity_token(&token_id.address());
-            client.open_credit_line(&borrower, &1_000, &500_u32, &60_u32);
-            client.close_credit_line(&borrower, &admin);
-            client.draw_credit(&borrower, &100);
-        }
-
-        #[test]
-        fn draw_credit_reserve_depletion_keeps_single_borrower_state_and_events_consistent() {
-            use soroban_sdk::testutils::Ledger;
-
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let borrower = Address::generate(&env);
-            let (client, token, contract_id, _admin) =
-                setup_with_reserve(&env, &borrower, 1_000, 500);
-
-            env.ledger().set_timestamp(100);
-            client.draw_credit(&borrower, &300);
-
-            let credit_line_after_first_draw = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(credit_line_after_first_draw.utilized_amount, 300);
-            assert_eq!(credit_line_after_first_draw.last_accrual_ts, 100);
-            assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
-
-            let event_count_before_failure = env.events().all().len();
-            let drawn_events_before_failure = count_credit_event(&env, "drawn");
-            let accrue_events_before_failure = count_credit_event(&env, "accrue");
-
-            env.ledger().set_timestamp(200);
-            let result = catch_unwind(AssertUnwindSafe(|| {
-                client.draw_credit(&borrower, &250);
-            }));
-
-            assert!(
-                result.is_err(),
-                "second draw should fail once reserve is depleted"
-            );
-            let _ = panic_message_contains_reserve_error(result.unwrap_err());
-
-            let credit_line_after_failure = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(
-                credit_line_after_failure.utilized_amount,
-                credit_line_after_first_draw.utilized_amount
-            );
-            assert_eq!(
-                credit_line_after_failure.accrued_interest,
-                credit_line_after_first_draw.accrued_interest
-            );
-            assert_eq!(
-                credit_line_after_failure.last_accrual_ts,
-                credit_line_after_first_draw.last_accrual_ts
-            );
-            assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
-            assert_eq!(env.events().all().len(), event_count_before_failure);
-            assert_eq!(
-                count_credit_event(&env, "drawn"),
-                drawn_events_before_failure
-            );
-            assert_eq!(
-                count_credit_event(&env, "accrue"),
-                accrue_events_before_failure
-            );
-
-            mint_liquidity(&env, &token, &contract_id, 50);
-            assert_eq!(liquidity_balance(&env, &token, &contract_id), 250);
-        }
-
-        #[test]
-        fn draw_credit_reserve_depletion_isolated_across_multiple_borrowers() {
-            use soroban_sdk::testutils::Ledger;
-
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let borrower_one = Address::generate(&env);
-            let borrower_two = Address::generate(&env);
-            let (client, token, contract_id, _admin) =
-                setup_with_reserve(&env, &borrower_one, 1_000, 500);
-            client.open_credit_line(&borrower_two, &1_000, &300_u32, &55_u32);
-
-            env.ledger().set_timestamp(100);
-            client.draw_credit(&borrower_one, &300);
-
-            let borrower_one_after_draw = client.get_credit_line(&borrower_one).unwrap();
-            let borrower_two_before_failure = client.get_credit_line(&borrower_two).unwrap();
-            assert_eq!(borrower_one_after_draw.utilized_amount, 300);
-            assert_eq!(borrower_two_before_failure.utilized_amount, 0);
-            assert_eq!(borrower_two_before_failure.last_accrual_ts, 0);
-            assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
-
-            let event_count_before_failure = env.events().all().len();
-            let drawn_events_before_failure = count_credit_event(&env, "drawn");
-            let accrue_events_before_failure = count_credit_event(&env, "accrue");
-
-            env.ledger().set_timestamp(200);
-            let result = catch_unwind(AssertUnwindSafe(|| {
-                client.draw_credit(&borrower_two, &250);
-            }));
-
-            assert!(
-                result.is_err(),
-                "shared reserve depletion should reject the second borrower draw"
-            );
-            let _ = panic_message_contains_reserve_error(result.unwrap_err());
-
-            let borrower_one_after_failure = client.get_credit_line(&borrower_one).unwrap();
-            let borrower_two_after_failure = client.get_credit_line(&borrower_two).unwrap();
-            assert_eq!(
-                borrower_one_after_failure.utilized_amount,
-                borrower_one_after_draw.utilized_amount
-            );
-            assert_eq!(
-                borrower_one_after_failure.last_accrual_ts,
-                borrower_one_after_draw.last_accrual_ts
-            );
-            assert_eq!(
-                borrower_two_after_failure.utilized_amount,
-                borrower_two_before_failure.utilized_amount
-            );
-            assert_eq!(
-                borrower_two_after_failure.last_accrual_ts,
-                borrower_two_before_failure.last_accrual_ts
-            );
-            assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
-            assert_eq!(env.events().all().len(), event_count_before_failure);
-            assert_eq!(
-                count_credit_event(&env, "drawn"),
-                drawn_events_before_failure
-            );
-            assert_eq!(
-                count_credit_event(&env, "accrue"),
-                accrue_events_before_failure
-            );
-        }
-
-        // ── update_risk_parameters: rate change interval passes ──────────────────
-
-        #[test]
-        fn rate_change_after_interval_succeeds() {
-            use soroban_sdk::testutils::Ledger;
-            let env = Env::default();
-            let (client, _admin, borrower) = base_setup(&env);
-            client.set_rate_change_limits(&1_000_u32, &86_400_u64);
-            env.ledger().set_timestamp(100);
-            client.update_risk_parameters(&borrower, &1_000, &600_u32, &60_u32);
-            // Advance past the minimum interval
-            env.ledger().set_timestamp(100 + 86_400 + 1);
-            client.update_risk_parameters(&borrower, &1_000, &700_u32, &60_u32);
-            assert_eq!(
-                client.get_credit_line(&borrower).unwrap().interest_rate_bps,
-                700
-            );
-        }
-
-        // ── suspend_credit_line from Defaulted → panic (not Active) ─────────────
-
-        #[test]
-        #[should_panic(expected = "Error(Contract, #20)")]
-        fn suspend_defaulted_line_reverts() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let (client, _admin, borrower) = base_setup(&env);
-            client.default_credit_line(&borrower);
-            client.suspend_credit_line(&borrower);
-        }
-
-        // ── close_credit_line: idempotent on already-Closed line ─────────────────
-
-        #[test]
-        fn close_credit_line_idempotent_when_already_closed() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-
-            let token_admin = Address::generate(&env);
-            let token = env.register_stellar_asset_contract_v2(token_admin);
-            let token_admin_client = StellarAssetClient::new(&env, &token.address());
-            client.set_liquidity_token(&token.address());
-            token_admin_client.mint(&contract_id, &500_i128);
-            client.close_credit_line(&borrower, &admin);
-            client.close_credit_line(&borrower, &admin);
-
-            assert_eq!(
-                client.get_credit_line(&borrower).unwrap().status,
-                CreditStatus::Closed
-            );
-        }
-
-        // ── draw_credit: overflow protection ─────────────────────────────────────
-
-        #[test]
-        #[should_panic]
-        fn draw_credit_overflow_on_utilized_amount_reverts() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let token_admin = Address::generate(&env);
-
-            let contract_id = env.register(Credit, ());
-            let _token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-
-            let token = env.register_stellar_asset_contract_v2(token_admin);
-            let token_admin_client = StellarAssetClient::new(&env, &token.address());
-
-            client.set_liquidity_token(&token.address());
-
-            token_admin_client.mint(&contract_id, &50_i128);
-            client.draw_credit(&borrower, &100_i128);
-        }
-
-        /// ContractError variants map to the expected contract error codes.
-        #[test]
-        fn test_contract_error_codes() {
-            let _ = ContractError::Unauthorized;
-            let _ = ContractError::NotAdmin;
-            let _ = ContractError::CreditLineNotFound;
-            let _ = ContractError::CreditLineClosed;
-            let _ = ContractError::InvalidAmount;
-            let _ = ContractError::OverLimit;
-            let _ = ContractError::NegativeLimit;
-            let _ = ContractError::RateTooHigh;
-            let _ = ContractError::ScoreTooHigh;
-            let _ = ContractError::UtilizationNotZero;
-            let _ = ContractError::Reentrancy;
-            let _ = ContractError::Overflow;
-            let _ = ContractError::LimitDecreaseRequiresRepayment;
-            let _ = ContractError::AlreadyInitialized;
-            let _ = ContractError::DrawsFrozen;
-        }
-
-        /// draw_credit panics with "overflow" when utilized_amount + amount overflows i128.
-        #[test]
-        #[should_panic(expected = "Error(Contract, #12)")]
-        fn test_draw_credit_overflow_panics() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            // Open with i128::MAX credit limit so the limit check won't fire first.
-            client.init(&admin);
-            client.open_credit_line(&borrower, &i128::MAX, &300_u32, &70_u32);
-
-            // Manually set utilized_amount to i128::MAX so the next draw overflows.
-            env.as_contract(&contract_id, || {
-                let mut line: CreditLineData = env
-                    .storage()
-                    .persistent()
-                    .get::<Address, CreditLineData>(&borrower)
-                    .unwrap();
-                line.utilized_amount = i128::MAX;
-                env.storage().persistent().set(&borrower, &line);
-            });
-
-            // Any positive draw now causes checked_add to return None → panic "overflow".
-            client.draw_credit(&borrower, &1_i128);
-        }
-
-        /// draw_credit is blocked on a Defaulted credit line.
-        #[test]
-        #[should_panic(expected = "Error(Contract, #21)")]
-        fn test_draw_credit_blocked_on_defaulted_line() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.default_credit_line(&borrower);
-
-            // Draw must fail because draw_credit blocks Defaulted status.
-            client.draw_credit(&borrower, &100_i128);
-        }
-
-        /// repay_credit succeeds on a Defaulted credit line.
-        #[test]
-        fn test_repay_credit_allowed_on_defaulted_line() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let token = token_id.address();
-            client.set_liquidity_token(&token);
-            StellarAssetClient::new(&env, &token).mint(&contract_id, &10_000_i128);
-            StellarAssetClient::new(&env, &token).mint(&borrower, &10_000_i128);
-            soroban_sdk::token::Client::new(&env, &token).approve(
-                &borrower,
-                &contract_id,
-                &10_000_i128,
-                &1_000_000_u32,
-            );
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.draw_credit(&borrower, &500_i128);
-            client.default_credit_line(&borrower);
-
-            client.repay_credit(&borrower, &200_i128);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.utilized_amount, 300);
-            assert_eq!(line.status, CreditStatus::Defaulted);
-        }
-
-        /// open_credit_line allows re-opening a previously Closed credit line.
-        #[test]
-        fn test_open_credit_line_after_closed_succeeds() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.close_credit_line(&borrower, &admin);
-
-            // Re-opening a Closed line should succeed.
-            client.open_credit_line(&borrower, &2000_i128, &400_u32, &60_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.credit_limit, 2000);
-            assert_eq!(line.status, CreditStatus::Active);
-        }
-
-        /// open_credit_line allows re-opening a Defaulted credit line.
-        #[test]
-        fn test_open_credit_line_after_defaulted_succeeds() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.default_credit_line(&borrower);
-
-            // Re-opening a Defaulted line should succeed.
-            client.open_credit_line(&borrower, &1500_i128, &350_u32, &65_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.credit_limit, 1500);
-            assert_eq!(line.status, CreditStatus::Active);
-        }
-
-        /// Admin can force-close a Defaulted credit line.
-        #[test]
-        fn test_close_credit_line_defaulted_admin_force_close() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.default_credit_line(&borrower);
-
-            client.close_credit_line(&borrower, &admin);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.status, CreditStatus::Closed);
-        }
-
-        /// Admin can force-close a Suspended credit line.
-        #[test]
-        fn test_close_credit_line_suspended_admin_force_close() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.suspend_credit_line(&borrower);
-
-            client.close_credit_line(&borrower, &admin);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.status, CreditStatus::Closed);
-        }
-
-        /// open_credit_line allows re-opening a Suspended credit line.
-        #[test]
-        fn test_open_credit_line_after_suspended_succeeds() {
-            let env = Env::default();
-            env.mock_all_auths();
-
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
-            client.suspend_credit_line(&borrower);
-
-            // Re-opening a Suspended line should succeed.
-            client.open_credit_line(&borrower, &2000_i128, &400_u32, &60_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.credit_limit, 2000);
-            assert_eq!(line.status, CreditStatus::Active);
-        }
-
-        #[test]
-        fn test_rate_change_at_exact_interval_boundary_succeeds() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 300);
-
-            client.set_rate_change_limits(&100_u32, &3600_u64);
-
-            env.ledger().set_timestamp(100);
-            client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
-
-            // Exactly on the interval boundary: elapsed == 3600.
-            env.ledger().set_timestamp(3700);
-            client.update_risk_parameters(&borrower, &5_000_i128, &330_u32, &70_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.interest_rate_bps, 330);
-            assert_eq!(line.last_rate_update_ts, 3700);
-        }
-
-        #[test]
-        fn test_rate_change_first_update_ignores_interval() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 300);
-
-            // Interval set but first update should always pass (last_rate_update_ts == 0).
-            client.set_rate_change_limits(&100_u32, &86400_u64);
-            env.ledger().set_timestamp(10);
-            client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.interest_rate_bps, 350);
-        }
-
-        #[test]
-        fn test_zero_interval_disables_timing_check_after_first_update() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 300);
-
-            client.set_rate_change_limits(&100_u32, &0_u64);
-
-            env.ledger().set_timestamp(100);
-            client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
-
-            // Immediate subsequent update should still pass because interval == 0 disables the gate.
-            env.ledger().set_timestamp(101);
-            client.update_risk_parameters(&borrower, &5_000_i128, &330_u32, &70_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.interest_rate_bps, 330);
-            assert_eq!(line.last_rate_update_ts, 101);
-        }
-
-        #[test]
-        fn test_same_rate_bypasses_limits() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 300);
-
-            // Strict limits: 0 bps max change, huge interval.
-            client.set_rate_change_limits(&0_u32, &999_999_u64);
-
-            // Same rate (300 → 300) should still succeed.
-            client.update_risk_parameters(&borrower, &5_000_i128, &300_u32, &70_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.interest_rate_bps, 300);
-        }
-
-        #[test]
-        fn test_no_rate_limits_configured_backward_compat() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 0);
-
-            // No set_rate_change_limits call → unlimited changes.
-            client.update_risk_parameters(&borrower, &5_000_i128, &9_999_u32, &70_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.interest_rate_bps, 9_999);
-        }
-
-        #[test]
-        fn test_set_and_get_rate_change_limits() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-
-            client.set_rate_change_limits(&200_u32, &7200_u64);
-            let cfg = client.get_rate_change_limits().unwrap();
-
-            assert_eq!(cfg.max_rate_change_bps, 200);
-            assert_eq!(cfg.rate_change_min_interval, 7200);
-        }
-
-        #[test]
-        fn test_rate_change_timestamp_recorded() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 300);
-
-            client.set_rate_change_limits(&100_u32, &0_u64);
-            env.ledger().set_timestamp(42);
-            client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.last_rate_update_ts, 42);
-        }
-
-        #[test]
-        fn test_rate_change_multiple_sequential_within_limits() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let borrower = Address::generate(&env);
-            let (client, _admin) = setup(&env, &borrower, 5_000, 300);
-
-            client.set_rate_change_limits(&50_u32, &60_u64);
-
-            // First update at t=100: 300 → 350
-            env.ledger().set_timestamp(100);
-            client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
-
-            // Second update at t=161: 350 → 320 (delta 30 ≤ 50)
-            env.ledger().set_timestamp(161);
-            client.update_risk_parameters(&borrower, &5_000_i128, &320_u32, &65_u32);
-
-            // Third update at t=222: 320 → 370 (delta 50 == limit)
-            env.ledger().set_timestamp(222);
-            client.update_risk_parameters(&borrower, &5_000_i128, &370_u32, &60_u32);
-
-            let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.interest_rate_bps, 370);
-            assert_eq!(line.risk_score, 60);
-        }
-
-        #[test]
-        #[should_panic(expected = "Unauthorized")]
-        fn test_set_rate_change_limits_unauthorized() {
-            let env = Env::default();
-            // NOTE: no mock_all_auths → admin auth will fail.
-            let admin = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-
-            client.set_rate_change_limits(&100_u32, &0_u64);
-        }
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let borrower = Address::generate(&env);
+        let (client, token, contract_id, _admin) = setup_with_reserve(&env, &borrower, 1_000, 500);
+
+        env.ledger().set_timestamp(100);
+        client.draw_credit(&borrower, &300);
+
+        let credit_line_after_first_draw = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(credit_line_after_first_draw.utilized_amount, 300);
+        assert_eq!(credit_line_after_first_draw.last_accrual_ts, 100);
+        assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
+
+        let event_count_before_failure = env.events().all().len();
+        let drawn_events_before_failure = count_credit_event(&env, "drawn");
+        let accrue_events_before_failure = count_credit_event(&env, "accrue");
+
+        env.ledger().set_timestamp(200);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            client.draw_credit(&borrower, &250);
+        }));
+
+        assert!(
+            result.is_err(),
+            "second draw should fail once reserve is depleted"
+        );
+        let _ = panic_message_contains_reserve_error(result.unwrap_err());
+
+        let credit_line_after_failure = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(
+            credit_line_after_failure.utilized_amount,
+            credit_line_after_first_draw.utilized_amount
+        );
+        assert_eq!(
+            credit_line_after_failure.accrued_interest,
+            credit_line_after_first_draw.accrued_interest
+        );
+        assert_eq!(
+            credit_line_after_failure.last_accrual_ts,
+            credit_line_after_first_draw.last_accrual_ts
+        );
+        assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
+        assert_eq!(env.events().all().len(), event_count_before_failure);
+        assert_eq!(
+            count_credit_event(&env, "drawn"),
+            drawn_events_before_failure
+        );
+        assert_eq!(
+            count_credit_event(&env, "accrue"),
+            accrue_events_before_failure
+        );
+
+        mint_liquidity(&env, &token, &contract_id, 50);
+        assert_eq!(liquidity_balance(&env, &token, &contract_id), 250);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────────
-    // Tests: global draw-freeze switch
-    // ─────────────────────────────────────────────────────────────────────────────
-    #[cfg(test)]
-    mod test_draw_freeze {
-        use super::*;
-        use crate::types::FreezeReason;
-        use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::Symbol;
-
-        /// Helper: deploy contract, init admin, open a credit line for borrower.
-        fn setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let borrower = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
-            let token = token_id.address();
-            client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(env, &token)
-                .mint(&contract_id, &1_000_000_i128);
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-            (client, admin, borrower)
-        }
-
-        // ── Default state ─────────────────────────────────────────────────────────
-
-        /// is_draws_frozen returns false before any toggle.
-        #[test]
-        fn draws_not_frozen_by_default() {
-            let env = Env::default();
-            let (client, _admin, _borrower) = setup(&env);
-            assert!(!client.is_draws_frozen());
-        }
-
-        // ── freeze_draws ──────────────────────────────────────────────────────────
-
-        /// freeze_draws sets the flag to true.
-        #[test]
-        fn freeze_draws_sets_flag() {
-            let env = Env::default();
-            let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-            assert!(client.is_draws_frozen());
-        }
-
-        /// draw_credit reverts with DrawsFrozen (error #19) when frozen.
-        #[test]
-        #[should_panic(expected = "Error(Contract, #19)")]
-        fn draw_credit_reverts_when_frozen() {
-            let env = Env::default();
-            let (client, _admin, borrower) = setup(&env);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-            client.draw_credit(&borrower, &100_i128);
-        }
-
-        /// repay_credit still works when draws are frozen.
-        #[test]
-        fn repay_credit_allowed_when_frozen() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            // Set up token so draw works before freeze
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let token_address = token_id.address();
-            client.set_liquidity_token(&token_address);
-            let sac = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
-            sac.mint(&contract_id, &1_000_i128);
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-            // Draw before freeze
-            client.draw_credit(&borrower, &500_i128);
-            // Freeze draws
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-            // Fund borrower and approve for repayment
-            sac.mint(&borrower, &200_i128);
-            soroban_sdk::token::Client::new(&env, &token_address).approve(
-                &borrower,
-                &contract_id,
-                &200_i128,
-                &1_000_u32,
-            );
-            // Repay should still succeed
-            client.repay_credit(&borrower, &200_i128);
-            let line = client.get_credit_line(&borrower).unwrap();
-            assert_eq!(line.utilized_amount, 300);
-        }
-
-        // ── unfreeze_draws ────────────────────────────────────────────────────────
-
-        /// unfreeze_draws clears the flag.
-        #[test]
-        fn unfreeze_draws_clears_flag() {
-            let env = Env::default();
-            let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-            assert!(client.is_draws_frozen());
-            client.unfreeze_draws();
-            assert!(!client.is_draws_frozen());
-        }
-
-        /// draw_credit succeeds after unfreeze.
-        #[test]
-        fn draw_credit_succeeds_after_unfreeze() {
-            let env = Env::default();
-            let (client, _admin, borrower) = setup(&env);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-            client.unfreeze_draws();
-            client.draw_credit(&borrower, &100_i128);
-            assert_eq!(
-                client.get_credit_line(&borrower).unwrap().utilized_amount,
-                100
-            );
-        }
-
-        // ── Authorization ─────────────────────────────────────────────────────────
-
-        /// Non-admin cannot freeze draws.
-        #[test]
-        #[should_panic]
-        fn freeze_draws_requires_admin_auth() {
-            let env = Env::default();
-            // Do NOT mock_all_auths — only admin auth is mocked via the contract
-            let admin = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            // No auth mocked → should panic
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-        }
-
-        /// Non-admin cannot unfreeze draws.
-        #[test]
-        #[should_panic]
-        fn unfreeze_draws_requires_admin_auth() {
-            let env = Env::default();
-            let admin = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.unfreeze_draws();
-        }
-
-        // ── Events ────────────────────────────────────────────────────────────────
-
-        /// freeze_draws emits a DrawsFrozenEvent with frozen=true.
-        #[test]
-        fn freeze_draws_emits_event_frozen_true() {
-            use crate::events::DrawsFrozenEvent;
-            use soroban_sdk::TryFromVal;
-            use soroban_sdk::TryIntoVal;
-
-            let env = Env::default();
-            let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-
-            let events = env.events().all();
-            let (_contract, topics, data) = events.last().unwrap();
-            let topic_sym = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
-            assert_eq!(topic_sym, Symbol::new(&env, "drw_freeze"));
-            let event: DrawsFrozenEvent = data.try_into_val(&env).unwrap();
-            assert!(event.frozen);
-            assert_eq!(event.reason, FreezeReason::LiquidityReserve);
-        }
-
-        /// unfreeze_draws emits a DrawsFrozenEvent with frozen=false.
-        #[test]
-        fn unfreeze_draws_emits_event_frozen_false() {
-            use crate::events::DrawsFrozenEvent;
-            use soroban_sdk::TryFromVal;
-            use soroban_sdk::TryIntoVal;
-
-            let env = Env::default();
-            let (client, _admin, _borrower) = setup(&env);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-            client.unfreeze_draws();
-
-            let events = env.events().all();
-            let (_contract, topics, data) = events.last().unwrap();
-            let topic_sym = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
-            assert_eq!(topic_sym, Symbol::new(&env, "drw_freeze"));
-            let event: DrawsFrozenEvent = data.try_into_val(&env).unwrap();
-            assert!(!event.frozen);
-        }
-
-        // ── Isolation: freeze is per-contract, not per-borrower ──────────────────
-
-        /// Freeze blocks draws for ALL borrowers, not just one.
-        #[test]
-        fn freeze_blocks_all_borrowers() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower_a = Address::generate(&env);
-            let borrower_b = Address::generate(&env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(&env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower_a, &1_000_i128, &300_u32, &70_u32);
-            client.open_credit_line(&borrower_b, &2_000_i128, &300_u32, &70_u32);
-            client.freeze_draws(&FreezeReason::LiquidityReserve);
-
-            // Verify the flag is set — both borrowers are blocked by the same flag
-            assert!(client.is_draws_frozen());
-        }
-
-        /// Freeze on one contract does not affect another contract instance.
-        #[test]
-        fn freeze_is_per_contract_instance() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let admin = Address::generate(&env);
-            let borrower = Address::generate(&env);
-
-            let contract_a = env.register(Credit, ());
-            let contract_b = env.register(Credit, ());
-            let client_a = CreditClient::new(&env, &contract_a);
-            let client_b = CreditClient::new(&env, &contract_b);
-
-            client_a.init(&admin);
-            client_b.init(&admin);
-            client_a.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-            client_b.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-
-            client_a.freeze_draws(&FreezeReason::LiquidityReserve);
-
-            assert!(client_a.is_draws_frozen());
-            assert!(!client_b.is_draws_frozen());
-        }
-    }
-
-    #[cfg(test)]
-    mod test_borrower_freeze {
-        use super::*;
-        use crate::events::BorrowerFrozenEvent;
-        use soroban_sdk::testutils::Events as _;
+    #[test]
+    fn draw_credit_reserve_depletion_isolated_across_multiple_borrowers() {
         use soroban_sdk::testutils::Ledger;
-        use soroban_sdk::{Symbol, TryFromVal, TryIntoVal};
 
-        fn setup(env: &Env) -> (CreditClient<'_>, Address, Address, Address) {
-            env.mock_all_auths();
-            let admin = Address::generate(env);
-            let borrower = Address::generate(env);
-            let contract_id = env.register(Credit, ());
-            let client = CreditClient::new(env, &contract_id);
-            client.init(&admin);
-            client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
-            (client, admin, borrower, contract_id)
-        }
+        let env = Env::default();
+        env.mock_all_auths();
 
-        /// freeze_borrower_until sets the freeze and stores the expiry.
-        #[test]
-        fn freeze_borrower_until_sets_freeze() {
-            let env = Env::default();
-            let (client, admin, borrower, _contract_id) = setup(&env);
+        let borrower_one = Address::generate(&env);
+        let borrower_two = Address::generate(&env);
+        let (client, token, contract_id, _admin) =
+            setup_with_reserve(&env, &borrower_one, 1_000, 500);
+        client.open_credit_line(&borrower_two, &1_000, &300_u32, &55_u32);
 
-            let now = 1_700_000_000u64;
-            env.ledger().set_timestamp(now);
+        env.ledger().set_timestamp(100);
+        client.draw_credit(&borrower_one, &300);
 
-            client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
+        let borrower_one_after_draw = client.get_credit_line(&borrower_one).unwrap();
+        let borrower_two_before_failure = client.get_credit_line(&borrower_two).unwrap();
+        assert_eq!(borrower_one_after_draw.utilized_amount, 300);
+        assert_eq!(borrower_two_before_failure.utilized_amount, 0);
+        assert_eq!(borrower_two_before_failure.last_accrual_ts, 0);
+        assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
 
-            assert!(client.is_borrower_frozen(&borrower));
-            assert_eq!(
-                client.get_borrower_frozen_until(&borrower),
-                Some(now + 3600)
-            );
-        }
+        let event_count_before_failure = env.events().all().len();
+        let drawn_events_before_failure = count_credit_event(&env, "drawn");
+        let accrue_events_before_failure = count_credit_event(&env, "accrue");
 
-        /// freeze_borrower_until with past or present timestamp reverts.
-        #[test]
-        #[should_panic(expected = "Error(Contract, #5)")]
-        fn freeze_borrower_until_past_ts_reverts() {
-            let env = Env::default();
-            let (client, admin, borrower, _contract_id) = setup(&env);
+        env.ledger().set_timestamp(200);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            client.draw_credit(&borrower_two, &250);
+        }));
 
-            let now = 1_700_000_000u64;
-            env.ledger().set_timestamp(now);
-            client.freeze_borrower_until(&admin, &borrower, &now);
-        }
+        assert!(
+            result.is_err(),
+            "shared reserve depletion should reject the second borrower draw"
+        );
+        let _ = panic_message_contains_reserve_error(result.unwrap_err());
 
-        /// Freeze expires automatically when ledger timestamp passes expiry_ts.
-        #[test]
-        fn freeze_auto_expires_after_ts() {
-            let env = Env::default();
-            let (client, admin, borrower, _contract_id) = setup(&env);
-
-            let start = 1_700_000_000u64;
-            env.ledger().set_timestamp(start);
-
-            client.freeze_borrower_until(&admin, &borrower, &(start + 3600));
-            assert!(client.is_borrower_frozen(&borrower));
-
-            env.ledger().set_timestamp(start + 3600);
-            assert!(!client.is_borrower_frozen(&borrower));
-        }
-
-        /// freeze_borrower_until requires admin auth.
-        #[test]
-        #[should_panic]
-        fn freeze_borrower_until_requires_auth() {
-            let env = Env::default();
-            let (client, _admin, borrower, _contract_id) = setup(&env);
-            let non_admin = Address::generate(&env);
-
-            let now = 1_700_000_000u64;
-            env.ledger().set_timestamp(now);
-            client.freeze_borrower_until(&non_admin, &borrower, &(now + 3600));
-        }
-
-        /// unfreeze_borrower lifts the freeze before expiry.
-        #[test]
-        fn unfreeze_borrower_lifts_freeze() {
-            let env = Env::default();
-            let (client, admin, borrower, _contract_id) = setup(&env);
-
-            let now = 1_700_000_000u64;
-            env.ledger().set_timestamp(now);
-
-            client.freeze_borrower_until(&admin, &borrower, &(now + 7200));
-            assert!(client.is_borrower_frozen(&borrower));
-
-            client.unfreeze_borrower(&admin, &borrower);
-            assert!(!client.is_borrower_frozen(&borrower));
-            assert_eq!(client.get_borrower_frozen_until(&borrower), None);
-        }
-
-        /// Unfrozen borrower returns false by default.
-        #[test]
-        fn is_borrower_frozen_defaults_false() {
-            let env = Env::default();
-            let (client, _admin, borrower, _contract_id) = setup(&env);
-
-            assert!(!client.is_borrower_frozen(&borrower));
-            assert_eq!(client.get_borrower_frozen_until(&borrower), None);
-        }
-
-        /// Event is emitted on freeze with correct topic and payload.
-        #[test]
-        fn freeze_emits_borrower_frozen_event() {
-            let env = Env::default();
-            let (client, admin, borrower, _contract_id) = setup(&env);
-
-            let now = 1_700_000_000u64;
-            let expiry = now + 3600;
-            env.ledger().set_timestamp(now);
-
-            client.freeze_borrower_until(&admin, &borrower, &expiry);
-
-            let events = env.events().all();
-            let (_contract, topics, data) = events.last().unwrap();
-            let topic_sym = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
-            assert_eq!(topic_sym, Symbol::new(&env, "br_freeze"));
-            let event: BorrowerFrozenEvent = data.try_into_val(&env).unwrap();
-            assert_eq!(event.borrower, borrower);
-            assert_eq!(event.frozen_until, expiry);
-        }
-
-        /// draw_credit reverts with BorrowerFrozen when a freeze is active.
-        #[test]
-        #[should_panic(expected = "Error(Contract, #40)")]
-        fn draw_credit_reverts_when_borrower_frozen() {
-            let env = Env::default();
-            env.mock_all_auths();
-            let (client, admin, borrower, contract_id) = setup(&env);
-
-            let now = 1_700_000_000u64;
-            env.ledger().set_timestamp(now);
-
-            let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-            let token = token_id.address();
-            client.set_liquidity_token(&token);
-            soroban_sdk::token::StellarAssetClient::new(&env, &token)
-                .mint(&contract_id, &1_000_i128);
-
-            client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
-            client.draw_credit(&borrower, &100_i128);
-        }
+        let borrower_one_after_failure = client.get_credit_line(&borrower_one).unwrap();
+        let borrower_two_after_failure = client.get_credit_line(&borrower_two).unwrap();
+        assert_eq!(
+            borrower_one_after_failure.utilized_amount,
+            borrower_one_after_draw.utilized_amount
+        );
+        assert_eq!(
+            borrower_one_after_failure.last_accrual_ts,
+            borrower_one_after_draw.last_accrual_ts
+        );
+        assert_eq!(
+            borrower_two_after_failure.utilized_amount,
+            borrower_two_before_failure.utilized_amount
+        );
+        assert_eq!(
+            borrower_two_after_failure.last_accrual_ts,
+            borrower_two_before_failure.last_accrual_ts
+        );
+        assert_eq!(liquidity_balance(&env, &token, &contract_id), 200);
+        assert_eq!(env.events().all().len(), event_count_before_failure);
+        assert_eq!(
+            count_credit_event(&env, "drawn"),
+            drawn_events_before_failure
+        );
+        assert_eq!(
+            count_credit_event(&env, "accrue"),
+            accrue_events_before_failure
+        );
     }
 
-    #[cfg(test)]
-    mod test_max_draw_amount {
-        use super::*;
+    // ── update_risk_parameters: rate change interval passes ──────────────────
+
+    #[test]
+    fn rate_change_after_interval_succeeds() {
         use soroban_sdk::testutils::Ledger;
-        use soroban_sdk::token::StellarAssetClient;
+        let env = Env::default();
+        let (client, _admin, borrower) = base_setup(&env);
+        client.set_rate_change_limits(&1_000_u32, &86_400_u64);
+        env.ledger().set_timestamp(100);
+        client.update_risk_parameters(&borrower, &1_000, &600_u32, &60_u32);
+        // Advance past the minimum interval
+        env.ledger().set_timestamp(100 + 86_400 + 1);
+        client.update_risk_parameters(&borrower, &1_000, &700_u32, &60_u32);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().interest_rate_bps,
+            700
+        );
+    }
+
+    // ── suspend_credit_line from Defaulted → panic (not Active) ─────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #20)")]
+    fn suspend_defaulted_line_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, borrower) = base_setup(&env);
+        client.default_credit_line(&borrower);
+        client.suspend_credit_line(&borrower);
+    }
+
+    // ── close_credit_line: idempotent on already-Closed line ─────────────────
+
+    #[test]
+    fn close_credit_line_idempotent_when_already_closed() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+        let token_admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(token_admin);
+        let token_admin_client = StellarAssetClient::new(&env, &token.address());
+        client.set_liquidity_token(&token.address());
+        token_admin_client.mint(&contract_id, &500_i128);
+        client.close_credit_line(&borrower, &admin);
+        client.close_credit_line(&borrower, &admin);
+
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().status,
+            CreditStatus::Closed
+        );
+    }
+
+    // ── draw_credit: overflow protection ─────────────────────────────────────
+
+    #[test]
+    #[should_panic]
+    fn draw_credit_overflow_on_utilized_amount_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+
+        let contract_id = env.register(Credit, ());
+        let _token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+        let token = env.register_stellar_asset_contract_v2(token_admin);
+        let token_admin_client = StellarAssetClient::new(&env, &token.address());
+
+        client.set_liquidity_token(&token.address());
+
+        token_admin_client.mint(&contract_id, &50_i128);
+        client.draw_credit(&borrower, &100_i128);
+    }
+
+    /// ContractError variants map to the expected contract error codes.
+    #[test]
+    fn test_contract_error_codes() {
+        let _ = ContractError::Unauthorized;
+        let _ = ContractError::NotAdmin;
+        let _ = ContractError::CreditLineNotFound;
+        let _ = ContractError::CreditLineClosed;
+        let _ = ContractError::InvalidAmount;
+        let _ = ContractError::OverLimit;
+        let _ = ContractError::NegativeLimit;
+        let _ = ContractError::RateTooHigh;
+        let _ = ContractError::ScoreTooHigh;
+        let _ = ContractError::UtilizationNotZero;
+        let _ = ContractError::Reentrancy;
+        let _ = ContractError::Overflow;
+        let _ = ContractError::LimitDecreaseRequiresRepayment;
+        let _ = ContractError::AlreadyInitialized;
+        let _ = ContractError::DrawsFrozen;
+    }
+
+    /// draw_credit panics with "overflow" when utilized_amount + amount overflows i128.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #12)")]
+    fn test_draw_credit_overflow_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        // Open with i128::MAX credit limit so the limit check won't fire first.
+        client.init(&admin);
+        client.open_credit_line(&borrower, &i128::MAX, &300_u32, &70_u32);
+
+        // Manually set utilized_amount to i128::MAX so the next draw overflows.
+        env.as_contract(&contract_id, || {
+            let mut line: CreditLineData = env
+                .storage()
+                .persistent()
+                .get::<Address, CreditLineData>(&borrower)
+                .unwrap();
+            line.utilized_amount = i128::MAX;
+            env.storage().persistent().set(&borrower, &line);
+        });
+
+        // Any positive draw now causes checked_add to return None → panic "overflow".
+        client.draw_credit(&borrower, &1_i128);
+    }
+
+    /// draw_credit is blocked on a Defaulted credit line.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #21)")]
+    fn test_draw_credit_blocked_on_defaulted_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.default_credit_line(&borrower);
+
+        // Draw must fail because draw_credit blocks Defaulted status.
+        client.draw_credit(&borrower, &100_i128);
+    }
+
+    /// repay_credit succeeds on a Defaulted credit line.
+    #[test]
+    fn test_repay_credit_allowed_on_defaulted_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let token = token_id.address();
+        client.set_liquidity_token(&token);
+        StellarAssetClient::new(&env, &token).mint(&contract_id, &10_000_i128);
+        StellarAssetClient::new(&env, &token).mint(&borrower, &10_000_i128);
+        soroban_sdk::token::Client::new(&env, &token).approve(
+            &borrower,
+            &contract_id,
+            &10_000_i128,
+            &1_000_000_u32,
+        );
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.draw_credit(&borrower, &500_i128);
+        client.default_credit_line(&borrower);
+
+        client.repay_credit(&borrower, &200_i128);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.utilized_amount, 300);
+        assert_eq!(line.status, CreditStatus::Defaulted);
+    }
+
+    /// open_credit_line allows re-opening a previously Closed credit line.
+    #[test]
+    fn test_open_credit_line_after_closed_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.close_credit_line(&borrower, &admin);
+
+        // Re-opening a Closed line should succeed.
+        client.open_credit_line(&borrower, &2000_i128, &400_u32, &60_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.credit_limit, 2000);
+        assert_eq!(line.status, CreditStatus::Active);
+    }
+
+    /// open_credit_line allows re-opening a Defaulted credit line.
+    #[test]
+    fn test_open_credit_line_after_defaulted_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.default_credit_line(&borrower);
+
+        // Re-opening a Defaulted line should succeed.
+        client.open_credit_line(&borrower, &1500_i128, &350_u32, &65_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.credit_limit, 1500);
+        assert_eq!(line.status, CreditStatus::Active);
+    }
+
+    /// Admin can force-close a Defaulted credit line.
+    #[test]
+    fn test_close_credit_line_defaulted_admin_force_close() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.default_credit_line(&borrower);
+
+        client.close_credit_line(&borrower, &admin);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.status, CreditStatus::Closed);
+    }
+
+    /// Admin can force-close a Suspended credit line.
+    #[test]
+    fn test_close_credit_line_suspended_admin_force_close() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.suspend_credit_line(&borrower);
+
+        client.close_credit_line(&borrower, &admin);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.status, CreditStatus::Closed);
+    }
+
+    /// open_credit_line allows re-opening a Suspended credit line.
+    #[test]
+    fn test_open_credit_line_after_suspended_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1000_i128, &300_u32, &70_u32);
+        client.suspend_credit_line(&borrower);
+
+        // Re-opening a Suspended line should succeed.
+        client.open_credit_line(&borrower, &2000_i128, &400_u32, &60_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.credit_limit, 2000);
+        assert_eq!(line.status, CreditStatus::Active);
+    }
+
+    #[test]
+    fn test_rate_change_at_exact_interval_boundary_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 300);
+
+        client.set_rate_change_limits(&100_u32, &3600_u64);
+
+        env.ledger().set_timestamp(100);
+        client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
+
+        // Exactly on the interval boundary: elapsed == 3600.
+        env.ledger().set_timestamp(3700);
+        client.update_risk_parameters(&borrower, &5_000_i128, &330_u32, &70_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.interest_rate_bps, 330);
+        assert_eq!(line.last_rate_update_ts, 3700);
+    }
+
+    #[test]
+    fn test_rate_change_first_update_ignores_interval() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 300);
+
+        // Interval set but first update should always pass (last_rate_update_ts == 0).
+        client.set_rate_change_limits(&100_u32, &86400_u64);
+        env.ledger().set_timestamp(10);
+        client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.interest_rate_bps, 350);
+    }
+
+    #[test]
+    fn test_zero_interval_disables_timing_check_after_first_update() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 300);
+
+        client.set_rate_change_limits(&100_u32, &0_u64);
+
+        env.ledger().set_timestamp(100);
+        client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
+
+        // Immediate subsequent update should still pass because interval == 0 disables the gate.
+        env.ledger().set_timestamp(101);
+        client.update_risk_parameters(&borrower, &5_000_i128, &330_u32, &70_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.interest_rate_bps, 330);
+        assert_eq!(line.last_rate_update_ts, 101);
+    }
+
+    #[test]
+    fn test_same_rate_bypasses_limits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 300);
+
+        // Strict limits: 0 bps max change, huge interval.
+        client.set_rate_change_limits(&0_u32, &999_999_u64);
+
+        // Same rate (300 → 300) should still succeed.
+        client.update_risk_parameters(&borrower, &5_000_i128, &300_u32, &70_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.interest_rate_bps, 300);
+    }
+
+    #[test]
+    fn test_no_rate_limits_configured_backward_compat() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 0);
+
+        // No set_rate_change_limits call → unlimited changes.
+        client.update_risk_parameters(&borrower, &5_000_i128, &9_999_u32, &70_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.interest_rate_bps, 9_999);
+    }
+
+    #[test]
+    fn test_set_and_get_rate_change_limits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+
+        client.set_rate_change_limits(&200_u32, &7200_u64);
+        let cfg = client.get_rate_change_limits().unwrap();
+
+        assert_eq!(cfg.max_rate_change_bps, 200);
+        assert_eq!(cfg.rate_change_min_interval, 7200);
+    }
+
+    #[test]
+    fn test_rate_change_timestamp_recorded() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 300);
+
+        client.set_rate_change_limits(&100_u32, &0_u64);
+        env.ledger().set_timestamp(42);
+        client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.last_rate_update_ts, 42);
+    }
+
+    #[test]
+    fn test_rate_change_multiple_sequential_within_limits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let borrower = Address::generate(&env);
+        let (client, _admin) = setup(&env, &borrower, 5_000, 300);
+
+        client.set_rate_change_limits(&50_u32, &60_u64);
+
+        // First update at t=100: 300 → 350
+        env.ledger().set_timestamp(100);
+        client.update_risk_parameters(&borrower, &5_000_i128, &350_u32, &70_u32);
+
+        // Second update at t=161: 350 → 320 (delta 30 ≤ 50)
+        env.ledger().set_timestamp(161);
+        client.update_risk_parameters(&borrower, &5_000_i128, &320_u32, &65_u32);
+
+        // Third update at t=222: 320 → 370 (delta 50 == limit)
+        env.ledger().set_timestamp(222);
+        client.update_risk_parameters(&borrower, &5_000_i128, &370_u32, &60_u32);
+
+        let line: CreditLineData = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.interest_rate_bps, 370);
+        assert_eq!(line.risk_score, 60);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized")]
+    fn test_set_rate_change_limits_unauthorized() {
+        let env = Env::default();
+        // NOTE: no mock_all_auths → admin auth will fail.
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+
+        client.set_rate_change_limits(&100_u32, &0_u64);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: global draw-freeze switch
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod test_draw_freeze {
+    use super::*;
+    use crate::types::FreezeReason;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::Symbol;
+
+    /// Helper: deploy contract, init admin, open a credit line for borrower.
+    fn setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+        let token = token_id.address();
+        client.set_liquidity_token(&token);
+        soroban_sdk::token::StellarAssetClient::new(env, &token)
+            .mint(&contract_id, &1_000_000_i128);
+        client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+        (client, admin, borrower)
+    }
+
+    // ── Default state ─────────────────────────────────────────────────────────
+
+    /// is_draws_frozen returns false before any toggle.
+    #[test]
+    fn draws_not_frozen_by_default() {
+        let env = Env::default();
+        let (client, _admin, _borrower) = setup(&env);
+        assert!(!client.is_draws_frozen());
+    }
+
+    // ── freeze_draws ──────────────────────────────────────────────────────────
+
+    /// freeze_draws sets the flag to true.
+    #[test]
+    fn freeze_draws_sets_flag() {
+        let env = Env::default();
+        let (client, _admin, _borrower) = setup(&env);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+        assert!(client.is_draws_frozen());
+    }
+
+    /// draw_credit reverts with DrawsFrozen (error #19) when frozen.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #19)")]
+    fn draw_credit_reverts_when_frozen() {
+        let env = Env::default();
+        let (client, _admin, borrower) = setup(&env);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+        client.draw_credit(&borrower, &100_i128);
+    }
+
+    /// repay_credit still works when draws are frozen.
+    #[test]
+    fn repay_credit_allowed_when_frozen() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        // Set up token so draw works before freeze
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let token_address = token_id.address();
+        client.set_liquidity_token(&token_address);
+        let sac = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
+        sac.mint(&contract_id, &1_000_i128);
+        client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+        // Draw before freeze
+        client.draw_credit(&borrower, &500_i128);
+        // Freeze draws
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+        // Fund borrower and approve for repayment
+        sac.mint(&borrower, &200_i128);
+        soroban_sdk::token::Client::new(&env, &token_address).approve(
+            &borrower,
+            &contract_id,
+            &200_i128,
+            &1_000_u32,
+        );
+        // Repay should still succeed
+        client.repay_credit(&borrower, &200_i128);
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.utilized_amount, 300);
+    }
+
+    // ── unfreeze_draws ────────────────────────────────────────────────────────
+
+    /// unfreeze_draws clears the flag.
+    #[test]
+    fn unfreeze_draws_clears_flag() {
+        let env = Env::default();
+        let (client, _admin, _borrower) = setup(&env);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+        assert!(client.is_draws_frozen());
+        client.unfreeze_draws();
+        assert!(!client.is_draws_frozen());
+    }
+
+    /// draw_credit succeeds after unfreeze.
+    #[test]
+    fn draw_credit_succeeds_after_unfreeze() {
+        let env = Env::default();
+        let (client, _admin, borrower) = setup(&env);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+        client.unfreeze_draws();
+        client.draw_credit(&borrower, &100_i128);
+        assert_eq!(
+            client.get_credit_line(&borrower).unwrap().utilized_amount,
+            100
+        );
+    }
+
+    // ── Authorization ─────────────────────────────────────────────────────────
+
+    /// Non-admin cannot freeze draws.
+    #[test]
+    #[should_panic]
+    fn freeze_draws_requires_admin_auth() {
+        let env = Env::default();
+        // Do NOT mock_all_auths — only admin auth is mocked via the contract
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        // No auth mocked → should panic
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+    }
+
+    /// Non-admin cannot unfreeze draws.
+    #[test]
+    #[should_panic]
+    fn unfreeze_draws_requires_admin_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.unfreeze_draws();
+    }
+
+    // ── Events ────────────────────────────────────────────────────────────────
+
+    /// freeze_draws emits a DrawsFrozenEvent with frozen=true.
+    #[test]
+    fn freeze_draws_emits_event_frozen_true() {
+        use crate::events::DrawsFrozenEvent;
+        use soroban_sdk::TryFromVal;
+        use soroban_sdk::TryIntoVal;
+
+        let env = Env::default();
+        let (client, _admin, _borrower) = setup(&env);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+        let events = env.events().all();
+        let (_contract, topics, data) = events.last().unwrap();
+        let topic_sym = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+        assert_eq!(topic_sym, Symbol::new(&env, "drw_freeze"));
+        let event: DrawsFrozenEvent = data.try_into_val(&env).unwrap();
+        assert!(event.frozen);
+        assert_eq!(event.reason, FreezeReason::LiquidityReserve);
+    }
+
+    /// unfreeze_draws emits a DrawsFrozenEvent with frozen=false.
+    #[test]
+    fn unfreeze_draws_emits_event_frozen_false() {
+        use crate::events::DrawsFrozenEvent;
+        use soroban_sdk::TryFromVal;
+        use soroban_sdk::TryIntoVal;
+
+        let env = Env::default();
+        let (client, _admin, _borrower) = setup(&env);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+        client.unfreeze_draws();
+
+        let events = env.events().all();
+        let (_contract, topics, data) = events.last().unwrap();
+        let topic_sym = Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+        assert_eq!(topic_sym, Symbol::new(&env, "drw_freeze"));
+        let event: DrawsFrozenEvent = data.try_into_val(&env).unwrap();
+        assert!(!event.frozen);
+    }
+
+    // ── Isolation: freeze is per-contract, not per-borrower ──────────────────
+
+    /// Freeze blocks draws for ALL borrowers, not just one.
+    #[test]
+    fn freeze_blocks_all_borrowers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower_a = Address::generate(&env);
+        let borrower_b = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower_a, &1_000_i128, &300_u32, &70_u32);
+        client.open_credit_line(&borrower_b, &2_000_i128, &300_u32, &70_u32);
+        client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+        // Verify the flag is set — both borrowers are blocked by the same flag
+        assert!(client.is_draws_frozen());
+    }
+
+    /// Freeze on one contract does not affect another contract instance.
+    #[test]
+    fn freeze_is_per_contract_instance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let contract_a = env.register(Credit, ());
+        let contract_b = env.register(Credit, ());
+        let client_a = CreditClient::new(&env, &contract_a);
+        let client_b = CreditClient::new(&env, &contract_b);
+
+        client_a.init(&admin);
+        client_b.init(&admin);
+        client_a.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+        client_b.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+        client_a.freeze_draws(&FreezeReason::LiquidityReserve);
+
+        assert!(client_a.is_draws_frozen());
+        assert!(!client_b.is_draws_frozen());
+    }
+}
+
+#[cfg(test)]
+mod test_borrower_freeze {
+    use super::*;
+    use crate::events::BorrowerFrozenEvent;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::Events as _;
+    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::{Symbol, TryFromVal, TryIntoVal};
+
+    fn setup(env: &Env) -> (CreditClient<'_>, Address, Address, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+        (client, admin, borrower, contract_id)
+    }
+
+    /// freeze_borrower_until sets the freeze and stores the expiry.
+    #[test]
+    fn freeze_borrower_until_sets_freeze() {
+        let env = Env::default();
+        let (client, admin, borrower, _contract_id) = setup(&env);
+
+        let now = 1_700_000_000u64;
+        env.ledger().set_timestamp(now);
+
+        client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
+
+        assert!(client.is_borrower_frozen(&borrower));
+        assert_eq!(
+            client.get_borrower_frozen_until(&borrower),
+            Some(now + 3600)
+        );
+    }
+
+    /// freeze_borrower_until with past or present timestamp reverts.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn freeze_borrower_until_past_ts_reverts() {
+        let env = Env::default();
+        let (client, admin, borrower, _contract_id) = setup(&env);
+
+        let now = 1_700_000_000u64;
+        env.ledger().set_timestamp(now);
+        client.freeze_borrower_until(&admin, &borrower, &now);
+    }
+
+    /// Freeze expires automatically when ledger timestamp passes expiry_ts.
+    #[test]
+    fn freeze_auto_expires_after_ts() {
+        let env = Env::default();
+        let (client, admin, borrower, _contract_id) = setup(&env);
+
+        let start = 1_700_000_000u64;
+        env.ledger().set_timestamp(start);
+
+        client.freeze_borrower_until(&admin, &borrower, &(start + 3600));
+        assert!(client.is_borrower_frozen(&borrower));
+
+        env.ledger().set_timestamp(start + 3600);
+        assert!(!client.is_borrower_frozen(&borrower));
+    }
+
+    /// freeze_borrower_until requires admin auth.
+    #[test]
+    #[should_panic]
+    fn freeze_borrower_until_requires_auth() {
+        let env = Env::default();
+        let (client, _admin, borrower, _contract_id) = setup(&env);
+        let non_admin = Address::generate(&env);
+
+        let now = 1_700_000_000u64;
+        env.ledger().set_timestamp(now);
+        client.freeze_borrower_until(&non_admin, &borrower, &(now + 3600));
+    }
+
+    /// unfreeze_borrower lifts the freeze before expiry.
+    #[test]
+    fn unfreeze_borrower_lifts_freeze() {
+        let env = Env::default();
+        let (client, admin, borrower, _contract_id) = setup(&env);
+
+        let now = 1_700_000_000u64;
+        env.ledger().set_timestamp(now);
+
+        client.freeze_borrower_until(&admin, &borrower, &(now + 7200));
+        assert!(client.is_borrower_frozen(&borrower));
+
+        client.unfreeze_borrower(&admin, &borrower);
+        assert!(!client.is_borrower_frozen(&borrower));
+        assert_eq!(client.get_borrower_frozen_until(&borrower), None);
+    }
+
+    /// Unfrozen borrower returns false by default.
+    #[test]
+    fn is_borrower_frozen_defaults_false() {
+        let env = Env::default();
+        let (client, _admin, borrower, _contract_id) = setup(&env);
+
+        assert!(!client.is_borrower_frozen(&borrower));
+        assert_eq!(client.get_borrower_frozen_until(&borrower), None);
+    }
+
+    /// Event is emitted on freeze with correct topic and payload.
+    #[test]
+    fn freeze_emits_borrower_frozen_event() {
+        let env = Env::default();
+        let (client, admin, borrower, _contract_id) = setup(&env);
+
+        let now = 1_700_000_000u64;
+        let expiry = now + 3600;
+        env.ledger().set_timestamp(now);
+
+        client.freeze_borrower_until(&admin, &borrower, &expiry);
+
+        let events = env.events().all();
+        let (_contract, topics, data) = events.last().unwrap();
+        let topic_sym = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        assert_eq!(topic_sym, Symbol::new(&env, "br_freeze"));
+        let event: BorrowerFrozenEvent = data.try_into_val(&env).unwrap();
+        assert_eq!(event.borrower, borrower);
+        assert_eq!(event.frozen_until, expiry);
+    }
+
+    /// draw_credit reverts with BorrowerFrozen when a freeze is active.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #40)")]
+    fn draw_credit_reverts_when_borrower_frozen() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, borrower, contract_id) = setup(&env);
+
+        let now = 1_700_000_000u64;
+        env.ledger().set_timestamp(now);
+
+        let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let token = token_id.address();
+        client.set_liquidity_token(&token);
+        soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_i128);
+
+        client.freeze_borrower_until(&admin, &borrower, &(now + 3600));
+        client.draw_credit(&borrower, &100_i128);
+    }
+}
+
+#[cfg(test)]
+mod test_max_draw_amount {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::token::StellarAssetClient;
 
     #[test]
     fn close_credit_line_idempotent_when_already_closed() {
@@ -5283,7 +5199,6 @@ mod test_mock_liquidity_token {
     mod test_health_factor {
         use super::*;
         use crate::collateral;
-        use soroban_sdk::testutils::Address as _;
         use soroban_sdk::token::StellarAssetClient;
 
         /// Setup: contract + admin + borrower + token (used for both liquidity

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -1,45 +1,380 @@
 // SPDX-License-Identifier: MIT
 
-//! Credit-line lifecycle operations: open, suspend, close, default, reinstate.
+//! Credit line lifecycle management: suspend, close, default, reinstate, and liquidation settlement.
 //!
-//! # TTL bumping
-//! Every function that writes a credit-line entry to persistent storage also
-//! calls [`extend_ttl`](soroban_sdk::storage::Persistent::extend_ttl) to keep
-//! the entry live for [`CREDIT_LINE_TTL_EXTEND_TO`] ledgers.  The threshold
-//! [`CREDIT_LINE_TTL_THRESHOLD`] ensures we only pay for the extension when
-//! there is a real risk of expiry.
+//! # What
+//!
+//! The state-transition layer for [`CreditLineData`]. Implements:
+//!
+//! - [`open_credit_line`] — admin-only line creation; idempotent re-open
+//!   of non-Active lines under admin auth.
+//! - [`suspend_credit_line_internal`] / [`suspend_credit_line`] /
+//!   [`self_suspend_credit_line`] — Active → Suspended transition (admin
+//!   path and borrower path).
+//! - [`close_credit_line`] — Active/Suspended/Restricted → Closed.
+//!   Borrower path requires `utilized_amount == 0`; admin path is
+//!   unconditional. Idempotent on already-Closed.
+//! - [`default_credit_line`] — Active/Restricted/Suspended → Defaulted.
+//!   Emits `("credit","liq_req")` for the off-chain orchestrator.
+//! - [`reinstate_credit_line`] — Defaulted → Active or Restricted
+//!   (admin-controlled cure).
+//! - [`forgive_debt`] — admin write-off; reduces `accrued_interest`
+//!   first, then `utilized_amount`.
+//! - [`settle_default_liquidation`] — accounting half of the
+//!   cross-contract handoff with the auction; replay-protected, oracle-
+//!   gated, atomic with status transition to Closed when
+//!   `utilized_amount` hits 0.
+//! - [`set_credit_limit_bounds`] / [`validate_credit_limit_bounds`] —
+//!   global per-line bounds enforced on origination and on
+//!   `update_risk_parameters`.
+//! - [`set_repayment_schedule`] /
+//!   [`advance_repayment_schedule_after_repay`] — installment ledger
+//!   advancement.
+//!
+//! Restricted is **not** a separate transition target — it is a
+//! repayment-capable cure state created by
+//! [`crate::risk::update_risk_parameters`] when a limit decrease drops the
+//! configured limit below current utilization. Repayments auto-cure back
+//! to Active when `utilized_amount <= credit_limit`.
+//!
+//! # How
+//!
+//! Every transition:
+//!
+//! 1. Calls [`crate::auth::require_admin_auth`] (or the borrower path's
+//!    `require_auth`).
+//! 2. Calls [`crate::storage::assert_not_paused`].
+//! 3. Calls [`crate::accrual::apply_accrual`] before reading
+//!    `utilized_amount`, so the transition acts on capitalized debt.
+//! 4. Calls [`crate::storage::assert_ts_monotonic`] on every timestamp
+//!    write (`suspension_ts`, `last_rate_update_ts`).
+//! 5. Persists via [`crate::storage::persist_credit_line`] with the
+//!    captured `previous_utilized` so the global `TotalUtilized`
+//!    accumulator stays consistent.
+//! 6. Emits the transition's `CreditLineEvent` on the appropriate
+//!    `("credit", _)` topic.
+//!
+//! # Storage
+//!
+//! - **Borrower credit lines**: Persistent storage (independent TTL per borrower).
+//!   - Key: `borrower: Address` (via `DataKey::CreditLineIdByBorrower`)
+//!   - Value: `CreditLineData`
+//! - **Liquidation settlement markers**: Persistent storage (replay protection).
+//!   - Key: `(Symbol("liq_seen"), borrower, settlement_id)`
+//!   - Value: `bool` (presence = settled; replay reverts
+//!     `ContractError::AlreadyInitialized = 14`)
+//! - **Credit-limit bounds**: Instance storage (`MinCreditLimit`,
+//!   `MaxCreditLimit`).
+//! - **Repayment schedule**: Persistent storage
+//!   (`DataKey::RepaymentSchedule(Address)`).
+//!
+//! # Why (settlement replay safety)
+//!
+//! The `(borrower, settlement_id)` marker is the credit-side half of a
+//! two-sided replay barrier. The auction contract enforces the same
+//! property on `auction_id` via `AuctionKey::LiquidationSettled(auction_id)`.
+//! Together they ensure a defaulted line cannot be settled twice by the
+//! same admin transaction, by the same admin re-running with a stale
+//! settlement_id, or by the auction contract returning a duplicate value.
+//! The cross-contract return is additionally asserted equal to the
+//! admin-supplied `recovered_amount` in
+//! [`crate::lib::settle_default_liquidation`]; mismatch reverts
+//! `InvalidAmount = 5`.
+//!
+//! See [`docs/state-machine.md`](../../../docs/state-machine.md) for the
+//! authoritative transition table and
+//! [`docs/default-liquidation-auction-hook.md`](../../../docs/default-liquidation-auction-hook.md)
+//! for the handoff protocol.
 
 use crate::auth::{require_admin, require_admin_auth};
-use crate::events::{publish_credit_line_event, CreditLineEvent};
-use crate::storage::{CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD};
-use crate::types::{CreditLineData, CreditStatus};
-use soroban_sdk::{symbol_short, Address, Env};
+use crate::events::{
+    publish_credit_line_event, publish_default_liquidation_requested_event,
+    publish_default_liquidation_settled_event, publish_late_fee_charged_event, CreditLineEvent,
+    DefaultLiquidationSettledEvent, LateFeeChargedEvent,
+};
+use crate::risk::{MAX_INTEREST_RATE_BPS, MAX_RISK_SCORE};
+use crate::storage::{
+    add_treasury_balance as storage_add_treasury_balance, assert_not_paused, assert_ts_monotonic,
+    clear_repayment_schedule, get_late_fee_flat as storage_get_late_fee_flat, get_max_credit_limit,
+    get_min_credit_limit, get_repayment_schedule as storage_get_repayment_schedule,
+    persist_credit_line, set_late_fee_flat as storage_set_late_fee_flat, set_max_credit_limit,
+    set_min_credit_limit, set_repayment_schedule as storage_set_repayment_schedule,
+};
+use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
+use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
-/// Helper: bump the TTL of a borrower's persistent credit-line entry.
+/// Generate a unique key for tracking liquidation settlements.
 ///
-/// Should be called after every read **or** write that constitutes an
-/// "interaction" with the credit line so the ledger entry never silently
-/// expires while the line is still in use.
-fn bump_credit_line_ttl(env: &Env, borrower: &Address) {
-    env.storage()
-        .persistent()
-        .extend_ttl(borrower, CREDIT_LINE_TTL_THRESHOLD, CREDIT_LINE_TTL_EXTEND_TO);
+/// # Storage
+/// - **Type**: Persistent storage (independent TTL per settlement)
+/// - **Key**: `(Symbol("liq_seen"), borrower, settlement_id)`
+/// - **Purpose**: Prevents replay of the same liquidation settlement
+fn liquidation_settlement_key(
+    borrower: &Address,
+    settlement_id: &Symbol,
+) -> (Symbol, Address, Symbol) {
+    (
+        symbol_short!("liq_seen"),
+        borrower.clone(),
+        settlement_id.clone(),
+    )
 }
 
-/// Open a new credit line for a borrower (admin only).
+// ── Credit Limit Bounds Management ───────────────────────────────────────────
+
+/// Set global credit limit bounds (admin only).
+///
+/// Configures the minimum and maximum allowed credit limits for all credit lines.
+/// These bounds are enforced when opening new credit lines or increasing existing limits.
 ///
 /// # Parameters
-/// - `borrower`: Address of the borrower.
-/// - `credit_limit`: Maximum drawable amount (must be > 0).
-/// - `interest_rate_bps`: Annual interest rate in basis points (0–10 000).
-/// - `risk_score`: Borrower risk score (0–100).
+/// - `env`: The Soroban environment.
+/// - `min`: Minimum allowed credit limit. Must be >= 0.
+/// - `max`: Maximum allowed credit limit. Must be >= min.
+///
+/// # Authorization
+/// Requires admin authorization via `require_admin_auth()`.
 ///
 /// # Panics
-/// - If `credit_limit` ≤ 0, `interest_rate_bps` > 10 000, or `risk_score` > 100.
-/// - If the borrower already has an Active credit line.
+/// - `ContractError::InvalidAmount` if `min < 0`
+/// - `ContractError::LimitOutOfBounds` if `max < min`
 ///
-/// # Events
-/// Emits a `("credit", "opened")` [`CreditLineEvent`].
+/// # Storage
+/// - Writes `min` to instance storage under `DataKey::MinCreditLimit`
+/// - Writes `max` to instance storage under `DataKey::MaxCreditLimit`
+///
+/// # Example
+/// ```ignore
+/// set_credit_limit_bounds(env, 1_000, 1_000_000_000);
+/// // Now all credit lines must have limits between 1,000 and 1,000,000,000
+/// ```
+pub fn set_credit_limit_bounds(env: Env, min: i128, max: i128) {
+    assert_not_paused(&env);
+    require_admin_auth(&env);
+
+    // Validate minimum is non-negative
+    if min < 0 {
+        env.panic_with_error(ContractError::InvalidAmount);
+    }
+
+    // Validate max >= min
+    if max < min {
+        env.panic_with_error(ContractError::LimitOutOfBounds);
+    }
+
+    // Store bounds in instance storage
+    set_min_credit_limit(&env, min);
+    set_max_credit_limit(&env, max);
+}
+
+/// Get the configured global credit limit bounds.
+///
+/// Returns the minimum and maximum allowed credit limits, if configured.
+///
+/// # Returns
+/// `(min_credit_limit, max_credit_limit)` tuple, or `(None, None)` if not configured.
+///
+/// # Storage
+/// - Reads from instance storage keys `DataKey::MinCreditLimit` and `DataKey::MaxCreditLimit`
+pub fn get_credit_limit_bounds(env: Env) -> (Option<i128>, Option<i128>) {
+    let min = get_min_credit_limit(&env);
+    let max = get_max_credit_limit(&env);
+    (min, max)
+}
+
+/// Validate that a credit limit falls within configured bounds.
+///
+/// # Parameters
+/// - `env`: The Soroban environment.
+/// - `credit_limit`: The credit limit to validate.
+///
+/// # Panics
+/// - `ContractError::LimitOutOfBounds` if the limit is outside configured bounds
+///
+/// # Behavior
+/// - If bounds are not configured, validation passes (no restrictions)
+/// - If only min is configured, validates `credit_limit >= min`
+/// - If only max is configured, validates `credit_limit <= max`
+/// - If both are configured, validates `min <= credit_limit <= max`
+pub fn validate_credit_limit_bounds(env: &Env, credit_limit: i128) {
+    let min = get_min_credit_limit(env);
+    let max = get_max_credit_limit(env);
+
+    // Check minimum bound if configured
+    if let Some(min_limit) = min {
+        if credit_limit < min_limit {
+            env.panic_with_error(ContractError::LimitOutOfBounds);
+        }
+    }
+
+    // Check maximum bound if configured
+    if let Some(max_limit) = max {
+        if credit_limit > max_limit {
+            env.panic_with_error(ContractError::LimitOutOfBounds);
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn suspend_credit_line_internal(env: &Env, borrower: Address) {
+    let stored_line: CreditLineData = env
+        .storage()
+        .persistent()
+        .get(&borrower)
+        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
+    let previous_utilized = stored_line.utilized_amount;
+
+    let previous_status = stored_line.status;
+
+    // Apply interest accrual before any mutation.
+    let mut credit_line = crate::accrual::apply_accrual(env, stored_line);
+
+    if credit_line.status != CreditStatus::Active {
+        env.panic_with_error(ContractError::CreditLineSuspended);
+    }
+
+    credit_line.status = CreditStatus::Suspended;
+    let new_ts = env.ledger().timestamp();
+    assert_ts_monotonic(env, credit_line.suspension_ts, new_ts);
+    credit_line.suspension_ts = new_ts;
+    persist_credit_line(
+        env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
+
+    publish_credit_line_event(
+        env,
+        (symbol_short!("credit"), symbol_short!("suspend")),
+        CreditLineEvent {
+            borrower,
+            status: CreditStatus::Suspended,
+            credit_limit: credit_line.credit_limit,
+            interest_rate_bps: credit_line.interest_rate_bps,
+            risk_score: credit_line.risk_score,
+        },
+    );
+}
+
+/// Set or replace a borrower's installment repayment schedule.
+pub fn set_repayment_schedule(
+    env: &Env,
+    borrower: Address,
+    amount_per_period: i128,
+    period_seconds: u64,
+    first_due_ts: u64,
+) {
+    assert_not_paused(env);
+    require_admin_auth(env);
+
+    if amount_per_period <= 0 || period_seconds == 0 {
+        env.panic_with_error(ContractError::InvalidAmount);
+    }
+
+    let stored_line: CreditLineData = env
+        .storage()
+        .persistent()
+        .get(&borrower)
+        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
+
+    if stored_line.status == CreditStatus::Closed {
+        env.panic_with_error(ContractError::CreditLineClosed);
+    }
+
+    storage_set_repayment_schedule(
+        env,
+        &borrower,
+        &RepaymentSchedule {
+            amount_per_period,
+            period_seconds,
+            next_due_ts: first_due_ts,
+        },
+    );
+}
+
+/// Advance the next due timestamp when a qualifying repayment covers one or more installments.
+/// Also charges a flat late fee per overdue installment when `LateFeeFlat` is configured.
+pub fn advance_repayment_schedule_after_repay(env: &Env, borrower: &Address, amount: i128) {
+    if amount <= 0 {
+        return;
+    }
+
+    let Some(mut schedule) = storage_get_repayment_schedule(env, borrower) else {
+        return;
+    };
+
+    if schedule.amount_per_period <= 0 || schedule.period_seconds == 0 {
+        return;
+    }
+
+    let installments_paid = (amount / schedule.amount_per_period) as u64;
+    if installments_paid == 0 {
+        return;
+    }
+
+    // ── Late-fee surcharge ──────────────────────────────────────────────────
+    let late_fee = storage_get_late_fee_flat(env);
+    if late_fee > 0 {
+        let now = env.ledger().timestamp();
+        for i in 0_u64..installments_paid {
+            let due_ts = schedule
+                .next_due_ts
+                .saturating_add(i.saturating_mul(schedule.period_seconds));
+            if now > due_ts {
+                storage_add_treasury_balance(env, late_fee);
+                publish_late_fee_charged_event(
+                    env,
+                    LateFeeChargedEvent {
+                        borrower: borrower.clone(),
+                        fee: late_fee,
+                        installment_index: i.saturating_add(1),
+                    },
+                );
+            }
+        }
+    }
+
+    let advance_seconds = schedule.period_seconds.saturating_mul(installments_paid);
+    schedule.next_due_ts = schedule.next_due_ts.saturating_add(advance_seconds);
+    storage_set_repayment_schedule(env, borrower, &schedule);
+}
+
+/// Set the flat late fee per missed installment (admin only).
+///
+/// When non-zero, this fee is charged to `TreasuryBalance` for each
+/// installment that is detected as overdue during
+/// [`advance_repayment_schedule_after_repay`].
+///
+/// # Parameters
+/// - `fee`: The fee amount. Set to `0` to disable flat late-fee charges.
+///
+/// # Panics
+/// - If `fee < 0` (negative fees not allowed).
+pub fn set_late_fee_flat(env: Env, fee: i128) {
+    assert_not_paused(&env);
+    require_admin_auth(&env);
+    if fee < 0 {
+        env.panic_with_error(ContractError::InvalidAmount);
+    }
+    storage_set_late_fee_flat(&env, fee);
+}
+
+/// Get the configured flat late fee per missed installment.
+///
+/// Returns `0` if not configured (no flat late fee).
+pub fn get_late_fee_flat(env: Env) -> i128 {
+    storage_get_late_fee_flat(&env)
+}
+
+/// Open a new credit line.
+///
+/// Creating a brand-new line preserves the existing backend/risk-engine trust
+/// boundary. Re-opening any existing non-Active line requires admin auth so a
+/// borrower cannot self-suspend and then reactivate themselves on-chain.
+#[allow(dead_code)]
 pub fn open_credit_line(
     env: Env,
     borrower: Address,
@@ -62,7 +397,6 @@ pub fn open_credit_line(
     // Validate credit limit is within configured bounds
     validate_credit_limit_bounds(&env, credit_limit);
 
-    // Prevent overwriting an existing Active credit line.
     if let Some(existing) = env
         .storage()
         .persistent()
@@ -76,6 +410,13 @@ pub fn open_credit_line(
         require_admin_auth(&env);
     }
 
+    let previous_utilized = env
+        .storage()
+        .persistent()
+        .get::<Address, CreditLineData>(&borrower)
+        .map(|existing| existing.utilized_amount)
+        .unwrap_or(0);
+
     let credit_line = CreditLineData {
         borrower: borrower.clone(),
         credit_limit,
@@ -88,10 +429,8 @@ pub fn open_credit_line(
         last_accrual_ts: env.ledger().timestamp(),
         suspension_ts: 0,
     };
-
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: newly opened lines start with a full TTL window.
-    bump_credit_line_ttl(&env, &borrower);
+    persist_credit_line(&env, &borrower, &credit_line, previous_utilized, None);
+    clear_repayment_schedule(&env, &borrower);
 
     publish_credit_line_event(
         &env,
@@ -108,63 +447,72 @@ pub fn open_credit_line(
 
 /// Suspend a credit line temporarily (admin only).
 ///
-/// Only lines in [`CreditStatus::Active`] status may be suspended.
+/// # State transition
+/// `Active → Suspended`
 ///
 /// # Parameters
 /// - `borrower`: The borrower's address.
 ///
 /// # Panics
 /// - If no credit line exists for the given borrower.
-/// - If the credit line is not currently Active.
+/// - If the credit line is not currently `Active`.
 ///
 /// # Events
 /// Emits a `("credit", "suspend")` [`CreditLineEvent`].
 pub fn suspend_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
     require_admin_auth(&env);
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .expect("Credit line not found");
-
-    if credit_line.status != CreditStatus::Active {
-        panic!("Only active credit lines can be suspended");
-    }
-
-    credit_line.status = CreditStatus::Suspended;
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: interacting with a suspended line keeps it live.
-    bump_credit_line_ttl(&env, &borrower);
-
-    publish_credit_line_event(
-        &env,
-        (symbol_short!("credit"), symbol_short!("suspend")),
-        CreditLineEvent {
-            event_type: symbol_short!("suspend"),
-            borrower: borrower.clone(),
-            status: CreditStatus::Suspended,
-            credit_limit: credit_line.credit_limit,
-            interest_rate_bps: credit_line.interest_rate_bps,
-            risk_score: credit_line.risk_score,
-        },
-    );
+    suspend_credit_line_internal(&env, borrower);
 }
 
-/// Close a credit line. Callable by admin (force-close) or by borrower
-/// when utilization is zero. Idempotent if already Closed.
+/// Suspend the caller's own active credit line.
 ///
-/// # Arguments
-/// * `closer` - Must be either the contract admin (can close regardless of
-///   utilization) or the borrower (can close only when `utilized_amount` is zero).
+/// This is a borrower safety control that blocks future draws while leaving
+/// repayments available. Reactivation still requires a separate admin-controlled
+/// workflow.
+pub fn self_suspend_credit_line(env: Env, borrower: Address) {
+    assert_not_paused(&env);
+    borrower.require_auth();
+    suspend_credit_line_internal(&env, borrower);
+}
+
+/// Close a credit line permanently.
+///
+/// Transitions the credit line to [`CreditStatus::Closed`]. Once closed, no further draws or
+/// repayments are permitted. A closed line can be replaced by a new [`open_credit_line`] call.
+///
+/// # Authorization rules
+///
+/// | `closer` identity | Condition to close |
+/// |-------------------|--------------------|
+/// | Admin             | Always allowed, regardless of `utilized_amount` or current status |
+/// | Borrower          | Allowed only when `utilized_amount == 0` |
+/// | Any other address | Always rejected with `"unauthorized"` |
+///
+/// # Idempotency
+/// If the credit line is already [`CreditStatus::Closed`], the call returns without error or
+/// event. This makes the function safe to call defensively (e.g., in cleanup workflows).
+///
+/// # Parameters
+/// - `borrower`: Address whose credit line is being closed.
+/// - `closer`:   Address authorizing the close. Must be the admin or the borrower.
 ///
 /// # Panics
-/// - If the credit line does not exist.
-/// - If `closer` is not the admin or borrower.
-/// - If the borrower attempts to close while `utilized_amount != 0`.
+/// - `"Credit line not found"` — no credit line exists for `borrower`.
+/// - `"cannot close: utilized amount not zero"` — `closer == borrower` but outstanding balance > 0.
+/// - `"unauthorized"` — `closer` is neither the admin nor the borrower.
 ///
 /// # Events
-/// Emits a `("credit", "closed")` [`CreditLineEvent`].
+/// Emits a `("credit", "closed")` [`CreditLineEvent`] on successful state change.
+/// No event is emitted when the line is already closed (idempotent path).
+///
+/// # Security notes
+/// - `closer.require_auth()` is called before any storage reads, so an unauthenticated
+///   call is rejected at the Soroban host level before any state is inspected.
+/// - The authorization check uses address equality against the stored admin and the
+///   `borrower` parameter — there is no privileged role beyond these two identities.
+/// - Closing does **not** require prior suspension or default; admin can force-close from any
+///   non-closed status. This is intentional for operational efficiency.
 pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
     assert_not_paused(&env);
     // Authenticate the closer before any storage access.
@@ -197,18 +545,23 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
     } else if closer == borrower {
         // Borrower self-close: only allowed when fully repaid.
         if credit_line.utilized_amount != 0 {
-            env.panic_with_error(ContractError::UtilizationNotZero);
+            panic!("cannot close: utilized amount not zero");
         }
     } else {
         // Third party: unconditionally rejected.
-        env.panic_with_error(ContractError::Unauthorized);
+        panic!("unauthorized");
     }
 
     let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Closed;
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: keep the closed record live so history is queryable.
-    bump_credit_line_ttl(&env, &borrower);
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
+    clear_repayment_schedule(&env, &borrower);
 
     publish_credit_line_event(
         &env,
@@ -254,11 +607,8 @@ pub fn close_credit_lines_batch(env: Env, borrowers: Vec<Address>) {
 
 /// Mark a credit line as defaulted (admin only).
 ///
-/// Transition: Active or Suspended → Defaulted.
-/// After this, `draw_credit` is disabled and `repay_credit` remains allowed.
-///
-/// # Panics
-/// - If no credit line exists for the given borrower.
+/// Transition: `Active` or `Suspended` → `Defaulted`.
+/// After defaulting, `draw_credit` is disabled and `repay_credit` remains allowed.
 ///
 /// # Events
 /// Emits a `("credit", "default")` [`CreditLineEvent`].
@@ -290,9 +640,13 @@ pub fn default_credit_line(env: Env, borrower: Address) {
 
     let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Defaulted;
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: defaulted lines must remain queryable during workout period.
-    bump_credit_line_ttl(&env, &borrower);
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
 
     publish_credit_line_event(
         &env,
@@ -311,15 +665,11 @@ pub fn default_credit_line(env: Env, borrower: Address) {
 
 /// Forgive outstanding debt without transferring tokens (admin only).
 ///
-/// Allowed only when status is Defaulted. Transition: Defaulted → Active.
-///
-/// # Panics
-/// - If no credit line exists for the given borrower.
-/// - If the credit line is not currently Defaulted.
-///
-/// # Events
-/// Emits a `("credit", "reinstate")` [`CreditLineEvent`].
-pub fn reinstate_credit_line(env: Env, borrower: Address) {
+/// This is an accounting-only write-off path intended for explicit admin debt
+/// relief or off-chain settlements that have already been handled elsewhere.
+/// The forgiven amount is capped to the current `utilized_amount`.
+pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
+    assert_not_paused(&env);
     require_admin_auth(&env);
 
     if amount <= 0 {
@@ -350,7 +700,14 @@ pub fn reinstate_credit_line(env: Env, borrower: Address) {
         .checked_sub(effective_forgive)
         .unwrap_or(0);
 
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    let previous_status = credit_line.status;
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
 }
 
 /// Apply auction liquidation proceeds to a defaulted credit line (admin only).
@@ -373,11 +730,6 @@ pub fn settle_default_liquidation(
 
     if close_factor_bps == 0 || close_factor_bps > 10_000 {
         env.panic_with_error(ContractError::InvalidAmount);
-    }
-
-    let max_close_factor = crate::storage::get_close_factor_bps(&env);
-    if close_factor_bps > max_close_factor {
-        env.panic_with_error(ContractError::CloseFactorAboveMax);
     }
 
     let settlement_key = liquidation_settlement_key(&borrower, &settlement_id);
@@ -415,11 +767,18 @@ pub fn settle_default_liquidation(
         .checked_sub(recovered_amount)
         .unwrap_or_else(|| env.panic_with_error(ContractError::Overflow));
 
+    let previous_status = credit_line.status;
     if credit_line.utilized_amount == 0 {
         credit_line.status = CreditStatus::Closed;
     }
 
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
     if credit_line.status == CreditStatus::Closed {
         clear_repayment_schedule(&env, &borrower);
     }
@@ -489,9 +848,16 @@ pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditS
         env.panic_with_error(ContractError::CreditLineDefaulted);
     }
 
+    let previous_status = credit_line.status;
     credit_line.status = target_status;
     credit_line.suspension_ts = 0;
-    persist_credit_line(&env, &borrower, &credit_line, previous_utilized);
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
 
     publish_credit_line_event(
         &env,
@@ -509,6 +875,91 @@ pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditS
 // ──────────────────────────────────────────────────────────────────────────────
 // Tests
 // ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod self_suspend {
+    use crate::types::{ContractError, CreditStatus};
+    use crate::Credit;
+    use crate::CreditClient;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Address;
+    use soroban_sdk::Env;
+
+    fn setup(env: &Env) -> (CreditClient<'_>, Address) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+        (client, borrower)
+    }
+
+    /// A borrower can self-suspend their own active line; status transitions
+    /// to Suspended without admin involvement.
+    #[test]
+    fn self_suspend_transitions_active_to_suspended() {
+        let env = Env::default();
+        let (client, borrower) = setup(&env);
+
+        client.self_suspend_credit_line(&borrower);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.status, CreditStatus::Suspended);
+    }
+
+    /// Self-suspend requires the borrower's own authorization. `init` and a
+    /// brand-new `open_credit_line` need no auth, so with nothing mocked at
+    /// all, only `self_suspend_credit_line`'s `borrower.require_auth()` can
+    /// be the source of the panic.
+    #[test]
+    #[should_panic]
+    fn self_suspend_requires_borrower_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+        client.self_suspend_credit_line(&borrower);
+    }
+
+    /// Once self-suspended, draws are blocked but repayments remain available.
+    #[test]
+    fn self_suspend_blocks_draws_but_allows_repay() {
+        let env = Env::default();
+        let (client, borrower) = setup(&env);
+
+        client.self_suspend_credit_line(&borrower);
+
+        let draw_result = client.try_draw_credit(&borrower, &100_i128);
+        assert_eq!(
+            draw_result.err().unwrap().unwrap(),
+            ContractError::CreditLineSuspended.into()
+        );
+
+        // Repayment against a Suspended line is allowed (no draw occurred, so
+        // utilized_amount is 0 — this just confirms repay_credit doesn't panic
+        // on the suspended status itself).
+        client.repay_credit(&borrower, &1_i128);
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.status, CreditStatus::Suspended);
+    }
+
+    /// Self-suspending an already-suspended line panics (not idempotent).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #20)")]
+    fn self_suspend_twice_reverts() {
+        let env = Env::default();
+        let (client, borrower) = setup(&env);
+
+        client.self_suspend_credit_line(&borrower);
+        client.self_suspend_credit_line(&borrower);
+    }
+}
 
 #[cfg(test)]
 mod installment {

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -1,5 +1,7 @@
-use crate::storage::{CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD};
-use crate::types::CreditLineData;
+use crate::storage::grace_period_key;
+use crate::types::{
+    CreditLineData, CreditStatus, GracePeriodConfig, ProtocolSummary, RepaymentSchedule,
+};
 use soroban_sdk::{Address, Env};
 
 /// Return the credit line for `borrower`, or `None` if no line exists.
@@ -36,7 +38,6 @@ pub fn get_protocol_summary(env: Env) -> ProtocolSummary {
         treasury_balance: crate::storage::get_treasury_balance(&env),
         bounty_balance: crate::storage::get_bounty_balance(&env),
     }
-    result
 }
 
 /// Return the configured installment repayment schedule for `borrower`, if any.
@@ -130,7 +131,9 @@ pub fn get_health_factor(env: Env, borrower: Address) -> u32 {
         .checked_mul(100_000_000)
         .unwrap_or(u128::MAX);
 
-    let denominator = utilized_u128.checked_mul(min_ratio_u128).unwrap_or(u128::MAX);
+    let denominator = utilized_u128
+        .checked_mul(min_ratio_u128)
+        .unwrap_or(u128::MAX);
 
     // If the denominator overflowed to u128::MAX, the result will be small.
     // We guard against division-by-zero: `utilized > 0` and `min_ratio_bps`

--- a/contracts/credit/src/risk.rs
+++ b/contracts/credit/src/risk.rs
@@ -17,7 +17,7 @@
 //!     - the magnitude+cadence cap encoded by [`RateChangeConfig`] in
 //!       `Symbol("rate_cfg")` instance storage,
 //!     - the global ceiling [`MAX_INTEREST_RATE_BPS`] = 10_000.
-//! - [`set_rate_change_limits_legacy`] — configure the magnitude+cadence
+//! - [`set_rate_change_limits`] — configure the magnitude+cadence
 //!   cap.
 //! - [`set_penalty_surcharge_bps`] — configure the additive surcharge
 //!   applied to delinquent lines during accrual (see [`crate::accrual`]).
@@ -59,9 +59,11 @@
 #![warn(missing_docs)]
 
 use crate::auth::require_admin_auth;
-use crate::events::{publish_risk_parameters_updated, RiskParametersUpdatedEvent};
-use crate::storage::{rate_cfg_key, CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD};
-use crate::types::{CreditLineData, RateChangeConfig};
+use crate::events::publish_risk_parameters_updated;
+use crate::storage::{assert_not_paused, persist_credit_line, rate_cfg_key, rate_formula_key};
+use crate::types::{
+    ContractError, CreditLineData, CreditStatus, RateChangeConfig, RateFormulaConfig,
+};
 use soroban_sdk::{Address, Env};
 
 /// Maximum interest rate in basis points (100%).
@@ -70,85 +72,27 @@ pub const MAX_INTEREST_RATE_BPS: u32 = 10_000;
 /// Maximum risk score on the normalized 0-100 scale.
 pub const MAX_RISK_SCORE: u32 = 100;
 
-pub fn update_risk_parameters(
-    env: Env,
-    borrower: Address,
-    credit_limit: i128,
-    interest_rate_bps: u32,
-    risk_score: u32,
-) {
-    require_admin_auth(&env);
-
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .expect("Credit line not found");
-
-    if credit_limit < 0 {
-        panic!("credit_limit must be non-negative");
-    }
-    if credit_limit < credit_line.utilized_amount {
-        panic!("credit_limit cannot be less than utilized amount");
-    }
-    if interest_rate_bps > MAX_INTEREST_RATE_BPS {
-        panic!("interest_rate_bps exceeds maximum");
-    }
-    if risk_score > MAX_RISK_SCORE {
-        panic!("risk_score exceeds maximum");
-    }
-
-    if interest_rate_bps != credit_line.interest_rate_bps {
-        if let Some(cfg) = env
-            .storage()
-            .instance()
-            .get::<_, RateChangeConfig>(&rate_cfg_key(&env))
-        {
-            let old_rate = credit_line.interest_rate_bps;
-            let delta = interest_rate_bps.abs_diff(old_rate);
-
-            if delta > cfg.max_rate_change_bps {
-                panic!("rate change exceeds maximum allowed delta");
-            }
-
-            if cfg.rate_change_min_interval > 0 && credit_line.last_rate_update_ts != 0 {
-                let now = env.ledger().timestamp();
-                let elapsed = now.saturating_sub(credit_line.last_rate_update_ts);
-                if elapsed < cfg.rate_change_min_interval {
-                    panic!("rate change too soon: minimum interval not elapsed");
-                }
-            }
-        }
-
-        credit_line.last_rate_update_ts = env.ledger().timestamp();
-    }
-
-    credit_line.credit_limit = credit_limit;
-    credit_line.interest_rate_bps = interest_rate_bps;
-    credit_line.risk_score = risk_score;
-    env.storage().persistent().set(&borrower, &credit_line);
-    // Bump TTL: every risk-parameter update is an interaction with the line.
-    env.storage()
-        .persistent()
-        .extend_ttl(&borrower, CREDIT_LINE_TTL_THRESHOLD, CREDIT_LINE_TTL_EXTEND_TO);
-
-    publish_risk_parameters_updated(
-        &env,
-        RiskParametersUpdatedEvent {
-            borrower: borrower.clone(),
-            credit_limit,
-            interest_rate_bps,
-            risk_score,
-        },
-    );
+/// Compute interest rate from risk score using the piecewise-linear formula.
+///
+/// # Formula
+/// ```text
+/// raw_rate = base_rate_bps + (risk_score * slope_bps_per_score)
+/// effective_rate = clamp(raw_rate, min_rate_bps, min(max_rate_bps, MAX_INTEREST_RATE_BPS))
+/// ```
+///
+/// Uses saturating arithmetic to prevent overflow — if the multiplication
+/// overflows u32, it saturates to `u32::MAX` and is then clamped by the
+/// upper bound.
+pub fn compute_rate_from_score(cfg: &RateFormulaConfig, risk_score: u32) -> u32 {
+    let raw = cfg
+        .base_rate_bps
+        .saturating_add(risk_score.saturating_mul(cfg.slope_bps_per_score));
+    let upper = cfg.max_rate_bps.min(MAX_INTEREST_RATE_BPS);
+    raw.clamp(cfg.min_rate_bps, upper)
 }
 
 /// Set optional global rate-change caps (admin only).
-pub fn set_rate_change_limits_legacy(
-    env: Env,
-    max_rate_change_bps: u32,
-    rate_change_min_interval: u64,
-) {
+pub fn set_rate_change_limits(env: Env, max_rate_change_bps: u32, rate_change_min_interval: u64) {
     assert_not_paused(&env);
     require_admin_auth(&env);
 

--- a/contracts/credit/src/scoring.rs
+++ b/contracts/credit/src/scoring.rs
@@ -82,9 +82,7 @@ pub fn commit_vrf_output(env: Env, borrower: Address, commitment_hash: BytesN<32
         committed_at: env.ledger().timestamp(),
     };
 
-    env.storage()
-        .persistent()
-        .set(&key, &commitment);
+    env.storage().persistent().set(&key, &commitment);
     env.storage().persistent().set(&key, &commitment);
     bump_credit_line_ttl(&env, &borrower);
 }
@@ -237,11 +235,17 @@ mod tests {
     #[test]
     fn test_derive_score_from_hash_range() {
         let env = Env::default();
-        
+
         // Test with various hash patterns
         let hash_zero: BytesN<32> = BytesN::from_array(&env, &[0u8; 32]);
         let hash_max: BytesN<32> = BytesN::from_array(&env, &[255u8; 32]);
-        let hash_mixed: BytesN<32> = BytesN::from_array(&env, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+        let hash_mixed: BytesN<32> = BytesN::from_array(
+            &env,
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+        );
 
         // Test with various hash patterns
         let hash_zero: BytesN<32> = BytesN::from_array(&env, &[0u8; 32]);

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -58,9 +58,7 @@
 //! [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) §3 for the
 //! full per-variant tier table.
 
-use crate::types::{
-    ContractError, CreditLineData, CreditStatus, DrawsFreezeState, FreezeReason, RepaymentSchedule,
-};
+use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
 use soroban_sdk::{contracttype, Address, Env, Symbol};
 
 /// Storage keys used in instance and persistent storage.
@@ -143,6 +141,8 @@ pub enum DataKey {
     MinCreditLimit,
     /// Maximum allowed credit limit for new credit lines (admin-configurable).
     MaxCreditLimit,
+    /// Protocol-level max close factor in basis points for partial liquidation.
+    CloseFactorBps,
     /// Penalty surcharge in basis points applied to delinquent credit lines.
     /// Admin-configurable via `set_penalty_surcharge_bps`. Default is 0.
     PenaltySurchargeBps,
@@ -508,9 +508,7 @@ pub fn clear_treasury_balance(env: &Env) {
 
 /// Return configured treasury fee share in basis points, if set.
 pub fn get_treasury_fee_share_bps(env: &Env) -> Option<u32> {
-    env.storage()
-        .instance()
-        .get(&DataKey::TreasuryFeeShareBps)
+    env.storage().instance().get(&DataKey::TreasuryFeeShareBps)
 }
 
 /// Persist treasury fee share in basis points.
@@ -785,9 +783,7 @@ pub fn get_close_factor_bps(env: &Env) -> u32 {
 /// Supply `10_000` for full-liquidation-only (no partial), or any value
 /// `1..=10_000` to cap partial settlements.
 pub fn set_close_factor_bps(env: &Env, bps: u32) {
-    env.storage()
-        .instance()
-        .set(&DataKey::CloseFactorBps, &bps);
+    env.storage().instance().set(&DataKey::CloseFactorBps, &bps);
 }
 
 /// Return the installment schedule for a borrower, if configured.
@@ -818,30 +814,6 @@ pub fn set_last_draw_ts(env: &Env, borrower: &Address, ts: u64) {
         .set(&DataKey::LastDrawTs(borrower.clone()), &ts);
 }
 
-/// Get the configured max draw amount, if set.
-pub fn get_max_draw_amount(env: &Env) -> Option<i128> {
-    env.storage().instance().get(&DataKey::MaxDrawAmount)
-}
-
-/// Set the max draw amount (admin only, enforced by caller).
-pub fn set_max_draw_amount(env: &Env, amount: i128) {
-    env.storage()
-        .instance()
-        .set(&DataKey::MaxDrawAmount, &amount);
-}
-
-/// Get the configured max repay amount, if set.
-pub fn get_max_repay_amount(env: &Env) -> Option<i128> {
-    env.storage().instance().get(&DataKey::MaxRepayAmount)
-}
-
-/// Set the max repay amount (admin only, enforced by caller).
-pub fn set_max_repay_amount(env: &Env, amount: i128) {
-    env.storage()
-        .instance()
-        .set(&DataKey::MaxRepayAmount, &amount);
-}
-
 /// Get the configured draw min interval, if set.
 pub fn get_draw_min_interval(env: &Env) -> Option<u64> {
     env.storage()
@@ -854,21 +826,6 @@ pub fn set_draw_min_interval(env: &Env, seconds: u64) {
     env.storage()
         .instance()
         .set(&DataKey::DrawMinIntervalSeconds, &seconds);
-}
-
-/// Set/unset the global draws frozen flag (admin only, enforced by caller).
-pub fn set_draws_frozen(env: &Env, frozen: bool, reason: FreezeReason) {
-    env.storage()
-        .instance()
-        .set(&DataKey::DrawsFrozen, &DrawsFreezeState { frozen, reason });
-}
-
-/// Check if draws are globally frozen.
-pub fn is_draws_frozen(env: &Env) -> bool {
-    env.storage()
-        .instance()
-        .get::<DataKey, DrawsFreezeState>(&DataKey::DrawsFrozen)
-        .map_or(false, |state| state.frozen)
 }
 
 /// Check if the protocol is paused.
@@ -906,9 +863,7 @@ pub fn get_pause_reason(env: &Env) -> Option<crate::types::PauseReason> {
 /// Should be called by the entrypoint that sets the pause flag, so the reason
 /// and the flag are written atomically within the same host transaction.
 pub fn set_pause_reason(env: &Env, reason: &crate::types::PauseReason) {
-    env.storage()
-        .instance()
-        .set(&DataKey::PauseReason, reason);
+    env.storage().instance().set(&DataKey::PauseReason, reason);
 }
 
 /// Assert the protocol is not paused. Reverts with ContractError::Paused if paused.
@@ -1098,7 +1053,7 @@ pub fn is_borrower_frozen(env: &Env, borrower: &Address) -> bool {
     env.storage()
         .persistent()
         .get(&DataKey::FrozenBorrower(borrower.clone()))
-        .map_or(false, |expiry: u64| now < expiry)
+        .is_some_and(|expiry: u64| now < expiry)
 }
 
 /// Get the freeze expiry timestamp for a borrower, if one is set.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -230,6 +230,104 @@ pub enum ContractError {
     DrawReversalWindowExpired = 41,
     /// Original draw audit record not found for the specified (borrower, timestamp) pair.
     OriginalDrawNotFound = 42,
+    /// The borrower's credit line has an admin freeze with a structured reason; draws are blocked.
+    CreditLineFrozen = 43,
+    /// Bounty address has not been configured when attempting a bounty withdrawal.
+    BountyNotSet = 44,
+}
+
+/// Stable category grouping for [`ContractError`] variants.
+///
+/// Each category groups semantically related errors that share a common
+/// SDK-side recovery action. See [`docs/error-taxonomy.md`](../../../docs/error-taxonomy.md)
+/// for the full categorized reference.
+///
+/// # Stability guarantee
+/// Discriminants are **permanent**. Never reorder or renumber existing
+/// variants — doing so would break deployed SDK clients. New categories
+/// must be appended at the end with the next available integer.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractErrorCategory {
+    /// Authorization failures (wrong caller, missing admin).
+    Auth = 1,
+    /// Credit-line lifecycle state violations.
+    Lifecycle = 2,
+    /// Numeric validation or arithmetic errors.
+    Numeric = 3,
+    /// Credit limit and per-transaction cap violations.
+    Limit = 4,
+    /// Liquidity, reserve, and treasury availability failures.
+    Liquidity = 5,
+    /// Risk-score, rate, pause, and cooldown violations.
+    Risk = 6,
+    /// Oracle price-feed circuit-breaker failures.
+    Oracle = 7,
+    /// Collateral ratio or balance violations.
+    Collateral = 8,
+    /// Borrower-blocked or draw-freeze state.
+    Block = 9,
+    /// Reentrancy guard triggered.
+    Reentrancy = 10,
+    /// Miscellaneous errors that do not fit a specific category.
+    Misc = 11,
+}
+
+impl ContractError {
+    /// Return the stable category for this error variant.
+    ///
+    /// Clients can use this to group errors for UI display, analytics,
+    /// or recovery heuristics without hard-coding variant-to-category
+    /// mappings.
+    pub fn category(&self) -> ContractErrorCategory {
+        match self {
+            Self::Unauthorized | Self::NotAdmin | Self::AdminNotInitialized => {
+                ContractErrorCategory::Auth
+            }
+            Self::CreditLineClosed
+            | Self::AlreadyInitialized
+            | Self::CreditLineSuspended
+            | Self::CreditLineDefaulted => ContractErrorCategory::Lifecycle,
+            Self::InvalidAmount
+            | Self::NegativeLimit
+            | Self::Overflow
+            | Self::TimestampRegression
+            | Self::LimitOutOfBounds => ContractErrorCategory::Numeric,
+            Self::OverLimit
+            | Self::UtilizationNotZero
+            | Self::LimitDecreaseRequiresRepayment
+            | Self::DrawExceedsMaxAmount
+            | Self::RepayExceedsMaxAmount => ContractErrorCategory::Limit,
+            Self::MissingLiquidityToken
+            | Self::MissingLiquiditySource
+            | Self::InsufficientLiquidityReserve
+            | Self::LiquidityTokenCallFailed
+            | Self::InsufficientRepaymentAllowance
+            | Self::InsufficientRepaymentBalance
+            | Self::TreasuryNotSet
+            | Self::ExposureCapExceeded
+            | Self::BountyNotSet => ContractErrorCategory::Liquidity,
+            Self::RateTooHigh | Self::ScoreTooHigh | Self::Paused | Self::DrawCooldownActive => {
+                ContractErrorCategory::Risk
+            }
+            Self::OraclePriceInvalid | Self::OraclePriceStale | Self::OraclePriceDeviation => {
+                ContractErrorCategory::Oracle
+            }
+            Self::CollateralRatioBelowMinimum | Self::InsufficientCollateralBalance => {
+                ContractErrorCategory::Collateral
+            }
+            Self::BorrowerBlocked
+            | Self::DrawsFrozen
+            | Self::BorrowerFrozen
+            | Self::CreditLineFrozen => ContractErrorCategory::Block,
+            Self::Reentrancy => ContractErrorCategory::Reentrancy,
+            Self::CreditLineNotFound
+            | Self::AdminAcceptTooEarly
+            | Self::DrawReversalWindowExpired
+            | Self::OriginalDrawNotFound => ContractErrorCategory::Misc,
+        }
+    }
 }
 
 /// Stored credit line data for a borrower.
@@ -412,6 +510,42 @@ pub struct ProtocolSummaryView {
     pub total_collateral: i128,
     /// Count of currently Active credit lines.
     pub active_line_count: u32,
+}
+
+/// Structured taxonomy for credit-line and global draw freezes.
+///
+/// # Discriminant stability
+/// Discriminants are part of the contract ABI. New variants must be appended;
+/// existing values must never be reordered or renumbered.
+///
+/// # Usage
+/// - [`crate::freeze::freeze_draws`] records a global reason alongside the
+///   contract-wide draw kill-switch.
+/// - [`crate::freeze::freeze_credit_line`] records a per-borrower reason without
+///   mutating [`CreditStatus`], preserving lifecycle history for indexers.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FreezeReason {
+    /// Scheduled reserve or treasury operations affecting draw liquidity.
+    LiquidityReserve = 0,
+    /// Regulatory or compliance-mandated draw pause.
+    Compliance = 1,
+    /// Active risk investigation or off-chain risk signal.
+    RiskInvestigation = 2,
+    /// Planned operational maintenance window.
+    OperationalMaintenance = 3,
+    /// Borrower-initiated voluntary draw pause.
+    BorrowerRequest = 4,
+}
+
+/// Global draw-freeze state stored under [`crate::storage::DataKey::DrawsFrozen`].
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DrawsFreezeState {
+    /// Whether draws are currently frozen contract-wide.
+    pub frozen: bool,
+    /// Structured reason recorded when the freeze was last activated.
+    pub reason: FreezeReason,
 }
 
 /// Reason for protocol pause (escape-hatch audit trail).

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -255,56 +255,176 @@ fn category_variant_count_is_known() {
 #[test]
 fn category_mappings_are_stable() {
     // Auth
-    assert_eq!(ContractError::Unauthorized.category(), ContractErrorCategory::Auth);
-    assert_eq!(ContractError::NotAdmin.category(), ContractErrorCategory::Auth);
-    assert_eq!(ContractError::AdminNotInitialized.category(), ContractErrorCategory::Auth);
+    assert_eq!(
+        ContractError::Unauthorized.category(),
+        ContractErrorCategory::Auth
+    );
+    assert_eq!(
+        ContractError::NotAdmin.category(),
+        ContractErrorCategory::Auth
+    );
+    assert_eq!(
+        ContractError::AdminNotInitialized.category(),
+        ContractErrorCategory::Auth
+    );
     // Lifecycle
-    assert_eq!(ContractError::CreditLineClosed.category(), ContractErrorCategory::Lifecycle);
-    assert_eq!(ContractError::AlreadyInitialized.category(), ContractErrorCategory::Lifecycle);
-    assert_eq!(ContractError::CreditLineSuspended.category(), ContractErrorCategory::Lifecycle);
-    assert_eq!(ContractError::CreditLineDefaulted.category(), ContractErrorCategory::Lifecycle);
+    assert_eq!(
+        ContractError::CreditLineClosed.category(),
+        ContractErrorCategory::Lifecycle
+    );
+    assert_eq!(
+        ContractError::AlreadyInitialized.category(),
+        ContractErrorCategory::Lifecycle
+    );
+    assert_eq!(
+        ContractError::CreditLineSuspended.category(),
+        ContractErrorCategory::Lifecycle
+    );
+    assert_eq!(
+        ContractError::CreditLineDefaulted.category(),
+        ContractErrorCategory::Lifecycle
+    );
     // Numeric
-    assert_eq!(ContractError::InvalidAmount.category(), ContractErrorCategory::Numeric);
-    assert_eq!(ContractError::NegativeLimit.category(), ContractErrorCategory::Numeric);
-    assert_eq!(ContractError::Overflow.category(), ContractErrorCategory::Numeric);
-    assert_eq!(ContractError::TimestampRegression.category(), ContractErrorCategory::Numeric);
-    assert_eq!(ContractError::LimitOutOfBounds.category(), ContractErrorCategory::Numeric);
+    assert_eq!(
+        ContractError::InvalidAmount.category(),
+        ContractErrorCategory::Numeric
+    );
+    assert_eq!(
+        ContractError::NegativeLimit.category(),
+        ContractErrorCategory::Numeric
+    );
+    assert_eq!(
+        ContractError::Overflow.category(),
+        ContractErrorCategory::Numeric
+    );
+    assert_eq!(
+        ContractError::TimestampRegression.category(),
+        ContractErrorCategory::Numeric
+    );
+    assert_eq!(
+        ContractError::LimitOutOfBounds.category(),
+        ContractErrorCategory::Numeric
+    );
     // Limit
-    assert_eq!(ContractError::OverLimit.category(), ContractErrorCategory::Limit);
-    assert_eq!(ContractError::UtilizationNotZero.category(), ContractErrorCategory::Limit);
-    assert_eq!(ContractError::LimitDecreaseRequiresRepayment.category(), ContractErrorCategory::Limit);
-    assert_eq!(ContractError::DrawExceedsMaxAmount.category(), ContractErrorCategory::Limit);
-    assert_eq!(ContractError::RepayExceedsMaxAmount.category(), ContractErrorCategory::Limit);
+    assert_eq!(
+        ContractError::OverLimit.category(),
+        ContractErrorCategory::Limit
+    );
+    assert_eq!(
+        ContractError::UtilizationNotZero.category(),
+        ContractErrorCategory::Limit
+    );
+    assert_eq!(
+        ContractError::LimitDecreaseRequiresRepayment.category(),
+        ContractErrorCategory::Limit
+    );
+    assert_eq!(
+        ContractError::DrawExceedsMaxAmount.category(),
+        ContractErrorCategory::Limit
+    );
+    assert_eq!(
+        ContractError::RepayExceedsMaxAmount.category(),
+        ContractErrorCategory::Limit
+    );
     // Liquidity
-    assert_eq!(ContractError::MissingLiquidityToken.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::MissingLiquiditySource.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::InsufficientLiquidityReserve.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::LiquidityTokenCallFailed.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::InsufficientRepaymentAllowance.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::InsufficientRepaymentBalance.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::TreasuryNotSet.category(), ContractErrorCategory::Liquidity);
-    assert_eq!(ContractError::ExposureCapExceeded.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(
+        ContractError::MissingLiquidityToken.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::MissingLiquiditySource.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::InsufficientLiquidityReserve.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::LiquidityTokenCallFailed.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::InsufficientRepaymentAllowance.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::InsufficientRepaymentBalance.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::TreasuryNotSet.category(),
+        ContractErrorCategory::Liquidity
+    );
+    assert_eq!(
+        ContractError::ExposureCapExceeded.category(),
+        ContractErrorCategory::Liquidity
+    );
     // Risk
-    assert_eq!(ContractError::RateTooHigh.category(), ContractErrorCategory::Risk);
-    assert_eq!(ContractError::ScoreTooHigh.category(), ContractErrorCategory::Risk);
-    assert_eq!(ContractError::Paused.category(), ContractErrorCategory::Risk);
-    assert_eq!(ContractError::DrawCooldownActive.category(), ContractErrorCategory::Risk);
+    assert_eq!(
+        ContractError::RateTooHigh.category(),
+        ContractErrorCategory::Risk
+    );
+    assert_eq!(
+        ContractError::ScoreTooHigh.category(),
+        ContractErrorCategory::Risk
+    );
+    assert_eq!(
+        ContractError::Paused.category(),
+        ContractErrorCategory::Risk
+    );
+    assert_eq!(
+        ContractError::DrawCooldownActive.category(),
+        ContractErrorCategory::Risk
+    );
     // Oracle
-    assert_eq!(ContractError::OraclePriceInvalid.category(), ContractErrorCategory::Oracle);
-    assert_eq!(ContractError::OraclePriceStale.category(), ContractErrorCategory::Oracle);
-    assert_eq!(ContractError::OraclePriceDeviation.category(), ContractErrorCategory::Oracle);
+    assert_eq!(
+        ContractError::OraclePriceInvalid.category(),
+        ContractErrorCategory::Oracle
+    );
+    assert_eq!(
+        ContractError::OraclePriceStale.category(),
+        ContractErrorCategory::Oracle
+    );
+    assert_eq!(
+        ContractError::OraclePriceDeviation.category(),
+        ContractErrorCategory::Oracle
+    );
     // Collateral
-    assert_eq!(ContractError::CollateralRatioBelowMinimum.category(), ContractErrorCategory::Collateral);
-    assert_eq!(ContractError::InsufficientCollateralBalance.category(), ContractErrorCategory::Collateral);
+    assert_eq!(
+        ContractError::CollateralRatioBelowMinimum.category(),
+        ContractErrorCategory::Collateral
+    );
+    assert_eq!(
+        ContractError::InsufficientCollateralBalance.category(),
+        ContractErrorCategory::Collateral
+    );
     // Block
-    assert_eq!(ContractError::BorrowerBlocked.category(), ContractErrorCategory::Block);
-    assert_eq!(ContractError::DrawsFrozen.category(), ContractErrorCategory::Block);
-    assert_eq!(ContractError::BorrowerFrozen.category(), ContractErrorCategory::Block);
+    assert_eq!(
+        ContractError::BorrowerBlocked.category(),
+        ContractErrorCategory::Block
+    );
+    assert_eq!(
+        ContractError::DrawsFrozen.category(),
+        ContractErrorCategory::Block
+    );
+    assert_eq!(
+        ContractError::BorrowerFrozen.category(),
+        ContractErrorCategory::Block
+    );
     // Reentrancy
-    assert_eq!(ContractError::Reentrancy.category(), ContractErrorCategory::Reentrancy);
+    assert_eq!(
+        ContractError::Reentrancy.category(),
+        ContractErrorCategory::Reentrancy
+    );
     // Misc
-    assert_eq!(ContractError::CreditLineNotFound.category(), ContractErrorCategory::Misc);
-    assert_eq!(ContractError::AdminAcceptTooEarly.category(), ContractErrorCategory::Misc);
+    assert_eq!(
+        ContractError::CreditLineNotFound.category(),
+        ContractErrorCategory::Misc
+    );
+    assert_eq!(
+        ContractError::AdminAcceptTooEarly.category(),
+        ContractErrorCategory::Misc
+    );
 }
 
 /// Verify every ContractError variant's category matches its discriminant table.
@@ -357,7 +477,11 @@ fn every_variant_has_known_category() {
     ];
 
     let unique: HashSet<ContractErrorCategory> = all_variants.iter().cloned().collect();
-    assert_eq!(unique.len(), 11, "Not all 11 categories are covered by variant mappings");
+    assert_eq!(
+        unique.len(),
+        11,
+        "Not all 11 categories are covered by variant mappings"
+    );
     assert_eq!(all_variants.len(), 40, "Expected 40 ContractError variants");
 }
 
@@ -370,7 +494,7 @@ fn every_variant_has_known_category() {
 
 #[cfg(test)]
 mod error_path_tests {
-use creditra_credit::types::ContractError;
+    use creditra_credit::types::ContractError;
     use creditra_credit::{Credit, CreditClient};
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
@@ -422,7 +546,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::AdminNotInitialized,
+            ContractError::AdminNotInitialized.into(),
             "Expected AdminNotInitialized error"
         );
     }
@@ -444,7 +568,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::CreditLineNotFound,
+            ContractError::CreditLineNotFound.into(),
             "Expected CreditLineNotFound error on draw"
         );
     }
@@ -466,7 +590,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::CreditLineNotFound,
+            ContractError::CreditLineNotFound.into(),
             "Expected CreditLineNotFound error on repay"
         );
     }
@@ -488,7 +612,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::CreditLineNotFound,
+            ContractError::CreditLineNotFound.into(),
             "Expected CreditLineNotFound error on close"
         );
     }
@@ -510,7 +634,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::CreditLineNotFound,
+            ContractError::CreditLineNotFound.into(),
             "Expected CreditLineNotFound error on suspend"
         );
     }
@@ -532,7 +656,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::CreditLineNotFound,
+            ContractError::CreditLineNotFound.into(),
             "Expected CreditLineNotFound error on default"
         );
     }
@@ -554,7 +678,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::CreditLineNotFound,
+            ContractError::CreditLineNotFound.into(),
             "Expected CreditLineNotFound error on risk update"
         );
     }
@@ -587,7 +711,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::Overflow,
+            ContractError::Overflow.into(),
             "Expected Overflow error on utilization add"
         );
     }
@@ -611,6 +735,8 @@ use creditra_credit::types::ContractError;
             &borrower,
             &2000_i128,
             &soroban_sdk::symbol_short!("settle1"),
+            &10_000_u32,
+            &None,
         );
 
         assert!(
@@ -643,7 +769,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::MissingLiquidityToken,
+            ContractError::MissingLiquidityToken.into(),
             "Expected MissingLiquidityToken error"
         );
     }
@@ -673,7 +799,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::MissingLiquiditySource,
+            ContractError::MissingLiquiditySource.into(),
             "Expected MissingLiquiditySource error"
         );
     }
@@ -693,7 +819,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::TreasuryNotSet,
+            ContractError::TreasuryNotSet.into(),
             "Expected TreasuryNotSet error"
         );
     }
@@ -728,7 +854,7 @@ use creditra_credit::types::ContractError;
             let err = result.err().unwrap();
             assert_eq!(
                 err.unwrap(),
-                ContractError::Overflow,
+                ContractError::Overflow.into(),
                 "Expected Overflow error on cap calculation"
             );
         }
@@ -767,7 +893,7 @@ use creditra_credit::types::ContractError;
         let err = result.err().unwrap();
         assert_eq!(
             err.unwrap(),
-            ContractError::ExposureCapExceeded,
+            ContractError::ExposureCapExceeded.into(),
             "Expected ExposureCapExceeded error"
         );
     }
@@ -809,7 +935,7 @@ use creditra_credit::types::ContractError;
         if result.is_err() {
             let err = result.err().unwrap();
             // Could be TimestampRegression or another validation error
-            assert!(err.is_ok() || err.unwrap() == ContractError::TimestampRegression);
+            assert!(err.is_ok() || err.unwrap() == ContractError::TimestampRegression.into());
         }
     }
 }


### PR DESCRIPTION
## Summary

#620 reported a duplicated `self_suspend_credit_line` in `lifecycle.rs`. Investigating it surfaced a much larger problem: `main` currently does not compile at all (`cargo check --workspace` fails). The root cause traces back to a chain of bad auto-merges starting at PR #660 ("conflicts auto-resolved -X theirs"), which clobbered concurrent work across `lib.rs`, `lifecycle.rs`, `risk.rs`, `borrow.rs`, `query.rs`, `storage.rs`, and `types.rs`. Every merge since then compounded on top of an already-broken base.

This PR restores `cargo check --workspace` to a clean, passing state:

- **`lifecycle.rs`** — the actual duplicate wasn't `self_suspend_credit_line` (it had been deleted entirely, even though `lib.rs` still called it) — it was a corrupted second copy of `forgive_debt` mislabeled as a duplicate `reinstate_credit_line`. Dropped the corrupted duplicate, restored `self_suspend_credit_line` and its supporting helpers from the last known-good pre-corruption revision, and added 4 focused unit tests (transition to Suspended, borrower-auth requirement, draw-blocking post-suspend, non-idempotency).
- **`lib.rs`** — fixed an unclosed delimiter, restored missing `mod` declarations (`collateral`, `math_utils`, `views`), removed a corrupted duplicate `test_helpers`/`test_mock_liquidity_token` module, fixed several tests left with undefined variables or wrong call arity from the bad merges, and rewired admin entrypoints (`forgive_debt`, `set_late_fee_flat`/`get_late_fee_flat`, borrower rate floor/ceiling, penalty surcharge) whose implementations existed but had lost their public API wiring.
- **`risk.rs`** — removed a stale duplicate `update_risk_parameters` and restored the `compute_rate_from_score` helper it depends on.
- **`borrow.rs`** — dropped an unused/broken duplicate `draw_credit`/`repay_credit` (the real implementations live inline in `lib.rs`); kept only the `draw_status_error` helper that's actually called.
- **`types.rs`** — restored `FreezeReason`/`DrawsFreezeState` (already depended on by `freeze.rs`) and the `ContractErrorCategory` taxonomy, plus two new error variants (`CreditLineFrozen`, `BountyNotSet`) already referenced elsewhere.
- **`storage.rs`** — added the missing `CloseFactorBps` `DataKey` variant; removed six functions that were dead duplicates of logic already implemented directly in `lib.rs`.
- **`query.rs`** — fixed broken imports and a stray statement after a function's return.
- **`tests/error_discriminants.rs`** — fixed `Error`/`ContractError` comparison mismatches and a call missing arguments added by a later PR.

## Known follow-ups (out of scope here)

- ~83 pre-existing test failures across `accrual_tests`, `amount_validation_tests`, `math_utils`, and other modules — confirmed byte-for-byte unchanged since before the corruption, caused by test fixtures never updated for the minimum-collateral-ratio enforcement in `draw_credit`.
- `gateway-auction` (pulled in as a dev-dependency for the auction-hook tests) has its own pre-existing, unrelated compile error (`DutchAuctionDecay`/`ScVal`), which blocks `cargo test -p creditra-credit` from running end-to-end without temporarily removing the dependency.
- Several integration test files under `tests/` (`limit_increase_matrix`, `event_block_ledger_seq`, `accrual_monotonic`, `installment_interest_only_repay`, `borrower_self_suspend`, `unauthorized_matrix`) don't compile against the current SDK/API; confirmed pre-existing and unrelated to this fix.
- A handful of test modules in `lib.rs` remain nested one level deeper than their names suggest (e.g. `test_health_factor` under `test_max_draw_amount`) due to the same historical merge damage; harmless for test discovery but worth flattening in a follow-up cleanup.

## Test plan

- [x] `cargo check --workspace` passes (was failing before this PR)
- [x] `cargo clippy -p creditra-credit --all-targets -- -D warnings` is clean for every file touched in this diff (broader pre-existing clippy debt in untouched files remains, see follow-ups)
- [x] `cargo fmt --all -- --check` is clean for every file touched in this diff
- [x] `cargo test -p creditra-credit --lib` — 211 passed (incl. 4 new `self_suspend_credit_line` tests), 83 pre-existing failures unrelated to this change (see follow-ups)
- [x] `lifecycle::installment::*` (late-fee tests) and `lifecycle::self_suspend::*` all pass

Closes #620