### PR TITLE
#584 Add installment-advance proptest with random schedules FIXED

### DIFF
--- a/contracts/credit/Cargo.toml
+++ b/contracts/credit/Cargo.toml
@@ -20,8 +20,8 @@ instrument = ["dep:serde", "dep:serde_json", "soroban-sdk/testutils"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", optional = true, default-features = false }
 
 [[example]]
 name = "budget_baseline"

--- a/contracts/credit/src/borrow.rs
+++ b/contracts/credit/src/borrow.rs
@@ -3,6 +3,7 @@ use crate::events::{
     publish_drawn_event, publish_interest_accrued_event, publish_repayment_event, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent,
 };
+use crate::lifecycle;
 use crate::math_utils::{mul_div, Rounding};
 use crate::storage::{
     clear_reentrancy_guard, get_collateral_balance, persist_credit_line, set_reentrancy_guard,
@@ -120,6 +121,7 @@ pub fn draw_credit(env: Env, borrower: Address, amount: i128) {
 /// - `credit_line.accrued_interest -= interest_repaid`
 /// - `credit_line.utilized_amount -= effective_repay`
 /// - Persists the credit line via [`persist_credit_line`]
+/// - Advances the installment schedule by principal installments only
 /// - Emits [`InterestAccruedEvent`] and [`RepaymentEvent`]
 pub(crate) fn repay_credit_internal(
     env: &Env,
@@ -142,6 +144,12 @@ pub(crate) fn repay_credit_internal(
     credit_line.utilized_amount = new_utilized;
 
     persist_credit_line(env, borrower, credit_line, previous_utilized, Some(previous_status));
+    lifecycle::advance_repayment_schedule_after_repay(
+        env,
+        borrower,
+        effective_repay,
+        interest_repaid,
+    );
 
     publish_interest_accrued_event(
         env,

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -616,7 +616,12 @@ impl Credit {
             previous_utilized,
             Some(previous_status),
         );
-        lifecycle::advance_repayment_schedule_after_repay(&env, &borrower, effective_repay);
+        lifecycle::advance_repayment_schedule_after_repay(
+            &env,
+            &borrower,
+            effective_repay,
+            interest_repaid,
+        );
 
         let _timestamp = env.ledger().timestamp();
         publish_interest_accrued_event(

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -509,7 +509,7 @@ pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditS
 ///
 /// # Parameters
 /// - `borrower`: Borrower whose credit line schedule is being configured.
-/// - `amount_per_period`: Required repayment amount per installment; must be positive.
+/// - `amount_per_period`: Required principal repayment amount per installment; must be positive.
 /// - `period_seconds`: Duration of each installment period in seconds; must be positive.
 /// - `first_due_ts`: Timestamp at which the first installment is due.
 ///
@@ -547,27 +547,32 @@ pub fn set_repayment_schedule(
     storage_set_repayment_schedule(env, &borrower, &schedule);
 }
 
-/// Advance a borrower's installment schedule after an effective repayment.
+/// Advance a borrower's installment schedule after a repayment.
 ///
-/// The public `repay_credit` entrypoint caps the requested repayment to the
-/// outstanding debt before calling this helper.  This function therefore uses
-/// `effective_repay` directly and advances `next_due_ts` by the whole number of
-/// installments covered:
+/// `effective_repay` is the amount actually applied to the debt after capping
+/// an overpayment to the outstanding balance. `interest_repaid` is the portion
+/// of that amount that was allocated to accrued interest. Only the principal
+/// portion of a repayment can satisfy installment obligations:
 ///
 /// ```text
-/// floor(effective_repay / amount_per_period) * period_seconds
+/// principal_repaid  = effective_repay - interest_repaid
+/// installments_paid = floor(principal_repaid / amount_per_period)
+/// next_due_ts       = next_due_ts + installments_paid * period_seconds
 /// ```
 ///
-/// Partial installments do not move the due date.  Arithmetic uses saturating
-/// `u64` operations so extreme schedule values cannot wrap timestamps.
+/// Interest-only repayments and partial principal installments do not move the
+/// due date. Arithmetic uses checked/saturating operations so malformed state or
+/// extreme schedule values cannot wrap timestamps.
 pub fn advance_repayment_schedule_after_repay(
     env: &Env,
     borrower: &Address,
     effective_repay: i128,
+    interest_repaid: i128,
 ) {
-    if effective_repay <= 0 {
-        return;
-    }
+    let principal_repaid = match effective_repay.checked_sub(interest_repaid) {
+        Some(principal) if principal > 0 => principal,
+        _ => return,
+    };
 
     let Some(mut schedule) = get_repayment_schedule(env, borrower) else {
         return;
@@ -577,7 +582,7 @@ pub fn advance_repayment_schedule_after_repay(
         return;
     }
 
-    let installments_paid = (effective_repay / schedule.amount_per_period) as u64;
+    let installments_paid = (principal_repaid / schedule.amount_per_period) as u64;
     if installments_paid == 0 {
         return;
     }

--- a/contracts/credit/tests/proptest_installment.rs
+++ b/contracts/credit/tests/proptest_installment.rs
@@ -1,24 +1,25 @@
 // SPDX-License-Identifier: MIT
 //! Property tests for installment-schedule advancement during repayments.
 //!
-//! The schedule is advanced from `repay_credit` via
-//! `advance_repayment_schedule_after_repay`.  These tests exercise random
+//! The schedule is advanced from `repay_credit` through
+//! `advance_repayment_schedule_after_repay`. These tests exercise random
 //! repayment schedules and random repayment streams, asserting that
-//! `next_due_ts` advances by exactly the whole number of installments covered
-//! by the effective repayment amount:
+//! `next_due_ts` advances by exactly the whole number of principal installments
+//! covered by the effective repayment amount:
 //!
 //! ```text
-//! installments_paid = floor(effective_repay / amount_per_period)
+//! principal_repaid  = effective_repay - interest_repaid
+//! installments_paid = floor(principal_repaid / amount_per_period)
 //! next_due_ts       = previous_next_due_ts + installments_paid * period_seconds
 //! ```
 //!
-//! Partial repayments (`effective_repay < amount_per_period`) must not advance
-//! the due date.  Repayments above the remaining debt are capped by
+//! Interest-only repayments and partial principal installments must not advance
+//! the due date. Repayments above the remaining debt are capped by
 //! `repay_credit`, so the expected model applies the same cap before computing
 //! installment advancement.
 
 use proptest::prelude::*;
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{token, Address, Env};
 
 use creditra_credit::{Credit, CreditClient};
@@ -29,6 +30,8 @@ const CREDIT_LIMIT: i128 = 30_000;
 const DRAW_AMOUNT: i128 = 10_000;
 const COLLATERAL_AMOUNT: i128 = 15_000;
 const TOKEN_BALANCE: i128 = 1_000_000;
+const RATE_BPS: u32 = 2_500;
+const SECONDS_PER_YEAR: u64 = 31_536_000;
 
 /// Test harness for a funded borrower with an open, drawn credit line.
 struct Ctx {
@@ -66,10 +69,10 @@ fn setup_env() -> Ctx {
     token_admin.mint(&contract_id, &TOKEN_BALANCE);
     token_admin.mint(&borrower, &TOKEN_BALANCE);
 
-    // The same token is used for collateral and repayments.  Deposit enough
+    // The same token is used for collateral and repayments. Deposit enough
     // collateral before drawing so the default collateral-ratio guard is met.
     client.deposit_collateral(&borrower, &COLLATERAL_AMOUNT);
-    client.open_credit_line(&borrower, &CREDIT_LIMIT, &500_u32, &50_u32);
+    client.open_credit_line(&borrower, &CREDIT_LIMIT, &RATE_BPS, &50_u32);
     client.draw_credit(&borrower, &DRAW_AMOUNT);
 
     Ctx {
@@ -94,16 +97,26 @@ fn fund_repayment(ctx: &Ctx, amount: i128) {
 /// Model the installment advancement performed by the contract.
 fn expected_next_due(
     current_next_due: u64,
-    effective_repay: i128,
+    principal_repaid: i128,
     amount_per_period: i128,
     period_seconds: u64,
 ) -> u64 {
-    let installments_paid = (effective_repay / amount_per_period) as u64;
+    let installments_paid = (principal_repaid / amount_per_period) as u64;
     current_next_due.saturating_add(installments_paid.saturating_mul(period_seconds))
 }
 
+/// Floor interest used by the contract's prorating helper.
+fn accrued_interest(principal: i128, elapsed_seconds: u64) -> i128 {
+    (principal as u128)
+        .saturating_mul(RATE_BPS as u128)
+        .saturating_mul(elapsed_seconds as u128)
+        .checked_div(10_000_u128.saturating_mul(SECONDS_PER_YEAR as u128))
+        .unwrap_or(0) as i128
+}
+
 proptest! {
-    /// A single random repayment advances the schedule by `floor(repay / installment)` periods.
+    /// A single random repayment advances the schedule by
+    /// `floor(principal_repaid / installment)` periods.
     #[test]
     fn installment_advance_single_random_repayment(
         amount_per_period in 1_i128..=2_000_i128,
@@ -184,6 +197,59 @@ proptest! {
             );
         }
     }
+
+    /// Repayment streams with accrued interest only advance by the principal
+    /// component after the interest-first allocation is applied.
+    #[test]
+    fn installment_advance_random_repayment_schedule_with_interest(
+        amount_per_period in 1_i128..=2_000_i128,
+        period_seconds in 1_u64..=86_400_u64,
+        elapsed_seconds in 1_000_u64..=2_000_000_u64,
+        repayments in proptest::collection::vec(1_i128..=5_000_i128, 1..8),
+    ) {
+        let ctx = setup_env();
+        ctx.env.ledger().set_timestamp(INITIAL_TIMESTAMP + elapsed_seconds);
+
+        ctx.client().set_repayment_schedule(
+            &ctx.borrower,
+            &amount_per_period,
+            &period_seconds,
+            &INITIAL_NEXT_DUE,
+        );
+
+        let mut expected_due = INITIAL_NEXT_DUE;
+        let mut accrued = accrued_interest(DRAW_AMOUNT, elapsed_seconds);
+        let mut outstanding = DRAW_AMOUNT + accrued;
+
+        for requested_repay in repayments {
+            if outstanding == 0 {
+                break;
+            }
+
+            let effective_repay = requested_repay.min(outstanding);
+            let interest_repaid = effective_repay.min(accrued);
+            let principal_repaid = effective_repay - interest_repaid;
+
+            fund_repayment(&ctx, requested_repay);
+            ctx.client().repay_credit(&ctx.borrower, &requested_repay);
+
+            expected_due = expected_next_due(
+                expected_due,
+                principal_repaid,
+                amount_per_period,
+                period_seconds,
+            );
+            accrued -= interest_repaid;
+            outstanding -= effective_repay;
+
+            let schedule = ctx.client().get_repayment_schedule(&ctx.borrower).unwrap();
+            prop_assert_eq!(
+                schedule.next_due_ts,
+                expected_due,
+                "amount_per_period={amount_per_period}, period_seconds={period_seconds}, elapsed_seconds={elapsed_seconds}, requested_repay={requested_repay}, effective_repay={effective_repay}, interest_repaid={interest_repaid}, principal_repaid={principal_repaid}, outstanding={outstanding}",
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -244,5 +310,43 @@ mod edge_cases {
         let schedule = ctx.client().get_repayment_schedule(&ctx.borrower).unwrap();
         let expected = expected_next_due(INITIAL_NEXT_DUE, DRAW_AMOUNT, 3_000, 60);
         assert_eq!(schedule.next_due_ts, expected);
+    }
+
+    #[test]
+    fn interest_only_repay_does_not_advance() {
+        let ctx = setup_env();
+        let elapsed_seconds = 1_000_000;
+        ctx.env
+            .ledger()
+            .set_timestamp(INITIAL_TIMESTAMP + elapsed_seconds);
+        ctx.client()
+            .set_repayment_schedule(&ctx.borrower, &100_i128, &86_400_u64, &INITIAL_NEXT_DUE);
+
+        let interest = accrued_interest(DRAW_AMOUNT, elapsed_seconds);
+        assert!(interest > 0);
+
+        fund_repayment(&ctx, interest);
+        ctx.client().repay_credit(&ctx.borrower, &interest);
+
+        let schedule = ctx.client().get_repayment_schedule(&ctx.borrower).unwrap();
+        assert_eq!(schedule.next_due_ts, INITIAL_NEXT_DUE);
+    }
+
+    #[test]
+    fn interest_plus_installment_advances_one_period() {
+        let ctx = setup_env();
+        let elapsed_seconds = 1_000_000;
+        ctx.env
+            .ledger()
+            .set_timestamp(INITIAL_TIMESTAMP + elapsed_seconds);
+        ctx.client()
+            .set_repayment_schedule(&ctx.borrower, &100_i128, &86_400_u64, &INITIAL_NEXT_DUE);
+
+        let repay = accrued_interest(DRAW_AMOUNT, elapsed_seconds) + 100;
+        fund_repayment(&ctx, repay);
+        ctx.client().repay_credit(&ctx.borrower, &repay);
+
+        let schedule = ctx.client().get_repayment_schedule(&ctx.borrower).unwrap();
+        assert_eq!(schedule.next_due_ts, INITIAL_NEXT_DUE + 86_400);
     }
 }

--- a/docs/PROTOCOL_SPEC.md
+++ b/docs/PROTOCOL_SPEC.md
@@ -269,7 +269,7 @@ emits `("credit","rate_form")` with `true`.
 | `set_utilization_cap(borrower, cap_bps)` | `lib.rs:607` | `DataKey::UtilizationCapBps(borrower)` (Persistent) | `cap_bps ∈ 1..=10000`; `0` clears. |
 | `set_max_total_exposure(amount)` | `lib.rs:827` | `DataKey::MaxTotalExposure` | `0` removes the cap. |
 | `set_credit_limit_bounds(min, max)` | `lib.rs:862` | `MinCreditLimit`, `MaxCreditLimit` | `min >= 0`, `max >= min`. |
-| `set_repayment_schedule(borrower, amount_per_period, period_seconds, first_due_ts)` | `lifecycle.rs:182` | `DataKey::RepaymentSchedule(borrower)` (Persistent) | All > 0. |
+| `set_repayment_schedule(borrower, amount_per_period, period_seconds, first_due_ts)` | `lifecycle.rs:182` | `DataKey::RepaymentSchedule(borrower)` (Persistent) | `amount_per_period` is principal-only; interest repayments do not advance `next_due_ts`. All > 0. |
 | `set_grace_period_config(grace_period_seconds, waiver_mode, reduced_rate_bps)` | `lib.rs:646` | `Symbol("grace_cfg")` (Instance) | `reduced_rate <= 10000`. |
 
 ### 2.6 Collateral

--- a/docs/credit.md
+++ b/docs/credit.md
@@ -32,7 +32,7 @@ Optional per-borrower installment schedule stored in persistent storage under th
 
 | Field | Type | Description |
 |---|---|---|
-| `amount_per_period` | `i128` | Required amount for each installment |
+| `amount_per_period` | `i128` | Required principal amount for each installment; interest-only repayment does not advance the schedule |
 | `period_seconds` | `u64` | Installment interval in seconds |
 | `next_due_ts` | `u64` | Timestamp for the next installment due date |
 

--- a/gateway-contract/contracts/auction_contract/tests/transition_matrix.rs
+++ b/gateway-contract/contracts/auction_contract/tests/transition_matrix.rs
@@ -216,7 +216,7 @@ fn setup_auction(mode: AuctionMode, from: AuctionStatus) -> (Env, Address, Symbo
         &1_i128,
         &0_u32,
         &DutchAuctionDecay::None,
-       &DutchAuctionDecay::None,
+        &DutchAuctionDecay::None,
         &DutchAuctionDecay::None,
         &DutchAuctionDecay::None,
     );


### PR DESCRIPTION

### Findings

The issue was in installment schedule advancement after repayments.

The previous behavior advanced the borrower’s repayment schedule using the full effective repayment amount:

```rust
installments_paid = effective_repay / amount_per_period
```

That is incorrect because Creditra repayments are allocated interest-first.

So if a borrower repaid only accrued interest, the contract could still treat that repayment as covering an installment and advance:

```rust
next_due_ts
```

This could make a delinquent or near-due borrower appear current even though no installment principal was actually repaid.

### Root Cause

The schedule helper did not distinguish between:

- interest repaid
- principal repaid

It only received:

```rust
effective_repay
```

So it could not know how much of the repayment actually counted toward installment principal.

### Fix Implemented

The schedule advancement helper was changed to receive both:

```rust
effective_repay
interest_repaid
```

Then it computes:

```rust
principal_repaid = effective_repay - interest_repaid
```

The installment schedule now advances only by whole principal installments:

```rust
installments_paid = principal_repaid / amount_per_period
next_due_ts = next_due_ts + installments_paid * period_seconds
```

### New Correct Behavior

#### Interest-only repayment

Does **not** advance schedule.

```rust
principal_repaid = 0
installments_paid = 0
next_due_ts unchanged
```

#### Partial principal repayment

Does **not** advance schedule.

```rust
principal_repaid < amount_per_period
installments_paid = 0
next_due_ts unchanged
```

#### Exact installment repayment

Advances by one period.

```rust
principal_repaid = amount_per_period
installments_paid = 1
next_due_ts += period_seconds
```

#### Multiple-installment repayment

Advances by multiple periods.

```rust
principal_repaid = amount_per_period * n
installments_paid = n
next_due_ts += n * period_seconds
```

#### Overpayment

Still capped by the existing repayment logic before schedule advancement.

```rust
effective_repay = min(requested_repay, outstanding_debt)
```

### Security / Safety Features

The fix preserves safe math behavior:

```rust
effective_repay.checked_sub(interest_repaid)
```

If subtraction would be invalid, the function returns without advancing.

Timestamp advancement still uses saturating math:

```rust
schedule.next_due_ts = schedule.next_due_ts.saturating_add(advance_seconds);
```

Installment period multiplication remains saturating:

```rust
installments_paid.saturating_mul(schedule.period_seconds)
```

This avoids timestamp wraparound.

### Tests Added / Expanded

The installment property test file was expanded:

```text
contracts/credit/tests/proptest_installment.rs
```

Coverage added for:

- random repayment schedules
- random repayment streams
- random repayment streams with accrued interest
- interest-only repayment
- interest + exact installment repayment
- partial repayment below installment threshold
- exact installment repayment
- multiple installment repayment
- overpayment capped to outstanding debt

### Documentation Updated

Updated:

```text
docs/credit.md
docs/PROTOCOL_SPEC.md
```

The docs now clarify that:

```text
amount_per_period
```

is a required **principal** amount per installment, and interest-only repayments do not advance the schedule.

CLOSE #584 

### Files Changed for This Step

```text
contracts/credit/src/lifecycle.rs
contracts/credit/src/lib.rs
contracts/credit/src/borrow.rs
contracts/credit/tests/proptest_installment.rs
docs/credit.md
docs/PROTOCOL_SPEC.md