### PR TITLE
feat: add ContractError::AlreadySettled variant (#598)

### DIFF
--- a/contracts/credit/docs/errors.md
+++ b/contracts/credit/docs/errors.md
@@ -420,6 +420,17 @@ This error protects the protocol from extreme concentration risk by enforcing ad
 
 ---
 
+### 45. AlreadySettled (Code: 45)
+**Description:** The liquidation for this (borrower, settlement_id) pair has already been settled.
+
+**Trigger Conditions:**
+- Calling `settle_default_liquidation` with a `settlement_id` that has already been used
+- Replay attack protection triggered
+
+**Recovery:** No action needed — the settlement has already been processed. Use a unique `settlement_id` per liquidation event.
+
+---
+
 ## Error Handling Best Practices
 
 ### For SDK Clients
@@ -462,6 +473,6 @@ Error discriminants are **permanent** and form part of the contract's public API
 
 ---
 
-**Last Updated:** 2026-05-29  
+**Last Updated:** 2026-06-29  
 **Contract Version:** 1.0.0  
-**Total Error Variants:** 34
+**Total Error Variants:** 45

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -379,7 +379,7 @@ pub fn settle_default_liquidation(
 
     let settlement_key = liquidation_settlement_key(&borrower, &settlement_id);
     if env.storage().persistent().has(&settlement_key) {
-        env.panic_with_error(ContractError::AlreadyInitialized);
+        env.panic_with_error(ContractError::AlreadySettled);
     }
 
     let stored_line: CreditLineData = env

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -8,7 +8,7 @@
 //!
 //! ABI-stable types that cross the contract boundary:
 //!
-//! - [`ContractError`] — 40-variant `#[repr(u32)]` error enum (discriminants
+//! - [`ContractError`] — 45-variant `#[repr(u32)]` error enum (discriminants
 //!   pinned by `tests/error_discriminants.rs`). Each variant maps to a stable
 //!   [`ContractErrorCategory`] via [`ContractError::category`]. See
 //!   [`docs/contract-errors.md`](../../../docs/contract-errors.md) for the
@@ -144,6 +144,7 @@ pub enum CreditStatus {
 /// | 42   | `NoPendingTreasuryWithdrawal`  | No pending treasury withdrawal proposal exists |
 /// | 43   | `TreasuryTimelockActive`       | Treasury withdrawal timelock has not yet elapsed |
 /// | 44   | `TreasuryProposalExists`       | A treasury withdrawal proposal already exists |
+/// | 45   | `AlreadySettled`               | The liquidation for this (borrower, settlement_id) pair has already been settled |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -236,6 +237,80 @@ pub enum ContractError {
     TreasuryTimelockActive = 43,
     /// A treasury withdrawal proposal already exists; cancel or execute it first.
     TreasuryProposalExists = 44,
+    /// The liquidation for this (borrower, settlement_id) pair has already been settled.
+    AlreadySettled = 45,
+}
+
+/// Stable category for grouping `ContractError` variants in SDK clients.
+///
+/// # Stability guarantee
+/// Discriminants are permanent. New categories may be appended; existing
+/// categories must never be reordered or renumbered.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractErrorCategory {
+    /// Authentication / authorization errors (1, 2, 32).
+    Auth = 1,
+    /// Credit-line lifecycle errors (4, 14, 20, 21, 45).
+    Lifecycle = 2,
+    /// Numeric validation errors (5, 7, 12, 33, 34).
+    Numeric = 3,
+    /// Credit-limit errors (6, 10, 13, 17, 28).
+    Limit = 4,
+    /// Liquidity / reserve errors (22–27, 30, 31).
+    Liquidity = 5,
+    /// Risk / rate / pause errors (8, 9, 18, 29).
+    Risk = 6,
+    /// Oracle price-feed errors (36–38).
+    Oracle = 7,
+    /// Collateral errors (35, 39).
+    Collateral = 8,
+    /// Borrower-block / freeze errors (16, 19, 40).
+    Block = 9,
+    /// Reentrancy guard error (11).
+    Reentrancy = 10,
+    /// Miscellaneous errors (3, 15).
+    Misc = 11,
+}
+
+impl ContractError {
+    /// Map this error to its stable [`ContractErrorCategory`].
+    pub fn category(&self) -> ContractErrorCategory {
+        match self {
+            Self::Unauthorized | Self::NotAdmin | Self::AdminNotInitialized => ContractErrorCategory::Auth,
+            Self::CreditLineClosed
+            | Self::AlreadyInitialized
+            | Self::CreditLineSuspended
+            | Self::CreditLineDefaulted
+            | Self::AlreadySettled => ContractErrorCategory::Lifecycle,
+            Self::InvalidAmount | Self::NegativeLimit | Self::Overflow | Self::TimestampRegression | Self::LimitOutOfBounds => ContractErrorCategory::Numeric,
+            Self::OverLimit
+            | Self::UtilizationNotZero
+            | Self::LimitDecreaseRequiresRepayment
+            | Self::DrawExceedsMaxAmount
+            | Self::RepayExceedsMaxAmount => ContractErrorCategory::Limit,
+            Self::MissingLiquidityToken
+            | Self::MissingLiquiditySource
+            | Self::InsufficientLiquidityReserve
+            | Self::LiquidityTokenCallFailed
+            | Self::InsufficientRepaymentAllowance
+            | Self::InsufficientRepaymentBalance
+            | Self::TreasuryNotSet
+            | Self::ExposureCapExceeded
+            | Self::BountyNotSet => ContractErrorCategory::Liquidity,
+            Self::RateTooHigh | Self::ScoreTooHigh | Self::Paused | Self::DrawCooldownActive => ContractErrorCategory::Risk,
+            Self::OraclePriceInvalid | Self::OraclePriceStale | Self::OraclePriceDeviation => ContractErrorCategory::Oracle,
+            Self::CollateralRatioBelowMinimum | Self::InsufficientCollateralBalance => ContractErrorCategory::Collateral,
+            Self::BorrowerBlocked | Self::DrawsFrozen | Self::BorrowerFrozen => ContractErrorCategory::Block,
+            Self::Reentrancy => ContractErrorCategory::Reentrancy,
+            Self::CreditLineNotFound
+            | Self::AdminAcceptTooEarly
+            | Self::NoPendingTreasuryWithdrawal
+            | Self::TreasuryTimelockActive
+            | Self::TreasuryProposalExists => ContractErrorCategory::Misc,
+        }
+    }
 }
 
 /// Stored credit line data for a borrower.

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -59,6 +59,7 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::NoPendingTreasuryWithdrawal as u32, 42);
     assert_eq!(ContractError::TreasuryTimelockActive as u32, 43);
     assert_eq!(ContractError::TreasuryProposalExists as u32, 44);
+    assert_eq!(ContractError::AlreadySettled as u32, 45);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -113,6 +114,7 @@ fn no_duplicate_discriminants() {
         ContractError::NoPendingTreasuryWithdrawal as u32,
         ContractError::TreasuryTimelockActive as u32,
         ContractError::TreasuryProposalExists as u32,
+        ContractError::AlreadySettled as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -127,8 +129,8 @@ fn no_duplicate_discriminants() {
 /// Update this number when adding new variants (and add the assertion above).
 #[test]
 fn variant_count_is_known() {
-    // 44 variants as of this writing (added 42-44 for treasury timelock in #606).
-    const EXPECTED_VARIANT_COUNT: usize = 44;
+    // 45 variants as of this writing (added 45 for AlreadySettled in #598).
+    const EXPECTED_VARIANT_COUNT: usize = 45;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -175,6 +177,7 @@ fn variant_count_is_known() {
         ContractError::NoPendingTreasuryWithdrawal as u32,
         ContractError::TreasuryTimelockActive as u32,
         ContractError::TreasuryProposalExists as u32,
+        ContractError::AlreadySettled as u32,
     ];
 
     assert_eq!(
@@ -269,6 +272,7 @@ fn category_mappings_are_stable() {
     assert_eq!(ContractError::AlreadyInitialized.category(), ContractErrorCategory::Lifecycle);
     assert_eq!(ContractError::CreditLineSuspended.category(), ContractErrorCategory::Lifecycle);
     assert_eq!(ContractError::CreditLineDefaulted.category(), ContractErrorCategory::Lifecycle);
+    assert_eq!(ContractError::AlreadySettled.category(), ContractErrorCategory::Lifecycle);
     // Numeric
     assert_eq!(ContractError::InvalidAmount.category(), ContractErrorCategory::Numeric);
     assert_eq!(ContractError::NegativeLimit.category(), ContractErrorCategory::Numeric);
@@ -290,6 +294,7 @@ fn category_mappings_are_stable() {
     assert_eq!(ContractError::InsufficientRepaymentBalance.category(), ContractErrorCategory::Liquidity);
     assert_eq!(ContractError::TreasuryNotSet.category(), ContractErrorCategory::Liquidity);
     assert_eq!(ContractError::ExposureCapExceeded.category(), ContractErrorCategory::Liquidity);
+    assert_eq!(ContractError::BountyNotSet.category(), ContractErrorCategory::Liquidity);
     // Risk
     assert_eq!(ContractError::RateTooHigh.category(), ContractErrorCategory::Risk);
     assert_eq!(ContractError::ScoreTooHigh.category(), ContractErrorCategory::Risk);
@@ -311,6 +316,9 @@ fn category_mappings_are_stable() {
     // Misc
     assert_eq!(ContractError::CreditLineNotFound.category(), ContractErrorCategory::Misc);
     assert_eq!(ContractError::AdminAcceptTooEarly.category(), ContractErrorCategory::Misc);
+    assert_eq!(ContractError::NoPendingTreasuryWithdrawal.category(), ContractErrorCategory::Misc);
+    assert_eq!(ContractError::TreasuryTimelockActive.category(), ContractErrorCategory::Misc);
+    assert_eq!(ContractError::TreasuryProposalExists.category(), ContractErrorCategory::Misc);
 }
 
 /// Verify every ContractError variant's category matches its discriminant table.
@@ -360,11 +368,16 @@ fn every_variant_has_known_category() {
         ContractError::OraclePriceDeviation.category(),
         ContractError::InsufficientCollateralBalance.category(),
         ContractError::BorrowerFrozen.category(),
+        ContractError::BountyNotSet.category(),
+        ContractError::NoPendingTreasuryWithdrawal.category(),
+        ContractError::TreasuryTimelockActive.category(),
+        ContractError::TreasuryProposalExists.category(),
+        ContractError::AlreadySettled.category(),
     ];
 
     let unique: HashSet<ContractErrorCategory> = all_variants.iter().cloned().collect();
     assert_eq!(unique.len(), 11, "Not all 11 categories are covered by variant mappings");
-    assert_eq!(all_variants.len(), 40, "Expected 40 ContractError variants");
+    assert_eq!(all_variants.len(), 45, "Expected 45 ContractError variants");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -817,5 +830,55 @@ use creditra_credit::types::ContractError;
             // Could be TimestampRegression or another validation error
             assert!(err.is_ok() || err.unwrap() == ContractError::TimestampRegression);
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 16: AlreadySettled - replay of same settlement_id
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_settlement_replay_returns_already_settled() {
+        let (env, client, _contract_id, _admin, _token) = setup_with_token();
+
+        let borrower = Address::generate(&env);
+
+        // Open and default a credit line
+        client.open_credit_line(&borrower, &2000_i128, &500_u32, &50_u32);
+        client.default_credit_line(&borrower);
+
+        let settlement_id = soroban_sdk::Symbol::new(&env, "test_replay");
+
+        // First settlement should succeed
+        client.settle_default_liquidation(
+            &borrower,
+            &500_i128,
+            &settlement_id,
+            &10_000_u32,
+            &None,
+        );
+
+        // Replay with the same settlement_id must fail with AlreadySettled
+        let result = client.try_settle_default_liquidation(
+            &borrower,
+            &200_i128,
+            &settlement_id,
+            &10_000_u32,
+            &None,
+        );
+
+        assert!(result.is_err(), "Replay of settlement_id must fail");
+        let err = result.err().unwrap();
+        assert_eq!(
+            err.unwrap(),
+            ContractError::AlreadySettled,
+            "Expected AlreadySettled error on settlement replay"
+        );
+
+        // Verify state was not mutated by the replay attempt
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(
+            line.utilized_amount, 1500_i128,
+            "State must not change after replay attempt"
+        );
     }
 }

--- a/docs/contract-errors.md
+++ b/docs/contract-errors.md
@@ -62,6 +62,11 @@ See the [category enum reference](#contracterrorcategory) below.
 | 38 | `OraclePriceDeviation` | Oracle | Oracle price deviation exceeds configured maximum. |
 | 39 | `InsufficientCollateralBalance` | Collateral | Borrower collateral balance below withdrawal amount. |
 | 40 | `BorrowerFrozen` | Block | Borrower's draws are temporarily frozen until expiry. |
+| 41 | `BountyNotSet` | Liquidity | Bounty pool address is not configured. |
+| 42 | `NoPendingTreasuryWithdrawal` | Misc | No pending treasury withdrawal proposal exists. |
+| 43 | `TreasuryTimelockActive` | Misc | The 24-hour treasury withdrawal timelock has not elapsed. |
+| 44 | `TreasuryProposalExists` | Misc | A treasury withdrawal proposal already exists. |
+| 45 | `AlreadySettled` | Lifecycle | The liquidation for this (borrower, settlement_id) pair has already been settled. |
 
 ## `ContractErrorCategory`
 
@@ -72,20 +77,20 @@ categories. Access it at runtime via [`ContractError::category()`](../contracts/
 | Code | Category | Variants |
 | ---: | -------- | -------- |
 | 1  | Auth | `Unauthorized`, `NotAdmin`, `AdminNotInitialized` |
-| 2  | Lifecycle | `CreditLineClosed`, `AlreadyInitialized`, `CreditLineSuspended`, `CreditLineDefaulted` |
+| 2  | Lifecycle | `CreditLineClosed`, `AlreadyInitialized`, `CreditLineSuspended`, `CreditLineDefaulted`, `AlreadySettled` |
 | 3  | Numeric | `InvalidAmount`, `NegativeLimit`, `Overflow`, `TimestampRegression`, `LimitOutOfBounds` |
 | 4  | Limit | `OverLimit`, `UtilizationNotZero`, `LimitDecreaseRequiresRepayment`, `DrawExceedsMaxAmount`, `RepayExceedsMaxAmount` |
-| 5  | Liquidity | `MissingLiquidityToken`, `MissingLiquiditySource`, `InsufficientLiquidityReserve`, `LiquidityTokenCallFailed`, `InsufficientRepaymentAllowance`, `InsufficientRepaymentBalance`, `TreasuryNotSet`, `ExposureCapExceeded` |
+| 5  | Liquidity | `MissingLiquidityToken`, `MissingLiquiditySource`, `InsufficientLiquidityReserve`, `LiquidityTokenCallFailed`, `InsufficientRepaymentAllowance`, `InsufficientRepaymentBalance`, `TreasuryNotSet`, `ExposureCapExceeded`, `BountyNotSet` |
 | 6  | Risk | `RateTooHigh`, `ScoreTooHigh`, `Paused`, `DrawCooldownActive` |
 | 7  | Oracle | `OraclePriceInvalid`, `OraclePriceStale`, `OraclePriceDeviation` |
 | 8  | Collateral | `CollateralRatioBelowMinimum`, `InsufficientCollateralBalance` |
 | 9  | Block | `BorrowerBlocked`, `DrawsFrozen`, `BorrowerFrozen` |
 | 10 | Reentrancy | `Reentrancy` |
-| 11 | Misc | `CreditLineNotFound`, `AdminAcceptTooEarly` |
+| 11 | Misc | `CreditLineNotFound`, `AdminAcceptTooEarly`, `NoPendingTreasuryWithdrawal`, `TreasuryTimelockActive`, `TreasuryProposalExists` |
 
 ## Taxonomy
 
 See [`docs/error-taxonomy.md`](./error-taxonomy.md) for the authoritative
-grouping of all 40 variants into **named categories** (Auth, Lifecycle,
+grouping of all 45 variants into **named categories** (Auth, Lifecycle,
 Numeric, Limit, Liquidity, Risk, Oracle, Collateral, Block, Reentrancy, Misc)
 with **SDK-side recovery actions** per category.

--- a/docs/error-taxonomy.md
+++ b/docs/error-taxonomy.md
@@ -29,20 +29,21 @@ valid admin address before any admin-gated operation.
 
 ---
 
-## Lifecycle (codes 4, 14, 20, 21)
+## Lifecycle (codes 4, 14, 20, 21, 45)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
 | 4    | `CreditLineClosed` | Action attempted on a permanently closed credit line. |
-| 14   | `AlreadyInitialized` | `init()` called more than once, or settlement replay detected. |
+| 14   | `AlreadyInitialized` | `init()` called more than once. |
 | 20   | `CreditLineSuspended` | Draw or admin action on a suspended credit line. |
 | 21   | `CreditLineDefaulted` | Draw or admin action on a defaulted credit line. |
+| 45   | `AlreadySettled` | The liquidation for this (borrower, settlement_id) pair has already been processed. |
 
 **Recovery action:**
 - `CreditLineClosed`: No recovery — the line is terminal. Create a new credit
   line.
-- `AlreadyInitialized`: No action needed (contract is already live). If this
-  surfaces in a settlement context, the settlement has already been processed.
+- `AlreadyInitialized`: No action needed (contract is already live).
+- `AlreadySettled`: No action needed — the settlement has already been processed.
 - `CreditLineSuspended`: Wait for admin reinstatement or self-reinstatement
   (see [`lifecycle.rs`](../contracts/credit/src/lifecycle.rs)); repayments are
   still allowed.
@@ -240,14 +241,14 @@ ensure it does not re-enter the credit contract during `transfer` /
 | Category | Codes | Count | Dominant SDK recovery |
 | -------- | ----- | ----- | --------------------- |
 | Auth | 1, 2, 32 | 3 | Reconnect wallet / re-deploy with admin init |
-| Lifecycle | 4, 14, 20, 21 | 4 | Await admin action or create new line |
+| Lifecycle | 4, 14, 20, 21, 45 | 5 | Await admin action or create new line |
 | Numeric | 5, 7, 12, 33, 34 | 5 | Validate inputs / re-sync ledger view |
 | Limit | 6, 10, 13, 17, 28 | 5 | Reduce amount or repay first |
-| Liquidity | 22, 23, 24, 25, 26, 27, 30, 31 | 8 | Replenish allowance / wait for reserve |
+| Liquidity | 22, 23, 24, 25, 26, 27, 30, 31, 41 | 9 | Replenish allowance / wait for reserve |
 | Risk | 8, 9, 18, 29 | 4 | Clamp inputs / wait for cooldown or unpause |
 | Oracle | 36, 37, 38 | 3 | Await valid price feed |
 | Collateral | 35, 39 | 2 | Reduce withdrawal amount |
 | Block | 16, 19, 40 | 3 | Contact admin or wait for unfreeze / expiry |
 | Reentrancy | 11 | 1 | Do not retry; inspect on-chain state |
-| Misc | 3, 15 | 2 | Create line first / wait for delay |
-| **Total** | 1–40 | **40** | — |
+| Misc | 3, 15, 42, 43, 44 | 5 | Create line first / wait for delay |
+| **Total** | 1–45 | **45** | — |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -56,6 +56,7 @@ Rules enforced by CI (`tests/error_discriminants.rs`):
 | `25` | `LiquidityTokenCallFailed`       | A liquidity token interaction failed where the contract can expose a canonical token-call failure. | Inspect the configured token contract and retry only after the token issue is resolved. |
 | `26` | `InsufficientRepaymentAllowance` | The borrower has not approved enough liquidity token allowance for `repay_credit`. | Approve at least the effective repayment amount for the credit contract. |
 | `27` | `InsufficientRepaymentBalance`   | The borrower's liquidity token balance is below the effective repayment amount. | Transfer or mint enough tokens to the borrower before retrying repayment. |
+| `45` | `AlreadySettled`                 | The liquidation for this (borrower, settlement_id) pair has already been settled. | No action needed — the settlement has already been processed. |
 
 ---
 


### PR DESCRIPTION
close #598
- Add AlreadySettled = 45 to ContractError enum with Lifecycle category
- Add ContractErrorCategory enum and category() impl for SDK grouping
- Replace misused AlreadyInitialized with AlreadySettled in settlement replay
- Add discriminant stability tests and focused replay test
- Update all error documentation