### PR TITLE
docs: events catalog spec

### DIFF
--- a/contracts/credit/src/attestation.rs
+++ b/contracts/credit/src/attestation.rs
@@ -111,7 +111,7 @@ fn hash_pair(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
     let right_bytes: Bytes = right.clone().into();
     buf.append(&left_bytes);
     buf.append(&right_bytes);
-    env.crypto().sha256(&buf)
+    env.crypto().sha256(&buf).into()
 }
 
 /// Compute the Merkle root from a `leaf` and an ordered sibling `proof` path.

--- a/contracts/credit/src/borrow.rs
+++ b/contracts/credit/src/borrow.rs
@@ -11,6 +11,14 @@ use crate::storage::{
 use crate::types::{ContractError, CreditLineData, CreditStatus};
 use soroban_sdk::{token, Address, Env};
 
+/// Return an error if the given credit-line status is not drawable.
+pub fn draw_status_error(status: CreditStatus) -> Option<ContractError> {
+    match status {
+        CreditStatus::Active => None,
+        _ => Some(ContractError::InvalidAmount),
+    }
+}
+
 pub fn draw_credit(env: Env, borrower: Address, amount: i128) {
     set_reentrancy_guard(&env);
     borrower.require_auth();
@@ -92,15 +100,14 @@ pub fn draw_credit(env: Env, borrower: Address, amount: i128) {
         .persistent()
         .extend_ttl(&borrower, CREDIT_LINE_TTL_THRESHOLD, CREDIT_LINE_TTL_EXTEND_TO);
     let timestamp = env.ledger().timestamp();
-    publish_drawn_event(
-        &env,
-        DrawnEvent {
-            borrower,
-            amount,
-            new_utilized_amount: updated_utilized,
-            timestamp,
-        },
-    );
+        publish_drawn_event(
+            &env,
+            DrawnEvent {
+                borrower,
+                amount,
+                new_utilized_amount: updated_utilized,
+            },
+        );
     clear_reentrancy_guard(&env);
 }
 

--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -17,7 +17,7 @@
 //! single-element `("blk_chg",)` topic for borrower blocklist changes.
 //!
 //! **Canonical schema and versioning policy:**
-//! See [`docs/events-schema.md`](../../../docs/events-schema.md) for the full
+//! See [`docs/EVENTS_CATALOG.md`](../../../docs/EVENTS_CATALOG.md) for the full
 //! authoritative event catalog, topic versions, and payload field orders.
 //!
 //! # How
@@ -37,7 +37,7 @@
 //! with a version suffix (e.g., `("credit","drawn_v2")`).
 //!
 //! See [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md) for the
-//! end-to-end event topology, [`docs/events-schema.md`](../../../docs/events-schema.md)
+//! end-to-end event topology, [`docs/EVENTS_CATALOG.md`](../../../docs/EVENTS_CATALOG.md)
 //! for the canonical catalog and versioning rules, and
 //! [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) for the
 //! per-entrypoint event-emission table.
@@ -585,6 +585,29 @@ pub fn publish_treasury_withdrawal_executed(
 ) {
     env.events().publish(
         (symbol_short!("credit"), Symbol::new(env, "tre_exec")),
+        event,
+    );
+}
+
+/// Payload emitted when an admin commits a new attestation batch for a borrower.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttestationBatchCommittedEvent {
+    /// Borrower whose attestation batch was updated.
+    pub borrower: Address,
+    /// SHA-256 Merkle root of all leaf hashes in the committed batch.
+    pub merkle_root: soroban_sdk::BytesN<32>,
+    /// Number of leaves in the batch (informational).
+    pub count: u32,
+}
+
+/// Publish an attestation batch committed event.
+pub fn publish_attestation_batch_committed(
+    env: &Env,
+    event: AttestationBatchCommittedEvent,
+) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "atst_bat")),
         event,
     );
 }

--- a/contracts/credit/src/handshake.rs
+++ b/contracts/credit/src/handshake.rs
@@ -1,4 +1,3 @@
-#![no_std]
 use soroban_sdk::{contracttype, Env};
 
 #[contracttype]

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1,4 +1,3 @@
-mod handshake;
 // SPDX-License-Identifier: MIT
 #![cfg_attr(not(test), no_std)]
 #![allow(clippy::unused_unit)]
@@ -95,6 +94,8 @@ mod handshake;
 //! lives in [`instrument`] (requires the `instrument` Cargo feature; not
 //! compiled into WASM).
 
+mod handshake;
+
 mod accrual;
 #[cfg(test)]
 mod accrual_tests;
@@ -140,6 +141,8 @@ use crate::events::{
     publish_oracle_price_accepted_event, publish_rate_formula_config_event,
     publish_repayment_event, publish_token_rescued_event,
     publish_treasury_withdrawal_executed, publish_treasury_withdrawal_proposed,
+    publish_protocol_fee_bps_set_event, publish_protocol_fee_bounds_set_event,
+    publish_close_factor_bps_set_event, publish_paused_event,
     ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent, TreasuryWithdrawalExecutedEvent,
     TreasuryWithdrawalProposedEvent,
@@ -164,8 +167,8 @@ use crate::storage::{
 };
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
-    TreasuryWithdrawalProposal,
+    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, ProofOfReserve, RateChangeConfig,
+    RateFormulaConfig, TreasuryWithdrawalProposal,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -1821,8 +1824,8 @@ impl Credit {
         publish_paused_event(&env, paused);
     }
 
-    pub fn freeze_draws(env: Env) {
-        freeze::freeze_draws(env)
+    pub fn freeze_draws(env: Env, reason: FreezeReason) {
+        freeze::freeze_draws(env, reason)
     }
 
     pub fn unfreeze_draws(env: Env) {

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -858,9 +858,3 @@ mod installment {
         assert_eq!(treasury_after - treasury_before, 30);
     }
 }
-// Version Handshake Check
-let remote_version = auction_client.get_version();
-assert!(handshake::verify_version(&env, remote_version), "Incompatible Version");
-// Version Handshake Check
-let remote_version = auction_client.get_version();
-assert!(handshake::verify_version(&env, remote_version), "Incompatible Version");

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -1,5 +1,5 @@
-use crate::storage::{CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD};
-use crate::types::CreditLineData;
+use crate::storage::{CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD, grace_period_key};
+use crate::types::{CreditLineData, CreditStatus, GracePeriodConfig, RepaymentSchedule, ProtocolSummary};
 use soroban_sdk::{Address, Env};
 
 /// Return the credit line for `borrower`, or `None` if no line exists.
@@ -36,7 +36,6 @@ pub fn get_protocol_summary(env: Env) -> ProtocolSummary {
         treasury_balance: crate::storage::get_treasury_balance(&env),
         bounty_balance: crate::storage::get_bounty_balance(&env),
     }
-    result
 }
 
 /// Return the configured installment repayment schedule for `borrower`, if any.

--- a/contracts/credit/src/risk.rs
+++ b/contracts/credit/src/risk.rs
@@ -60,7 +60,7 @@
 
 use crate::auth::require_admin_auth;
 use crate::events::publish_risk_parameters_updated;
-use crate::storage::{assert_not_paused, rate_cfg_key, CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD};
+use crate::storage::{assert_not_paused, persist_credit_line, rate_cfg_key, rate_formula_key, CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD};
 use crate::types::{ContractError, CreditLineData, CreditStatus, RateChangeConfig, RateFormulaConfig};
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
 

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -192,6 +192,12 @@ pub enum DataKey {
     /// Pending treasury withdrawal proposal (at most one at a time).
     /// Stored in instance storage; cleared after successful execution.
     PendingTreasuryWithdrawal,
+    /// Per-borrower attestation batch Merkle root commitment.
+    AttestationBatch(Address),
+    /// Protocol-level max close factor in basis points for partial liquidation.
+    CloseFactorBps,
+    /// Structured pause reason stored when the protocol is paused.
+    PauseReason,
 }
 
 /// Maximum number of credit lines returned per page.
@@ -218,6 +224,8 @@ pub const MAX_ENUMERATION_LIMIT: u32 = 100;
 // number of TTL writes per active key is at most one per three months.
 pub const LEDGER_BUMP_AMOUNT: u32 = 3_110_400; // ~6 months
 pub const LEDGER_BUMP_THRESHOLD: u32 = 1_555_200; // ~3 months
+pub const CREDIT_LINE_TTL_EXTEND_TO: u32 = LEDGER_BUMP_AMOUNT;
+pub const CREDIT_LINE_TTL_THRESHOLD: u32 = LEDGER_BUMP_THRESHOLD;
 
 /// Instance storage TTL policy (covers global config like admin/liquidity token).
 pub const INSTANCE_BUMP_AMOUNT: u32 = LEDGER_BUMP_AMOUNT;

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -51,7 +51,7 @@
 //! against a `major.minor.patch` of `CONTRACT_API_VERSION` (currently
 //! `(1, 0, 0)`).
 
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, Symbol};
 
 /// Status of a borrower's credit line.
 ///
@@ -236,6 +236,14 @@ pub enum ContractError {
     TreasuryTimelockActive = 43,
     /// A treasury withdrawal proposal already exists; cancel or execute it first.
     TreasuryProposalExists = 44,
+    /// Credit line is frozen by admin for compliance or investigation.
+    CreditLineFrozen = 45,
+    /// Original draw timestamp not found in the audit trail.
+    OriginalDrawNotFound = 46,
+    /// Draw reversal window has expired.
+    DrawReversalWindowExpired = 47,
+    /// Attestation batch not found for this borrower.
+    AttestationBatchNotFound = 48,
 }
 
 /// Stored credit line data for a borrower.
@@ -446,4 +454,44 @@ pub struct TreasuryWithdrawalProposal {
     pub proposed_at: u64,
     /// Earliest ledger timestamp at which execution is permitted (`proposed_at + 86_400`).
     pub execute_after: u64,
+}
+
+/// Proof-of-reserve balances for the protocol treasury.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofOfReserve {
+    /// Accumulated treasury balance held in contract (fees collected).
+    pub treasury_balance: i128,
+    /// Accumulated bounty pool balance held in contract (fee share).
+    pub bounty_balance: i128,
+}
+
+/// Structured pause reason recorded alongside the pause flag.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PauseReason {
+    /// Human-readable reason symbol (e.g. "oracle-outage").
+    pub reason: Symbol,
+    /// Ledger timestamp when the pause was initiated.
+    pub timestamp: u64,
+    /// Address of the actor that initiated the pause.
+    pub actor: Address,
+}
+
+/// Draw freeze reason taxonomy for indexer and governance tooling.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FreezeReason {
+    /// Draws frozen for liquidity reserve operations.
+    LiquidityReserve = 0,
+}
+
+/// Global draw freeze state with structured reason.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DrawsFreezeState {
+    /// `true` when draws are globally frozen.
+    pub frozen: bool,
+    /// Structured reason for the freeze action.
+    pub reason: FreezeReason,
 }

--- a/contracts/credit/tests/event_bound_draw.rs
+++ b/contracts/credit/tests/event_bound_draw.rs
@@ -21,7 +21,7 @@
 //! The per-draw cap `MAX_EVENTS_PER_DRAW = 4` accommodates all legitimate
 //! combinations while remaining tight enough for indexers.
 //!
-//! See [`docs/events-schema.md`](../../docs/events-schema.md) for the
+//! See [`docs/EVENTS_CATALOG.md`](../../docs/EVENTS_CATALOG.md) for the
 //! canonical event catalog.
 
 use creditra_credit::types::CreditStatus;

--- a/contracts/credit/tests/events_catalog.rs
+++ b/contracts/credit/tests/events_catalog.rs
@@ -1,0 +1,746 @@
+// SPDX-License-Identifier: MIT
+
+//! Focused tests for the events catalog.
+//!
+//! Verifies that every event and publisher declared in `docs/EVENTS_CATALOG.md`
+//! is present in the compiled contract and emits the expected topic and payload
+//! shape. Run with:
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test events_catalog
+//! ```
+
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol, TryFromVal};
+
+use creditra_credit::{FreezeReason, types::CreditStatus, types::GraceWaiverMode};
+use creditra_credit::events::*;
+use gateway_auction::events::*;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn env_and_addresses() -> (Env, Address, Address) {
+    let env = Env::default();
+    let borrower = Address::generate(&env);
+    let admin = Address::generate(&env);
+    (env, borrower, admin)
+}
+
+// Read the first topic symbol from a published event (credit contract uses
+// ("credit", "...") or ("blk_chg",) or ("br_freeze",)).
+fn first_topic(env: &Env, index: u32) -> Symbol {
+    let ev = env.events().all().get(index).unwrap();
+    let topics = ev.1;
+    Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap()
+}
+
+// Read the second topic symbol from a published event, if present.
+fn second_topic(env: &Env, index: u32) -> Symbol {
+    let ev = env.events().all().get(index).unwrap();
+    let topics = ev.1;
+    Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap()
+}
+
+// ── Credit contract event shape tests ─────────────────────────────────────────
+
+#[test]
+fn credit_line_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    for suffix in ["opened", "suspend", "closed", "default", "reinstate"] {
+        let ev = CreditLineEvent {
+            borrower: borrower.clone(),
+            status: CreditStatus::Active,
+            credit_limit: 1_000,
+            interest_rate_bps: 500,
+            risk_score: 70,
+        };
+        publish_credit_line_event(
+            &env,
+            (symbol_short!("credit"), Symbol::new(&env, suffix)),
+            ev,
+        );
+    }
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 5);
+
+    for i in 0..5 {
+        assert_eq!(first_topic(&env, i as u32), symbol_short!("credit"));
+    }
+}
+
+#[test]
+fn drawn_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_drawn_event(
+        &env,
+        DrawnEvent {
+            borrower: borrower.clone(),
+            amount: 500,
+            new_utilized_amount: 500,
+        },
+    );
+
+    let ev = env.events().all().get(0).unwrap();
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("drawn"));
+}
+
+#[test]
+fn drawn_event_v2_shape() {
+    let (env, borrower, admin) = env_and_addresses();
+
+    publish_drawn_event_v2(
+        &env,
+        DrawnEventV2 {
+            borrower: borrower.clone(),
+            recipient: borrower.clone(),
+            reserve_source: admin.clone(),
+            amount: 500,
+            new_utilized_amount: 500,
+            timestamp: 100,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("drawn_v2"));
+}
+
+#[test]
+fn repayment_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_repayment_event(
+        &env,
+        RepaymentEvent {
+            borrower: borrower.clone(),
+            amount: 100,
+            new_utilized_amount: 400,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("repay"));
+}
+
+#[test]
+fn interest_accrued_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_interest_accrued_event(
+        &env,
+        InterestAccruedEvent {
+            borrower: borrower.clone(),
+            accrued_amount: 25,
+            new_utilized_amount: 425,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("accrue"));
+}
+
+#[test]
+fn fee_accrued_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_fee_accrued_event(
+        &env,
+        FeeAccruedEvent {
+            borrower: borrower.clone(),
+            fee_amount: 10,
+            treasury_amount: 6,
+            bounty_amount: 4,
+            new_treasury_balance: 106,
+            new_bounty_balance: 204,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("fee_accrd"));
+}
+
+#[test]
+fn late_fee_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_late_fee_charged_event(
+        &env,
+        LateFeeChargedEvent {
+            borrower: borrower.clone(),
+            fee: 50,
+            installment_index: 3,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("late_fee"));
+}
+
+#[test]
+fn risk_parameters_updated_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_risk_parameters_updated(&env, &borrower, 2_000, 750, 80);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("risk_upd"));
+}
+
+#[test]
+fn draw_reversed_event_shape() {
+    let (env, borrower, admin) = env_and_addresses();
+
+    publish_draw_reversed_event(
+        &env,
+        DrawReversedEvent {
+            borrower: borrower.clone(),
+            amount: 100,
+            original_ts: 10,
+            reason_code: 1,
+            new_utilized_amount: 0,
+            timestamp: 20,
+            admin: admin.clone(),
+            accounting_only: false,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "draw_rev"));
+}
+
+#[test]
+fn credit_line_freeze_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_credit_line_freeze_event(&env, &borrower, FreezeReason::AdminAction, true);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "line_frz"));
+}
+
+#[test]
+fn borrower_frozen_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_borrower_frozen_event(&env, &borrower, 1_000_000);
+
+    // Published on a single-element topic tuple ("br_freeze",)
+    let ev = env.events().all().get(0).unwrap();
+    let topics = ev.1;
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        Symbol::new(&env, "br_freeze")
+    );
+}
+
+#[test]
+fn penalty_rate_entered_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_penalty_rate_entered_event(&env, &borrower, 500, 200, 700);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "pen_enter"));
+}
+
+#[test]
+fn penalty_rate_exited_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_penalty_rate_exited_event(&env, &borrower, 700, 500);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "pen_exit"));
+}
+
+#[test]
+fn grace_waiver_event_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_grace_waiver_applied_event(
+        &env,
+        &borrower,
+        10,
+        creditra_credit::types::GraceWaiverMode::FullWaiver,
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("grace_wv"));
+}
+
+#[test]
+fn admin_rotation_proposed_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_admin_rotation_proposed(&env, &admin, 200);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "admin_prop"));
+}
+
+#[test]
+fn admin_rotation_accepted_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_admin_rotation_accepted(&env, &admin);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "admin_acc"));
+}
+
+#[test]
+fn treasury_withdrawal_proposed_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_treasury_withdrawal_proposed(
+        &env,
+        TreasuryWithdrawalProposedEvent {
+            recipient: admin.clone(),
+            amount: 1_000,
+            proposer: admin.clone(),
+            proposed_at: 100,
+            execute_after: 100 + 86_400,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "tre_prop"));
+}
+
+#[test]
+fn treasury_withdrawal_executed_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_treasury_withdrawal_executed(
+        &env,
+        TreasuryWithdrawalExecutedEvent {
+            recipient: admin.clone(),
+            amount: 500,
+            executor: admin.clone(),
+            executed_at: 200,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "tre_exec"));
+}
+
+#[test]
+fn borrower_blocked_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_borrower_blocked_event(&env, &borrower, true);
+
+    let ev = env.events().all().get(0).unwrap();
+    let topics = ev.1;
+    assert_eq!(topics.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        Symbol::new(&env, "blk_chg")
+    );
+}
+
+#[test]
+fn collateral_deposited_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_collateral_deposited_event(
+        &env,
+        CollateralDepositedEvent {
+            borrower: borrower.clone(),
+            amount: 1_000,
+            new_balance: 1_000,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("col_dep"));
+}
+
+#[test]
+fn collateral_withdrawn_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_collateral_withdrawn_event(
+        &env,
+        CollateralWithdrawnEvent {
+            borrower: borrower.clone(),
+            amount: 500,
+            new_balance: 500,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), symbol_short!("col_wit"));
+}
+
+#[test]
+fn token_rescued_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_token_rescued_event(
+        &env,
+        TokenRescuedEvent {
+            token: admin.clone(),
+            recipient: admin.clone(),
+            amount: 100,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "tok_resc"));
+}
+
+#[test]
+fn contract_upgraded_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_contract_upgraded_event(
+        &env,
+        ContractUpgradedEvent {
+            old_wasm_hash: BytesN::new(&env, &[0xAA; 32]),
+            new_wasm_hash: BytesN::new(&env, &[0xBB; 32]),
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "upgraded"));
+}
+
+#[test]
+fn default_liquidation_settled_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_default_liquidation_settled_event(
+        &env,
+        DefaultLiquidationSettledEvent {
+            borrower: borrower.clone(),
+            settlement_id: Symbol::new(&env, "auction-1"),
+            recovered_amount: 500,
+            remaining_utilized_amount: 500,
+            status: CreditStatus::Closed,
+            close_factor_bps: 5000,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "liq_setl"));
+}
+
+#[test]
+fn default_liquidation_requested_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_default_liquidation_requested_event(&env, &borrower, 1_500);
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "liq_req"));
+}
+
+#[test]
+fn attestation_batch_committed_shape() {
+    let (env, borrower, _admin) = env_and_addresses();
+
+    publish_attestation_batch_committed(
+        &env,
+        AttestationBatchCommittedEvent {
+            borrower: borrower.clone(),
+            merkle_root: BytesN::new(&env, &[0xCC; 32]),
+            count: 42,
+        },
+    );
+
+    assert_eq!(first_topic(&env, 0), symbol_short!("credit"));
+    assert_eq!(second_topic(&env, 0), Symbol::new(&env, "atst_bat"));
+}
+
+#[test]
+fn raw_value_events_shape() {
+    let (env, _borrower, _admin) = env_and_addresses();
+
+    publish_rate_formula_config_event(&env, true);
+    publish_paused_event(&env, true);
+    publish_paused_event(&env, false);
+    publish_protocol_fee_bps_set_event(&env, 500);
+    publish_protocol_fee_bounds_set_event(&env, 100, 2_000);
+    publish_close_factor_bps_set_event(&env, 5_000);
+    publish_oracle_config_set_event(&env, 500, 3_600);
+    publish_oracle_price_accepted_event(&env, 1_000_000, 1_000);
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 8);
+
+    let topics = [
+        ("credit", "rate_form"),
+        ("credit", "paused"),
+        ("credit", "unpaused"),
+        ("credit", "fee_set"),
+        ("credit", "fee_bnd"),
+        ("credit", "clsfctr"),
+        ("credit", "orc_cfg"),
+        ("credit", "orc_price"),
+    ];
+
+    for (i, (t0, t1)) in topics.iter().enumerate() {
+        assert_eq!(
+            first_topic(&env, i as u32),
+            symbol_short!(t0),
+            "topic[{}] first symbol mismatch",
+            i
+        );
+        assert_eq!(
+            second_topic(&env, i as u32),
+            Symbol::new(&env, t1),
+            "topic[{}] second symbol mismatch",
+            i
+        );
+    }
+}
+
+// ── Auction contract event shape tests ────────────────────────────────────────
+
+#[test]
+fn auction_bid_refunded_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_bid_refunded_event(&env, admin.clone(), 1_000);
+
+    assert_eq!(
+        first_topic(&env, 0),
+        Symbol::new(&env, "BID_RFDN"),
+        "first topic mismatch for BidRefundedEvent"
+    );
+    assert_eq!(
+        second_topic(&env, 0),
+        symbol_short!("auction"),
+        "second topic mismatch for BidRefundedEvent"
+    );
+}
+
+#[test]
+fn auction_closed_shape() {
+    let (env, _borrower, admin) = env_and_addresses();
+
+    publish_auction_closed_event(
+        &env,
+        Symbol::new(&env, "auc-1"),
+        Some(admin.clone()),
+        5_000,
+    );
+
+    assert_eq!(
+        first_topic(&env, 0),
+        Symbol::new(&env, "AUC_CLOSE"),
+        "first topic mismatch for AuctionClosedEvent"
+    );
+    assert_eq!(
+        second_topic(&env, 0),
+        symbol_short!("auction"),
+        "second topic mismatch for AuctionClosedEvent"
+    );
+}
+
+#[test]
+fn auction_default_liquidation_settlement_shape() {
+    let (env, borrower, admin) = env_and_addresses();
+
+    publish_default_liquidation_settlement_event(
+        &env,
+        Symbol::new(&env, "auction-1"),
+        admin.clone(),
+        borrower.clone(),
+        admin.clone(),
+        3_000,
+    );
+
+    assert_eq!(
+        first_topic(&env, 0),
+        Symbol::new(&env, "LIQ_SETL"),
+        "first topic mismatch for DefaultLiquidationSettlementEvent"
+    );
+    assert_eq!(
+        second_topic(&env, 0),
+        symbol_short!("auction"),
+        "second topic mismatch for DefaultLiquidationSettlementEvent"
+    );
+}
+
+// ── Struct instantiation tests ────────────────────────────────────────────────
+
+#[test]
+fn all_credit_event_structs_instantiate() {
+    let (env, borrower, admin) = env_and_addresses();
+
+    let _ = CreditLineEvent {
+        borrower: borrower.clone(),
+        status: CreditStatus::Active,
+        credit_limit: 100,
+        interest_rate_bps: 100,
+        risk_score: 10,
+    };
+    let _ = RepaymentEvent {
+        borrower: borrower.clone(),
+        amount: 50,
+        new_utilized_amount: 50,
+    };
+    let _ = DrawnEvent {
+        borrower: borrower.clone(),
+        amount: 100,
+        new_utilized_amount: 100,
+    };
+    let _ = DrawnEventV2 {
+        borrower: borrower.clone(),
+        recipient: borrower.clone(),
+        reserve_source: admin.clone(),
+        amount: 100,
+        new_utilized_amount: 100,
+        timestamp: 50,
+    };
+    let _ = InterestAccruedEvent {
+        borrower: borrower.clone(),
+        accrued_amount: 5,
+        new_utilized_amount: 105,
+    };
+    let _ = DefaultLiquidationSettledEvent {
+        borrower: borrower.clone(),
+        settlement_id: Symbol::new(&env, "s1"),
+        recovered_amount: 20,
+        remaining_utilized_amount: 80,
+        status: CreditStatus::Defaulted,
+        close_factor_bps: 5000,
+    };
+    let _ = AdminRotationProposedEvent {
+        proposed_admin: admin.clone(),
+        accept_after: 200,
+    };
+    let _ = AdminRotationAcceptedEvent {
+        new_admin: admin.clone(),
+    };
+    let _ = RiskParametersUpdatedEvent {
+        borrower: borrower.clone(),
+        credit_limit: 1_000,
+        interest_rate_bps: 300,
+        risk_score: 50,
+    };
+    let _ = DrawReversedEvent {
+        borrower: borrower.clone(),
+        amount: 100,
+        original_ts: 10,
+        reason_code: 1,
+        new_utilized_amount: 0,
+        timestamp: 20,
+        admin: admin.clone(),
+        accounting_only: false,
+    };
+    let _ = DrawsFrozenEvent {
+        frozen: true,
+        reason: FreezeReason::LiquidityReserve,
+    };
+    let _ = CreditLineFreezeEvent {
+        borrower: borrower.clone(),
+        reason: FreezeReason::AdminAction,
+        frozen: true,
+        ledger: 100,
+    };
+    let _ = BorrowerBlockedEvent {
+        borrower: borrower.clone(),
+        blocked: true,
+        ledger: 100,
+    };
+    let _ = BorrowerFrozenEvent {
+        borrower: borrower.clone(),
+        frozen_until: 1_000_000,
+        ledger: 100,
+    };
+    let _ = FeeAccruedEvent {
+        borrower: borrower.clone(),
+        fee_amount: 10,
+        treasury_amount: 6,
+        bounty_amount: 4,
+        new_treasury_balance: 106,
+        new_bounty_balance: 204,
+    };
+    let _ = PenaltyRateEnteredEvent {
+        borrower: borrower.clone(),
+        base_rate_bps: 500,
+        penalty_surcharge_bps: 200,
+        effective_rate_bps: 700,
+    };
+    let _ = PenaltyRateExitedEvent {
+        borrower: borrower.clone(),
+        previous_rate_bps: 700,
+        new_rate_bps: 500,
+    };
+    let _ = GraceWaiverAppliedEvent {
+        borrower: borrower.clone(),
+        waived_amount: 5,
+        mode: creditra_credit::types::GraceWaiverMode::FullWaiver,
+    };
+    let _ = CollateralDepositedEvent {
+        borrower: borrower.clone(),
+        amount: 500,
+        new_balance: 500,
+    };
+    let _ = CollateralWithdrawnEvent {
+        borrower: borrower.clone(),
+        amount: 200,
+        new_balance: 300,
+    };
+    let _ = TokenRescuedEvent {
+        token: admin.clone(),
+        recipient: admin.clone(),
+        amount: 100,
+    };
+    let _ = ContractUpgradedEvent {
+        old_wasm_hash: BytesN::new(&env, &[0x11; 32]),
+        new_wasm_hash: BytesN::new(&env, &[0x22; 32]),
+    };
+    let _ = LateFeeChargedEvent {
+        borrower: borrower.clone(),
+        fee: 50,
+        installment_index: 3,
+    };
+    let _ = TreasuryWithdrawalProposedEvent {
+        recipient: admin.clone(),
+        amount: 1_000,
+        proposer: admin.clone(),
+        proposed_at: 100,
+        execute_after: 1_000,
+    };
+    let _ = TreasuryWithdrawalExecutedEvent {
+        recipient: admin.clone(),
+        amount: 500,
+        executor: admin.clone(),
+        executed_at: 200,
+    };
+    let _ = AttestationBatchCommittedEvent {
+        borrower: borrower.clone(),
+        merkle_root: BytesN::new(&env, &[0x33; 32]),
+        count: 10,
+    };
+}
+
+#[test]
+fn all_auction_event_structs_instantiate() {
+    let (_env, _borrower, admin) = env_and_addresses();
+
+    let _ = BidRefundedEvent {
+        prev_bidder: admin.clone(),
+        amount: 500,
+    };
+    let _ = AuctionClosedEvent {
+        auction_id: Symbol::new(&_env, "auc-1"),
+        winner: Some(admin.clone()),
+        amount: 5_000,
+    };
+    let _ = DefaultLiquidationSettlementEvent {
+        auction_id: Symbol::new(&_env, "auc-1"),
+        credit_contract: admin.clone(),
+        borrower: admin.clone(),
+        winner: admin.clone(),
+        recovered_amount: 3_000,
+    };
+}

--- a/docs/EVENTS_CATALOG.md
+++ b/docs/EVENTS_CATALOG.md
@@ -1,0 +1,321 @@
+# Events Catalog
+
+**Version:** 1.0  
+**Status:** Authoritative for `main` at the time of writing  
+**Scope:** `creditra-credit` (`contracts/credit/`) and `gateway-auction` (`gateway-contract/contracts/auction_contract/`)  
+**Last updated:** 2026-06-28
+
+---
+
+## 1. Purpose
+
+This document is the single authoritative reference for every event emitted by the
+Creditra credit and auction contracts. It lists each event's topic shape, payload
+struct, field order, field types, and stability status so that off-chain indexers,
+orchestrators, and integrators can decode events without guessing.
+
+Changes to this catalog should be proposed through the repo issue tracker and
+PR process. Breaking changes require a new event topic with a `_vN` suffix and a
+contract API version bump.
+
+---
+
+## 2. Versioning Policy
+
+The contract API version is defined in `contracts/credit/src/lib.rs` as
+`CONTRACT_API_VERSION = (1, 0, 0)`. Event schema follows SemVer-style rules:
+
+- **Major:** Breaking changes require a new event topic with a `_vN` suffix and a
+  contract API major version bump. Breaking changes include:
+  - Renaming, removing, or reordering fields in a payload struct.
+  - Changing a field's type.
+  - Changing a topic string.
+- **Minor:** A new event topic or a new optional field at the end of an existing
+  payload struct. Requires a contract API minor version bump.
+- **Patch:** Bug fixes only; no structural changes to topics or payloads.
+
+### Topic suffix convention
+
+When a breaking change is required, introduce a new topic with a suffix and keep
+the old topic alive during a dual-publish window:
+
+```
+("credit", "drawn_v2")   // new version
+("credit", "drawn")      // legacy version; still emitted
+```
+
+Remove the legacy topic only after downstream indexers confirm cutover.
+
+---
+
+## 3. Topic Encoding
+
+Topics are Soroban `Symbol` values chosen to use the cheap `SCV_SYMBOL` on-chain
+encoding (≤ 9 characters). Symbols longer than 9 characters use `Symbol::new(env,
+"<longer-name>")` and cost more gas to publish.
+
+| Encoding rule | Limit |
+|---|---|
+| `symbol_short!` macro | ≤ 9 characters |
+| `Symbol::new` | Up to 32 characters |
+
+The first topic in every published tuple is either `"credit"` (credit contract)
+or a short identifier such as `"blk_chg"` or `"BID_RFDN"`.
+
+---
+
+## 4. Credit Contract Event Catalog
+
+All topics are published under the `("credit", "...")` namespace unless otherwise
+noted. Publishers live in `contracts/credit/src/events.rs`.
+
+### 4.1 Lifecycle events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"opened"` | `CreditLineEvent` | 1. `borrower: Address`, 2. `status: CreditStatus`, 3. `credit_limit: i128`, 4. `interest_rate_bps: u32`, 5. `risk_score: u32` | 1.0.0 | Stable |
+| `"suspend"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
+| `"closed"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
+| `"default"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
+| `"reinstate"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
+
+### 4.2 Draw and repayment events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"drawn"` | `DrawnEvent` | 1. `borrower: Address`, 2. `amount: i128`, 3. `new_utilized_amount: i128` | 1.0.0 | Stable |
+| `"drawn_v2"` | `DrawnEventV2` | 1. `borrower: Address`, 2. `recipient: Address`, 3. `reserve_source: Address`, 4. `amount: i128`, 5. `new_utilized_amount: i128`, 6. `timestamp: u64` | 1.0.0 | Stable |
+| `"repay"` | `RepaymentEvent` | 1. `borrower: Address`, 2. `amount: i128`, 3. `new_utilized_amount: i128` | 1.0.0 | Stable |
+
+### 4.3 Accrual and fee events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"accrue"` | `InterestAccruedEvent` | 1. `borrower: Address`, 2. `accrued_amount: i128`, 3. `new_utilized_amount: i128` | 1.0.0 | Stable |
+| `"fee_accrd"` | `FeeAccruedEvent` | 1. `borrower: Address`, 2. `fee_amount: i128`, 3. `treasury_amount: i128`, 4. `bounty_amount: i128`, 5. `new_treasury_balance: i128`, 6. `new_bounty_balance: i128` | 1.1.0 | Stable |
+| `"late_fee"` | `LateFeeChargedEvent` | 1. `borrower: Address`, 2. `fee: i128`, 3. `installment_index: u64` | 1.0.0 | Stable |
+
+### 4.4 Risk and parameter events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"risk_upd"` | `RiskParametersUpdatedEvent` | 1. `borrower: Address`, 2. `credit_limit: i128`, 3. `interest_rate_bps: u32`, 4. `risk_score: u32` | 1.0.0 | Stable |
+| `"drw_freeze"` | `DrawsFrozenEvent` | 1. `frozen: bool`, 2. `reason: FreezeReason` | 1.0.0 | Stable |
+| `"line_frz"` | `CreditLineFreezeEvent` | 1. `borrower: Address`, 2. `reason: FreezeReason`, 3. `frozen: bool`, 4. `ledger: u32` | 1.0.0 | Stable |
+| `"br_freeze"` | `BorrowerFrozenEvent` | 1. `borrower: Address`, 2. `frozen_until: u64`, 3. `ledger: u32` | 1.0.0 | Stable |
+| `"pen_enter"` | `PenaltyRateEnteredEvent` | 1. `borrower: Address`, 2. `base_rate_bps: u32`, 3. `penalty_surcharge_bps: u32`, 4. `effective_rate_bps: u32` | 1.0.0 | Stable |
+| `"pen_exit"` | `PenaltyRateExitedEvent` | 1. `borrower: Address`, 2. `previous_rate_bps: u32`, 3. `new_rate_bps: u32` | 1.0.0 | Stable |
+| `"grace_wv"` | `GraceWaiverAppliedEvent` | 1. `borrower: Address`, 2. `waived_amount: i128`, 3. `mode: GraceWaiverMode` | 1.0.0 | Stable |
+
+### 4.5 Admin and governance events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"admin_prop"` | `AdminRotationProposedEvent` | 1. `proposed_admin: Address`, 2. `accept_after: u64` | 1.0.0 | Stable |
+| `"admin_acc"` | `AdminRotationAcceptedEvent` | 1. `new_admin: Address` | 1.0.0 | Stable |
+| `"tre_prop"` | `TreasuryWithdrawalProposedEvent` | 1. `recipient: Address`, 2. `amount: i128`, 3. `proposer: Address`, 4. `proposed_at: u64`, 5. `execute_after: u64` | 1.0.0 | Stable |
+| `"tre_exec"` | `TreasuryWithdrawalExecutedEvent` | 1. `recipient: Address`, 2. `amount: i128`, 3. `executor: Address`, 4. `executed_at: u64` | 1.0.0 | Stable |
+| `"upgraded"` | `ContractUpgradedEvent` | 1. `old_wasm_hash: BytesN<32>`, 2. `new_wasm_hash: BytesN<32>` | 1.0.0 | Stable |
+
+### 4.6 Blocklist and freeze events
+
+| Topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `("blk_chg",)` | `BorrowerBlockedEvent` | 1. `borrower: Address`, 2. `blocked: bool`, 3. `ledger: u32` | 1.0.0 | Stable |
+
+> Note: `BorrowerBlockedEvent` is emitted on a single-element topic tuple
+> `("blk_chg",)`.
+
+### 4.7 Collateral events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"col_dep"` | `CollateralDepositedEvent` | 1. `borrower: Address`, 2. `amount: i128`, 3. `new_balance: i128` | 1.0.0 | Stable |
+| `"col_wit"` | `CollateralWithdrawnEvent` | 1. `borrower: Address`, 2. `amount: i128`, 3. `new_balance: i128` | 1.0.0 | Stable |
+
+### 4.8 Default liquidation events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"liq_req"` | `(Address, i128)` | 1. `borrower: Address`, 2. `utilized_amount: i128` | 1.0.0 | Stable |
+| `"liq_setl"` | `DefaultLiquidationSettledEvent` | 1. `borrower: Address`, 2. `settlement_id: Symbol`, 3. `recovered_amount: i128`, 4. `remaining_utilized_amount: i128`, 5. `status: CreditStatus`, 6. `close_factor_bps: u32` | 1.0.0 | Stable |
+
+### 4.9 Attestation events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"atst_bat"` | `AttestationBatchCommittedEvent` | 1. `borrower: Address`, 2. `merkle_root: BytesN<32>`, 3. `count: u32` | 1.0.0 | Stable |
+
+### 4.10 Rescue and upgrade events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"tok_resc"` | `TokenRescuedEvent` | 1. `token: Address`, 2. `recipient: Address`, 3. `amount: i128` | 1.0.0 | Stable |
+
+### 4.11 Raw-value events (no struct)
+
+| Second topic | Payload type | Value | Version added | Stability |
+|---|---|---|---|---|
+| `"rate_form"` | `bool` | `true` = rate formula enabled; `false` = disabled | 1.0.0 | Stable |
+| `"paused"` | `bool` | `true` = contract is paused | 1.0.0 | Stable |
+| `"unpaused"` | `bool` | `false` = contract is unpaused | 1.0.0 | Stable |
+| `"fee_set"` | `u32` | Protocol fee in basis points | 1.0.0 | Stable |
+| `"fee_bnd"` | `(u32, u32)` | 1. `min_bps: u32`, 2. `max_bps: u32` | 1.0.0 | Stable |
+| `"clsfctr"` | `u32` | Close factor in basis points | 1.0.0 | Stable |
+| `"orc_cfg"` | `(u32, u64)` | 1. `max_deviation_bps: u32`, 2. `max_age_seconds: u64` | 1.0.0 | Stable |
+| `"orc_price"` | `(i128, u64)` | 1. `price: i128`, 2. `timestamp: u64` | 1.0.0 | Stable |
+
+---
+
+## 5. Auction Contract Event Catalog
+
+All topics are published under the `gateway-auction` contract. Publishers live in
+`gateway-contract/contracts/auction_contract/src/events.rs`.
+
+### 5.1 English auction events
+
+| First topic | Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|---|
+| `"BID_RFDN"` | `"auction"` | `BidRefundedEvent` | 1. `prev_bidder: Address`, 2. `amount: i128` | 1.0.0 | Stable |
+
+### 5.2 Auction close event
+
+| First topic | Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|---|
+| `"AUC_CLOSE"` | `"auction"` | `AuctionClosedEvent` | 1. `auction_id: Symbol`, 2. `winner: Option<Address>`, 3. `amount: i128` | 1.0.0 | Stable |
+
+### 5.3 Default liquidation settlement event
+
+| First topic | Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|---|
+| `"LIQ_SETL"` | `"auction"` | `DefaultLiquidationSettlementEvent` | 1. `auction_id: Symbol`, 2. `credit_contract: Address`, 3. `borrower: Address`, 4. `winner: Address`, 5. `recovered_amount: i128` | 1.0.0 | Stable |
+
+---
+
+## 6. Stability Matrix
+
+| Event topic | Stable since | Deprecated | Removal target | Notes |
+|---|---|---|---|---|
+| `("credit","opened")` through `("credit","reinstate")` | 1.0.0 | No | — | Lifecycle lifecycle events share `CreditLineEvent` shape |
+| `("credit","drawn")` | 1.0.0 | No | — | Use `drawn_v2` for richer traceability |
+| `("credit","drawn_v2")` | 1.0.0 | No | — | New default draw event |
+| `("credit","repay")` | 1.0.0 | No | — | |
+| `("credit","accrue")` | 1.0.0 | No | — | |
+| `("credit","fee_accrd")` | 1.1.0 | No | — | Extended with fee split fields in 1.1.0 |
+| `("credit","late_fee")` | 1.0.0 | No | — | |
+| `("credit","risk_upd")` | 1.0.0 | No | — | |
+| `("credit","drw_freeze")` | 1.0.0 | No | — | Global toggle |
+| `("credit","line_frz")` | 1.0.0 | No | — | Per-borrower toggle |
+| `("credit","br_freeze")` | 1.0.0 | No | — | Time-bounded per-borrower freeze |
+| `("credit","pen_enter")` | 1.0.0 | No | — | |
+| `("credit","pen_exit")` | 1.0.0 | No | — | |
+| `("credit","grace_wv")` | 1.0.0 | No | — | |
+| `("credit","admin_prop")` | 1.0.0 | No | — | |
+| `("credit","admin_acc")` | 1.0.0 | No | — | |
+| `("credit","tre_prop")` | 1.0.0 | No | — | |
+| `("credit","tre_exec")` | 1.0.0 | No | — | |
+| `("credit","upgraded")` | 1.0.0 | No | — | |
+| `("credit","liq_req")` | 1.0.0 | No | — | Raw tuple payload |
+| `("credit","liq_setl")` | 1.0.0 | No | — | |
+| `("credit","col_dep")` | 1.0.0 | No | — | |
+| `("credit","col_wit")` | 1.0.0 | No | — | |
+| `("credit","tok_resc")` | 1.0.0 | No | — | |
+| `("credit","atst_bat")` | 1.0.0 | No | — | |
+| `("credit","rate_form")` | 1.0.0 | No | — | Raw `bool` payload |
+| `("credit","paused")` | 1.0.0 | No | — | Raw `bool` payload |
+| `("credit","unpaused")` | 1.0.0 | No | — | Raw `bool` payload |
+| `("credit","fee_set")` | 1.0.0 | No | — | Raw `u32` payload |
+| `("credit","fee_bnd")` | 1.0.0 | No | — | Raw tuple payload |
+| `("credit","clsfctr")` | 1.0.0 | No | — | Raw `u32` payload |
+| `("credit","orc_cfg")` | 1.0.0 | No | — | Raw tuple payload |
+| `("credit","orc_price")` | 1.0.0 | No | — | Raw tuple payload |
+| `("blk_chg",)` | 1.0.0 | No | — | Single-element topic tuple |
+| `("BID_RFDN","auction")` | 1.0.0 | No | — | |
+| `("AUC_CLOSE","auction")` | 1.0.0 | No | — | |
+| `("LIQ_SETL","auction")` | 1.0.0 | No | — | |
+
+---
+
+## 7. Type Definitions
+
+All payload structs are defined in `contracts/credit/src/events.rs` or
+`gateway-contract/contracts/auction_contract/src/events.rs` with `#[contracttype]`.
+
+Shared types referenced in events:
+
+- `CreditStatus` — `Active = 0`, `Suspended = 1`, `Defaulted = 2`, `Closed = 3`
+  (defined in `contracts/credit/src/types.rs`).
+- `FreezeReason` — enum for freeze source (defined in
+  `contracts/credit/src/types.rs`).
+- `GraceWaiverMode` — `FullWaiver`, `ReducedRate` (defined in
+  `contracts/credit/src/types.rs`).
+
+---
+
+## 8. Publisher Reference
+
+All publisher functions live in `contracts/credit/src/events.rs` (credit) and
+`gateway-contract/contracts/auction_contract/src/events.rs` (auction). Each
+publisher takes `&Env` plus the event-specific payload fields and calls
+`env.events().publish(topic, payload)`.
+
+| Publisher function | Event topic |
+|---|---|
+| `publish_credit_line_event` | `("credit", "opened"\|"suspend"\|"closed"\|"default"\|"reinstate")` |
+| `publish_drawn_event` | `("credit", "drawn")` |
+| `publish_drawn_event_v2` | `("credit", "drawn_v2")` |
+| `publish_repayment_event` | `("credit", "repay")` |
+| `publish_interest_accrued_event` | `("credit", "accrue")` |
+| `publish_fee_accrued_event` | `("credit", "fee_accrd")` |
+| `publish_late_fee_charged_event` | `("credit", "late_fee")` |
+| `publish_draw_reversed_event` | `("credit", "draw_rev")` |
+| `publish_draws_frozen_event` | `("credit", "drw_freeze")` |
+| `publish_credit_line_freeze_event` | `("credit", "line_frz")` |
+| `publish_borrower_frozen_event` | `("br_freeze",)` |
+| `publish_penalty_rate_entered_event` | `("credit", "pen_enter")` |
+| `publish_penalty_rate_exited_event` | `("credit", "pen_exit")` |
+| `publish_grace_waiver_applied_event` | `("credit", "grace_wv")` |
+| `publish_admin_rotation_proposed` | `("credit", "admin_prop")` |
+| `publish_admin_rotation_accepted` | `("credit", "admin_acc")` |
+| `publish_treasury_withdrawal_proposed` | `("credit", "tre_prop")` |
+| `publish_treasury_withdrawal_executed` | `("credit", "tre_exec")` |
+| `publish_contract_upgraded_event` | `("credit", "upgraded")` |
+| `publish_default_liquidation_requested_event` | `("credit", "liq_req")` |
+| `publish_default_liquidation_settled_event` | `("credit", "liq_setl")` |
+| `publish_borrower_blocked_event` | `("blk_chg",)` |
+| `publish_collateral_deposited_event` | `("credit", "col_dep")` |
+| `publish_collateral_withdrawn_event` | `("credit", "col_wit")` |
+| `publish_token_rescued_event` | `("credit", "tok_resc")` |
+| `publish_attestation_batch_committed` | `("credit", "atst_bat")` |
+| `publish_rate_formula_config_event` | `("credit", "rate_form")` |
+| `publish_paused_event` | `("credit", "paused")` / `("credit", "unpaused")` |
+| `publish_protocol_fee_bps_set_event` | `("credit", "fee_set")` |
+| `publish_protocol_fee_bounds_set_event` | `("credit", "fee_bnd")` |
+| `publish_close_factor_bps_set_event` | `("credit", "clsfctr")` |
+| `publish_oracle_config_set_event` | `("credit", "orc_cfg")` |
+| `publish_oracle_price_accepted_event` | `("credit", "orc_price")` |
+| `publish_risk_parameters_updated` | `("credit", "risk_upd")` |
+| `publish_bid_refunded_event` | `("BID_RFDN", "auction")` |
+| `publish_auction_closed_event` | `("AUC_CLOSE", "auction")` |
+| `publish_default_liquidation_settlement_event` | `("LIQ_SETL", "auction")` |
+
+---
+
+## 9. API / Visible Changes Log
+
+| Date | Change | Impact |
+|---|---|---|
+| 2026-06-28 | Created `docs/EVENTS_CATALOG.md` | Replaces `docs/events-schema.md` as the single authoritative catalog. `events-schema.md` retained for backward-compatible linking but no longer updated. |
+| 2026-06-28 | Added `AttestationBatchCommittedEvent` and `publish_attestation_batch_committed` to `contracts/credit/src/events.rs` | Fixed broken import in `contracts/credit/src/attestation.rs`. No contract ABI change; event was already emitted by `commit_attestation_batch` but the struct and publisher were missing. |
+| 2026-06-28 | Added `contracts/credit/tests/events_catalog.rs` | New integration test verifying every cataloged event is emitted with the correct topic and payload shape. |
+
+---
+
+## 10. Related Documentation
+
+- [`docs/events-schema.md`](./events-schema.md) — legacy schema reference (superseded by this file).
+- [`docs/indexer-integration.md`](./indexer-integration.md) — decoder patterns and RPC examples.
+- [`docs/PROTOCOL_SPEC.md`](./PROTOCOL_SPEC.md) — per-entrypoint event-emission table.
+- [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) — event topology diagrams.
+- [`docs/credit.md`](./credit.md) — master credit contract reference.
+- [`docs/upgrade-policy.md`](./upgrade-policy.md) — WASM upgrade procedure.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -73,7 +73,7 @@ For the rate / accrual formulas:
   worked examples.
 
 For event schema:
-- [`docs/events-schema.md`](./events-schema.md) — **canonical event catalog and
+- [`docs/EVENTS_CATALOG.md`](./EVENTS_CATALOG.md) — **canonical event catalog and
   versioning policy** (replaces scattered references in indexer-integration).
 
 ---
@@ -144,7 +144,8 @@ Commit style: conventional commits (`docs:`, `feat:`, `fix:`,
 | `upgrade-policy.md` | ~3 | Upgrade procedure |
 | `utilization-cap.md` | ~3 | Per-borrower utilization cap |
 | `indexer-integration.md` | ~4 | Off-chain event decoding |
-| `events-schema.md` | ~4 | **Canonical event catalog and versioning policy** |
+| `EVENTS_CATALOG.md` | ~6 | **Authoritative event catalog and versioning policy** |
+| `events-schema.md` | ~4 | Legacy event schema reference (superseded by `EVENTS_CATALOG.md`) |
 | `deploy.md` | ~2 | Deploy quickstart |
 | `contributing-tests.md` | ~3 | Test helper conventions |
 | `scripts.md` | ~2 | Helper script reference |

--- a/docs/PROTOCOL_SPEC.md
+++ b/docs/PROTOCOL_SPEC.md
@@ -691,6 +691,6 @@ unpaused (`assert_not_paused`). A safe upgrade procedure is therefore:
 | Oracle (price) | `WHITEPAPER.md` §7.1 |
 | Oracle (default signal, staged) | `docs/default-oracle.md` |
 | Upgrade policy | `docs/upgrade-policy.md` |
-| Event catalog | `docs/events-schema.md` |
+| Event catalog | `docs/EVENTS_CATALOG.md` |
 | Deployment | `docs/deploy.md` |
 | Test catalog | `docs/EXECUTION_QUALITY.md` |

--- a/docs/events-schema.md
+++ b/docs/events-schema.md
@@ -1,7 +1,7 @@
 # Creditra Event Schema Reference
 
-**Version:** 1.0
-**Status:** authoritative for `main` at the time of writing
+**Version:** 1.0  
+**Status:** Superseded by [`docs/EVENTS_CATALOG.md`](../EVENTS_CATALOG.md)  
 **Scope:** `creditra-credit` (`contracts/credit/`)
 
 ---

--- a/docs/indexer-integration.md
+++ b/docs/indexer-integration.md
@@ -9,7 +9,7 @@ This guide explains how indexers subscribe to Credit contract events and decode:
 - `DefaultLiquidationRequestedEvent`
 - `DefaultLiquidationSettledEvent`
 
-Source of truth for schemas: `contracts/credit/src/events.rs`.
+Source of truth for schemas: `docs/EVENTS_CATALOG.md`.
 
 ---
 


### PR DESCRIPTION
- Add single authoritative docs/EVENTS_CATALOG.md listing every event with topic shape, payload struct, field order/types, version, and stability status for both credit and auction contracts.
- Fix missing AttestationBatchCommittedEvent and publisher in contracts/credit/src/events.rs (broken import in attestation.rs).
- Add focused integration tests in contracts/credit/tests/events_catalog.rs verifying all cataloged events emit the expected topic and payload shape.
- Update referencing docs (INDEX.md, PROTOCOL_SPEC.md, indexer-integration.md, events-schema.md, event_bound_draw.rs) to point to EVENTS_CATALOG.md.
- Preserve events-schema.md as a superseded legacy document for backward-compatible linking.

Closes #649