### PR TITLE
task: add cargo check + clippy CI gate to catch merge-artifact duplic…

### DIFF
--- a/.github/workflows/build-hygiene.yml
+++ b/.github/workflows/build-hygiene.yml
@@ -1,0 +1,152 @@
+# build-hygiene.yml
+#
+# Required CI gate for merge-artifact detection.
+#
+# Motivation: Creditra-Contracts has shipped to main twice this quarter with
+# merge-artifact duplicates (self_suspend_credit_line in lifecycle.rs, double
+# use blocks in risk.rs). `cargo check` catches those errors as hard failures
+# before they reach reviewers; `cargo clippy -D warnings` catches the softer
+# class of problems (dead code, unused imports, redundant patterns) that
+# typically accompany incomplete conflict resolutions.
+#
+# This workflow is intentionally separate from ci.yml so it can be configured
+# as a *required* branch-protection status check independent of the broader
+# test suite — a long-running test pass should not block the hygiene gate, and
+# the hygiene gate should not gate coverage runs.
+#
+# Make it required:
+#   Repository Settings → Branches → main → Require status checks → search for
+#   "cargo check (workspace, all-targets)" and "cargo clippy (workspace, -D warnings)"
+#   and enable both.
+
+name: Build Hygiene
+
+on:
+  pull_request:
+    # Run on every PR targeting these integration branches.
+    branches: [main, master, develop]
+  # Also run on pushes to main so the check remains green in the branch
+  # protection history even when PRs are merged via the GitHub UI squash button.
+  push:
+    branches: [main, master]
+
+defaults:
+  run:
+    shell: bash
+
+# Cancel any in-progress run for the same PR/branch so a force-push does not
+# queue two back-to-back runs against the same commit.
+concurrency:
+  group: build-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+# Minimal permissions: this workflow only reads the repo and writes no secrets.
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # cargo-check
+  # ---------------------------------------------------------------------------
+  # `cargo check --workspace --all-targets` is the fastest way to run the
+  # compiler's name-resolution and borrow-checker passes over every crate,
+  # target type (lib, bins, tests, examples, benches), and feature combination
+  # that the workspace defines — without spending time on codegen.
+  #
+  # It catches:
+  #   - Duplicate symbol definitions left over from merge conflicts.
+  #   - Missing `use` items or broken module paths introduced during rebases.
+  #   - Type mismatches and borrow errors in test-only code paths
+  #     (`#[cfg(test)]`) that `cargo build` typically skips.
+  # ---------------------------------------------------------------------------
+  cargo-check:
+    name: cargo check (workspace, all-targets)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # dtolnay/rust-toolchain reads the channel from rust-toolchain.toml when
+      # no explicit `toolchain:` override is supplied.  Pinning to @v1 keeps the
+      # action reproducible across GitHub Runner image updates.
+      - name: Install Rust toolchain (rust-toolchain.toml → stable)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          # Mirror the channel declared in rust-toolchain.toml so both local
+          # developers and CI use the same compiler.
+          toolchain: stable
+          # clippy is bundled here so the single toolchain install step covers
+          # both jobs; the component is a no-op cost when the toolchain is cached.
+          components: clippy
+
+      # Cache the Cargo registry index, downloaded crate sources, and the
+      # compiled output.  The key is hashed from Cargo.lock so the cache is
+      # invalidated only when dependency versions change — not on every Cargo.toml
+      # edit that does not affect the resolved graph.
+      - name: Restore Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          # Primary key: exact Cargo.lock hash — guarantees a clean cache on any
+          # dependency bump and avoids stale incremental artefacts.
+          key: ${{ runner.os }}-cargo-hygiene-${{ hashFiles('**/Cargo.lock') }}
+          # Fallback: pick the most recent cache for this OS when the lock file
+          # changed (e.g. after a `cargo update`).  This avoids a cold build on
+          # every dependency update PR.
+          restore-keys: |
+            ${{ runner.os }}-cargo-hygiene-
+
+      # Core gate: fail immediately if the workspace cannot be compiled.
+      # --all-targets includes lib, bins, integration-test crates, examples, and
+      # benchmarks so test-only duplicate symbols are also caught.
+      - name: cargo check --workspace --all-targets
+        run: cargo check --workspace --all-targets
+
+  # ---------------------------------------------------------------------------
+  # cargo-clippy
+  # ---------------------------------------------------------------------------
+  # Runs after a successful check so that clippy diagnostics are only surfaced
+  # when the codebase is already syntactically valid — mixing type errors with
+  # lint warnings makes both harder to read.
+  #
+  # `-D warnings` promotes every clippy warning to a hard error.  This is the
+  # recommended setting for CI because it prevents lint debt from accumulating
+  # silently across PRs.
+  # ---------------------------------------------------------------------------
+  cargo-clippy:
+    name: cargo clippy (workspace, -D warnings)
+    runs-on: ubuntu-latest
+    # Only run clippy when check passes; avoids redundant, noisy output.
+    needs: cargo-check
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (rust-toolchain.toml → stable)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Restore Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          # Use the same cache key as cargo-check so the already-compiled
+          # incremental artefacts are reused and clippy runs in seconds.
+          key: ${{ runner.os }}-cargo-hygiene-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-hygiene-
+
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/docs/contributing-tests.md
+++ b/docs/contributing-tests.md
@@ -1,5 +1,48 @@
 # Contributing Tests
 
+## Required CI Gate — Build Hygiene
+
+Every pull request must pass the **Build Hygiene** workflow
+(`.github/workflows/build-hygiene.yml`) before it can be merged.  The workflow
+is configured as a required branch-protection status check under two job names:
+
+| Status check name | Command |
+|---|---|
+| `cargo check (workspace, all-targets)` | `cargo check --workspace --all-targets` |
+| `cargo clippy (workspace, -D warnings)` | `cargo clippy --workspace --all-targets -- -D warnings` |
+
+### Why this gate exists
+
+Creditra-Contracts shipped to `main` twice this quarter with merge-artifact
+duplicates (`self_suspend_credit_line` in `lifecycle.rs`, double `use` blocks in
+`risk.rs`).  `cargo check --workspace --all-targets` catches duplicate symbol
+definitions and broken module paths — including those inside `#[cfg(test)]`
+blocks that a plain `cargo build` skips.  `cargo clippy -D warnings` catches the
+softer class of problems (dead code, redundant patterns, unused imports) that
+often accompany incomplete conflict resolutions.
+
+### Running the checks locally
+
+```bash
+# Mirror exactly what CI runs:
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Both commands use the toolchain pinned in `rust-toolchain.toml` (`stable`).
+Run `rustup update stable` if your local toolchain is more than a few weeks
+behind to keep diagnostic output in sync with CI.
+
+### Making the check required (maintainers)
+
+1. Go to **Repository Settings → Branches → Branch protection rules → `main`**.
+2. Enable **Require status checks to pass before merging**.
+3. Search for and add both status check names from the table above.
+4. Enable **Require branches to be up to date before merging** to prevent a
+   stale-base bypass.
+
+---
+
 This guide covers test-only helpers used in `contracts/credit/src/lib.rs` for
 draw/repay integration scenarios.
 


### PR DESCRIPTION
Closes #452

---

…ates (#452)

Add .github/workflows/build-hygiene.yml as a dedicated, required CI status check that runs on every PR targeting main/master/develop.

The gate runs two steps in sequence:
  cargo check --workspace --all-targets
  cargo clippy --workspace --all-targets -- -D warnings

cargo check catches duplicate symbol definitions and broken module paths — including those inside #[cfg(test)] blocks that cargo build skips — making it the earliest possible signal for merge-artifact duplicates like the self_suspend_credit_line and double use-block regressions that reached main this quarter.

cargo clippy -D warnings catches the softer class of problems (dead code, unused imports, redundant patterns) that typically accompany incomplete conflict resolutions, and promotes them to hard errors so lint debt cannot accumulate across PRs.

The workflow:
- Triggers on pull_request (all-targets) and push to main/master.
- Runs cargo-clippy only after cargo-check passes (needs: cargo-check) to avoid noisy mixed output when the workspace has compile errors.
- Caches ~/.cargo/registry, ~/.cargo/git/db, and target/ keyed on Cargo.lock hash so dependency-unchanged PRs restore compiled artifacts in seconds.
- Uses minimal permissions (contents: read).
- Uses dtolnay/rust-toolchain@v1 with toolchain: stable to mirror the channel in rust-toolchain.toml.
- Uses concurrency cancel-in-progress to avoid queuing duplicate runs on force-pushes.

Also updates docs/contributing-tests.md with a "Required CI Gate — Build Hygiene" section covering the status check names, rationale, local repro commands, and maintainer instructions for enabling branch protection.