### PR TITLE
feat: min-bid bps enforcement

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -19,16 +19,25 @@ use events::{
 };
 use storage::{bump_auction_state_ttl, bump_settlement_marker_ttl};
 
-fn min_next_bid(highest_bid: i128, min_increment_bps: u32) -> i128 {
+/// Returns the minimum bid amount that satisfies the `min_increment_bps`
+/// requirement over `highest_bid`.
+///
+/// The threshold is `highest_bid + ceil(highest_bid * bps / 10_000)`, with a
+/// floor increment of 1 stroop so there is always forward progress.
+///
+/// # Errors
+/// Panics with [`AuctionError::BidTooLow`] on i128 overflow (requires a bid
+/// in the quintillion-strobe range; effectively unreachable in practice).
+fn min_next_bid(env: &Env, highest_bid: i128, min_increment_bps: u32) -> i128 {
     let bps = min_increment_bps as i128;
     let product = highest_bid
         .checked_mul(bps)
-        .expect("overflow in bid increment calculation");
+        .unwrap_or_else(|| env.panic_with_error(AuctionError::BidTooLow));
     let bps_increment = product / 10_000 + i128::from(product % 10_000 != 0);
     let increment = bps_increment.max(1);
     highest_bid
         .checked_add(increment)
-        .expect("overflow computing minimum next bid threshold")
+        .unwrap_or_else(|| env.panic_with_error(AuctionError::BidTooLow))
 }
 
 /// Computes the current Dutch auction price based on elapsed time.
@@ -271,13 +280,16 @@ impl Auction {
 
         match state.config.mode {
             AuctionMode::English => {
-                let min_floor = state.config.min_bid.saturating_sub(1);
-                let required_floor = if state.highest_bid > min_floor {
-                    state.highest_bid
+                // When no bid has been placed yet, enforce the configured min_bid.
+                // Once a bid exists, enforce min_increment_bps over the current
+                // highest bid (≥ 1-stroop forward progress even at 0 bps).
+                let threshold = if state.highest_bid > 0 {
+                    min_next_bid(&env, state.highest_bid, state.config.min_increment_bps)
+                        .max(state.config.min_bid)
                 } else {
-                    min_floor
+                    state.config.min_bid
                 };
-                if amount <= required_floor {
+                if amount < threshold {
                     env.panic_with_error(AuctionError::BidTooLow);
                 }
 

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -1534,6 +1534,190 @@ mod tests {
         assert_eq!(stored.highest_bidder.unwrap(), bob);
         assert_eq!(stored.highest_bid, 200_i128);
     }
+
+    // ── min-bid bps enforcement (English auction) ─────────────────────────────
+
+    /// Helper: open an English auction with the given min_increment_bps.
+    fn english_auction_with_bps(env: &Env, client: &AuctionClient, auction_id: &Symbol, bps: u32) {
+        client.init_auction(
+            auction_id,
+            &AuctionMode::English,
+            &0,
+            &1_000_000,
+            &1_i128,
+            &bps,
+            &None,
+            &None,
+            &DutchAuctionDecay::None,
+            &None,
+        );
+    }
+
+    /// Exact threshold bid (= min_next_bid result) must be accepted.
+    #[test]
+    fn bps_exact_threshold_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_exact");
+
+        // 500 bps = 5%; highest = 1000 → threshold = 1050
+        english_auction_with_bps(&env, &client, &auction_id, 500);
+        client.place_bid(&auction_id, &alice, &1_000_i128);
+        client.place_bid(&auction_id, &bob, &1_050_i128);
+
+        let stored: crate::types::AuctionState = env
+            .as_contract(&contract_id, || env.storage().persistent().get(&auction_id))
+            .unwrap();
+        assert_eq!(stored.highest_bid, 1_050_i128);
+        assert_eq!(stored.highest_bidder.unwrap(), bob);
+    }
+
+    /// One stroop below threshold must be rejected with BidTooLow.
+    #[test]
+    fn bps_one_below_threshold_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_low");
+
+        // 500 bps; highest = 1000 → threshold = 1050; 1049 must fail
+        english_auction_with_bps(&env, &client, &auction_id, 500);
+        client.place_bid(&auction_id, &alice, &1_000_i128);
+
+        let result = client.try_place_bid(&auction_id, &bob, &1_049_i128);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().unwrap(), AuctionError::BidTooLow.into());
+    }
+
+    /// A bid equal to the current highest (0 bps, but no increment) must be rejected.
+    #[test]
+    fn bps_equal_to_highest_rejected_at_zero_bps() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_zero_eq");
+
+        // 0 bps means 1-stroop increment; highest + 0 must be rejected
+        english_auction_with_bps(&env, &client, &auction_id, 0);
+        client.place_bid(&auction_id, &alice, &100_i128);
+
+        let result = client.try_place_bid(&auction_id, &bob, &100_i128);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().unwrap(), AuctionError::BidTooLow.into());
+    }
+
+    /// At 0 bps the floor increment is 1 stroop; highest + 1 must be accepted.
+    #[test]
+    fn bps_zero_requires_one_stroop_increment() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_zero_one");
+
+        english_auction_with_bps(&env, &client, &auction_id, 0);
+        client.place_bid(&auction_id, &alice, &100_i128);
+        client.place_bid(&auction_id, &bob, &101_i128);
+
+        let stored: crate::types::AuctionState = env
+            .as_contract(&contract_id, || env.storage().persistent().get(&auction_id))
+            .unwrap();
+        assert_eq!(stored.highest_bid, 101_i128);
+    }
+
+    /// First bid in an English auction only needs to meet min_bid, not bps.
+    #[test]
+    fn bps_first_bid_only_needs_min_bid() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_first");
+
+        // 10_000 bps (100%) would double the price — but on the first bid
+        // there is no highest_bid, so min_bid (= 100) applies directly.
+        client.init_auction(
+            &auction_id,
+            &AuctionMode::English,
+            &0,
+            &1_000_000,
+            &100_i128,
+            &10_000_u32,
+            &None,
+            &None,
+            &DutchAuctionDecay::None,
+            &None,
+        );
+        client.place_bid(&auction_id, &alice, &100_i128);
+
+        let stored: crate::types::AuctionState = env
+            .as_contract(&contract_id, || env.storage().persistent().get(&auction_id))
+            .unwrap();
+        assert_eq!(stored.highest_bid, 100_i128);
+    }
+
+    /// Ceiling division: fractional bps must round up (1 bps on 999 = ceil(0.999) = 1).
+    #[test]
+    fn bps_ceiling_division_rounds_up() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_ceil");
+
+        // 1 bps on 999 → floor(999/10_000) = 0, but remainder ≠ 0 → increment = 1
+        // threshold = 1000; bid of 999 must fail.
+        english_auction_with_bps(&env, &client, &auction_id, 1);
+        client.place_bid(&auction_id, &alice, &999_i128);
+
+        let result = client.try_place_bid(&auction_id, &bob, &999_i128);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().unwrap(), AuctionError::BidTooLow.into());
+
+        // 1000 = 999 + ceil(0.0999) = 999 + 1 must succeed.
+        client.place_bid(&auction_id, &bob, &1_000_i128);
+        let stored: crate::types::AuctionState = env
+            .as_contract(&contract_id, || env.storage().persistent().get(&auction_id))
+            .unwrap();
+        assert_eq!(stored.highest_bid, 1_000_i128);
+    }
+
+    /// A bid far above threshold is always accepted.
+    #[test]
+    fn bps_bid_well_above_threshold_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let contract_id = env.register(Auction, ());
+        let client = AuctionClient::new(&env, &contract_id);
+        let auction_id = Symbol::new(&env, "bps_high");
+
+        english_auction_with_bps(&env, &client, &auction_id, 1_000); // 10%
+        client.place_bid(&auction_id, &alice, &1_000_i128);
+        // threshold = 1100; bid 5000 >> 1100 → accepted
+        client.place_bid(&auction_id, &bob, &5_000_i128);
+
+        let stored: crate::types::AuctionState = env
+            .as_contract(&contract_id, || env.storage().persistent().get(&auction_id))
+            .unwrap();
+        assert_eq!(stored.highest_bid, 5_000_i128);
+    }
 }
 
 // ── reentrancy_exploration ────────────────────────────────────────────────────


### PR DESCRIPTION
Enforce min_increment_bps over the current highest bid in English auctions.

- Wire min_next_bid() into place_bid English branch; threshold is highest_bid + ceil(highest_bid * bps / 10_000), floor 1 stroop.
- First bid still only requires min_bid (no prior highest to compare).
- Fix min_next_bid: env-aware (no expect()), add rustdoc.
- Add 7 focused tests covering exact threshold, one-below, 0-bps, first-bid, ceiling rounding, and well-above cases.

closes #645