### PR TITLE
feat: credit-line snapshot view

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -163,9 +163,9 @@ use crate::storage::{
     set_pending_treasury_withdrawal,
 };
 use crate::types::{
-    ContractError, CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig,
-    ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig, RateFormulaConfig,
-    TreasuryWithdrawalProposal,
+    ContractError, CreditLineData, CreditLineSnapshot, CreditStatus, GracePeriodConfig,
+    GraceWaiverMode, OracleConfig, ProofOfReserve, ProtocolConfig, ProtocolSummary,
+    ProtocolSummaryView, RateChangeConfig, RateFormulaConfig, TreasuryWithdrawalProposal,
 };
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -1638,6 +1638,31 @@ impl Credit {
     /// Backward-compatible alias for older tests and SDK callers.
     pub fn get_credit_line_summary(env: Env, borrower: Address) -> Option<CreditLineData> {
         Self::get_credit_line(env, borrower)
+    }
+
+    /// Return a full snapshot of `borrower`'s credit line, or `None` if no line exists.
+    ///
+    /// Assembles all per-borrower state — the core [`CreditLineData`] record, collateral
+    /// balance, health factor, repayment schedule, and delinquency flag — in a single
+    /// read-only call. This avoids the multiple round-trips that callers would otherwise
+    /// issue for `get_credit_line` + `get_collateral` + `get_health_factor` +
+    /// `get_repayment_schedule` + `is_delinquent`.
+    ///
+    /// # Returns
+    /// - `Some(CreditLineSnapshot)` when a credit line exists for the borrower.
+    /// - `None` when no credit line has been opened for the borrower.
+    ///
+    /// # Authentication
+    /// None — pure read with no state mutations.
+    ///
+    /// # Accrual laziness
+    /// `snapshot.line.accrued_interest` and `snapshot.line.utilized_amount` reflect the
+    /// last mutating checkpoint (draw, repay, suspend, etc.), not the current ledger time.
+    pub fn get_credit_line_snapshot(
+        env: Env,
+        borrower: Address,
+    ) -> Option<CreditLineSnapshot> {
+        views::get_credit_line_snapshot(env, borrower)
     }
 
     pub fn get_rate_formula_config(env: Env) -> Option<RateFormulaConfig> {

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -420,6 +420,55 @@ pub struct ProtocolSummaryView {
     pub active_line_count: u32,
 }
 
+/// Reserve balances returned by `get_proof_of_reserve`.
+///
+/// Exposes the accumulated treasury and bounty pool reserves for transparency
+/// and indexer integration. Callers may compare the sum of these fields against
+/// the on-chain token balance to verify reserve integrity.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofOfReserve {
+    /// Accumulated protocol fees awaiting treasury withdrawal.
+    pub treasury_balance: i128,
+    /// Accumulated bounty pool fees awaiting bounty withdrawal.
+    pub bounty_balance: i128,
+}
+
+/// Full snapshot of a credit line returned by `get_credit_line_snapshot`.
+///
+/// Aggregates every piece of per-borrower state that an indexer, keeper, or
+/// risk dashboard might need in a single read-only call, avoiding multiple
+/// round-trips for the common "show me everything about this borrower" query.
+///
+/// # Field notes
+///
+/// - `line` — the core [`CreditLineData`] record (limit, utilized, rate, score,
+///   status, accrual timestamps). Accrual is **lazy**: `accrued_interest` and
+///   `utilized_amount` reflect the last checkpoint, not the current ledger time.
+/// - `collateral_balance` — tokens deposited against this line (may be `0` if
+///   collateral is not in use or has not been deposited).
+/// - `health_factor_bps` — collateral health expressed in basis points. `u32::MAX`
+///   means no debt; below `10_000` the line is eligible for liquidation. See
+///   `get_health_factor` for the formula.
+/// - `repayment_schedule` — the optional installment schedule; `None` when no
+///   schedule has been set.
+/// - `is_delinquent` — `true` if the line has missed an installment past the
+///   grace window. Always `false` when `repayment_schedule` is `None`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineSnapshot {
+    /// Core per-borrower credit line record.
+    pub line: CreditLineData,
+    /// Tokens deposited as collateral against this credit line.
+    pub collateral_balance: i128,
+    /// Collateral health factor in basis points. `u32::MAX` = no debt.
+    pub health_factor_bps: u32,
+    /// Configured installment repayment schedule, if any.
+    pub repayment_schedule: Option<RepaymentSchedule>,
+    /// `true` if the borrower has missed an installment past the grace window.
+    pub is_delinquent: bool,
+}
+
 /// A pending treasury withdrawal proposal created by `propose_treasury_withdrawal`.
 ///
 /// Exactly one proposal can exist at a time. It must be executed (or superseded

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -1,17 +1,24 @@
 // SPDX-License-Identifier: MIT
 
-//! Read-only query views for specialized campaign indexing.
+//! Read-only query views for the Creditra credit contract.
 //!
-//! Provides the protocol summary view requested for the GrantFox campaign
-//! and the proof-of-reserve view for protocol treasury transparency.
+//! Each function is a pure storage read — no state mutations, no token CPIs,
+//! no authentication required. TTL may be bumped by `get_credit_line` via the
+//! storage layer when the persistent entry nears expiry.
 
-use crate::types::{ProofOfReserve, ProtocolSummaryView};
-use soroban_sdk::Env;
+use crate::storage::DataKey;
+use crate::types::{
+    CreditLineSnapshot, CreditStatus, GracePeriodConfig, ProofOfReserve, ProtocolSummaryView,
+    RepaymentSchedule,
+};
+use soroban_sdk::{Address, Env};
 
-/// Return protocol-level dashboard aggregates including ActiveLineCount.
+// ── Protocol-level views ─────────────────────────────────────────────────────
+
+/// Return protocol-level dashboard aggregates including `active_line_count`.
 ///
-/// This reads aggregate storage slots to return TotalUtilized, TotalCollateral,
-/// and ActiveLineCount without iterating through individual borrower records.
+/// Reads aggregate instance-storage slots only; does not touch per-borrower
+/// records and does not bump persistent-entry TTL.
 pub fn get_protocol_summary_view(env: Env) -> ProtocolSummaryView {
     ProtocolSummaryView {
         total_utilized: crate::storage::get_total_utilized(&env),
@@ -23,8 +30,8 @@ pub fn get_protocol_summary_view(env: Env) -> ProtocolSummaryView {
 /// Return proof-of-reserve balances for the protocol treasury.
 ///
 /// Exposes the accumulated treasury and bounty pool reserves held in the
-/// contract as a result of protocol fee collection. This is a pure
-/// storage read — no token CPIs or borrower records are touched.
+/// contract as a result of protocol fee collection. A pure storage read —
+/// no token CPIs or borrower records are touched.
 ///
 /// Callers can compare `treasury_balance + bounty_balance` against the
 /// on-chain token balance of the contract to verify reserve integrity.
@@ -33,4 +40,112 @@ pub fn get_proof_of_reserve(env: Env) -> ProofOfReserve {
         treasury_balance: crate::storage::get_treasury_balance(&env),
         bounty_balance: crate::storage::get_bounty_balance(&env),
     }
+}
+
+// ── Per-borrower snapshot view ────────────────────────────────────────────────
+
+/// Return a full snapshot of `borrower`'s credit line, or `None` if no line exists.
+///
+/// Assembles [`CreditLineSnapshot`] in a single entrypoint call, avoiding the
+/// multiple round-trips that callers would otherwise need to issue for
+/// `get_credit_line` + `get_collateral` + `get_health_factor` +
+/// `get_repayment_schedule` + `is_delinquent`.
+///
+/// # Authentication
+/// None — this is a pure read with no state mutations or trust boundary.
+///
+/// # Laziness
+/// Interest accrual is lazy: `line.accrued_interest` and `line.utilized_amount`
+/// reflect the last mutating checkpoint, not the current ledger timestamp.
+///
+/// # Collateral health
+/// `health_factor_bps` is `u32::MAX` when `utilized_amount == 0`. A value
+/// below `10_000` signals the line is eligible for liquidation via
+/// `default_credit_line`.
+///
+/// # Delinquency
+/// `is_delinquent` is always `false` when `repayment_schedule` is `None` or
+/// when `utilized_amount == 0` or status is `Closed`.
+pub fn get_credit_line_snapshot(env: Env, borrower: Address) -> Option<CreditLineSnapshot> {
+    // A single storage read; returns None immediately for unknown borrowers.
+    let line = crate::storage::get_credit_line(&env, &borrower)?;
+
+    let collateral_balance = crate::storage::get_collateral_balance(&env, &borrower);
+
+    let health_factor_bps = compute_health_factor_bps(&env, &borrower, line.utilized_amount);
+
+    let repayment_schedule: Option<RepaymentSchedule> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RepaymentSchedule(borrower.clone()));
+
+    let is_delinquent =
+        check_is_delinquent(&env, &line.status, line.utilized_amount, &repayment_schedule);
+
+    Some(CreditLineSnapshot {
+        line,
+        collateral_balance,
+        health_factor_bps,
+        repayment_schedule,
+        is_delinquent,
+    })
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+/// Compute the collateral health factor in basis points for a borrower.
+///
+/// Returns `u32::MAX` when `utilized_amount <= 0` (no debt).
+/// Formula: `collateral * 100_000_000 / (utilized * min_ratio_bps)`.
+fn compute_health_factor_bps(env: &Env, borrower: &Address, utilized_amount: i128) -> u32 {
+    if utilized_amount <= 0 {
+        return u32::MAX;
+    }
+
+    let collateral = crate::storage::get_collateral_balance(env, borrower);
+    let min_ratio_bps = crate::storage::get_min_collateral_ratio_bps(env).unwrap_or(15_000);
+
+    let collateral_u128 = collateral.max(0) as u128;
+    let utilized_u128 = utilized_amount.max(0) as u128;
+    let min_ratio_u128 = min_ratio_bps as u128;
+
+    let numerator = collateral_u128
+        .checked_mul(100_000_000)
+        .unwrap_or(u128::MAX);
+    let denominator = utilized_u128
+        .checked_mul(min_ratio_u128)
+        .unwrap_or(u128::MAX);
+
+    u32::try_from(numerator / denominator).unwrap_or(u32::MAX)
+}
+
+/// Determine whether the borrower is past an installment due date.
+///
+/// Returns `false` when:
+/// - The line is `Closed` or `utilized_amount <= 0`.
+/// - No repayment schedule is configured.
+/// - The current timestamp is within the grace window.
+fn check_is_delinquent(
+    env: &Env,
+    status: &CreditStatus,
+    utilized_amount: i128,
+    schedule: &Option<RepaymentSchedule>,
+) -> bool {
+    if *status == CreditStatus::Closed || utilized_amount <= 0 {
+        return false;
+    }
+    let Some(sched) = schedule else {
+        return false;
+    };
+
+    let grace_cfg: Option<GracePeriodConfig> = env
+        .storage()
+        .instance()
+        .get(&crate::storage::grace_period_key(env));
+    let grace_seconds = grace_cfg
+        .map(|cfg| cfg.grace_period_seconds)
+        .unwrap_or(0);
+    let delinquent_after = sched.next_due_ts.saturating_add(grace_seconds);
+
+    env.ledger().timestamp() > delinquent_after
 }

--- a/contracts/credit/tests/credit_line_snapshot.rs
+++ b/contracts/credit/tests/credit_line_snapshot.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for the `get_credit_line_snapshot` entrypoint.
+//!
+//! Covers:
+//! - Returns `None` for an unknown borrower.
+//! - Returns the correct `CreditLineData` fields after `open_credit_line`.
+//! - Reflects collateral balance when collateral is deposited.
+//! - Reports `health_factor_bps == u32::MAX` with zero utilization.
+//! - Reports correct health factor with outstanding debt and collateral.
+//! - Returns the configured `repayment_schedule` when set.
+//! - `is_delinquent` is `false` without a schedule.
+//! - `is_delinquent` is `true` when past the grace window.
+//! - `is_delinquent` is `false` within the grace window.
+//! - Snapshot reflects status changes (Suspended, Closed).
+//! - Snapshot is `None` after close for a borrower with no line.
+//!   (Actually close preserves the record — status is Closed, not None.)
+
+#![cfg(test)]
+
+use creditra_credit::types::{CreditStatus, GraceWaiverMode};
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::{self, StellarAssetClient},
+    Address, Env,
+};
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+/// Minimal setup: init contract with a real SAC token (so draws/repays work).
+fn setup(env: &Env) -> (CreditClient<'_>, Address, Address, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+    let admin = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    // Real SAC so token transfers actually work.
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&token);
+
+    // Seed the reserve so draws can succeed.
+    StellarAssetClient::new(env, &token).mint(&token, &1_000_000_i128);
+
+    (client, admin, contract_id, token)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn returns_none_for_unknown_borrower() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    assert!(client.get_credit_line_snapshot(&borrower).is_none());
+}
+
+#[test]
+fn returns_core_line_fields_after_open() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &300_u32, &50_u32);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("snapshot must be Some after open");
+
+    assert_eq!(snap.line.borrower, borrower);
+    assert_eq!(snap.line.credit_limit, 10_000);
+    assert_eq!(snap.line.utilized_amount, 0);
+    assert_eq!(snap.line.interest_rate_bps, 300);
+    assert_eq!(snap.line.risk_score, 50);
+    assert_eq!(snap.line.status, CreditStatus::Active);
+    assert_eq!(snap.line.accrued_interest, 0);
+}
+
+#[test]
+fn collateral_balance_zero_before_deposit() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+
+    assert_eq!(snap.collateral_balance, 0);
+}
+
+#[test]
+fn collateral_balance_reflects_deposit() {
+    let env = Env::default();
+    let (client, _, contract_id, token) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+
+    // Fund borrower with tokens so deposit_collateral can transfer.
+    StellarAssetClient::new(&env, &token).mint(&borrower, &5_000_i128);
+    client.deposit_collateral(&borrower, &3_000);
+
+    let _ = contract_id; // used indirectly by client
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+
+    assert_eq!(snap.collateral_balance, 3_000);
+}
+
+#[test]
+fn health_factor_is_max_with_zero_utilization() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+
+    assert_eq!(snap.health_factor_bps, u32::MAX);
+}
+
+#[test]
+fn health_factor_computed_with_debt_and_collateral() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+
+    // Deposit collateral first so the draw passes the min ratio check.
+    StellarAssetClient::new(&env, &token).mint(&borrower, &10_000_i128);
+    client.deposit_collateral(&borrower, &3_000);
+
+    // Draw 1_000 → utilized = 1_000, collateral = 3_000, default min_ratio = 15_000 bps
+    // health_bps = 3_000 * 100_000_000 / (1_000 * 15_000) = 300_000_000 / 15_000_000 = 20
+    client.draw_credit(&borrower, &1_000);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+
+    assert_eq!(snap.line.utilized_amount, 1_000);
+    assert_eq!(snap.collateral_balance, 3_000);
+    // Health factor should be 20 (well above 10_000 minimum → healthy).
+    assert_eq!(snap.health_factor_bps, 20);
+}
+
+#[test]
+fn repayment_schedule_is_none_when_not_set() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+
+    assert!(snap.repayment_schedule.is_none());
+}
+
+#[test]
+fn repayment_schedule_present_when_set() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+    // amount_per_period=500, period_seconds=86_400, first_due_ts=100_000
+    client.set_repayment_schedule(&borrower, &500_i128, &86_400_u64, &100_000_u64);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+    let sched = snap.repayment_schedule.expect("schedule must be Some");
+
+    assert_eq!(sched.amount_per_period, 500);
+    assert_eq!(sched.period_seconds, 86_400);
+    assert_eq!(sched.next_due_ts, 100_000);
+}
+
+#[test]
+fn is_delinquent_false_without_schedule() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+    StellarAssetClient::new(&env, &token).mint(&borrower, &3_000_i128);
+    client.deposit_collateral(&borrower, &3_000);
+    client.draw_credit(&borrower, &1_000);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+
+    assert!(!snap.is_delinquent);
+}
+
+#[test]
+fn is_delinquent_false_before_grace_window_expires() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 10_000);
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+    StellarAssetClient::new(&env, &token).mint(&borrower, &3_000_i128);
+    client.deposit_collateral(&borrower, &3_000);
+    client.draw_credit(&borrower, &1_000);
+
+    // Grace window of 120 seconds; due_ts = 9_900 → delinquent_after = 10_020
+    client.set_grace_period_config(&120_u64, &GraceWaiverMode::FullWaiver, &0_u32);
+    client.set_repayment_schedule(&borrower, &100_i128, &86_400_u64, &9_900_u64);
+
+    // At ts=10_000, delinquent_after=10_020 → not yet delinquent
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+    assert!(!snap.is_delinquent);
+}
+
+#[test]
+fn is_delinquent_true_past_grace_window() {
+    let env = Env::default();
+    let (client, _, _, token) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 10_000);
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+    StellarAssetClient::new(&env, &token).mint(&borrower, &3_000_i128);
+    client.deposit_collateral(&borrower, &3_000);
+    client.draw_credit(&borrower, &1_000);
+
+    // Grace window of 60 seconds; due_ts = 9_900 → delinquent_after = 9_960
+    client.set_grace_period_config(&60_u64, &GraceWaiverMode::FullWaiver, &0_u32);
+    client.set_repayment_schedule(&borrower, &100_i128, &86_400_u64, &9_900_u64);
+
+    // At ts=10_000 > 9_960 → delinquent
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some");
+    assert!(snap.is_delinquent);
+}
+
+#[test]
+fn snapshot_reflects_suspended_status() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+    client.suspend_credit_line(&borrower);
+
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some after suspend");
+
+    assert_eq!(snap.line.status, CreditStatus::Suspended);
+    // No debt → health is max even when suspended.
+    assert_eq!(snap.health_factor_bps, u32::MAX);
+    // No schedule → not delinquent.
+    assert!(!snap.is_delinquent);
+}
+
+#[test]
+fn snapshot_reflects_closed_status_after_close() {
+    let env = Env::default();
+    let (client, admin, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &10_000_i128, &0_u32, &0_u32);
+    client.close_credit_line(&borrower, &admin);
+
+    // Record is preserved after close — status is Closed, not None.
+    let snap = client
+        .get_credit_line_snapshot(&borrower)
+        .expect("Some after close");
+
+    assert_eq!(snap.line.status, CreditStatus::Closed);
+    assert_eq!(snap.collateral_balance, 0);
+    assert_eq!(snap.health_factor_bps, u32::MAX); // zero utilization
+    assert!(snap.repayment_schedule.is_none());
+    assert!(!snap.is_delinquent); // Closed → never delinquent
+}
+
+#[test]
+fn snapshot_is_none_for_borrower_that_never_opened() {
+    let env = Env::default();
+    let (client, _, _, _) = setup(&env);
+    let never_opened = Address::generate(&env);
+    assert!(client.get_credit_line_snapshot(&never_opened).is_none());
+}


### PR DESCRIPTION
Add get_credit_line_snapshot entrypoint returning a full per-borrower snapshot in one read-only call.

- types.rs: add CreditLineSnapshot and ProofOfReserve structs
- views.rs: implement get_credit_line_snapshot (clean up merge artifact); add private compute_health_factor_bps and check_is_delinquent helpers
- lib.rs: wire get_credit_line_snapshot entrypoint after get_credit_line_summary; add CreditLineSnapshot and ProofOfReserve to the types import
- tests/credit_line_snapshot.rs: 13 integration tests covering None for unknown borrower, core fields, collateral, health factor, repayment schedule, delinquency inside/outside grace window, status changes

closes #644