### PR TITLE
test: Kani prorate_interest harness (proves monotonicity + overflow-safety)

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,0 +1,49 @@
+name: Kani Proofs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - feature/**
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: kani-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kani:
+    name: prorate_interest harness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.kani
+            target
+          key: ${{ runner.os }}-kani-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-kani-
+
+      - name: Install Kani
+        run: |
+          cargo install --locked kani-verifier
+          cargo kani setup
+
+      - name: Run prorate_interest proof harnesses
+        run: cargo kani -p creditra-credit

--- a/contracts/credit/proofs/prorate_interest.rs
+++ b/contracts/credit/proofs/prorate_interest.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+
+//! # Kani proof harnesses for [`crate::math_utils::prorate_interest`]
+//!
+//! These harnesses use the [Kani](https://model-checking.github.io/kani/)
+//! model checker to prove — exhaustively over a bounded symbolic input
+//! domain — that [`prorate_interest`] is **monotonic** in each numeric
+//! argument and **overflow-safe** (never panics) within the protocol's
+//! realistic operating envelope.
+//!
+//! They compile only under `cfg(kani)` and are invisible to the normal
+//! `cargo build` / `cargo test` pipeline. Run them with:
+//!
+//! ```text
+//! cargo kani -p creditra-credit
+//! ```
+//!
+//! ## Why these properties
+//!
+//! `prorate_interest` computes
+//! `round((principal × rate_bps × time_delta) / (BPS_DENOMINATOR × SECONDS_PER_YEAR))`
+//! using two `checked_mul` steps. The accrual layer relies on two
+//! behavioural guarantees that were previously only asserted by
+//! example-based unit tests:
+//!
+//! 1. **Monotonicity.** Interest must never *decrease* when principal,
+//!    rate, or elapsed time increases. A violation would let a borrower
+//!    reduce owed interest by accruing over a longer window, or let a
+//!    larger debt accrue less than a smaller one — accounting-integrity
+//!    bugs.
+//! 2. **Overflow-safety.** Within the realistic input envelope the function
+//!    must never trigger the `checked_mul` panic. *Outside* the envelope the
+//!    panic is the intended behaviour (the caller maps it to
+//!    [`crate::types::ContractError::Overflow`]), so these proofs bound the
+//!    domain to the safe envelope rather than the full type range.
+//!
+//! ## The safe envelope
+//!
+//! The worst-case product is `principal × rate_bps × time_delta`. With the
+//! bounds below it is at most `10^24 × 10^4 × 10^9 = 10^37`, comfortably
+//! under `u128::MAX ≈ 3.4 × 10^38` (~300× margin), so neither `checked_mul`
+//! can overflow:
+//!
+//! | Input        | Bound            | Justification                                              |
+//! |--------------|------------------|-----------------------------------------------------------|
+//! | `principal`  | `≤ 10^24`        | Far above any realistic utilized balance (7–18 decimals)  |
+//! | `rate_bps`   | `≤ 10_000`       | Enforced cap `risk::MAX_INTEREST_RATE_BPS` (100 % APR)     |
+//! | `time_delta` | `≤ 10^9` (≈31.7y)| Generous bound on a single accrual window                 |
+
+#![cfg(kani)]
+
+use crate::math_utils::{prorate_interest, Rounding};
+
+/// Upper bound on `principal` for the overflow-safe envelope (`10^24`).
+const PRINCIPAL_MAX: u128 = 1_000_000_000_000_000_000_000_000;
+
+/// Upper bound on `rate_bps`: the protocol's enforced interest-rate cap
+/// (`risk::MAX_INTEREST_RATE_BPS = 10_000`, i.e. 100 % APR).
+const RATE_MAX: u32 = 10_000;
+
+/// Upper bound on `time_delta` (`10^9` seconds ≈ 31.7 years).
+const TIME_MAX: u64 = 1_000_000_000;
+
+/// Draw a symbolic input triple constrained to the overflow-safe envelope.
+fn bounded() -> (u128, u32, u64) {
+    let principal: u128 = kani::any();
+    let rate_bps: u32 = kani::any();
+    let time_delta: u64 = kani::any();
+    kani::assume(principal <= PRINCIPAL_MAX);
+    kani::assume(rate_bps <= RATE_MAX);
+    kani::assume(time_delta <= TIME_MAX);
+    (principal, rate_bps, time_delta)
+}
+
+/// Within the safe envelope, `prorate_interest` never panics (no
+/// `checked_mul` overflow) for either rounding direction.
+#[kani::proof]
+fn prorate_interest_overflow_safe() {
+    let (principal, rate_bps, time_delta) = bounded();
+    let _ = prorate_interest(principal, rate_bps, time_delta, Rounding::Floor);
+    let _ = prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil);
+}
+
+/// Interest is non-decreasing in `principal` (other args fixed).
+#[kani::proof]
+fn prorate_interest_monotonic_in_principal() {
+    let principal: u128 = kani::any();
+    let rate_bps: u32 = kani::any();
+    let time_delta: u64 = kani::any();
+    // `principal + 1` must stay in-envelope, so bound strictly below MAX.
+    kani::assume(principal < PRINCIPAL_MAX);
+    kani::assume(rate_bps <= RATE_MAX);
+    kani::assume(time_delta <= TIME_MAX);
+
+    let lo_floor = prorate_interest(principal, rate_bps, time_delta, Rounding::Floor);
+    let hi_floor = prorate_interest(principal + 1, rate_bps, time_delta, Rounding::Floor);
+    assert!(hi_floor >= lo_floor);
+
+    let lo_ceil = prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil);
+    let hi_ceil = prorate_interest(principal + 1, rate_bps, time_delta, Rounding::Ceil);
+    assert!(hi_ceil >= lo_ceil);
+}
+
+/// Interest is non-decreasing in `rate_bps` (other args fixed).
+#[kani::proof]
+fn prorate_interest_monotonic_in_rate() {
+    let principal: u128 = kani::any();
+    let rate_bps: u32 = kani::any();
+    let time_delta: u64 = kani::any();
+    kani::assume(principal <= PRINCIPAL_MAX);
+    kani::assume(rate_bps < RATE_MAX);
+    kani::assume(time_delta <= TIME_MAX);
+
+    let lo_floor = prorate_interest(principal, rate_bps, time_delta, Rounding::Floor);
+    let hi_floor = prorate_interest(principal, rate_bps + 1, time_delta, Rounding::Floor);
+    assert!(hi_floor >= lo_floor);
+
+    let lo_ceil = prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil);
+    let hi_ceil = prorate_interest(principal, rate_bps + 1, time_delta, Rounding::Ceil);
+    assert!(hi_ceil >= lo_ceil);
+}
+
+/// Interest is non-decreasing in `time_delta` (other args fixed).
+#[kani::proof]
+fn prorate_interest_monotonic_in_time() {
+    let principal: u128 = kani::any();
+    let rate_bps: u32 = kani::any();
+    let time_delta: u64 = kani::any();
+    kani::assume(principal <= PRINCIPAL_MAX);
+    kani::assume(rate_bps <= RATE_MAX);
+    kani::assume(time_delta < TIME_MAX);
+
+    let lo_floor = prorate_interest(principal, rate_bps, time_delta, Rounding::Floor);
+    let hi_floor = prorate_interest(principal, rate_bps, time_delta + 1, Rounding::Floor);
+    assert!(hi_floor >= lo_floor);
+
+    let lo_ceil = prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil);
+    let hi_ceil = prorate_interest(principal, rate_bps, time_delta + 1, Rounding::Ceil);
+    assert!(hi_ceil >= lo_ceil);
+}
+
+/// The `Ceil` result is always ≥ the `Floor` result and exceeds it by at
+/// most one base unit — rounding can never move interest by more than 1.
+#[kani::proof]
+fn prorate_interest_rounding_bounds() {
+    let (principal, rate_bps, time_delta) = bounded();
+    let floor = prorate_interest(principal, rate_bps, time_delta, Rounding::Floor);
+    let ceil = prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil);
+    assert!(ceil >= floor);
+    assert!(ceil - floor <= 1);
+}
+
+/// Any zero argument yields exactly zero interest (documented short-circuit).
+#[kani::proof]
+fn prorate_interest_zero_short_circuit() {
+    let (principal, rate_bps, time_delta) = bounded();
+    assert_eq!(prorate_interest(0, rate_bps, time_delta, Rounding::Ceil), 0);
+    assert_eq!(prorate_interest(principal, 0, time_delta, Rounding::Ceil), 0);
+    assert_eq!(prorate_interest(principal, rate_bps, 0, Rounding::Ceil), 0);
+}

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -101,6 +101,7 @@ mod accrual_tests;
 mod amount_validation_tests;
 mod auth;
 mod borrow;
+mod collateral;
 mod config;
 pub mod events;
 mod fees;
@@ -108,6 +109,7 @@ mod freeze;
 #[cfg(all(not(target_arch = "wasm32"), feature = "instrument"))]
 pub mod instrument;
 mod lifecycle;
+pub mod math_utils;
 mod query;
 mod risk;
 pub use crate::risk::compute_rate_from_score;
@@ -115,13 +117,23 @@ pub use crate::types::FreezeReason;
 mod scoring;
 mod storage;
 pub mod types;
+mod views;
 
 #[cfg(test)]
 mod boundary_tests;
 #[cfg(test)]
+mod limit_decrease_tests;
+#[cfg(test)]
 mod risk_formula_tests;
 #[cfg(test)]
 mod views_tests;
+
+/// Kani proof harnesses for the interest-prorating math primitive.
+/// Compiled only under `cfg(kani)`; invisible to normal builds and tests.
+/// Run with `cargo kani -p creditra-credit`.
+#[cfg(kani)]
+#[path = "../proofs/prorate_interest.rs"]
+mod prorate_interest_proofs;
 
 use crate::auth::require_admin_auth;
 use crate::events::{

--- a/contracts/credit/src/math_utils.rs
+++ b/contracts/credit/src/math_utils.rs
@@ -768,4 +768,90 @@ mod tests {
     fn deviation_negative_last_price_returns_none() {
         assert_eq!(compute_deviation_bps(100, -1), None);
     }
+    // ── prorate_interest: monotonicity & overflow-safety properties ──────────
+    //
+    // These mirror the `cfg(kani)` harnesses in `proofs/prorate_interest.rs`
+    // so the same guarantees run under the normal `cargo test` suite (Kani
+    // runs only in CI). Inputs use the same overflow-safe envelope.
+    mod prorate_interest_properties {
+        use crate::math_utils::{prorate_interest, Rounding};
+        use proptest::prelude::*;
+
+        const PRINCIPAL_MAX: u128 = 1_000_000_000_000_000_000_000_000; // 10^24
+        const RATE_MAX: u32 = 10_000;
+        const TIME_MAX: u64 = 1_000_000_000; // 10^9 (~31.7 years)
+
+        #[test]
+        fn overflow_safe_at_envelope_corners() {
+            let _ = prorate_interest(PRINCIPAL_MAX, RATE_MAX, TIME_MAX, Rounding::Floor);
+            let _ = prorate_interest(PRINCIPAL_MAX, RATE_MAX, TIME_MAX, Rounding::Ceil);
+        }
+
+        #[test]
+        fn ceil_within_one_of_floor() {
+            for &(p, r, t) in &[
+                (10_000u128, 300u32, 86_400u64),
+                (1, 1, 1),
+                (PRINCIPAL_MAX, RATE_MAX, TIME_MAX),
+                (123_456_789, 777, 1_000_000),
+            ] {
+                let f = prorate_interest(p, r, t, Rounding::Floor);
+                let c = prorate_interest(p, r, t, Rounding::Ceil);
+                assert!(c >= f, "ceil < floor for ({p}, {r}, {t})");
+                assert!(c - f <= 1, "ceil - floor > 1 for ({p}, {r}, {t})");
+            }
+        }
+
+        proptest! {
+            #[test]
+            fn monotonic_in_principal(
+                principal in 0u128..PRINCIPAL_MAX,
+                rate_bps in 0u32..=RATE_MAX,
+                time_delta in 0u64..=TIME_MAX,
+            ) {
+                prop_assert!(
+                    prorate_interest(principal + 1, rate_bps, time_delta, Rounding::Floor)
+                        >= prorate_interest(principal, rate_bps, time_delta, Rounding::Floor)
+                );
+                prop_assert!(
+                    prorate_interest(principal + 1, rate_bps, time_delta, Rounding::Ceil)
+                        >= prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil)
+                );
+            }
+
+            #[test]
+            fn monotonic_in_rate(
+                principal in 0u128..=PRINCIPAL_MAX,
+                rate_bps in 0u32..RATE_MAX,
+                time_delta in 0u64..=TIME_MAX,
+            ) {
+                prop_assert!(
+                    prorate_interest(principal, rate_bps + 1, time_delta, Rounding::Floor)
+                        >= prorate_interest(principal, rate_bps, time_delta, Rounding::Floor)
+                );
+            }
+
+            #[test]
+            fn monotonic_in_time(
+                principal in 0u128..=PRINCIPAL_MAX,
+                rate_bps in 0u32..=RATE_MAX,
+                time_delta in 0u64..TIME_MAX,
+            ) {
+                prop_assert!(
+                    prorate_interest(principal, rate_bps, time_delta + 1, Rounding::Floor)
+                        >= prorate_interest(principal, rate_bps, time_delta, Rounding::Floor)
+                );
+            }
+
+            #[test]
+            fn overflow_safe_envelope(
+                principal in 0u128..=PRINCIPAL_MAX,
+                rate_bps in 0u32..=RATE_MAX,
+                time_delta in 0u64..=TIME_MAX,
+            ) {
+                let _ = prorate_interest(principal, rate_bps, time_delta, Rounding::Floor);
+                let _ = prorate_interest(principal, rate_bps, time_delta, Rounding::Ceil);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #573

## Summary

Adds [Kani](https://model-checking.github.io/kani/) proof harnesses that formally verify the interest-prorating math primitive `math_utils::prorate_interest`, proving it is **monotonic** in each numeric argument and **overflow-safe** within the protocol's realistic input envelope. The same properties are also mirrored as `proptest` cases so they run under the normal `cargo test` suite even without Kani installed, plus a CI workflow that runs the proofs.

## What's proven

The harnesses prove, over a bounded symbolic input domain:

- `prorate_interest_overflow_safe` — no panic / no `checked_mul` overflow anywhere in the safe envelope (both rounding modes)
- `prorate_interest_monotonic_in_principal` — non-decreasing as `principal` rises
- `prorate_interest_monotonic_in_rate` — non-decreasing as `rate_bps` rises
- `prorate_interest_monotonic_in_time` — non-decreasing as `time_delta` rises
- `prorate_interest_rounding_bounds` — `Ceil ≥ Floor` and `Ceil − Floor ≤ 1`
- `prorate_interest_zero_short_circuit` — any zero argument yields `0`

### Safe envelope

`principal ≤ 10^24`, `rate_bps ≤ 10_000` (the enforced `MAX_INTEREST_RATE_BPS` cap), `time_delta ≤ 10^9` (≈31.7 years). Worst-case product `10^37 < u128::MAX (≈3.4×10^38)`, so neither `checked_mul` can overflow inside the envelope. Outside it, the overflow panic is the *intended* behaviour (the caller maps it to `ContractError::Overflow`), so the proofs deliberately bound the domain rather than the full type range.

## Files

**Added**
- `contracts/credit/proofs/prorate_interest.rs` — the six Kani proof harnesses (compiled only under `cfg(kani)`)
- `contracts/credit/proofs/README.md` — what each harness proves + how to run
- `.github/workflows/kani.yml` — installs Kani and runs `cargo kani -p creditra-credit` on PRs

**Modified**
- `contracts/credit/src/math_utils.rs` — added a `prorate_interest_properties` test module (deterministic + `proptest` cases mirroring the harnesses)
- `contracts/credit/src/lib.rs` — `#[cfg(kani)]` hook wiring in the proof module **and** a build fix (see note below)

## ⚠️ Build fix included

While implementing this, I found `main` does not currently compile: the merge in #666 (auto-resolved with `-X theirs`) silently dropped four module declarations from `contracts/credit/src/lib.rs`, leaving `crate::math_utils`, `crate::collateral`, and `crate::views` as unresolved imports. Since `prorate_interest` lives in `math_utils`, the crate had to build before these proofs could exist. This PR restores the dropped declarations:

```rust
mod collateral;
pub mod math_utils;
mod views;
#[cfg(test)]
mod limit_decrease_tests;
```

Happy to split this into a separate PR if maintainers prefer — flagging it prominently so it's reviewed deliberately rather than buried.

## API changes

None. `prorate_interest`'s signature is unchanged. The only public-surface change is restoring `pub mod math_utils` (which was the pre-#666 state).

## Notes for reviewers

- `require_auth` guidance does not apply here — `prorate_interest` is a pure helper with no state-changing entrypoint or auth surface.
- No `unwrap()` in production paths; the function uses `checked_mul(...).expect(...)` with descriptive messages, and the proofs confirm those expects are unreachable inside the envelope.
- The `cfg(kani)` proof module is invisible to `cargo build`/`cargo test`/`clippy`, so it adds no new clippy warnings.