### PR TITLE
feat: per-borrower exposure cap

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -109,6 +109,7 @@ mod freeze;
 pub mod instrument;
 mod lifecycle;
 mod query;
+pub mod limits;
 mod risk;
 pub use crate::risk::compute_rate_from_score;
 pub use crate::types::FreezeReason;
@@ -416,6 +417,13 @@ impl Credit {
             }
         }
 
+        // Per-borrower exposure cap: block draws that would push this
+        // borrower's utilization above the configured absolute maximum.
+        if let Err(e) = limits::check_borrower_exposure_cap(&env, &borrower, updated_utilized) {
+            clear_reentrancy_guard(&env);
+            env.panic_with_error(e);
+        }
+
         // Global protocol exposure cap: block draws that would push total
         // utilization across all lines above the configured maximum.
         if let Some(max_exposure) = crate::storage::get_max_total_exposure(&env) {
@@ -666,6 +674,37 @@ impl Credit {
     /// Get the utilization cap in basis points for a borrower, if set.
     pub fn get_utilization_cap(env: Env, borrower: Address) -> Option<u32> {
         storage_get_utilization_cap_bps(&env, &borrower)
+    }
+
+    /// Set a per-borrower maximum exposure cap (admin only).
+    ///
+    /// When set, `draw_credit` rejects any draw where `utilized_amount` would
+    /// exceed this absolute cap, regardless of the borrower's credit limit.
+    /// This complements the per-borrower utilization ratio cap and the global
+    /// exposure cap by providing a hard ceiling on concentration risk.
+    ///
+    /// # Parameters
+    /// - `borrower`: The borrower whose cap to configure.
+    /// - `cap`: Maximum total borrowed amount allowed. Pass `0` to remove the cap.
+    ///
+    /// # Authorization
+    /// Requires admin privileges.
+    ///
+    /// # Errors
+    /// - Reverts with [`ContractError::InvalidAmount`] if `cap` is negative.
+    pub fn set_borrower_exposure_cap(env: Env, borrower: Address, cap: i128) {
+        require_admin_auth(&env);
+        if cap < 0 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+        crate::storage::set_max_borrower_exposure(&env, &borrower, cap);
+    }
+
+    /// Get the per-borrower maximum exposure cap, if set.
+    ///
+    /// Returns `Some(cap)` when a cap is configured, `None` when uncapped.
+    pub fn get_borrower_exposure_cap(env: Env, borrower: Address) -> Option<i128> {
+        crate::storage::get_max_borrower_exposure(&env, &borrower)
     }
 
     /// Commit to a VRF output for a borrower's credit score derivation (admin only).

--- a/contracts/credit/src/limits.rs
+++ b/contracts/credit/src/limits.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+//! Per-borrower exposure cap for the Credit contract.
+//!
+//! # What
+//!
+//! Provides an absolute `i128` cap on total borrowed exposure per borrower,
+//! enforced during [`draw_credit`]. Unlike the utilization cap (which is a
+//! percentage of `credit_limit`), this is a flat amount ceiling independent of
+//! the credit limit.
+//!
+//! # How
+//!
+//! The cap is stored under [`DataKey::MaxBorrowerExposure(Address)`] in
+//! persistent storage and administered via `set_borrower_exposure_cap`.
+//! The check function [`check_borrower_exposure_cap`] is called during
+//! `draw_credit` after the utilization cap check and before the global
+//! exposure cap check.
+//!
+//! # Why
+//!
+//! A per-borrower absolute exposure cap protects the protocol from
+//! concentration risk — no single borrower can draw more than the cap
+//! even if their credit limit is higher. This is complementary to the
+//! global [`MaxTotalExposure`] cap.
+
+use crate::storage::get_max_borrower_exposure;
+use crate::types::ContractError;
+use soroban_sdk::{Address, Env};
+
+/// Check that a borrower's updated utilization does not exceed their
+/// configured per-borrower exposure cap.
+///
+/// Returns `Ok(())` when:
+/// - No cap is configured (`None`),
+/// - `updated_utilized <= cap`.
+///
+/// Returns `Err(ContractError::BorrowerExposureCapExceeded)` when
+/// `updated_utilized > cap`.
+pub fn check_borrower_exposure_cap(
+    env: &Env,
+    borrower: &Address,
+    updated_utilized: i128,
+) -> Result<(), ContractError> {
+    if let Some(cap) = get_max_borrower_exposure(env, borrower) {
+        if updated_utilized > cap {
+            return Err(ContractError::BorrowerExposureCapExceeded);
+        }
+    }
+    Ok(())
+}

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -187,6 +187,10 @@ pub enum DataKey {
     /// Structured reason for the most recent protocol pause (escape-hatch audit trail).
     /// Stored when admin invokes pause with a reason; cleared on unpause.
     PauseReason,
+    /// Per-borrower maximum total exposure cap (absolute i128 amount).
+    /// When set, draw_credit enforces: utilized_amount <= max_borrower_exposure.
+    /// Pass 0 to remove the cap for this borrower.
+    MaxBorrowerExposure(Address),
 }
 
 /// Maximum number of credit lines returned per page.
@@ -702,6 +706,32 @@ pub fn get_utilization_cap_bps(env: &Env, borrower: &Address) -> Option<u32> {
     env.storage()
         .persistent()
         .get(&DataKey::UtilizationCapBps(borrower.clone()))
+}
+
+/// Return the per-borrower maximum exposure cap, if set.
+///
+/// When `None`, no per-borrower exposure cap is enforced for this borrower.
+/// Configured via `set_max_borrower_exposure`.
+pub fn get_max_borrower_exposure(env: &Env, borrower: &Address) -> Option<i128> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MaxBorrowerExposure(borrower.clone()))
+}
+
+/// Set or remove the per-borrower maximum exposure cap (admin only, enforced by caller).
+///
+/// Passing `0` removes the cap entirely for this borrower.
+/// A non-zero value caps the borrower's total `utilized_amount` in `draw_credit`.
+pub fn set_max_borrower_exposure(env: &Env, borrower: &Address, cap: i128) {
+    if cap == 0 {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::MaxBorrowerExposure(borrower.clone()));
+    } else {
+        env.storage()
+            .persistent()
+            .set(&DataKey::MaxBorrowerExposure(borrower.clone()), &cap);
+    }
 }
 
 /// Clear the installment schedule for a borrower.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -8,7 +8,7 @@
 //!
 //! ABI-stable types that cross the contract boundary:
 //!
-//! - [`ContractError`] — 40-variant `#[repr(u32)]` error enum (discriminants
+//! - [`ContractError`] — 43-variant `#[repr(u32)]` error enum (discriminants
 //!   pinned by `tests/error_discriminants.rs`). Each variant maps to a stable
 //!   [`ContractErrorCategory`] via [`ContractError::category`]. See
 //!   [`docs/contract-errors.md`](../../../docs/contract-errors.md) for the
@@ -142,6 +142,7 @@ pub enum CreditStatus {
 /// | 40   | `BorrowerFrozen`               | Borrower's draws are temporarily frozen until expiry |
 /// | 41   | `DrawReversalWindowExpired`     | Draw reversal window has expired |
 /// | 42   | `OriginalDrawNotFound`           | Original draw record not found for borrower |
+/// | 43   | `BorrowerExposureCapExceeded`     | Draw would exceed the per-borrower exposure cap |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -230,6 +231,8 @@ pub enum ContractError {
     DrawReversalWindowExpired = 41,
     /// Original draw audit record not found for the specified (borrower, timestamp) pair.
     OriginalDrawNotFound = 42,
+    /// Draw would exceed the configured per-borrower exposure cap.
+    BorrowerExposureCapExceeded = 43,
 }
 
 /// Stored credit line data for a borrower.
@@ -429,4 +432,101 @@ pub struct PauseReason {
     pub timestamp: u64,
     /// Admin address that invoked the pause.
     pub actor: soroban_sdk::Address,
+}
+
+/// Error categories for client-side grouping of [`ContractError`] variants.
+///
+/// # Discriminant stability
+/// Discriminants are permanently pinned. New variants must be appended at the
+/// end with the next available integer.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ContractErrorCategory {
+    /// Authentication / authorization errors (Unauthorized, NotAdmin, AdminNotInitialized).
+    Auth = 1,
+    /// Credit line lifecycle state errors (Closed, Suspended, Defaulted, AlreadyInitialized).
+    Lifecycle = 2,
+    /// Numeric domain errors (InvalidAmount, NegativeLimit, Overflow, TimestampRegression, LimitOutOfBounds).
+    Numeric = 3,
+    /// Per-borrower limit enforcement (OverLimit, UtilizationNotZero, DrawExceedsMaxAmount, BorrowerExposureCapExceeded).
+    Limit = 4,
+    /// Liquidity / reserve / exposure errors (MissingLiquidityToken, ExposureCapExceeded, TreasuryNotSet, etc.).
+    Liquidity = 5,
+    /// Risk / rate / score / circuit-breaker errors (RateTooHigh, ScoreTooHigh, Paused, DrawCooldownActive).
+    Risk = 6,
+    /// Oracle price-feed errors (OraclePriceInvalid, OraclePriceStale, OraclePriceDeviation).
+    Oracle = 7,
+    /// Collateral ratio errors (CollateralRatioBelowMinimum, InsufficientCollateralBalance).
+    Collateral = 8,
+    /// Blocklist / freeze / draw-freeze errors (BorrowerBlocked, DrawsFrozen, BorrowerFrozen).
+    Block = 9,
+    /// Reentrancy guard trigger.
+    Reentrancy = 10,
+    /// Unclassified errors (CreditLineNotFound, AdminAcceptTooEarly).
+    Misc = 11,
+}
+
+impl ContractError {
+    /// Return the error category for this variant.
+    ///
+    /// Categories allow clients to group errors without matching on individual
+    /// discriminant values. Every variant maps to exactly one category.
+    pub fn category(&self) -> ContractErrorCategory {
+        match self {
+            ContractError::Unauthorized
+            | ContractError::NotAdmin
+            | ContractError::AdminNotInitialized => ContractErrorCategory::Auth,
+
+            ContractError::CreditLineClosed
+            | ContractError::AlreadyInitialized
+            | ContractError::CreditLineSuspended
+            | ContractError::CreditLineDefaulted => ContractErrorCategory::Lifecycle,
+
+            ContractError::InvalidAmount
+            | ContractError::NegativeLimit
+            | ContractError::Overflow
+            | ContractError::TimestampRegression
+            | ContractError::LimitOutOfBounds => ContractErrorCategory::Numeric,
+
+            ContractError::OverLimit
+            | ContractError::UtilizationNotZero
+            | ContractError::LimitDecreaseRequiresRepayment
+            | ContractError::DrawExceedsMaxAmount
+            | ContractError::RepayExceedsMaxAmount
+            | ContractError::BorrowerExposureCapExceeded => ContractErrorCategory::Limit,
+
+            ContractError::MissingLiquidityToken
+            | ContractError::MissingLiquiditySource
+            | ContractError::InsufficientLiquidityReserve
+            | ContractError::LiquidityTokenCallFailed
+            | ContractError::InsufficientRepaymentAllowance
+            | ContractError::InsufficientRepaymentBalance
+            | ContractError::TreasuryNotSet
+            | ContractError::ExposureCapExceeded => ContractErrorCategory::Liquidity,
+
+            ContractError::RateTooHigh
+            | ContractError::ScoreTooHigh
+            | ContractError::Paused
+            | ContractError::DrawCooldownActive => ContractErrorCategory::Risk,
+
+            ContractError::OraclePriceInvalid
+            | ContractError::OraclePriceStale
+            | ContractError::OraclePriceDeviation => ContractErrorCategory::Oracle,
+
+            ContractError::CollateralRatioBelowMinimum
+            | ContractError::InsufficientCollateralBalance => ContractErrorCategory::Collateral,
+
+            ContractError::BorrowerBlocked
+            | ContractError::DrawsFrozen
+            | ContractError::BorrowerFrozen => ContractErrorCategory::Block,
+
+            ContractError::Reentrancy => ContractErrorCategory::Reentrancy,
+
+            ContractError::CreditLineNotFound
+            | ContractError::AdminAcceptTooEarly
+            | ContractError::DrawReversalWindowExpired
+            | ContractError::OriginalDrawNotFound => ContractErrorCategory::Misc,
+        }
+    }
 }

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -57,6 +57,7 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::BorrowerFrozen as u32, 40);
     assert_eq!(ContractError::DrawReversalWindowExpired as u32, 41);
     assert_eq!(ContractError::OriginalDrawNotFound as u32, 42);
+    assert_eq!(ContractError::BorrowerExposureCapExceeded as u32, 43);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -109,6 +110,7 @@ fn no_duplicate_discriminants() {
         ContractError::BorrowerFrozen as u32,
         ContractError::DrawReversalWindowExpired as u32,
         ContractError::OriginalDrawNotFound as u32,
+        ContractError::BorrowerExposureCapExceeded as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -123,8 +125,8 @@ fn no_duplicate_discriminants() {
 /// Update this number when adding new variants (and add the assertion above).
 #[test]
 fn variant_count_is_known() {
-    // 40 variants as of this writing. Update when adding new ones.
-    const EXPECTED_VARIANT_COUNT: usize = 42;
+    // 43 variants as of this writing. Update when adding new ones.
+    const EXPECTED_VARIANT_COUNT: usize = 43;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -169,6 +171,7 @@ fn variant_count_is_known() {
         ContractError::BorrowerFrozen as u32,
         ContractError::DrawReversalWindowExpired as u32,
         ContractError::OriginalDrawNotFound as u32,
+        ContractError::BorrowerExposureCapExceeded as u32,
     ];
 
     assert_eq!(
@@ -275,6 +278,7 @@ fn category_mappings_are_stable() {
     assert_eq!(ContractError::LimitDecreaseRequiresRepayment.category(), ContractErrorCategory::Limit);
     assert_eq!(ContractError::DrawExceedsMaxAmount.category(), ContractErrorCategory::Limit);
     assert_eq!(ContractError::RepayExceedsMaxAmount.category(), ContractErrorCategory::Limit);
+    assert_eq!(ContractError::BorrowerExposureCapExceeded.category(), ContractErrorCategory::Limit);
     // Liquidity
     assert_eq!(ContractError::MissingLiquidityToken.category(), ContractErrorCategory::Liquidity);
     assert_eq!(ContractError::MissingLiquiditySource.category(), ContractErrorCategory::Liquidity);
@@ -354,11 +358,14 @@ fn every_variant_has_known_category() {
         ContractError::OraclePriceDeviation.category(),
         ContractError::InsufficientCollateralBalance.category(),
         ContractError::BorrowerFrozen.category(),
+        ContractError::DrawReversalWindowExpired.category(),
+        ContractError::OriginalDrawNotFound.category(),
+        ContractError::BorrowerExposureCapExceeded.category(),
     ];
 
     let unique: HashSet<ContractErrorCategory> = all_variants.iter().cloned().collect();
     assert_eq!(unique.len(), 11, "Not all 11 categories are covered by variant mappings");
-    assert_eq!(all_variants.len(), 40, "Expected 40 ContractError variants");
+    assert_eq!(all_variants.len(), 43, "Expected 43 ContractError variants");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contracts/credit/tests/limits.rs
+++ b/contracts/credit/tests/limits.rs
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for the per-borrower exposure cap (`max_borrower_exposure`).
+//!
+//! The cap enforces: `utilized_amount + draw_amount <= max_borrower_exposure`.
+//! It is checked on every `draw_credit` call independently of the credit limit,
+//! utilization cap, and global exposure cap.
+//!
+//! Covered scenarios:
+//! - Happy path: draw succeeds when under per-borrower cap
+//! - Draw exactly at cap succeeds (boundary)
+//! - Draw that would exceed cap reverts with `BorrowerExposureCapExceeded` (#43)
+//! - Cap is independent of credit limit (draw to limit but blocked by exposure cap)
+//! - Cap is admin-configurable; non-admin is rejected
+//! - Setting cap = 0 removes it (draws unrestricted again)
+//! - Negative cap value reverts with `InvalidAmount`
+//! - Multi-borrower: caps apply independently per borrower
+//! - Cap below current utilization blocks new draws but repay still works
+//! - get_borrower_exposure_cap returns None before set, Some after
+//! - Interaction with global exposure cap
+
+use creditra_credit::types::ContractError;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (CreditClient<'_>, Address, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+
+    // Mint reserve tokens into the contract (liquidity source = contract address by default).
+    StellarAssetClient::new(env, &token).mint(&contract_id, &1_000_000_i128);
+
+    client.open_credit_line(&borrower, &10_000_i128, &300_u32, &50_u32);
+
+    (client, admin, borrower, contract_id)
+}
+
+fn setup_multi(
+    env: &Env,
+    borrower_count: usize,
+) -> (CreditClient<'_>, Address, std::vec::Vec<Address>, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    StellarAssetClient::new(env, &token).mint(&contract_id, &1_000_000_i128);
+
+    let mut borrowers = std::vec::Vec::new();
+    for _ in 0..borrower_count {
+        let b = Address::generate(env);
+        client.open_credit_line(&b, &10_000_i128, &300_u32, &50_u32);
+        borrowers.push(b);
+    }
+
+    (client, admin, borrowers, contract_id)
+}
+
+// ── Basic cap management ──────────────────────────────────────────────────────
+
+#[test]
+fn get_borrower_exposure_cap_returns_none_before_set() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    assert_eq!(client.get_borrower_exposure_cap(&borrower), None);
+}
+
+#[test]
+fn set_and_get_borrower_exposure_cap_round_trips() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &5_000_i128);
+    assert_eq!(
+        client.get_borrower_exposure_cap(&borrower),
+        Some(5_000_i128)
+    );
+}
+
+#[test]
+fn set_borrower_exposure_cap_zero_removes_cap() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &5_000_i128);
+    assert_eq!(
+        client.get_borrower_exposure_cap(&borrower),
+        Some(5_000_i128)
+    );
+    client.set_borrower_exposure_cap(&borrower, &0_i128);
+    assert_eq!(client.get_borrower_exposure_cap(&borrower), None);
+}
+
+#[test]
+fn set_borrower_exposure_cap_can_be_updated() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &3_000_i128);
+    client.set_borrower_exposure_cap(&borrower, &7_500_i128);
+    assert_eq!(
+        client.get_borrower_exposure_cap(&borrower),
+        Some(7_500_i128)
+    );
+}
+
+// ── Authorization ─────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn set_borrower_exposure_cap_requires_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    // Drop all auths so the next call is unauthorized.
+    let env2 = Env::default();
+    let client2 = CreditClient::new(&env2, &contract_id);
+    client2.set_borrower_exposure_cap(&borrower, &1_000_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn set_borrower_exposure_cap_rejects_negative_value() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &-1_i128);
+}
+
+// ── Draw enforcement ──────────────────────────────────────────────────────────
+
+#[test]
+fn draw_succeeds_when_under_borrower_cap() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &5_000_i128);
+
+    client.draw_credit(&borrower, &1_000_i128);
+
+    assert_eq!(client.get_total_utilized(), 1_000);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        1_000
+    );
+}
+
+#[test]
+fn draw_succeeds_at_exact_borrower_cap_boundary() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &3_000_i128);
+
+    // Draw exactly up to the cap — must not revert.
+    client.draw_credit(&borrower, &3_000_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        3_000
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #43)")]
+fn draw_reverts_when_exceeding_borrower_cap_by_one() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &500_i128);
+    client.draw_credit(&borrower, &501_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #43)")]
+fn draw_reverts_when_second_draw_would_exceed_borrower_cap() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &600_i128);
+
+    client.draw_credit(&borrower, &400_i128);
+    // utilized = 400; cap = 600; next draw of 201 → projected = 601 > 600
+    client.draw_credit(&borrower, &201_i128);
+}
+
+#[test]
+fn draw_without_borrower_cap_is_unrestricted() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    // No per-borrower cap set — large draw within line limit succeeds.
+    client.draw_credit(&borrower, &9_000_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        9_000
+    );
+}
+
+#[test]
+fn removing_borrower_cap_re_enables_large_draws() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    client.set_borrower_exposure_cap(&borrower, &200_i128);
+
+    client.draw_credit(&borrower, &200_i128);
+    // Would fail with cap in place; remove it first.
+    client.set_borrower_exposure_cap(&borrower, &0_i128);
+    client.draw_credit(&borrower, &500_i128);
+
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        700
+    );
+}
+
+// ── Cap independent of credit limit ──────────────────────────────────────────
+
+#[test]
+fn borrower_cap_blocks_draw_within_credit_limit() {
+    let env = Env::default();
+    let (client, _admin, borrower, _cid) = setup(&env);
+    // Borrower has a 10_000 credit limit, but we set a 300 exposure cap.
+    client.set_borrower_exposure_cap(&borrower, &300_i128);
+
+    // Draw 300 — at cap but within credit limit.
+    client.draw_credit(&borrower, &300_i128);
+
+    // Next draw of 1 would exceed the borrower cap even though it's within limit.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &1_i128);
+    }));
+    assert!(result.is_err());
+}
+
+// ── Accumulator consistency after repay ───────────────────────────────────────
+
+#[test]
+fn repay_reduces_utilized_and_re_enables_draws_under_borrower_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    StellarAssetClient::new(&env, &token).mint(&contract_id, &10_000_i128);
+    client.open_credit_line(&borrower, &5_000_i128, &300_u32, &50_u32);
+
+    client.set_borrower_exposure_cap(&borrower, &1_000_i128);
+    client.draw_credit(&borrower, &1_000_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        1_000
+    );
+
+    // Repay 400 — utilized drops to 600, cap is 1_000 so next draw of 400 should work.
+    StellarAssetClient::new(&env, &token).mint(&borrower, &400_i128);
+    soroban_sdk::token::Client::new(&env, &token).approve(
+        &borrower,
+        &contract_id,
+        &400_i128,
+        &9_999_u32,
+    );
+    client.repay_credit(&borrower, &400_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        600
+    );
+
+    client.draw_credit(&borrower, &400_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        1_000
+    );
+}
+
+// ── Multi-borrower independent caps ──────────────────────────────────────────
+
+#[test]
+fn borrower_cap_applies_independently_per_borrower() {
+    let env = Env::default();
+    let (client, _admin, borrowers, _cid) = setup_multi(&env, 3);
+
+    let b0 = borrowers[0].clone();
+    let b1 = borrowers[1].clone();
+    let b2 = borrowers[2].clone();
+
+    // Each borrower gets their own cap.
+    client.set_borrower_exposure_cap(&b0, &500_i128);
+    client.set_borrower_exposure_cap(&b1, &1_000_i128);
+    client.set_borrower_exposure_cap(&b2, &1_500_i128);
+
+    client.draw_credit(&b0, &500_i128); // at b0's cap
+    client.draw_credit(&b1, &1_000_i128); // at b1's cap
+    client.draw_credit(&b2, &1_500_i128); // at b2's cap
+
+    assert_eq!(
+        client.get_credit_line(&b0).unwrap().utilized_amount,
+        500
+    );
+    assert_eq!(
+        client.get_credit_line(&b1).unwrap().utilized_amount,
+        1_000
+    );
+    assert_eq!(
+        client.get_credit_line(&b2).unwrap().utilized_amount,
+        1_500
+    );
+}
+
+#[test]
+fn borrower_cap_does_not_affect_other_borrowers() {
+    let env = Env::default();
+    let (client, _admin, borrowers, _cid) = setup_multi(&env, 2);
+
+    let b0 = borrowers[0].clone();
+    let b1 = borrowers[1].clone();
+
+    // Only b0 has a cap.
+    client.set_borrower_exposure_cap(&b0, &500_i128);
+
+    // b0 draws up to cap.
+    client.draw_credit(&b0, &500_i128);
+
+    // b1 has no cap — can draw up to their credit limit.
+    client.draw_credit(&b1, &9_000_i128);
+    assert_eq!(
+        client.get_credit_line(&b1).unwrap().utilized_amount,
+        9_000
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #43)")]
+fn borrower_cap_blocks_only_capped_borrower() {
+    let env = Env::default();
+    let (client, _admin, borrowers, _cid) = setup_multi(&env, 2);
+
+    let b0 = borrowers[0].clone();
+    let b1 = borrowers[1].clone();
+
+    client.set_borrower_exposure_cap(&b0, &500_i128);
+    // b1 has no cap.
+
+    client.draw_credit(&b0, &500_i128); // at cap
+    client.draw_credit(&b0, &1_i128); // exceeds cap
+}
+
+// ── Cap below current utilization blocks draws but not repay ─────────────────
+
+#[test]
+fn borrower_cap_below_current_utilization_blocks_new_draws_but_not_repayments() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    StellarAssetClient::new(&env, &token).mint(&contract_id, &10_000_i128);
+    client.open_credit_line(&borrower, &5_000_i128, &300_u32, &50_u32);
+
+    // Draw 2_000 without a cap, then retroactively set cap below current utilization.
+    client.draw_credit(&borrower, &2_000_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        2_000
+    );
+
+    client.set_borrower_exposure_cap(&borrower, &1_500_i128); // cap < current utilization
+
+    // Any new draw must revert even for amount = 1.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&borrower, &1_i128);
+    }));
+    assert!(result.is_err(), "draw should revert when projected > cap");
+
+    // Repayment must still succeed regardless of cap.
+    StellarAssetClient::new(&env, &token).mint(&borrower, &500_i128);
+    soroban_sdk::token::Client::new(&env, &token).approve(
+        &borrower,
+        &contract_id,
+        &500_i128,
+        &9_999_u32,
+    );
+    client.repay_credit(&borrower, &500_i128);
+    assert_eq!(
+        client.get_credit_line(&borrower).unwrap().utilized_amount,
+        1_500
+    );
+}
+
+// ── Interaction with global exposure cap ─────────────────────────────────────
+
+#[test]
+fn borrower_cap_and_global_cap_apply_independently() {
+    let env = Env::default();
+    let (client, _admin, borrowers, _cid) = setup_multi(&env, 2);
+
+    let b0 = borrowers[0].clone();
+    let b1 = borrowers[1].clone();
+
+    // Global cap: 2_000 across all borrowers.
+    client.set_max_total_exposure(&2_000_i128);
+    // Per-borrower cap: 1_500 each.
+    client.set_borrower_exposure_cap(&b0, &1_500_i128);
+    client.set_borrower_exposure_cap(&b1, &1_500_i128);
+
+    // Both borrowers can draw up to their per-borrower cap.
+    client.draw_credit(&b0, &1_200_i128);
+    client.draw_credit(&b1, &800_i128);
+
+    // b0 tries to draw more — would exceed global cap (1_200 + 800 + 1 = 2_001 > 2_000)
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.draw_credit(&b0, &1_i128);
+    }));
+    assert!(result.is_err(), "draw should revert due to global cap");
+}
+
+// ── Error discriminant stability ──────────────────────────────────────────────
+
+#[test]
+fn borrower_exposure_cap_error_discriminant_is_43() {
+    assert_eq!(
+        ContractError::BorrowerExposureCapExceeded as u32,
+        43
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **per-borrower absolute exposure cap** — an `i128` ceiling on total borrowed amount per borrower, enforced during `draw_credit`. This is independent of the credit limit and the utilization ratio cap, providing a hard concentration-risk guard.

Closes #628

## Changes

### New files
- **`contracts/credit/src/limits.rs`** — Module with `check_borrower_exposure_cap()` validation function
- **`contracts/credit/tests/limits.rs`** — 20 integration tests

### Modified files
- **`contracts/credit/src/types.rs`** — Added `BorrowerExposureCapExceeded = 43` error variant; added `ContractErrorCategory` enum with `category()` method (previously missing)
- **`contracts/credit/src/storage.rs`** — Added `DataKey::MaxBorrowerExposure(Address)`, `get_max_borrower_exposure()`, `set_max_borrower_exposure()`
- **`contracts/credit/src/lib.rs`** — Added `pub mod limits;`, entrypoints `set_borrower_exposure_cap` (admin, `require_auth`-guarded) and `get_borrower_exposure_cap` (read-only); enforcement in `draw_credit`
- **`contracts/credit/tests/error_discriminants.rs`** — Updated variant lists from 42→43, added category mapping

## Design

| Aspect | Detail |
|---|---|
| Storage | Persistent per-borrower: `DataKey::MaxBorrowerExposure(Address)` |
| Zero = remove cap | Consistent with `set_max_total_exposure` convention |
| Error code | `BorrowerExposureCapExceeded` (#43), category `Limit` |
| Overflow safety | Simple `i128` comparison, no multiplication |
| Auth | `require_auth` + `require_admin_auth` on setter |

### Draw order
The per-borrower exposure cap is checked **after** the utilization ratio cap and **before** the global exposure cap in the `draw_credit` validation chain.

## Test Coverage (20 tests)

- Basic cap management: get/set/remove/update
- Authorization: non-admin rejected, negative value rejected
- Draw enforcement: under cap, at cap boundary, exceeding cap, second draw exceeding cap
- Cap independence: draw within credit limit but blocked by exposure cap
- Multi-borrower: independent caps per borrower, capped borrower does not affect others
- Repay interaction: repay reduces utilization and re-enables draws
- Cap reduction: setting cap below current utilization blocks draws but not repayments
- Global cap interaction: per-borrower and global caps apply independently
- Error discriminant stability (#43)