### PR TITLE
feat: multi-oracle quorum (closes #630)

### DIFF
--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -506,6 +506,34 @@ pub fn publish_oracle_price_accepted_event(env: &Env, price: i128, timestamp: u6
     );
 }
 
+/// Emit when `set_oracle_quorum_config` is called.
+pub fn publish_oracle_quorum_config_set_event(
+    env: &Env,
+    min_quorum_k: u32,
+    max_deviation_bps: u32,
+    max_age_seconds: u64,
+) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "orc_qcfg")),
+        (min_quorum_k, max_deviation_bps, max_age_seconds),
+    );
+}
+
+/// Emit when `submit_oracle_prices` successfully resolves a quorum price.
+///
+/// Data: `(resolved_price, min_quorum_k, timestamp)`.
+pub fn publish_oracle_quorum_price_set_event(
+    env: &Env,
+    price: i128,
+    quorum_k: u32,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "orc_qprc")),
+        (price, quorum_k, timestamp),
+    );
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LateFeeChargedEvent {

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -98,6 +98,7 @@ mod handshake;
 mod accrual;
 #[cfg(test)]
 mod accrual_tests;
+mod oracles;
 #[cfg(test)]
 mod amount_validation_tests;
 mod attestation;
@@ -137,7 +138,8 @@ use crate::events::{
     publish_borrower_blocked_event, publish_borrower_frozen_event, publish_contract_upgraded_event,
     publish_credit_line_event, publish_draw_reversed_event, publish_drawn_event,
     publish_interest_accrued_event, publish_oracle_config_set_event,
-    publish_oracle_price_accepted_event, publish_rate_formula_config_event,
+    publish_oracle_price_accepted_event, publish_oracle_quorum_config_set_event,
+    publish_oracle_quorum_price_set_event, publish_rate_formula_config_event,
     publish_repayment_event, publish_token_rescued_event,
     publish_treasury_withdrawal_executed, publish_treasury_withdrawal_proposed,
     ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent,
@@ -158,14 +160,16 @@ use crate::storage::{
     set_utilization_cap_bps as storage_set_utilization_cap_bps, DataKey, MAX_ENUMERATION_LIMIT,
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
+use crate::storage::{get_oracle_quorum_config, set_oracle_quorum_config};
+use crate::oracles::{resolve_quorum_price, MAX_ORACLE_FEEDS};
 use crate::storage::{
     clear_pending_treasury_withdrawal, get_pending_treasury_withdrawal,
     set_pending_treasury_withdrawal,
 };
 use crate::types::{
     ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
-    TreasuryWithdrawalProposal,
+    OracleQuorumConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
+    RateFormulaConfig, TreasuryWithdrawalProposal,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -1407,8 +1411,27 @@ impl Credit {
         // with an external auction contract, so we guard the full path.
         set_reentrancy_guard(&env);
 
-        // Oracle price-feed circuit breaker: validate price before settlement.
-        if let Some(cfg) = crate::storage::get_oracle_config(&env) {
+        // Oracle price validation — quorum mode takes precedence over single-oracle mode.
+        if let Some(qcfg) = crate::storage::get_oracle_quorum_config(&env) {
+            // Quorum mode: price was pre-validated by `submit_oracle_prices`.
+            // Only check that the stored quorum price is still within max_age_seconds.
+            let last_ts = crate::storage::get_oracle_last_price_ts(&env).unwrap_or_else(|| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::OraclePriceInvalid)
+            });
+            let now = env.ledger().timestamp();
+            if now.saturating_sub(last_ts) > qcfg.max_age_seconds {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::OraclePriceStale);
+            }
+            let price = crate::storage::get_oracle_last_price(&env).unwrap_or_else(|| {
+                clear_reentrancy_guard(&env);
+                env.panic_with_error(ContractError::OraclePriceInvalid)
+            });
+            publish_oracle_price_accepted_event(&env, price, now);
+        } else if let Some(cfg) = crate::storage::get_oracle_config(&env) {
+            // Single-oracle mode: validate the caller-supplied price against the
+            // last accepted price and the staleness threshold.
             let price = oracle_price.unwrap_or_else(|| {
                 clear_reentrancy_guard(&env);
                 env.panic_with_error(ContractError::OraclePriceInvalid)
@@ -1561,6 +1584,106 @@ impl Credit {
     /// Return the current oracle circuit-breaker configuration, if set.
     pub fn get_oracle_config(env: Env) -> Option<OracleConfig> {
         get_oracle_config(&env)
+    }
+
+    // ── Multi-oracle quorum admin ─────────────────────────────────────────────
+
+    /// Configure the multi-oracle quorum parameters (admin only).
+    ///
+    /// Once set, calls to `submit_oracle_prices` validate that at least
+    /// `min_quorum_k` of the supplied prices agree within `max_deviation_bps`
+    /// of each other. The resolved median price is stored and used by
+    /// `settle_default_liquidation` (staleness-checked against
+    /// `max_age_seconds`).
+    ///
+    /// Quorum mode takes precedence over the single-oracle circuit breaker:
+    /// when both are configured, `settle_default_liquidation` uses the quorum
+    /// price and ignores the `oracle_price` parameter.
+    ///
+    /// # Validation
+    /// - `min_quorum_k` must be ≥ 2.
+    /// - `max_deviation_bps` must be ≤ 10_000.
+    /// - `max_age_seconds` must be > 0.
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Events
+    /// Emits an `orc_qcfg` event with the new configuration.
+    pub fn set_oracle_quorum_config(
+        env: Env,
+        min_quorum_k: u32,
+        max_deviation_bps: u32,
+        max_age_seconds: u64,
+    ) {
+        assert_not_paused(&env);
+        require_admin_auth(&env);
+
+        if min_quorum_k < 2 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        if max_deviation_bps > 10_000 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        if max_age_seconds == 0 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+
+        set_oracle_quorum_config(
+            &env,
+            &OracleQuorumConfig {
+                min_quorum_k,
+                max_deviation_bps,
+                max_age_seconds,
+            },
+        );
+        publish_oracle_quorum_config_set_event(&env, min_quorum_k, max_deviation_bps, max_age_seconds);
+    }
+
+    /// Return the current multi-oracle quorum configuration, if set.
+    pub fn get_oracle_quorum_config(env: Env) -> Option<OracleQuorumConfig> {
+        get_oracle_quorum_config(&env)
+    }
+
+    /// Submit N oracle prices and resolve a quorum canonical price (admin only).
+    ///
+    /// Runs the quorum-of-K algorithm:
+    /// 1. Sorts submitted prices ascending.
+    /// 2. Finds the first K-wide window whose spread is within
+    ///    `max_deviation_bps` of the lowest price in that window.
+    /// 3. Returns the lower-median of that window as the canonical price.
+    /// 4. Stores the canonical price and the current ledger timestamp.
+    ///
+    /// The stored price is subsequently used by `settle_default_liquidation`
+    /// (staleness is re-checked there against `max_age_seconds`).
+    ///
+    /// # Validation
+    /// - Oracle quorum config must be set via `set_oracle_quorum_config` first.
+    /// - 2 ≤ `prices.len()` ≤ `MAX_ORACLE_FEEDS` (20).
+    /// - Every price must be strictly positive.
+    /// - At least `min_quorum_k` prices must agree within `max_deviation_bps`.
+    ///
+    /// # Authorization
+    /// Admin only.
+    ///
+    /// # Events
+    /// Emits an `orc_qprc` event with the resolved price, quorum K, and timestamp.
+    pub fn submit_oracle_prices(env: Env, prices: Vec<i128>) {
+        assert_not_paused(&env);
+        require_admin_auth(&env);
+
+        let qcfg = get_oracle_quorum_config(&env).unwrap_or_else(|| {
+            env.panic_with_error(ContractError::OraclePriceInvalid)
+        });
+
+        if prices.len() > MAX_ORACLE_FEEDS {
+            env.panic_with_error(ContractError::OraclePriceInvalid);
+        }
+
+        let canonical_price = resolve_quorum_price(&env, &prices, &qcfg);
+        let now = env.ledger().timestamp();
+        crate::storage::set_oracle_last_price(&env, canonical_price, now);
+        publish_oracle_quorum_price_set_event(&env, canonical_price, qcfg.min_quorum_k, now);
     }
 
     // ── Borrower blocklist ────────────────────────────────────────────────────

--- a/contracts/credit/src/oracles.rs
+++ b/contracts/credit/src/oracles.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT
+
+//! # Multi-oracle quorum price resolution
+//!
+//! Implements the quorum-of-K algorithm for combining multiple independent
+//! oracle price feeds into a single canonical price used by
+//! [`crate::lib::settle_default_liquidation`].
+//!
+//! ## Algorithm
+//!
+//! Given N submitted prices and a quorum threshold K:
+//!
+//! 1. Validate every price is strictly positive and N ≤ [`MAX_ORACLE_FEEDS`].
+//! 2. Sort prices ascending (selection sort; O(n²) but bounded by
+//!    [`MAX_ORACLE_FEEDS`] ≤ 20 to keep gas predictable).
+//! 3. Slide a window of K consecutive prices over the sorted array.
+//! 4. For each window, check whether the highest price deviates from the
+//!    lowest by no more than `max_deviation_bps` of the lowest.
+//! 5. Return the **lower-median** of the first qualifying window.
+//! 6. Panic with [`crate::types::ContractError::OracleQuorumNotMet`] if no
+//!    window qualifies.
+//!
+//! ## Security properties
+//!
+//! - An outlier feed cannot influence the result unless it falls inside a
+//!   qualifying K-wide window alongside K−1 honest feeds.
+//! - Requires at least K feeds to agree, so an attacker must corrupt K
+//!   independent feeds simultaneously to manipulate the canonical price.
+//! - The stack buffer is bounded at compile time; gas consumption is O(n²)
+//!   for sorting and O(n) for window scanning.
+
+use soroban_sdk::{Env, Vec};
+
+use crate::math_utils::compute_deviation_bps;
+use crate::types::{ContractError, OracleQuorumConfig};
+
+/// Maximum number of oracle price feeds accepted per `submit_oracle_prices` call.
+///
+/// Limits gas consumption and keeps the stack buffer within WASM limits.
+/// Adjust after gas profiling if the protocol sources more feeds.
+pub const MAX_ORACLE_FEEDS: u32 = 20;
+
+/// Resolve a single canonical price from N submitted oracle prices using
+/// the quorum-of-K sliding-window algorithm.
+///
+/// # Parameters
+/// - `env`: Soroban host environment (used to panic with typed errors).
+/// - `prices`: N submitted prices in any order, one per oracle feed.
+/// - `cfg`: Quorum configuration supplying K, max deviation, and max age.
+///
+/// # Returns
+/// The lower-median price of the first K-wide consecutive window (in sorted
+/// ascending order) whose highest-to-lowest spread is within
+/// `cfg.max_deviation_bps`.
+///
+/// # Errors
+///
+/// Panics with [`ContractError::OraclePriceInvalid`] when:
+/// - The price list is empty.
+/// - The price list exceeds [`MAX_ORACLE_FEEDS`].
+/// - Any individual price is ≤ 0.
+///
+/// Panics with [`ContractError::OracleQuorumNotMet`] when:
+/// - `min_quorum_k < 2` (a single feed is not a meaningful quorum).
+/// - `min_quorum_k > n` (cannot form a window larger than the input).
+/// - No K-wide window in the sorted array satisfies the deviation bound.
+pub fn resolve_quorum_price(env: &Env, prices: &Vec<i128>, cfg: &OracleQuorumConfig) -> i128 {
+    let n = prices.len();
+
+    if n == 0 || n > MAX_ORACLE_FEEDS {
+        env.panic_with_error(ContractError::OraclePriceInvalid);
+    }
+
+    let k = cfg.min_quorum_k;
+    if k < 2 || k > n {
+        env.panic_with_error(ContractError::OracleQuorumNotMet);
+    }
+
+    // Copy prices into a fixed stack buffer and validate positivity.
+    let mut buf = [0i128; MAX_ORACLE_FEEDS as usize];
+    for i in 0..n {
+        let p = prices.get(i).unwrap();
+        if p <= 0 {
+            env.panic_with_error(ContractError::OraclePriceInvalid);
+        }
+        buf[i as usize] = p;
+    }
+    let slice = &mut buf[..n as usize];
+
+    // Selection sort — O(n²), safe and predictable for n ≤ MAX_ORACLE_FEEDS.
+    let len = slice.len();
+    for i in 0..len {
+        let mut min_idx = i;
+        for j in (i + 1)..len {
+            if slice[j] < slice[min_idx] {
+                min_idx = j;
+            }
+        }
+        slice.swap(i, min_idx);
+    }
+
+    // Scan every consecutive K-wide window in sorted order.
+    // A window qualifies when the deviation of its highest element from its
+    // lowest is within cfg.max_deviation_bps. Return the lower-median of the
+    // first qualifying window.
+    let kk = k as usize;
+    for i in 0..=(len - kk) {
+        let lo = slice[i];
+        let hi = slice[i + kk - 1];
+        // lo > 0 is guaranteed; compute_deviation_bps returns None only for
+        // non-positive last_price, which cannot happen here.
+        let dev = compute_deviation_bps(hi, lo).unwrap_or(u32::MAX);
+        if dev <= cfg.max_deviation_bps {
+            // Lower-median: index (kk-1)/2 within the window.
+            let median_idx = i + (kk - 1) / 2;
+            return slice[median_idx];
+        }
+    }
+
+    env.panic_with_error(ContractError::OracleQuorumNotMet)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::OracleQuorumConfig;
+    use soroban_sdk::{vec, Env, Vec};
+
+    fn cfg(k: u32, dev: u32) -> OracleQuorumConfig {
+        OracleQuorumConfig {
+            min_quorum_k: k,
+            max_deviation_bps: dev,
+            max_age_seconds: 3_600,
+        }
+    }
+
+    // ── happy-path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn two_of_two_exact_match_returns_lower() {
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 1_000i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(2, 0)), 1_000);
+    }
+
+    #[test]
+    fn two_of_three_outlier_ignored() {
+        // Sorted: 1_000, 1_040, 2_000 — k=2, dev=500 bps (5%)
+        // Window [1_000, 1_040]: dev=400 bps ≤ 500 → qualifies
+        // Lower-median of size-2 window at index 0: index 0 → 1_000
+        let env = Env::default();
+        let prices = vec![&env, 2_000i128, 1_000i128, 1_040i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(2, 500)), 1_000);
+    }
+
+    #[test]
+    fn three_of_five_returns_median_of_window() {
+        // Sorted: 980, 990, 1_000, 1_010, 5_000 — k=3, dev=500 bps
+        // Window [980, 990, 1_000]: dev(1_000, 980)=204 bps ≤ 500 → qualifies
+        // Lower-median idx = 0+(3-1)/2 = 1 → 990
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 5_000i128, 980i128, 990i128, 1_010i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(3, 500)), 990);
+    }
+
+    #[test]
+    fn all_identical_prices_zero_deviation() {
+        let env = Env::default();
+        let prices = vec![&env, 500i128, 500i128, 500i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(3, 0)), 500);
+    }
+
+    #[test]
+    fn window_at_end_of_sorted_array() {
+        // Sorted: 1_000, 2_000, 2_010 — k=2, dev=100 bps (1%)
+        // Window [1_000, 2_000]: dev=10_000 bps > 100 → skip
+        // Window [2_000, 2_010]: dev=50 bps ≤ 100 → qualifies → 2_000
+        let env = Env::default();
+        let prices = vec![&env, 2_010i128, 1_000i128, 2_000i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(2, 100)), 2_000);
+    }
+
+    #[test]
+    fn four_of_four_returns_lower_median() {
+        // Sorted: 100, 110, 120, 130 — k=4, dev=5_000 bps (50%)
+        // Single window; lower-median idx = 0+(4-1)/2 = 1 → 110
+        let env = Env::default();
+        let prices = vec![&env, 130i128, 100i128, 120i128, 110i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(4, 5_000)), 110);
+    }
+
+    #[test]
+    fn two_of_two_within_boundary_bps() {
+        // Sorted: 1_000, 1_050 — dev = 500 bps == max_deviation_bps → qualifies
+        let env = Env::default();
+        let prices = vec![&env, 1_050i128, 1_000i128];
+        assert_eq!(resolve_quorum_price(&env, &prices, &cfg(2, 500)), 1_000);
+    }
+
+    // ── error paths ───────────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic]
+    fn empty_prices_panics() {
+        let env = Env::default();
+        let empty: Vec<i128> = Vec::new(&env);
+        resolve_quorum_price(&env, &empty, &cfg(2, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_price_panics() {
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, -1i128, 1_010i128];
+        resolve_quorum_price(&env, &prices, &cfg(2, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn zero_price_panics() {
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 0i128];
+        resolve_quorum_price(&env, &prices, &cfg(2, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn k_greater_than_n_panics() {
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 1_010i128];
+        resolve_quorum_price(&env, &prices, &cfg(3, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn k_equals_one_panics() {
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 1_010i128];
+        resolve_quorum_price(&env, &prices, &cfg(1, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn k_equals_zero_panics() {
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 1_010i128];
+        resolve_quorum_price(&env, &prices, &cfg(0, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn no_qualifying_window_panics() {
+        // All prices more than 5% apart: no 2-wide window qualifies
+        let env = Env::default();
+        let prices = vec![&env, 1_000i128, 2_000i128, 4_000i128];
+        resolve_quorum_price(&env, &prices, &cfg(2, 500));
+    }
+
+    #[test]
+    #[should_panic]
+    fn just_over_deviation_bound_panics() {
+        // 1_000 and 1_051 → dev = 510 bps > 500
+        let env = Env::default();
+        let prices = vec![&env, 1_051i128, 1_000i128];
+        resolve_quorum_price(&env, &prices, &cfg(2, 500));
+    }
+}

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -183,6 +183,8 @@ pub enum DataKey {
     DrawReversedAmount(Address, u64),
     /// Oracle circuit-breaker configuration.
     OracleConfig,
+    /// Multi-oracle quorum configuration.
+    OracleQuorumConfig,
     /// Last accepted oracle price.
     OracleLastPrice,
     /// Timestamp of the last accepted oracle price.
@@ -1014,6 +1016,27 @@ pub fn get_oracle_config(env: &Env) -> Option<crate::types::OracleConfig> {
 /// config satisfies the invariants documented on [`crate::types::OracleConfig`].
 pub fn set_oracle_config(env: &Env, cfg: &crate::types::OracleConfig) {
     env.storage().instance().set(&DataKey::OracleConfig, cfg);
+}
+
+/// Get the multi-oracle quorum configuration, if set.
+///
+/// When `Some`, `submit_oracle_prices` uses the quorum-of-K algorithm to
+/// validate submitted prices before storing the canonical price.
+/// When `None`, quorum mode is disabled and the single-oracle circuit breaker
+/// applies (if [`get_oracle_config`] is also set).
+pub fn get_oracle_quorum_config(env: &Env) -> Option<crate::types::OracleQuorumConfig> {
+    env.storage().instance().get(&DataKey::OracleQuorumConfig)
+}
+
+/// Set the multi-oracle quorum configuration.
+///
+/// Caller is responsible for admin auth and for validating that the supplied
+/// config satisfies the invariants documented on
+/// [`crate::types::OracleQuorumConfig`].
+pub fn set_oracle_quorum_config(env: &Env, cfg: &crate::types::OracleQuorumConfig) {
+    env.storage()
+        .instance()
+        .set(&DataKey::OracleQuorumConfig, cfg);
 }
 
 /// Get the last accepted oracle price, if any.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -8,7 +8,7 @@
 //!
 //! ABI-stable types that cross the contract boundary:
 //!
-//! - [`ContractError`] — 40-variant `#[repr(u32)]` error enum (discriminants
+//! - [`ContractError`] — 45-variant `#[repr(u32)]` error enum (discriminants
 //!   pinned by `tests/error_discriminants.rs`). Each variant maps to a stable
 //!   [`ContractErrorCategory`] via [`ContractError::category`]. See
 //!   [`docs/contract-errors.md`](../../../docs/contract-errors.md) for the
@@ -144,6 +144,7 @@ pub enum CreditStatus {
 /// | 42   | `NoPendingTreasuryWithdrawal`  | No pending treasury withdrawal proposal exists |
 /// | 43   | `TreasuryTimelockActive`       | Treasury withdrawal timelock has not yet elapsed |
 /// | 44   | `TreasuryProposalExists`       | A treasury withdrawal proposal already exists |
+/// | 45   | `OracleQuorumNotMet`           | Not enough oracle prices agreed within deviation threshold |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -236,6 +237,8 @@ pub enum ContractError {
     TreasuryTimelockActive = 43,
     /// A treasury withdrawal proposal already exists; cancel or execute it first.
     TreasuryProposalExists = 44,
+    /// Not enough oracle prices agreed within the configured deviation threshold.
+    OracleQuorumNotMet = 45,
 }
 
 /// Stored credit line data for a borrower.
@@ -358,6 +361,33 @@ pub struct OracleConfig {
     /// E.g. 500 = 5 %.
     pub max_deviation_bps: u32,
     /// Maximum age of an oracle price in seconds before it is considered stale.
+    pub max_age_seconds: u64,
+}
+
+/// Multi-oracle quorum configuration.
+///
+/// When set, `submit_oracle_prices` runs the quorum-of-K algorithm over the
+/// supplied prices before storing the resolved canonical price. Settlement via
+/// `settle_default_liquidation` then only validates that this stored price is
+/// still within `max_age_seconds`; the per-call deviation check is replaced by
+/// the quorum consensus established at submission time.
+///
+/// # Invariants
+/// - `min_quorum_k` must be ≥ 2 (a single feed is not a quorum).
+/// - `max_deviation_bps` must be in `0..=10_000` (0 = exact match required).
+/// - `max_age_seconds` must be > 0.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OracleQuorumConfig {
+    /// Minimum number of submitted prices that must agree within
+    /// `max_deviation_bps` to form a valid quorum.
+    pub min_quorum_k: u32,
+    /// Maximum allowed price deviation between the highest and lowest prices
+    /// in the qualifying quorum window, in basis points.
+    /// E.g. 500 = 5%.
+    pub max_deviation_bps: u32,
+    /// Maximum age of the stored quorum price in seconds before it is
+    /// considered stale for settlement purposes.
     pub max_age_seconds: u64,
 }
 

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -59,6 +59,7 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::NoPendingTreasuryWithdrawal as u32, 42);
     assert_eq!(ContractError::TreasuryTimelockActive as u32, 43);
     assert_eq!(ContractError::TreasuryProposalExists as u32, 44);
+    assert_eq!(ContractError::OracleQuorumNotMet as u32, 45);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -113,6 +114,7 @@ fn no_duplicate_discriminants() {
         ContractError::NoPendingTreasuryWithdrawal as u32,
         ContractError::TreasuryTimelockActive as u32,
         ContractError::TreasuryProposalExists as u32,
+        ContractError::OracleQuorumNotMet as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -127,8 +129,8 @@ fn no_duplicate_discriminants() {
 /// Update this number when adding new variants (and add the assertion above).
 #[test]
 fn variant_count_is_known() {
-    // 44 variants as of this writing (added 42-44 for treasury timelock in #606).
-    const EXPECTED_VARIANT_COUNT: usize = 44;
+    // 45 variants as of this writing (added 45 for oracle quorum in #630).
+    const EXPECTED_VARIANT_COUNT: usize = 45;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -175,6 +177,7 @@ fn variant_count_is_known() {
         ContractError::NoPendingTreasuryWithdrawal as u32,
         ContractError::TreasuryTimelockActive as u32,
         ContractError::TreasuryProposalExists as u32,
+        ContractError::OracleQuorumNotMet as u32,
     ];
 
     assert_eq!(

--- a/contracts/credit/tests/oracle_deviation.rs
+++ b/contracts/credit/tests/oracle_deviation.rs
@@ -116,7 +116,7 @@ fn settle_without_oracle_config_accepts_none_price() {
     let borrower = open_and_default(&client, &env, &contract_id, 500);
 
     // No oracle config set — None price must be accepted.
-    client.settle_default_liquidation(&borrower, &500_i128, &sid(&env, "s1"), &None);
+    client.settle_default_liquidation(&borrower, &500_i128, &sid(&env, "s1"), &10_000_u32, &None);
 
     assert_eq!(
         client.get_credit_line(&borrower).unwrap().status,
@@ -134,7 +134,13 @@ fn settle_with_oracle_config_first_price_accepted() {
     let borrower = open_and_default(&client, &env, &contract_id, 500);
 
     // First call — no prior price stored, any positive price is accepted.
-    client.settle_default_liquidation(&borrower, &500_i128, &sid(&env, "s1"), &Some(1_000_i128));
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
 
     assert_eq!(
         client.get_credit_line(&borrower).unwrap().status,
@@ -152,11 +158,23 @@ fn settle_within_deviation_bound_accepted() {
 
     // First settlement — seeds the last accepted price at 1_000.
     let b1 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+    client.settle_default_liquidation(
+        &b1,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
 
     // Second settlement — price 1_040 is 4% deviation from 1_000 (within 5%).
     let b2 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_040_i128));
+    client.settle_default_liquidation(
+        &b2,
+        &200_i128,
+        &sid(&env, "s2"),
+        &10_000_u32,
+        &Some(1_040_i128),
+    );
 
     assert_eq!(
         client.get_credit_line(&b2).unwrap().status,
@@ -175,11 +193,23 @@ fn settle_over_deviation_panics() {
 
     // Seed last price at 1_000.
     let b1 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+    client.settle_default_liquidation(
+        &b1,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
 
     // Price 1_100 is 10% deviation — exceeds 5% threshold.
     let b2 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_100_i128));
+    client.settle_default_liquidation(
+        &b2,
+        &200_i128,
+        &sid(&env, "s2"),
+        &10_000_u32,
+        &Some(1_100_i128),
+    );
 }
 
 #[test]
@@ -190,11 +220,23 @@ fn settle_over_deviation_downward_panics() {
     client.set_oracle_config(&500_u32, &3600_u64);
 
     let b1 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+    client.settle_default_liquidation(
+        &b1,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
 
     // Price 900 is 10% below 1_000 — exceeds 5% threshold.
     let b2 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(900_i128));
+    client.settle_default_liquidation(
+        &b2,
+        &200_i128,
+        &sid(&env, "s2"),
+        &10_000_u32,
+        &Some(900_i128),
+    );
 }
 
 // ── stale price rejected ──────────────────────────────────────────────────────
@@ -209,14 +251,26 @@ fn settle_stale_price_panics() {
     // Seed last price at t=1000.
     env.ledger().with_mut(|l| l.timestamp = 1_000);
     let b1 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+    client.settle_default_liquidation(
+        &b1,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
 
     // Advance time beyond max_age_seconds (1 hour = 3600s).
     env.ledger().with_mut(|l| l.timestamp = 1_000 + 3_601);
 
     // Price is now stale — should panic.
     let b2 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_010_i128));
+    client.settle_default_liquidation(
+        &b2,
+        &200_i128,
+        &sid(&env, "s2"),
+        &10_000_u32,
+        &Some(1_010_i128),
+    );
 }
 
 #[test]
@@ -227,12 +281,24 @@ fn settle_price_at_exact_max_age_accepted() {
 
     env.ledger().with_mut(|l| l.timestamp = 1_000);
     let b1 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b1, &200_i128, &sid(&env, "s1"), &Some(1_000_i128));
+    client.settle_default_liquidation(
+        &b1,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
 
     // Advance exactly max_age_seconds — age == 3600, not > 3600, so accepted.
     env.ledger().with_mut(|l| l.timestamp = 1_000 + 3_600);
     let b2 = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&b2, &200_i128, &sid(&env, "s2"), &Some(1_010_i128));
+    client.settle_default_liquidation(
+        &b2,
+        &200_i128,
+        &sid(&env, "s2"),
+        &10_000_u32,
+        &Some(1_010_i128),
+    );
 
     assert_eq!(
         client.get_credit_line(&b2).unwrap().status,
@@ -249,7 +315,13 @@ fn settle_zero_oracle_price_panics() {
     let (client, contract_id, _) = setup(&env);
     client.set_oracle_config(&500_u32, &3600_u64);
     let borrower = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&borrower, &200_i128, &sid(&env, "s1"), &Some(0_i128));
+    client.settle_default_liquidation(
+        &borrower,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(0_i128),
+    );
 }
 
 #[test]
@@ -259,7 +331,13 @@ fn settle_negative_oracle_price_panics() {
     let (client, contract_id, _) = setup(&env);
     client.set_oracle_config(&500_u32, &3600_u64);
     let borrower = open_and_default(&client, &env, &contract_id, 200);
-    client.settle_default_liquidation(&borrower, &200_i128, &sid(&env, "s1"), &Some(-1_i128));
+    client.settle_default_liquidation(
+        &borrower,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(-1_i128),
+    );
 }
 
 #[test]
@@ -270,5 +348,11 @@ fn settle_missing_price_when_config_set_panics() {
     client.set_oracle_config(&500_u32, &3600_u64);
     let borrower = open_and_default(&client, &env, &contract_id, 200);
     // oracle_price is None but config is set — must panic.
-    client.settle_default_liquidation(&borrower, &200_i128, &sid(&env, "s1"), &None);
+    client.settle_default_liquidation(
+        &borrower,
+        &200_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &None,
+    );
 }

--- a/contracts/credit/tests/oracle_quorum.rs
+++ b/contracts/credit/tests/oracle_quorum.rs
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for the multi-oracle quorum price feed.
+//!
+//! # Coverage
+//! - `set_oracle_quorum_config` stores config; `get_oracle_quorum_config` returns it.
+//! - `set_oracle_quorum_config` validates k ≥ 2, max_dev ≤ 10_000, max_age > 0.
+//! - `get_oracle_quorum_config` returns `None` when not set.
+//! - `submit_oracle_prices` validates quorum, stores the resolved median price.
+//! - Outlier feeds are excluded when a tighter K-wide window qualifies first.
+//! - `submit_oracle_prices` fails when quorum is not met (`OracleQuorumNotMet`).
+//! - `submit_oracle_prices` fails on non-positive prices (`OraclePriceInvalid`).
+//! - `submit_oracle_prices` fails when quorum config is not set.
+//! - Settlement uses the stored quorum price (oracle_price arg ignored).
+//! - Settlement rejects a stale quorum price (`OraclePriceStale`).
+//! - Settlement rejects when no quorum price has been submitted yet.
+//! - Quorum mode takes precedence over the single-oracle circuit breaker.
+//! - `orc_qcfg` and `orc_qprc` events are emitted correctly.
+
+use creditra_credit::types::{CreditStatus, OracleQuorumConfig};
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger};
+use soroban_sdk::{token, vec, Address, Env, Symbol, TryFromVal};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (CreditClient, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    (client, contract_id, admin)
+}
+
+/// Open a credit line for `utilized` units, draw, then default it. Returns the borrower.
+fn open_and_default(
+    client: &CreditClient,
+    env: &Env,
+    contract_id: &Address,
+    utilized: i128,
+) -> Address {
+    let borrower = Address::generate(env);
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token_addr = token_id.address();
+    client.set_liquidity_token(&token_addr);
+    token::StellarAssetClient::new(env, &token_addr).mint(contract_id, &1_000_000_i128);
+    token::StellarAssetClient::new(env, &token_addr).mint(&borrower, &1_000_000_i128);
+    token::Client::new(env, &token_addr).approve(
+        &borrower,
+        contract_id,
+        &1_000_000_i128,
+        &1_000_000_u32,
+    );
+    client.open_credit_line(&borrower, &10_000_i128, &300_u32, &60_u32);
+    if utilized > 0 {
+        client.draw_credit(&borrower, &utilized);
+    }
+    client.default_credit_line(&borrower);
+    borrower
+}
+
+fn sid(env: &Env, s: &str) -> Symbol {
+    Symbol::new(env, s)
+}
+
+fn has_event_topic(env: &Env, kind: &str) -> bool {
+    let ns = Symbol::new(env, "credit");
+    let k = Symbol::new(env, kind);
+    for (_contract, topics, _data) in env.events().all().iter() {
+        if topics.len() < 2 {
+            continue;
+        }
+        let t0: Result<Symbol, _> = Symbol::try_from_val(env, &topics.get(0).unwrap());
+        let t1: Result<Symbol, _> = Symbol::try_from_val(env, &topics.get(1).unwrap());
+        if let (Ok(t0), Ok(t1)) = (t0, t1) {
+            if t0 == ns && t1 == k {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ── set / get oracle quorum config ────────────────────────────────────────────
+
+#[test]
+fn set_oracle_quorum_config_stores_and_get_returns_it() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let cfg: OracleQuorumConfig = client.get_oracle_quorum_config().unwrap();
+    assert_eq!(cfg.min_quorum_k, 2);
+    assert_eq!(cfg.max_deviation_bps, 500);
+    assert_eq!(cfg.max_age_seconds, 3_600);
+}
+
+#[test]
+fn get_oracle_quorum_config_none_when_not_set() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    assert!(client.get_oracle_quorum_config().is_none());
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_quorum_config_k_less_than_two_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&1_u32, &500_u32, &3_600_u64);
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_quorum_config_k_zero_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&0_u32, &500_u32, &3_600_u64);
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_quorum_config_max_dev_over_10000_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &10_001_u32, &3_600_u64);
+}
+
+#[test]
+#[should_panic]
+fn set_oracle_quorum_config_zero_age_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &0_u64);
+}
+
+#[test]
+fn set_oracle_quorum_config_max_dev_10000_accepted() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    // max_deviation_bps == 10_000 is the inclusive upper bound
+    client.set_oracle_quorum_config(&2_u32, &10_000_u32, &3_600_u64);
+    let cfg = client.get_oracle_quorum_config().unwrap();
+    assert_eq!(cfg.max_deviation_bps, 10_000);
+}
+
+// ── submit_oracle_prices — happy path ─────────────────────────────────────────
+
+#[test]
+fn submit_two_of_three_quorum_stores_median() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    // k=2, dev=500 bps — two feeds within 5% form a quorum
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    // Sorted: 1_000, 1_040, 5_000 — window [1_000, 1_040]: dev=400 bps ≤ 500 ✓
+    let prices = vec![&env, 5_000i128, 1_000i128, 1_040i128];
+    client.submit_oracle_prices(&prices);
+
+    // Verify via settlement — quorum price should allow settlement without oracle_price
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "settle1"),
+        &10_000_u32,
+        &None,
+    );
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().status,
+        CreditStatus::Closed
+    );
+}
+
+#[test]
+fn submit_three_of_five_quorum_picks_correct_window() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&3_u32, &500_u32, &3_600_u64);
+
+    // Sorted: 980, 990, 1_000, 1_010, 5_000
+    // Window [980, 990, 1_000]: dev(1_000, 980)=204 bps ≤ 500 → qualifies
+    let prices = vec![&env, 1_010i128, 5_000i128, 980i128, 990i128, 1_000i128];
+    // Expect no panic — quorum was met
+    client.submit_oracle_prices(&prices);
+}
+
+#[test]
+fn submit_all_identical_prices_zero_deviation() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&3_u32, &0_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, 1_000i128, 1_000i128];
+    client.submit_oracle_prices(&prices);
+}
+
+// ── submit_oracle_prices — error paths ────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn submit_oracle_prices_without_quorum_config_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    // No quorum config set
+    let prices = vec![&env, 1_000i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+}
+
+#[test]
+#[should_panic]
+fn submit_quorum_not_met_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &100_u32, &3_600_u64);
+
+    // 1_000 and 2_000 are 100% apart — no 2-wide window qualifies at 1% max dev
+    let prices = vec![&env, 1_000i128, 2_000i128];
+    client.submit_oracle_prices(&prices);
+}
+
+#[test]
+#[should_panic]
+fn submit_negative_price_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, -1i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+}
+
+#[test]
+#[should_panic]
+fn submit_zero_price_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, 0i128];
+    client.submit_oracle_prices(&prices);
+}
+
+#[test]
+#[should_panic]
+fn submit_k_greater_than_n_panics() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    // k=3 but only 2 prices — OracleQuorumNotMet
+    client.set_oracle_quorum_config(&3_u32, &500_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+}
+
+// ── settlement in quorum mode ─────────────────────────────────────────────────
+
+#[test]
+fn settlement_uses_quorum_price_ignores_oracle_price_arg() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, 1_030i128];
+    client.submit_oracle_prices(&prices);
+
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    // oracle_price=None is fine in quorum mode — uses the stored quorum price
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "q1"),
+        &10_000_u32,
+        &None,
+    );
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().status,
+        CreditStatus::Closed
+    );
+}
+
+#[test]
+#[should_panic]
+fn settlement_fails_when_no_quorum_price_submitted() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    // Quorum config set but submit_oracle_prices never called
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "q1"),
+        &10_000_u32,
+        &None,
+    );
+}
+
+#[test]
+#[should_panic]
+fn settlement_fails_on_stale_quorum_price() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    // max_age = 1 hour
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    // Submit quorum price at t=1_000
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let prices = vec![&env, 1_000i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+
+    // Advance beyond max_age_seconds
+    env.ledger().with_mut(|l| l.timestamp = 1_000 + 3_601);
+
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "q1"),
+        &10_000_u32,
+        &None,
+    );
+}
+
+#[test]
+fn settlement_at_exact_max_age_succeeds() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let prices = vec![&env, 1_000i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+
+    // age == max_age_seconds exactly — should be accepted (> check, not >=)
+    env.ledger().with_mut(|l| l.timestamp = 1_000 + 3_600);
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "q1"),
+        &10_000_u32,
+        &None,
+    );
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().status,
+        CreditStatus::Closed
+    );
+}
+
+// ── quorum mode precedence over single-oracle mode ────────────────────────────
+
+#[test]
+fn quorum_mode_takes_precedence_over_single_oracle_config() {
+    // When both oracle_config and oracle_quorum_config are set,
+    // settlement should use the quorum price (oracle_price arg ignored).
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+
+    // Set both configs
+    client.set_oracle_config(&500_u32, &3_600_u64);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    // Submit quorum prices
+    let prices = vec![&env, 1_000i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+
+    // Settlement with oracle_price=None should succeed via quorum mode
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "q1"),
+        &10_000_u32,
+        &None,
+    );
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().status,
+        CreditStatus::Closed
+    );
+}
+
+#[test]
+fn single_oracle_mode_still_works_when_quorum_not_configured() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    // Only single-oracle config set
+    client.set_oracle_config(&500_u32, &3_600_u64);
+
+    let borrower = open_and_default(&client, &env, &contract_id, 500);
+    // Single-oracle path: first price accepted
+    client.settle_default_liquidation(
+        &borrower,
+        &500_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &Some(1_000_i128),
+    );
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().status,
+        CreditStatus::Closed
+    );
+}
+
+// ── event emission ────────────────────────────────────────────────────────────
+
+#[test]
+fn set_oracle_quorum_config_emits_orc_qcfg_event() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+    assert!(has_event_topic(&env, "orc_qcfg"), "expected orc_qcfg event");
+}
+
+#[test]
+fn submit_oracle_prices_emits_orc_qprc_event() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, 1_020i128];
+    client.submit_oracle_prices(&prices);
+
+    assert!(has_event_topic(&env, "orc_qprc"), "expected orc_qprc event");
+}
+
+// ── multiple settlements with a single quorum submission ─────────────────────
+
+#[test]
+fn multiple_settlements_reuse_same_quorum_price() {
+    let env = Env::default();
+    let (client, contract_id, _) = setup(&env);
+    client.set_oracle_quorum_config(&2_u32, &500_u32, &3_600_u64);
+
+    let prices = vec![&env, 1_000i128, 1_010i128];
+    client.submit_oracle_prices(&prices);
+
+    // First settlement
+    let b1 = open_and_default(&client, &env, &contract_id, 300);
+    client.settle_default_liquidation(
+        &b1,
+        &300_i128,
+        &sid(&env, "s1"),
+        &10_000_u32,
+        &None,
+    );
+    assert_eq!(client.get_credit_line(&b1).unwrap().status, CreditStatus::Closed);
+
+    // Second settlement reuses the stored quorum price without re-submitting
+    let b2 = open_and_default(&client, &env, &contract_id, 400);
+    client.settle_default_liquidation(
+        &b2,
+        &400_i128,
+        &sid(&env, "s2"),
+        &10_000_u32,
+        &None,
+    );
+    assert_eq!(client.get_credit_line(&b2).unwrap().status, CreditStatus::Closed);
+}


### PR DESCRIPTION
Implement quorum-of-K oracle price resolution in a new oracles module and wire it into the settlement path as a higher-priority mode than the existing single-oracle circuit breaker.

New module contracts/credit/src/oracles.rs:
- resolve_quorum_price(env, prices, cfg) - sorts N submitted prices, slides a K-wide window, returns the lower-median of the first window whose highest-to-lowest spread is within max_deviation_bps.

New type OracleQuorumConfig { min_quorum_k, max_deviation_bps, max_age_seconds }. New error OracleQuorumNotMet = 45 (discriminant stable, appended). New storage key OracleQuorumConfig in DataKey.

New entrypoints (admin-only, pause-gated):
- set_oracle_quorum_config, get_oracle_quorum_config
- submit_oracle_prices(prices: Vec<i128>) - runs quorum, stores canonical price.

Updated settle_default_liquidation: quorum mode takes precedence over single-oracle circuit breaker when OracleQuorumConfig is set. New events: orc_qcfg (config set), orc_qprc (quorum price resolved).

Tests: 11 unit tests in oracles.rs, 20 integration tests in oracle_quorum.rs.
oracle_deviation.rs fixed: add missing close_factor_bps arg (broken since #690).
error_discriminants.rs: OracleQuorumNotMet = 45, count 44 to 45.

Closes #630