### PR TITLE
feat: group ContractError variants by category with ContractErrorCategory enum

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -81,8 +81,9 @@
 //   `ContractError::TimestampRegression = 33`.
 // - `(borrower, settlement_id)` is the dedup key for cross-contract
 //   settlement replay safety.
-// - 38 `ContractError` discriminants are ABI-stable; CI test
-//   `tests/error_discriminants.rs` reverts on reorder.
+// - 52 `ContractError` discriminants are ABI-stable; CI test
+//   `tests/error_discriminants.rs` reverts on reorder (pins every discriminant
+//   and every category mapping).
 // - 25+ event topics under the `credit` namespace are stability-pinned by
 //   `tests/event_topic_stability.rs`.
 //

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -8,11 +8,13 @@
 //!
 //! ABI-stable types that cross the contract boundary:
 //!
-//! - [`ContractError`] — 45-variant `#[repr(u32)]` error enum (discriminants
+//! - [`ContractError`] — 52-variant `#[repr(u32)]` error enum (discriminants
 //!   pinned by `tests/error_discriminants.rs`). Each variant maps to a stable
 //!   [`ContractErrorCategory`] via [`ContractError::category`]. See
 //!   [`docs/ERROR_CODES.md`](../../../docs/ERROR_CODES.md) for the
 //!   categorized reference with codes and recovery hints.
+//! - [`ContractErrorCategory`] — 11-category enum (discriminants 1–11)
+//!   returned by [`ContractError::category`] for client-side grouping.
 //! - [`CreditStatus`] — 5-variant state-machine label (Active=0,
 //!   Suspended=1, Defaulted=2, Closed=3, Restricted=4). See
 //!   [`docs/state-machine.md`](../../../docs/state-machine.md) for the
@@ -107,56 +109,60 @@ pub enum CreditStatus {
 /// categorized reference with recovery actions.
 ///
 /// # Discriminant table (source of truth)
-/// | Code | Variant                        | Description |
-/// |------|--------------------------------|-------------|
-/// | 1    | `Unauthorized`                 | Caller is not authorized |
-/// | 2    | `NotAdmin`                     | Caller lacks admin privileges |
-/// | 3    | `CreditLineNotFound`           | Credit line does not exist |
-/// | 4    | `CreditLineClosed`             | Credit line is permanently closed |
-/// | 5    | `InvalidAmount`                | Amount is zero, negative, or otherwise invalid |
-/// | 6    | `OverLimit`                    | Draw would exceed the credit limit |
-/// | 7    | `NegativeLimit`                | Credit limit cannot be negative |
-/// | 8    | `RateTooHigh`                  | Interest rate exceeds the maximum allowed |
-/// | 9    | `ScoreTooHigh`                 | Risk score exceeds the maximum allowed (100) |
-/// | 10   | `UtilizationNotZero`           | Operation requires zero utilization |
-/// | 11   | `Reentrancy`                   | Reentrancy detected during cross-contract call |
-/// | 12   | `Overflow`                     | Arithmetic overflow during calculation |
-/// | 13   | `LimitDecreaseRequiresRepayment` | Limit decrease below utilized amount |
-/// | 14   | `AlreadyInitialized`           | Contract already initialized |
-/// | 15   | `AdminAcceptTooEarly`          | Admin acceptance attempted before delay elapsed |
-/// | 16   | `BorrowerBlocked`              | Borrower is on the blocked list |
-/// | 17   | `DrawExceedsMaxAmount`         | Draw amount exceeds per-transaction cap |
-/// | 18   | `Paused`                       | Protocol is paused; operation blocked by circuit breaker |
-/// | 19   | `DrawsFrozen`                  | Draws are globally frozen |
-/// | 20   | `CreditLineSuspended`          | Credit line is suspended |
-/// | 21   | `CreditLineDefaulted`          | Credit line is defaulted |
-/// | 22   | `MissingLiquidityToken`        | Liquidity token is not configured |
-/// | 23   | `MissingLiquiditySource`       | Liquidity source is not configured |
-/// | 24   | `InsufficientLiquidityReserve` | Reserve balance cannot cover the draw |
-/// | 25   | `LiquidityTokenCallFailed`     | Liquidity token call failed where observable |
-/// | 26   | `InsufficientRepaymentAllowance` | Borrower allowance cannot cover repayment |
-/// | 27   | `InsufficientRepaymentBalance` | Borrower balance cannot cover repayment |
-/// | 28   | `RepayExceedsMaxAmount`        | Repay amount exceeds per-transaction cap |
-/// | 29   | `DrawCooldownActive`          | Borrower attempted to draw before cooldown elapsed |
-/// | 30   | `TreasuryNotSet`              | Treasury address is not configured |
-/// | 31   | `ExposureCapExceeded`         | Draw would exceed the global protocol exposure cap |
-/// | 32   | `AdminNotInitialized`         | Admin address has not been initialized |
-/// | 33   | `TimestampRegression`         | Timestamp regression detected |
-/// | 34   | `LimitOutOfBounds`            | Credit limit is outside configured min/max bounds |
-/// | 35   | `CollateralRatioBelowMinimum` | Collateral ratio is below the minimum required ratio |
-/// | 36   | `OraclePriceInvalid`          | Oracle price is invalid (zero, negative, or malformed) |
-/// | 37   | `OraclePriceStale`            | Oracle price is stale (exceeds max_age_seconds) |
-/// | 38   | `OraclePriceDeviation`        | Oracle price deviation exceeds the configured maximum |
-/// | 39   | `InsufficientCollateralBalance` | Borrower collateral balance cannot cover withdrawal |
-/// | 40   | `BorrowerFrozen`               | Borrower's draws are temporarily frozen until expiry |
-/// | 41   | `BountyNotSet`                 | Bounty pool address is not configured |
-/// | 42   | `NoPendingTreasuryWithdrawal`  | No pending treasury withdrawal proposal exists |
-/// | 43   | `TreasuryTimelockActive`       | Treasury withdrawal timelock has not yet elapsed |
-/// | 44   | `TreasuryProposalExists`       | A treasury withdrawal proposal already exists |
-/// | 45   | `CloseFactorAboveMax`          | The supplied close_factor_bps exceeds the protocol maximum |
-/// | 46   | `CreditLineFrozen`             | Credit line draws are frozen by admin (compliance hold) |
-/// | 47   | `DrawReversalWindowExpired`    | Draw reversal attempted after the allowed window expired |
-/// | 48   | `OriginalDrawNotFound`         | Original draw record not found for reversal |
+/// | Code | Variant                        | Category      | Description |
+/// |------|--------------------------------|---------------|-------------|
+/// | 1    | `Unauthorized`                 | Auth          | Caller is not authorized |
+/// | 2    | `NotAdmin`                     | Auth          | Caller lacks admin privileges |
+/// | 3    | `CreditLineNotFound`           | Misc          | Credit line does not exist |
+/// | 4    | `CreditLineClosed`             | Lifecycle     | Credit line is permanently closed |
+/// | 5    | `InvalidAmount`                | Numeric       | Amount is zero, negative, or otherwise invalid |
+/// | 6    | `OverLimit`                    | Limit         | Draw would exceed the credit limit |
+/// | 7    | `NegativeLimit`                | Numeric       | Credit limit cannot be negative |
+/// | 8    | `RateTooHigh`                  | Risk          | Interest rate exceeds the maximum allowed |
+/// | 9    | `ScoreTooHigh`                 | Risk          | Risk score exceeds the maximum allowed (100) |
+/// | 10   | `UtilizationNotZero`           | Limit         | Operation requires zero utilization |
+/// | 11   | `Reentrancy`                   | Reentrancy    | Reentrancy detected during cross-contract call |
+/// | 12   | `Overflow`                     | Numeric       | Arithmetic overflow during calculation |
+/// | 13   | `LimitDecreaseRequiresRepayment` | Limit       | Limit decrease below utilized amount |
+/// | 14   | `AlreadyInitialized`           | Lifecycle     | Contract already initialized |
+/// | 15   | `AdminAcceptTooEarly`          | Misc          | Admin acceptance attempted before delay elapsed |
+/// | 16   | `BorrowerBlocked`              | Block         | Borrower is on the blocked list |
+/// | 17   | `DrawExceedsMaxAmount`         | Limit         | Draw amount exceeds per-transaction cap |
+/// | 18   | `Paused`                       | Risk          | Protocol is paused; operation blocked by circuit breaker |
+/// | 19   | `DrawsFrozen`                  | Block         | Draws are globally frozen |
+/// | 20   | `CreditLineSuspended`          | Lifecycle     | Credit line is suspended |
+/// | 21   | `CreditLineDefaulted`          | Lifecycle     | Credit line is defaulted |
+/// | 22   | `MissingLiquidityToken`        | Liquidity     | Liquidity token is not configured |
+/// | 23   | `MissingLiquiditySource`       | Liquidity     | Liquidity source is not configured |
+/// | 24   | `InsufficientLiquidityReserve` | Liquidity     | Reserve balance cannot cover the draw |
+/// | 25   | `LiquidityTokenCallFailed`     | Liquidity     | Liquidity token call failed where observable |
+/// | 26   | `InsufficientRepaymentAllowance` | Liquidity   | Borrower allowance cannot cover repayment |
+/// | 27   | `InsufficientRepaymentBalance` | Liquidity     | Borrower balance cannot cover repayment |
+/// | 28   | `RepayExceedsMaxAmount`        | Limit         | Repay amount exceeds per-transaction cap |
+/// | 29   | `DrawCooldownActive`          | Risk          | Borrower attempted to draw before cooldown elapsed |
+/// | 30   | `TreasuryNotSet`              | Liquidity     | Treasury address is not configured |
+/// | 31   | `ExposureCapExceeded`         | Liquidity     | Draw would exceed the global protocol exposure cap |
+/// | 32   | `AdminNotInitialized`         | Auth          | Admin address has not been initialized |
+/// | 33   | `TimestampRegression`         | Numeric       | Timestamp regression detected |
+/// | 34   | `LimitOutOfBounds`            | Numeric       | Credit limit is outside configured min/max bounds |
+/// | 35   | `CollateralRatioBelowMinimum` | Collateral    | Collateral ratio is below the minimum required ratio |
+/// | 36   | `OraclePriceInvalid`          | Oracle        | Oracle price is invalid (zero, negative, or malformed) |
+/// | 37   | `OraclePriceStale`            | Oracle        | Oracle price is stale (exceeds max_age_seconds) |
+/// | 38   | `OraclePriceDeviation`        | Oracle        | Oracle price deviation exceeds the configured maximum |
+/// | 39   | `InsufficientCollateralBalance` | Collateral  | Borrower collateral balance cannot cover withdrawal |
+/// | 40   | `BorrowerFrozen`               | Block         | Borrower's draws are temporarily frozen until expiry |
+/// | 41   | `BountyNotSet`                 | Liquidity     | Bounty pool address is not configured |
+/// | 42   | `NoPendingTreasuryWithdrawal`  | Misc          | No pending treasury withdrawal proposal exists |
+/// | 43   | `TreasuryTimelockActive`       | Misc          | Treasury withdrawal timelock has not yet elapsed |
+/// | 44   | `TreasuryProposalExists`       | Misc          | A treasury withdrawal proposal already exists |
+/// | 45   | `CloseFactorAboveMax`          | Limit         | The supplied close_factor_bps exceeds the protocol maximum |
+/// | 46   | `CreditLineFrozen`             | Block         | Credit line draws are frozen by admin (compliance hold) |
+/// | 47   | `DrawReversalWindowExpired`    | Limit         | Draw reversal attempted after the allowed window expired |
+/// | 48   | `OriginalDrawNotFound`         | Misc          | Original draw record not found for reversal |
+/// | 49   | `AttestationBatchNotFound`     | Misc          | No attestation batch has been committed |
+/// | 50   | `OracleQuorumNotMet`           | Oracle        | Oracle quorum condition not satisfied |
+/// | 51   | `AlreadySettled`               | Lifecycle     | Liquidation settlement already processed for this (borrower, id) pair |
+/// | 52   | `InvalidRiskWeight`            | Numeric       | Collateral risk weight exceeds the maximum allowed (10 000 bps) |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -259,7 +265,138 @@ pub enum ContractError {
     OriginalDrawNotFound = 48,
     /// No attestation batch has been committed for the specified borrower.
     AttestationBatchNotFound = 49,
+    /// Oracle quorum condition was not satisfied (too few agreeing feeds).
+    OracleQuorumNotMet = 50,
+    /// Liquidation settlement already processed for this (borrower, settlement_id) pair.
+    AlreadySettled = 51,
+    /// Collateral risk weight exceeds the maximum allowed (10 000 bps).
+    InvalidRiskWeight = 52,
 }
+
+/// ABI-stable category label for [`ContractError`] variants.
+///
+/// # Stability guarantee
+/// These discriminants are **permanent**. Never reorder or renumber existing
+/// variants — doing so would break deployed SDK clients that match on
+/// category codes. New variants must be appended at the end.
+///
+/// # Usage
+/// Use [`ContractError::category`] to map any error to its category at
+/// runtime. This allows SDK clients to group errors by category without
+/// matching on individual error codes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractErrorCategory {
+    /// Authentication / authorization failures.
+    Auth = 1,
+    /// Credit-line lifecycle state violations.
+    Lifecycle = 2,
+    /// Numeric computation failures (overflow, invalid input, bounds).
+    Numeric = 3,
+    /// Credit limit / draw / repay cap violations.
+    Limit = 4,
+    /// Liquidity configuration or reserve failures.
+    Liquidity = 5,
+    /// Risk-parameter violations (rate, score, cooldown, pause).
+    Risk = 6,
+    /// Oracle price-feed failures.
+    Oracle = 7,
+    /// Collateral ratio or balance violations.
+    Collateral = 8,
+    /// Draw-block conditions (blocked, frozen).
+    Block = 9,
+    /// Reentrancy guard violations.
+    Reentrancy = 10,
+    /// Miscellaneous errors (not found, admin timelock, treasury proposals).
+    Misc = 11,
+}
+
+impl ContractError {
+    /// Map this error to its [`ContractErrorCategory`] for client-side grouping.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use creditra_credit::types::{ContractError, ContractErrorCategory};
+    ///
+    /// assert_eq!(
+    ///     ContractError::Unauthorized.category(),
+    ///     ContractErrorCategory::Auth
+    /// );
+    /// assert_eq!(
+    ///     ContractError::Overflow.category(),
+    ///     ContractErrorCategory::Numeric
+    /// );
+    /// ```
+    pub fn category(&self) -> ContractErrorCategory {
+        use ContractErrorCategory::*;
+        match self {
+            // Auth (1)
+            Self::Unauthorized => Auth,
+            Self::NotAdmin => Auth,
+            Self::AdminNotInitialized => Auth,
+            // Lifecycle (2)
+            Self::CreditLineClosed => Lifecycle,
+            Self::AlreadyInitialized => Lifecycle,
+            Self::CreditLineSuspended => Lifecycle,
+            Self::CreditLineDefaulted => Lifecycle,
+            Self::AlreadySettled => Lifecycle,
+            // Numeric (3)
+            Self::InvalidAmount => Numeric,
+            Self::NegativeLimit => Numeric,
+            Self::Overflow => Numeric,
+            Self::TimestampRegression => Numeric,
+            Self::LimitOutOfBounds => Numeric,
+            Self::InvalidRiskWeight => Numeric,
+            // Limit (4)
+            Self::OverLimit => Limit,
+            Self::UtilizationNotZero => Limit,
+            Self::LimitDecreaseRequiresRepayment => Limit,
+            Self::DrawExceedsMaxAmount => Limit,
+            Self::RepayExceedsMaxAmount => Limit,
+            Self::CloseFactorAboveMax => Limit,
+            Self::DrawReversalWindowExpired => Limit,
+            // Liquidity (5)
+            Self::MissingLiquidityToken => Liquidity,
+            Self::MissingLiquiditySource => Liquidity,
+            Self::InsufficientLiquidityReserve => Liquidity,
+            Self::LiquidityTokenCallFailed => Liquidity,
+            Self::InsufficientRepaymentAllowance => Liquidity,
+            Self::InsufficientRepaymentBalance => Liquidity,
+            Self::TreasuryNotSet => Liquidity,
+            Self::ExposureCapExceeded => Liquidity,
+            Self::BountyNotSet => Liquidity,
+            // Risk (6)
+            Self::RateTooHigh => Risk,
+            Self::ScoreTooHigh => Risk,
+            Self::Paused => Risk,
+            Self::DrawCooldownActive => Risk,
+            // Oracle (7)
+            Self::OraclePriceInvalid => Oracle,
+            Self::OraclePriceStale => Oracle,
+            Self::OraclePriceDeviation => Oracle,
+            Self::OracleQuorumNotMet => Oracle,
+            // Collateral (8)
+            Self::CollateralRatioBelowMinimum => Collateral,
+            Self::InsufficientCollateralBalance => Collateral,
+            // Block (9)
+            Self::BorrowerBlocked => Block,
+            Self::DrawsFrozen => Block,
+            Self::BorrowerFrozen => Block,
+            Self::CreditLineFrozen => Block,
+            // Reentrancy (10)
+            Self::Reentrancy => Reentrancy,
+            // Misc (11)
+            Self::CreditLineNotFound => Misc,
+            Self::AdminAcceptTooEarly => Misc,
+            Self::NoPendingTreasuryWithdrawal => Misc,
+            Self::TreasuryTimelockActive => Misc,
+            Self::TreasuryProposalExists => Misc,
+            Self::OriginalDrawNotFound => Misc,
+            Self::AttestationBatchNotFound => Misc,
+        }
+    }
+}
+
 
 /// Stored credit line data for a borrower.
 #[contracttype]

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -59,12 +59,17 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::NoPendingTreasuryWithdrawal as u32, 42);
     assert_eq!(ContractError::TreasuryTimelockActive as u32, 43);
     assert_eq!(ContractError::TreasuryProposalExists as u32, 44);
-    assert_eq!(ContractError::OracleQuorumNotMet as u32, 45);
+    assert_eq!(ContractError::CloseFactorAboveMax as u32, 45);
+    assert_eq!(ContractError::CreditLineFrozen as u32, 46);
+    assert_eq!(ContractError::DrawReversalWindowExpired as u32, 47);
+    assert_eq!(ContractError::OriginalDrawNotFound as u32, 48);
+    assert_eq!(ContractError::AttestationBatchNotFound as u32, 49);
+    assert_eq!(ContractError::OracleQuorumNotMet as u32, 50);
+    assert_eq!(ContractError::AlreadySettled as u32, 51);
+    assert_eq!(ContractError::InvalidRiskWeight as u32, 52);
 }
 
 /// Verify no two variants share the same discriminant.
-/// This is a compile-time guarantee via `#[repr(u32)]`, but we make it
-/// explicit here so the intent is documented and visible in test output.
 #[test]
 fn no_duplicate_discriminants() {
     use std::collections::HashSet;
@@ -114,7 +119,14 @@ fn no_duplicate_discriminants() {
         ContractError::NoPendingTreasuryWithdrawal as u32,
         ContractError::TreasuryTimelockActive as u32,
         ContractError::TreasuryProposalExists as u32,
+        ContractError::CloseFactorAboveMax as u32,
+        ContractError::CreditLineFrozen as u32,
+        ContractError::DrawReversalWindowExpired as u32,
+        ContractError::OriginalDrawNotFound as u32,
+        ContractError::AttestationBatchNotFound as u32,
         ContractError::OracleQuorumNotMet as u32,
+        ContractError::AlreadySettled as u32,
+        ContractError::InvalidRiskWeight as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -126,11 +138,9 @@ fn no_duplicate_discriminants() {
 }
 
 /// Verify the total variant count matches expectations.
-/// Update this number when adding new variants (and add the assertion above).
 #[test]
 fn variant_count_is_known() {
-    // 45 variants as of this writing (added 45 for oracle quorum in #630).
-    const EXPECTED_VARIANT_COUNT: usize = 45;
+    const EXPECTED_VARIANT_COUNT: usize = 52;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -177,7 +187,14 @@ fn variant_count_is_known() {
         ContractError::NoPendingTreasuryWithdrawal as u32,
         ContractError::TreasuryTimelockActive as u32,
         ContractError::TreasuryProposalExists as u32,
+        ContractError::CloseFactorAboveMax as u32,
+        ContractError::CreditLineFrozen as u32,
+        ContractError::DrawReversalWindowExpired as u32,
+        ContractError::OriginalDrawNotFound as u32,
+        ContractError::AttestationBatchNotFound as u32,
         ContractError::OracleQuorumNotMet as u32,
+        ContractError::AlreadySettled as u32,
+        ContractError::InvalidRiskWeight as u32,
     ];
 
     assert_eq!(
@@ -195,9 +212,16 @@ fn variant_count_is_known() {
 #[test]
 fn category_discriminants_are_stable() {
     assert_eq!(ContractErrorCategory::Auth as u32, 1);
-    assert_eq!(ContractErrorCategory::Math as u32, 2);
-    assert_eq!(ContractErrorCategory::State as u32, 3);
-    assert_eq!(ContractErrorCategory::Oracle as u32, 4);
+    assert_eq!(ContractErrorCategory::Lifecycle as u32, 2);
+    assert_eq!(ContractErrorCategory::Numeric as u32, 3);
+    assert_eq!(ContractErrorCategory::Limit as u32, 4);
+    assert_eq!(ContractErrorCategory::Liquidity as u32, 5);
+    assert_eq!(ContractErrorCategory::Risk as u32, 6);
+    assert_eq!(ContractErrorCategory::Oracle as u32, 7);
+    assert_eq!(ContractErrorCategory::Collateral as u32, 8);
+    assert_eq!(ContractErrorCategory::Block as u32, 9);
+    assert_eq!(ContractErrorCategory::Reentrancy as u32, 10);
+    assert_eq!(ContractErrorCategory::Misc as u32, 11);
 }
 
 /// Verify no two `ContractErrorCategory` variants share a discriminant.
@@ -207,9 +231,16 @@ fn no_duplicate_category_discriminants() {
 
     let codes: Vec<u32> = vec![
         ContractErrorCategory::Auth as u32,
-        ContractErrorCategory::Math as u32,
-        ContractErrorCategory::State as u32,
+        ContractErrorCategory::Lifecycle as u32,
+        ContractErrorCategory::Numeric as u32,
+        ContractErrorCategory::Limit as u32,
+        ContractErrorCategory::Liquidity as u32,
+        ContractErrorCategory::Risk as u32,
         ContractErrorCategory::Oracle as u32,
+        ContractErrorCategory::Collateral as u32,
+        ContractErrorCategory::Block as u32,
+        ContractErrorCategory::Reentrancy as u32,
+        ContractErrorCategory::Misc as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -223,13 +254,20 @@ fn no_duplicate_category_discriminants() {
 /// Verify the total variant count for `ContractErrorCategory`.
 #[test]
 fn category_variant_count_is_known() {
-    const EXPECTED_VARIANT_COUNT: usize = 4;
+    const EXPECTED_VARIANT_COUNT: usize = 11;
 
     let codes = [
         ContractErrorCategory::Auth as u32,
-        ContractErrorCategory::Math as u32,
-        ContractErrorCategory::State as u32,
+        ContractErrorCategory::Lifecycle as u32,
+        ContractErrorCategory::Numeric as u32,
+        ContractErrorCategory::Limit as u32,
+        ContractErrorCategory::Liquidity as u32,
+        ContractErrorCategory::Risk as u32,
         ContractErrorCategory::Oracle as u32,
+        ContractErrorCategory::Collateral as u32,
+        ContractErrorCategory::Block as u32,
+        ContractErrorCategory::Reentrancy as u32,
+        ContractErrorCategory::Misc as u32,
     ];
 
     assert_eq!(
@@ -272,6 +310,10 @@ fn category_mappings_are_stable() {
         ContractError::CreditLineDefaulted.category(),
         ContractErrorCategory::Lifecycle
     );
+    assert_eq!(
+        ContractError::AlreadySettled.category(),
+        ContractErrorCategory::Lifecycle
+    );
     // Numeric
     assert_eq!(
         ContractError::InvalidAmount.category(),
@@ -293,6 +335,10 @@ fn category_mappings_are_stable() {
         ContractError::LimitOutOfBounds.category(),
         ContractErrorCategory::Numeric
     );
+    assert_eq!(
+        ContractError::InvalidRiskWeight.category(),
+        ContractErrorCategory::Numeric
+    );
     // Limit
     assert_eq!(
         ContractError::OverLimit.category(),
@@ -312,6 +358,14 @@ fn category_mappings_are_stable() {
     );
     assert_eq!(
         ContractError::RepayExceedsMaxAmount.category(),
+        ContractErrorCategory::Limit
+    );
+    assert_eq!(
+        ContractError::CloseFactorAboveMax.category(),
+        ContractErrorCategory::Limit
+    );
+    assert_eq!(
+        ContractError::DrawReversalWindowExpired.category(),
         ContractErrorCategory::Limit
     );
     // Liquidity
@@ -347,6 +401,10 @@ fn category_mappings_are_stable() {
         ContractError::ExposureCapExceeded.category(),
         ContractErrorCategory::Liquidity
     );
+    assert_eq!(
+        ContractError::BountyNotSet.category(),
+        ContractErrorCategory::Liquidity
+    );
     // Risk
     assert_eq!(
         ContractError::RateTooHigh.category(),
@@ -377,6 +435,10 @@ fn category_mappings_are_stable() {
         ContractError::OraclePriceDeviation.category(),
         ContractErrorCategory::Oracle
     );
+    assert_eq!(
+        ContractError::OracleQuorumNotMet.category(),
+        ContractErrorCategory::Oracle
+    );
     // Collateral
     assert_eq!(
         ContractError::CollateralRatioBelowMinimum.category(),
@@ -399,6 +461,10 @@ fn category_mappings_are_stable() {
         ContractError::BorrowerFrozen.category(),
         ContractErrorCategory::Block
     );
+    assert_eq!(
+        ContractError::CreditLineFrozen.category(),
+        ContractErrorCategory::Block
+    );
     // Reentrancy
     assert_eq!(
         ContractError::Reentrancy.category(),
@@ -413,10 +479,30 @@ fn category_mappings_are_stable() {
         ContractError::AdminAcceptTooEarly.category(),
         ContractErrorCategory::Misc
     );
+    assert_eq!(
+        ContractError::NoPendingTreasuryWithdrawal.category(),
+        ContractErrorCategory::Misc
+    );
+    assert_eq!(
+        ContractError::TreasuryTimelockActive.category(),
+        ContractErrorCategory::Misc
+    );
+    assert_eq!(
+        ContractError::TreasuryProposalExists.category(),
+        ContractErrorCategory::Misc
+    );
+    assert_eq!(
+        ContractError::OriginalDrawNotFound.category(),
+        ContractErrorCategory::Misc
+    );
+    assert_eq!(
+        ContractError::AttestationBatchNotFound.category(),
+        ContractErrorCategory::Misc
+    );
 }
 
-/// Verify every ContractError variant's category matches its discriminant table.
-/// This catches accidental miscategorization when new variants are added.
+/// Verify every ContractError variant has a known category and that all 11
+/// categories are covered.
 #[test]
 fn every_variant_has_known_category() {
     use std::collections::HashSet;
@@ -466,7 +552,14 @@ fn every_variant_has_known_category() {
         ContractError::NoPendingTreasuryWithdrawal.category(),
         ContractError::TreasuryTimelockActive.category(),
         ContractError::TreasuryProposalExists.category(),
+        ContractError::CloseFactorAboveMax.category(),
+        ContractError::CreditLineFrozen.category(),
+        ContractError::DrawReversalWindowExpired.category(),
+        ContractError::OriginalDrawNotFound.category(),
+        ContractError::AttestationBatchNotFound.category(),
+        ContractError::OracleQuorumNotMet.category(),
         ContractError::AlreadySettled.category(),
+        ContractError::InvalidRiskWeight.category(),
     ];
 
     let unique: HashSet<ContractErrorCategory> = all_variants.iter().cloned().collect();
@@ -475,7 +568,7 @@ fn every_variant_has_known_category() {
         11,
         "Not all 11 categories are covered by variant mappings"
     );
-    assert_eq!(all_variants.len(), 40, "Expected 40 ContractError variants");
+    assert_eq!(all_variants.len(), 52, "Expected 52 ContractError variants");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,138 +1,265 @@
-# ContractError Codes
+# ContractError Codes — Categorized Reference
 
 > **Source of truth:** [`ContractError`](../contracts/credit/src/types.rs) enum in
 > `contracts/credit/src/types.rs`.
 >
-> **CI guard:** `tests/error_discriminants.rs` pins every discriminant.
+> **CI guard:** `tests/error_discriminants.rs` pins every discriminant and category
+> mapping. `ContractErrorCategory` discriminants are also pinned.
+>
+> **Runtime API:** [`ContractError::category()`](../contracts/credit/src/types.rs)
+> returns the [`ContractErrorCategory`](../contracts/credit/src/types.rs) enum.
 
 ---
 
-## Error Categories
+## Categories
 
-| Code | Category | Description                          |
-|------|----------|--------------------------------------|
-| 1    | `Auth`   | Authentication / authorization failures |
-| 2    | `Math`   | Arithmetic / computation failures    |
-| 3    | `State`  | Contract or entity state prevents the operation |
-| 4    | `Oracle` | Oracle price-feed failures           |
-
-Each `ContractError` variant maps to exactly one category via
-[`ContractError::category()`](../contracts/credit/src/types.rs).
-
----
-
-## Auth (Category 1)
-
-Authentication or authorization failures — the caller does not have the
-required privileges.
-
-| Code | Variant                | Meaning                                      | Returned When |
-|------|------------------------|----------------------------------------------|---------------|
-| 1    | `Unauthorized`         | Caller is not authorized for this action      | `accept_admin` if caller is not the pending admin |
-| 2    | `NotAdmin`             | Caller does not have admin privileges         | Reserved; admin checks use `AdminNotInitialized` |
-| 11   | `Reentrancy`           | Reentrancy detected during cross-contract call | Reentrant call to a state-changing entrypoint |
-| 15   | `AdminAcceptTooEarly`  | Admin acceptance before timelock elapsed      | `accept_admin` before delay expires |
-| 32   | `AdminNotInitialized`  | Admin address not yet set in storage          | Any admin-gated entrypoint before `init` |
-
-### Compatibility
-
-- Codes 1, 2, 11, 15, 32 unchanged from previous releases.
+| Category      | Discriminant | Count | Description |
+|---------------|:------------:|:-----:|-------------|
+| Auth          | 1            | 3     | Authentication / authorization failures |
+| Lifecycle     | 2            | 5     | Credit-line lifecycle state violations |
+| Numeric       | 3            | 6     | Numeric computation failures |
+| Limit         | 4            | 7     | Credit limit / draw / repay cap violations |
+| Liquidity     | 5            | 9     | Liquidity configuration or reserve failures |
+| Risk          | 6            | 4     | Risk-parameter violations |
+| Oracle        | 7            | 4     | Oracle price-feed failures |
+| Collateral    | 8            | 2     | Collateral ratio or balance violations |
+| Block         | 9            | 4     | Draw-block conditions (blocked, frozen) |
+| Reentrancy    | 10           | 1     | Reentrancy guard violations |
+| Misc          | 11           | 7     | Miscellaneous errors |
+| **Total**     | 1–11         | **52** | — |
 
 ---
 
-## Math (Category 2)
+## 1. Auth (codes 1, 2, 32)
 
-Arithmetic or numeric computation failures — inputs or calculations fall
-outside acceptable ranges.
+Authentication or authorization failures — the caller does not have the required privileges.
 
-| Code | Variant              | Meaning                                  | Returned When |
-|------|----------------------|------------------------------------------|---------------|
-| 5    | `InvalidAmount`      | Amount is zero, negative, or invalid     | `draw_credit`, `repay_credit`, collateral operations, config setters |
-| 7    | `NegativeLimit`      | Credit limit cannot be negative          | `open_credit_line`, `update_risk_parameters` |
-| 12   | `Overflow`           | Arithmetic overflow during calculation   | `draw_credit` utilization add, collateral math, interest accrual |
-| 33   | `TimestampRegression`| Timestamp regression detected            | Storage guard `assert_ts_monotonic`, risk update |
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 1    | `Unauthorized` | Caller is not authorized for this action | `accept_admin` if caller is not the pending admin; borrower auth mismatch |
+| 2    | `NotAdmin` | Caller does not have admin privileges | Admin-gated entrypoints when caller is not the stored admin |
+| 32   | `AdminNotInitialized` | Admin address not yet set in storage | Any admin-gated entrypoint before `init` is called |
 
-### Compatibility
-
-- Codes 5, 7, 12, 33 unchanged from previous releases.
+**SDK recovery:** Prompt the caller to re-connect a wallet with the correct role. For `AdminNotInitialized`, advise the deployer to call `init()` with a valid admin address.
 
 ---
 
-## State (Category 3)
+## 2. Lifecycle (codes 4, 14, 20, 21, 51)
 
-The contract configuration, credit-line lifecycle, or entity state prevents
-the requested operation. This is the largest category and includes
-lifecycle, liquidity, limit, risk, collateral, and system-configuration
-errors.
+The credit-line is in a state that prevents the requested operation.
 
-| Code | Variant                           | Meaning                                    | Returned When |
-|------|-----------------------------------|--------------------------------------------|---------------|
-| 3    | `CreditLineNotFound`              | Credit line does not exist                 | Any operation on a borrower without an open line |
-| 4    | `CreditLineClosed`                | Credit line is permanently closed          | Draw or repay on closed line |
-| 6    | `OverLimit`                       | Draw exceeds credit limit                  | `draw_credit` when utilized + amount > limit |
-| 8    | `RateTooHigh`                     | Rate exceeds maximum allowed               | `open_credit_line`, `set_borrower_rate_ceiling` |
-| 9    | `ScoreTooHigh`                    | Risk score exceeds max (100)               | `open_credit_line` with score > 100 |
-| 10   | `UtilizationNotZero`              | Operation requires zero utilization        | `close_credit_line` with outstanding debt |
-| 13   | `LimitDecreaseRequiresRepayment`  | Limit decrease below utilized              | Reserved for limit-decrease enforcement |
-| 14   | `AlreadyInitialized`              | Contract already initialized               | `init` called a second time |
-| 16   | `BorrowerBlocked`                 | Borrower is on the blocked list            | `draw_credit` when borrower is blocked |
-| 17   | `DrawExceedsMaxAmount`            | Draw exceeds per-transaction cap           | `draw_credit` when amount > `MaxDrawAmount` |
-| 18   | `Paused`                          | Protocol is paused                         | `draw_credit`, admin actions while paused |
-| 19   | `DrawsFrozen`                     | Draws globally frozen                      | `draw_credit` when `DrawsFrozen` is set |
-| 20   | `CreditLineSuspended`             | Credit line is suspended                   | `draw_credit` when line status is Suspended |
-| 21   | `CreditLineDefaulted`             | Credit line is defaulted                   | `draw_credit` when line status is Defaulted |
-| 22   | `MissingLiquidityToken`           | Liquidity token not configured             | `draw_credit`, collateral ops before token set |
-| 23   | `MissingLiquiditySource`          | Liquidity source not configured            | `draw_credit` before source set |
-| 24   | `InsufficientLiquidityReserve`    | Reserve cannot cover draw                  | `draw_credit` when reserve balance < amount |
-| 25   | `LiquidityTokenCallFailed`        | Token call failed (observable)             | Reserved for token CPI failure |
-| 26   | `InsufficientRepaymentAllowance`  | Allowance below repayment                  | Reserved for allowance check |
-| 27   | `InsufficientRepaymentBalance`    | Balance below repayment                    | Reserved for balance check |
-| 28   | `RepayExceedsMaxAmount`           | Repay exceeds per-transaction cap          | `repay_credit` when amount > `MaxRepayAmount` |
-| 29   | `DrawCooldownActive`              | Draw within cooldown window                | `draw_credit` before cooldown elapses |
-| 30   | `TreasuryNotSet`                  | Treasury not configured                    | `propose_treasury_withdrawal` without treasury |
-| 31   | `ExposureCapExceeded`             | Global exposure cap exceeded               | `draw_credit` when total_utilized + amount > cap |
-| 34   | `LimitOutOfBounds`                | Limit outside min/max bounds               | `open_credit_line` with limit < min or > max |
-| 35   | `CollateralRatioBelowMinimum`     | Collateral ratio too low                   | `draw_credit`, collateral withdrawal |
-| 39   | `InsufficientCollateralBalance`   | Collateral balance too low                 | Collateral withdrawal |
-| 40   | `BorrowerFrozen`                  | Borrower draws frozen until expiry         | `draw_credit` when per-borrower freeze active |
-| 41   | `BountyNotSet`                    | Bounty address not configured              | `withdraw_bounty` without bounty set |
-| 42   | `NoPendingTreasuryWithdrawal`     | No pending withdrawal proposal             | `execute_treasury_withdrawal` without proposal |
-| 43   | `TreasuryTimelockActive`          | 24h timelock not elapsed                   | `execute_treasury_withdrawal` before timelock |
-| 44   | `TreasuryProposalExists`          | Proposal already exists                    | `propose_treasury_withdrawal` while pending |
-| 45   | `CreditLineFrozen`                | Credit line frozen by admin                | `draw_credit` when per-line freeze active |
-| 46   | `AttestationBatchNotFound`        | No attestation batch committed             | Attestation verification without a batch |
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 4    | `CreditLineClosed` | Credit line is permanently closed | Draw or repay on a closed line |
+| 14   | `AlreadyInitialized` | `init()` called more than once | Second call to `init` |
+| 20   | `CreditLineSuspended` | Credit line is suspended | Draw or state transition on a suspended line |
+| 21   | `CreditLineDefaulted` | Credit line is defaulted | Draw or state transition on a defaulted line |
+| 51   | `AlreadySettled` | Liquidation settlement already processed | Replay of the same `(borrower, settlement_id)` pair |
 
-### Compatibility
-
-- **Codes 3, 4, 6, 8, 9, 10, 13, 14, 16–31, 34, 35, 39–44** unchanged.
-- **Code 45 (`CreditLineFrozen`)** — new variant. Previously this was a gap
-  or unreachable path; it now maps to a stable discriminant.
-- **Code 46 (`AttestationBatchNotFound`)** — new variant. Previously this was
-  handled by `unwrap_or_else` in `attestation.rs` without a stable code.
+**SDK recovery:**
+- `CreditLineClosed`: No recovery — the line is terminal. Create a new credit line.
+- `AlreadyInitialized`: No action needed (contract is already live).
+- `AlreadySettled`: No action needed — the settlement has already been processed.
+- `CreditLineSuspended`: Wait for admin reinstatement or self-reinstatement; repayments are still allowed.
+- `CreditLineDefaulted`: The line is in default; the borrower must either cure via repayment or the position must be liquidated.
 
 ---
 
-## Oracle (Category 4)
+## 3. Numeric (codes 5, 7, 12, 33, 34, 52)
+
+Arithmetic or numeric computation failures — inputs or calculations fall outside acceptable ranges.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 5    | `InvalidAmount` | Amount is zero, negative, or malformed | `draw_credit`, `repay_credit`, collateral operations, config setters |
+| 7    | `NegativeLimit` | Credit limit cannot be negative | `open_credit_line`, `update_risk_parameters` |
+| 12   | `Overflow` | Arithmetic overflow during calculation | `draw_credit` utilization add, collateral math, interest accrual |
+| 33   | `TimestampRegression` | Timestamp regression detected | Storage guard `assert_ts_monotonic`, risk update |
+| 34   | `LimitOutOfBounds` | Credit limit outside configured min/max | `open_credit_line`, `update_risk_parameters` |
+| 52   | `InvalidRiskWeight` | Collateral risk weight exceeds 10 000 bps | `set_collateral_risk_weight` |
+
+**SDK recovery:**
+- `InvalidAmount`: Re-validate inputs client-side.
+- `NegativeLimit`: Clamp or reject the limit value before sending.
+- `Overflow`: Retry with a smaller amount or under different rate/accrual conditions.
+- `TimestampRegression`: Re-sync the caller's ledger view and retry.
+- `LimitOutOfBounds`: Adjust the proposed limit to `[min_limit, max_limit]`.
+- `InvalidRiskWeight`: Ensure risk weight is in `0..=10_000` bps.
+
+---
+
+## 4. Limit (codes 6, 10, 13, 17, 28, 45, 47)
+
+Draw, repay, or limit operations that violate numeric caps or boundary conditions.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 6    | `OverLimit` | Draw would exceed the credit limit | `draw_credit` when utilized + amount > limit |
+| 10   | `UtilizationNotZero` | Operation requires zero utilization | `close_credit_line` with outstanding debt |
+| 13   | `LimitDecreaseRequiresRepayment` | Limit decrease below utilized | Limit-decrease enforcement |
+| 17   | `DrawExceedsMaxAmount` | Draw exceeds per-transaction cap | `draw_credit` when amount > `MaxDrawAmount` |
+| 28   | `RepayExceedsMaxAmount` | Repay exceeds per-transaction cap | `repay_credit` when amount > `MaxRepayAmount` |
+| 45   | `CloseFactorAboveMax` | Close factor exceeds protocol maximum | `settle_default_liquidation` validation |
+| 47   | `DrawReversalWindowExpired` | Draw reversal window has expired | `reverse_draw` after `DRAW_REVERSAL_WINDOW_SECS` |
+
+**SDK recovery:**
+- `OverLimit`: Reduce draw amount to ≤ `credit_limit - utilized`.
+- `UtilizationNotZero`: Repay outstanding balance first.
+- `LimitDecreaseRequiresRepayment`: Repay excess before decreasing.
+- `DrawExceedsMaxAmount` / `RepayExceedsMaxAmount`: Split into smaller chunks.
+- `CloseFactorAboveMax`: Reduce close factor to ≤ configured max.
+- `DrawReversalWindowExpired`: Reversal is no longer possible.
+
+---
+
+## 5. Liquidity (codes 22, 23, 24, 25, 26, 27, 30, 31, 41)
+
+Liquidity configuration is missing or a reserve/allowance/balance check fails.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 22   | `MissingLiquidityToken` | Liquidity token not configured | `draw_credit`, collateral ops before token set |
+| 23   | `MissingLiquiditySource` | Liquidity source not configured | `draw_credit` before source set |
+| 24   | `InsufficientLiquidityReserve` | Reserve cannot cover draw | `draw_credit` when reserve balance < amount |
+| 25   | `LiquidityTokenCallFailed` | Token call failed (observable) | Token CPI failure |
+| 26   | `InsufficientRepaymentAllowance` | Allowance below repayment | Allowance check |
+| 27   | `InsufficientRepaymentBalance` | Balance below repayment | Balance check |
+| 30   | `TreasuryNotSet` | Treasury not configured | `propose_treasury_withdrawal` without treasury |
+| 31   | `ExposureCapExceeded` | Global exposure cap exceeded | `draw_credit` when total_utilized + amount > cap |
+| 41   | `BountyNotSet` | Bounty address not configured | `withdraw_bounty` without bounty set |
+
+**SDK recovery:**
+- `MissingLiquidityToken` / `MissingLiquiditySource`: Admin must complete liquidity configuration.
+- `InsufficientLiquidityReserve`: Wait for reserve replenishment.
+- `LiquidityTokenCallFailed`: Retry; if persistent, admin must replace token.
+- `InsufficientRepaymentAllowance`: Guide borrower to increase allowance.
+- `InsufficientRepaymentBalance`: Guide borrower to deposit more tokens.
+- `TreasuryNotSet`: Admin must call `set_treasury`.
+- `ExposureCapExceeded`: Reduce draw amount or wait for repayments.
+- `BountyNotSet`: Admin must call `set_bounty`.
+
+---
+
+## 6. Risk (codes 8, 9, 18, 29)
+
+Risk-parameter or protocol-state violations.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 8    | `RateTooHigh` | Rate exceeds maximum allowed | `open_credit_line`, `set_borrower_rate_ceiling` |
+| 9    | `ScoreTooHigh` | Risk score exceeds max (100) | `open_credit_line` with score > 100 |
+| 18   | `Paused` | Protocol is paused | State-changing operations while paused |
+| 29   | `DrawCooldownActive` | Draw within cooldown window | `draw_credit` before cooldown elapses |
+
+**SDK recovery:**
+- `RateTooHigh`: Clamp rate change within `RateChangeConfig` bounds.
+- `ScoreTooHigh`: Normalize risk score to `[0, 100]`.
+- `Paused`: Inform user; repayments are still accepted. Retry when unpaused.
+- `DrawCooldownActive`: Wait `draw_min_interval_seconds` before retrying.
+
+---
+
+## 7. Oracle (codes 36, 37, 38, 50)
 
 Oracle price-feed failures — the price data cannot be trusted.
 
-| Code | Variant               | Meaning                                  | Returned When |
-|------|-----------------------|------------------------------------------|---------------|
-| 36   | `OraclePriceInvalid`  | Price is zero, negative, or malformed    | `settle_default_liquidation` oracle validation |
-| 37   | `OraclePriceStale`    | Price exceeds max_age_seconds            | `settle_default_liquidation` staleness check |
-| 38   | `OraclePriceDeviation`| Price deviation exceeds max allowed      | `settle_default_liquidation` deviation check |
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 36   | `OraclePriceInvalid` | Price is zero, negative, or malformed | `settle_default_liquidation` oracle validation |
+| 37   | `OraclePriceStale` | Price exceeds `max_age_seconds` | `settle_default_liquidation` staleness check |
+| 38   | `OraclePriceDeviation` | Price deviation exceeds max allowed | `settle_default_liquidation` deviation check |
+| 50   | `OracleQuorumNotMet` | Quorum of K agreeing feeds not met | `submit_oracle_prices` quorum resolution |
 
-### Compatibility
-
-- Codes 36, 37, 38 unchanged from previous releases.
+**SDK recovery:**
+- `OraclePriceInvalid`: Ensure oracle returns a valid positive price.
+- `OraclePriceStale`: Wait for oracle price update.
+- `OraclePriceDeviation`: Circuit-breaker tripped; await a new price within bound.
+- `OracleQuorumNotMet`: Submit prices from more independent feeds.
 
 ---
 
-## Summary of Changes
+## 8. Collateral (codes 35, 39)
 
-| Aspect               | Change |
-|----------------------|--------|
-| **Categories**       | Reduced from 11 to 4: `Auth` (1), `Math` (2), `State` (3), `Oracle` (4) |
-| **Variants**         | Added `CreditLineFrozen` (45), `AttestationBatchNotFound` (46) |
-| **Codes preserved**  | All 44 existing codes (1–44) remain unchanged |
-| **Behavior**         | No runtime behavior changes; all panics and error returns identical |
+Collateral ratio or balance violations.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 35   | `CollateralRatioBelowMinimum` | Collateral ratio below minimum | `draw_credit`, collateral withdrawal |
+| 39   | `InsufficientCollateralBalance` | Collateral balance too low | Collateral withdrawal |
+
+**SDK recovery:**
+- Code 35: Reduce withdrawal amount so post-withdrawal HF ≥ minimum.
+- Code 39: Query `get_collateral_balance` and ensure requested amount ≤ balance.
+
+---
+
+## 9. Block (codes 16, 19, 40, 46)
+
+Draw-block conditions — the borrower, line, or protocol prevents draws.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 16   | `BorrowerBlocked` | Borrower is on the blocked list | `draw_credit` when borrower is blocked |
+| 19   | `DrawsFrozen` | Draws globally frozen | `draw_credit` when `DrawsFrozen` is set |
+| 40   | `BorrowerFrozen` | Borrower draws frozen until expiry | `draw_credit` when per-borrower freeze active |
+| 46   | `CreditLineFrozen` | Credit line frozen by admin | `draw_credit` when per-line freeze active |
+
+**SDK recovery:**
+- `BorrowerBlocked`: Permanent — borrower must contact admin.
+- `DrawsFrozen`: Temporary — repayments remain open.
+- `BorrowerFrozen`: Time-bounded — wait for expiry or contact admin.
+- `CreditLineFrozen`: Admin hold — wait for `unfreeze_credit_line`.
+
+---
+
+## 10. Reentrancy (code 11)
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 11   | `Reentrancy` | Reentrant call detected | Reentrant call to a state-changing entrypoint |
+
+**SDK recovery:** Do **not** retry the same transaction. Wait for resolution and inspect on-chain state before submitting a new call. If integrating a token contract, ensure it does not re-enter the credit contract during `transfer` / `transfer_from`.
+
+---
+
+## 11. Misc (codes 3, 15, 42, 43, 44, 48, 49)
+
+Errors that do not fit into other categories — entity-not-found, timelock, and treasury proposal conflicts.
+
+| Code | Variant | Meaning | Returned When |
+|:----:|---------|---------|---------------|
+| 3    | `CreditLineNotFound` | Credit line does not exist | Any operation on a borrower without an open line |
+| 15   | `AdminAcceptTooEarly` | Admin acceptance before timelock | `accept_admin` before delay expires |
+| 42   | `NoPendingTreasuryWithdrawal` | No pending proposal | `execute_treasury_withdrawal` without proposal |
+| 43   | `TreasuryTimelockActive` | 24h timelock not elapsed | `execute_treasury_withdrawal` before timelock |
+| 44   | `TreasuryProposalExists` | Proposal already exists | `propose_treasury_withdrawal` while pending |
+| 48   | `OriginalDrawNotFound` | Draw audit record not found | Draw reversal without matching record |
+| 49   | `AttestationBatchNotFound` | No attestation batch committed | `verify_attestation_proof` without batch |
+
+**SDK recovery:**
+- `CreditLineNotFound`: Create a credit line first via `open_credit_line`.
+- `AdminAcceptTooEarly`: Wait for the full delay window to elapse.
+- `NoPendingTreasuryWithdrawal`: Create a proposal first.
+- `TreasuryTimelockActive`: Wait for 24h timelock.
+- `TreasuryProposalExists`: Execute or cancel existing proposal first.
+- `OriginalDrawNotFound`: No reversal possible — no matching draw record.
+- `AttestationBatchNotFound`: Admin must commit a batch first.
+
+---
+
+## Summary
+
+| Category      | Codes | Count | Dominant SDK Recovery |
+|---------------|:-----:|:-----:|-----------------------|
+| Auth          | 1, 2, 32 | 3 | Reconnect wallet / re-deploy with admin init |
+| Lifecycle     | 4, 14, 20, 21, 51 | 5 | Await admin action or create new line |
+| Numeric       | 5, 7, 12, 33, 34, 52 | 6 | Validate inputs / re-sync ledger view |
+| Limit         | 6, 10, 13, 17, 28, 45, 47 | 7 | Reduce amount or repay first |
+| Liquidity     | 22, 23, 24, 25, 26, 27, 30, 31, 41 | 9 | Replenish allowance / wait for reserve |
+| Risk          | 8, 9, 18, 29 | 4 | Clamp inputs / wait for cooldown or unpause |
+| Oracle        | 36, 37, 38, 50 | 4 | Await valid price feed |
+| Collateral    | 35, 39 | 2 | Reduce withdrawal amount |
+| Block         | 16, 19, 40, 46 | 4 | Contact admin or wait for unfreeze / expiry |
+| Reentrancy    | 11 | 1 | Do not retry; inspect on-chain state |
+| Misc          | 3, 15, 42, 43, 44, 48, 49 | 7 | Create line first / wait for delay |
+| **Total**     | 1–52 | **52** | — |

--- a/docs/contract-errors.md
+++ b/docs/contract-errors.md
@@ -66,7 +66,14 @@ See the [category enum reference](#contracterrorcategory) below.
 | 42 | `NoPendingTreasuryWithdrawal` | Misc | No pending treasury withdrawal proposal exists. |
 | 43 | `TreasuryTimelockActive` | Misc | The 24-hour treasury withdrawal timelock has not elapsed. |
 | 44 | `TreasuryProposalExists` | Misc | A treasury withdrawal proposal already exists. |
-| 45 | `AlreadySettled` | Lifecycle | The liquidation for this (borrower, settlement_id) pair has already been settled. |
+| 45 | `CloseFactorAboveMax` | Limit | The supplied close_factor_bps exceeds the protocol maximum. |
+| 46 | `CreditLineFrozen` | Block | Credit line draws are frozen by admin (compliance hold). |
+| 47 | `DrawReversalWindowExpired` | Limit | Draw reversal attempted after the allowed window expired. |
+| 48 | `OriginalDrawNotFound` | Misc | Original draw record not found for reversal. |
+| 49 | `AttestationBatchNotFound` | Misc | No attestation batch has been committed. |
+| 50 | `OracleQuorumNotMet` | Oracle | Oracle quorum condition not satisfied. |
+| 51 | `AlreadySettled` | Lifecycle | Liquidation for this (borrower, id) already processed. |
+| 52 | `InvalidRiskWeight` | Numeric | Collateral risk weight exceeds 10 000 bps. |
 
 ## `ContractErrorCategory`
 
@@ -78,19 +85,19 @@ categories. Access it at runtime via [`ContractError::category()`](../contracts/
 | ---: | -------- | -------- |
 | 1  | Auth | `Unauthorized`, `NotAdmin`, `AdminNotInitialized` |
 | 2  | Lifecycle | `CreditLineClosed`, `AlreadyInitialized`, `CreditLineSuspended`, `CreditLineDefaulted`, `AlreadySettled` |
-| 3  | Numeric | `InvalidAmount`, `NegativeLimit`, `Overflow`, `TimestampRegression`, `LimitOutOfBounds` |
-| 4  | Limit | `OverLimit`, `UtilizationNotZero`, `LimitDecreaseRequiresRepayment`, `DrawExceedsMaxAmount`, `RepayExceedsMaxAmount` |
+| 3  | Numeric | `InvalidAmount`, `NegativeLimit`, `Overflow`, `TimestampRegression`, `LimitOutOfBounds`, `InvalidRiskWeight` |
+| 4  | Limit | `OverLimit`, `UtilizationNotZero`, `LimitDecreaseRequiresRepayment`, `DrawExceedsMaxAmount`, `RepayExceedsMaxAmount`, `CloseFactorAboveMax`, `DrawReversalWindowExpired` |
 | 5  | Liquidity | `MissingLiquidityToken`, `MissingLiquiditySource`, `InsufficientLiquidityReserve`, `LiquidityTokenCallFailed`, `InsufficientRepaymentAllowance`, `InsufficientRepaymentBalance`, `TreasuryNotSet`, `ExposureCapExceeded`, `BountyNotSet` |
 | 6  | Risk | `RateTooHigh`, `ScoreTooHigh`, `Paused`, `DrawCooldownActive` |
-| 7  | Oracle | `OraclePriceInvalid`, `OraclePriceStale`, `OraclePriceDeviation` |
+| 7  | Oracle | `OraclePriceInvalid`, `OraclePriceStale`, `OraclePriceDeviation`, `OracleQuorumNotMet` |
 | 8  | Collateral | `CollateralRatioBelowMinimum`, `InsufficientCollateralBalance` |
-| 9  | Block | `BorrowerBlocked`, `DrawsFrozen`, `BorrowerFrozen` |
+| 9  | Block | `BorrowerBlocked`, `DrawsFrozen`, `BorrowerFrozen`, `CreditLineFrozen` |
 | 10 | Reentrancy | `Reentrancy` |
-| 11 | Misc | `CreditLineNotFound`, `AdminAcceptTooEarly`, `NoPendingTreasuryWithdrawal`, `TreasuryTimelockActive`, `TreasuryProposalExists` |
+| 11 | Misc | `CreditLineNotFound`, `AdminAcceptTooEarly`, `NoPendingTreasuryWithdrawal`, `TreasuryTimelockActive`, `TreasuryProposalExists`, `OriginalDrawNotFound`, `AttestationBatchNotFound` |
 
 ## Taxonomy
 
-See [`docs/error-taxonomy.md`](./error-taxonomy.md) for the authoritative
-grouping of all 45 variants into **named categories** (Auth, Lifecycle,
+See [`docs/ERROR_CODES.md`](./ERROR_CODES.md) for the authoritative
+grouping of all 52 variants into **named categories** (Auth, Lifecycle,
 Numeric, Limit, Liquidity, Risk, Oracle, Collateral, Block, Reentrancy, Misc)
 with **SDK-side recovery actions** per category.

--- a/docs/error-taxonomy.md
+++ b/docs/error-taxonomy.md
@@ -10,8 +10,8 @@ Categories are also available as a stable `#[repr(u32)]` enum —
 any error to its category at runtime.
 
 Source of truth: `contracts/credit/src/types.rs`.
-Cross-reference: [`docs/contract-errors.md`](./contract-errors.md) (flat code
-table).
+Cross-reference: [`docs/ERROR_CODES.md`](./ERROR_CODES.md) (categorized reference
+with recovery actions).
 
 ---
 
@@ -29,7 +29,7 @@ valid admin address before any admin-gated operation.
 
 ---
 
-## Lifecycle (codes 4, 14, 20, 21, 45)
+## Lifecycle (codes 4, 14, 20, 21, 51)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
@@ -37,7 +37,7 @@ valid admin address before any admin-gated operation.
 | 14   | `AlreadyInitialized` | `init()` called more than once. |
 | 20   | `CreditLineSuspended` | Draw or admin action on a suspended credit line. |
 | 21   | `CreditLineDefaulted` | Draw or admin action on a defaulted credit line. |
-| 45   | `AlreadySettled` | The liquidation for this (borrower, settlement_id) pair has already been processed. |
+| 51   | `AlreadySettled` | The liquidation for this (borrower, settlement_id) pair has already been processed. |
 
 **Recovery action:**
 - `CreditLineClosed`: No recovery — the line is terminal. Create a new credit
@@ -52,7 +52,7 @@ valid admin address before any admin-gated operation.
 
 ---
 
-## Numeric (codes 5, 7, 12, 33, 34)
+## Numeric (codes 5, 7, 12, 33, 34, 52)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
@@ -62,6 +62,7 @@ valid admin address before any admin-gated operation.
 calculation). |
 | 33   | `TimestampRegression` | Provided or ledger timestamp is not strictly greater than the stored value. |
 | 34   | `LimitOutOfBounds` | Credit limit falls outside the configured `[min_limit, max_limit]` range. |
+| 52   | `InvalidRiskWeight` | Collateral risk weight exceeds 10 000 bps (100 %). |
 
 **Recovery action:**
 - `InvalidAmount`: Re-validate inputs client-side — ensure draw/repay amounts
@@ -74,10 +75,11 @@ calculation). |
   ledger view and retry.
 - `LimitOutOfBounds`: Adjust the proposed limit to `[min_limit, max_limit]`
   using `get_protocol_config()`.
+- `InvalidRiskWeight`: Ensure risk weight is in `0..=10_000` bps.
 
 ---
 
-## Limit (codes 6, 10, 13, 17, 28)
+## Limit (codes 6, 10, 13, 17, 28, 45, 47)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
@@ -86,6 +88,8 @@ calculation). |
 | 13   | `LimitDecreaseRequiresRepayment` | Credit limit decrease below the currently utilized amount. |
 | 17   | `DrawExceedsMaxAmount` | Draw amount exceeds the per-transaction `max_draw_amount`. |
 | 28   | `RepayExceedsMaxAmount` | Repay amount exceeds the per-transaction `max_repay_amount`. |
+| 45   | `CloseFactorAboveMax` | Supplied `close_factor_bps` exceeds the protocol-configured maximum. |
+| 47   | `DrawReversalWindowExpired` | Draw reversal attempted after the allowed reversal window elapsed. |
 
 **Recovery action:**
 - `OverLimit`: Reduce the draw amount to ≤ `credit_limit - utilized`. Query
@@ -97,10 +101,12 @@ calculation). |
 - `DrawExceedsMaxAmount` / `RepayExceedsMaxAmount`: Split the transaction into
   smaller chunks or query `max_draw_amount` / `max_repay_amount` from
   protocol config and adjust the input.
+- `CloseFactorAboveMax`: Reduce `close_factor_bps` to ≤ the protocol max.
+- `DrawReversalWindowExpired`: Reversal no longer possible; the window has passed.
 
 ---
 
-## Liquidity (codes 22, 23, 24, 25, 26, 27, 30, 31)
+## Liquidity (codes 22, 23, 24, 25, 26, 27, 30, 31, 41)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
@@ -113,6 +119,7 @@ where the contract can observe it. |
 | 27   | `InsufficientRepaymentBalance` | Borrower's token balance is below the effective repayment amount. |
 | 30   | `TreasuryNotSet` | Treasury address is not configured when attempting a treasury withdrawal. |
 | 31   | `ExposureCapExceeded` | Draw would push global `TotalUtilized` above `MaxTotalExposure`. |
+| 41   | `BountyNotSet` | Bounty pool address is not configured. |
 
 **Recovery action:**
 - `MissingLiquidityToken` / `MissingLiquiditySource`: Inform the admin to
@@ -127,8 +134,8 @@ where the contract can observe it. |
   into their wallet.
 - `TreasuryNotSet`: Admin must call `set_treasury` before withdrawing.
 - `ExposureCapExceeded`: Reduce the draw amount or wait for other borrowers to
-  repay so the global cap frees headroom. Query `MaxTotalExposure` and current
-  `TotalUtilized` from protocol config.
+  repay so the global cap frees headroom.
+- `BountyNotSet`: Admin must call `set_bounty` before withdrawing.
 
 ---
 
@@ -153,22 +160,22 @@ where the contract can observe it. |
 
 ---
 
-## Oracle (codes 36, 37, 38)
+## Oracle (codes 36, 37, 38, 50)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
 | 36   | `OraclePriceInvalid` | Oracle price is zero, negative, or malformed. |
 | 37   | `OraclePriceStale` | Oracle price exceeds `max_age_seconds` since last update. |
 | 38   | `OraclePriceDeviation` | Oracle price deviation exceeds `max_deviation_bps` relative to prior. |
+| 50   | `OracleQuorumNotMet` | Fewer than `min_quorum_k` prices agree within the deviation bound. |
 
 **Recovery action:**
 - `OraclePriceInvalid`: Ensure the oracle is returning a valid positive price.
-  May indicate a misconfigured oracle address.
 - `OraclePriceStale`: Wait for an oracle price update, or trigger one via the
-  oracle's push mechanism. Query `max_age_seconds` from `OracleConfig`.
-- `OraclePriceDeviation`: A market-moving event or oracle fault. The
-  circuit-breaker has tripped; await a new price within the deviation bound.
-  Do **not** retry with the same price.
+  oracle's push mechanism.
+- `OraclePriceDeviation`: Circuit-breaker tripped; await a new price within the
+  deviation bound. Do **not** retry with the same price.
+- `OracleQuorumNotMet`: Submit prices from more independent oracle feeds.
 
 ---
 
@@ -187,13 +194,14 @@ ensure the requested amount does not exceed it.
 
 ---
 
-## Block (codes 16, 19, 40)
+## Block (codes 16, 19, 40, 46)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
 | 16   | `BorrowerBlocked` | Borrower is on the admin-managed block list. |
 | 19   | `DrawsFrozen` | Global draw freeze is active (admin action for liquidity reserve ops). |
 | 40   | `BorrowerFrozen` | Borrower's draws are temporarily frozen until the specified expiry timestamp. |
+| 46   | `CreditLineFrozen` | Credit line draws are frozen by admin (compliance or investigation hold). |
 
 **Recovery action:**
 - `BorrowerBlocked`: The borrower is permanently blocked. No recovery from the
@@ -201,8 +209,8 @@ ensure the requested amount does not exceed it.
 - `DrawsFrozen`: Inform the user that draws are temporarily frozen. Repayments
   remain open. Retry when the admin unfreezes.
 - `BorrowerFrozen`: Wait for the freeze to expire (or contact the admin to
-  unfreeze early). The freeze is time-bounded and auto-expires; check
-  `get_borrower_frozen_until()` for the remaining duration.
+  unfreeze early). The freeze is time-bounded and auto-expires.
+- `CreditLineFrozen`: Admin-compliance hold; wait for `unfreeze_credit_line`.
 
 ---
 
@@ -215,24 +223,30 @@ ensure the requested amount does not exceed it.
 **Recovery action:** Do **not** retry the same transaction — the reentrancy
 guard prevents the contract from being called again during an ongoing
 operation. Wait for the current transaction to resolve and inspect the on-chain
-state before submitting a new call. If you are integrating a token contract,
-ensure it does not re-enter the credit contract during `transfer` /
-`transfer_from`.
+state before submitting a new call.
 
 ---
 
-## Misc (codes 3, 15)
+## Misc (codes 3, 15, 42, 43, 44, 48, 49)
 
 | Code | Variant | When raised |
 | ---- | ------- | ----------- |
 | 3    | `CreditLineNotFound` | The specified borrower has no credit line. |
 | 15   | `AdminAcceptTooEarly` | Admin acceptance attempted before the `propose_admin` delay elapsed. |
+| 42   | `NoPendingTreasuryWithdrawal` | No pending treasury withdrawal proposal exists. |
+| 43   | `TreasuryTimelockActive` | The 24-hour treasury timelock has not elapsed. |
+| 44   | `TreasuryProposalExists` | A treasury withdrawal proposal already exists. |
+| 48   | `OriginalDrawNotFound` | Original draw audit record not found for reversal. |
+| 49   | `AttestationBatchNotFound` | No attestation batch has been committed for this borrower. |
 
 **Recovery action:**
-- `CreditLineNotFound`: Direct the caller to create a credit line first via
-  `init_credit_line(borrower, limit, ...)`.
-- `AdminAcceptTooEarly`: Wait for the full delay window to elapse. Query
-  `get_pending_admin()` for the scheduled acceptance timestamp.
+- `CreditLineNotFound`: Create a credit line first via `open_credit_line`.
+- `AdminAcceptTooEarly`: Wait for the full delay window to elapse.
+- `NoPendingTreasuryWithdrawal`: Create a proposal via `propose_treasury_withdrawal`.
+- `TreasuryTimelockActive`: Wait for the 24-hour timelock.
+- `TreasuryProposalExists`: Execute or cancel the existing proposal first.
+- `OriginalDrawNotFound`: No reversal possible — no matching draw record.
+- `AttestationBatchNotFound`: Admin must commit a batch first.
 
 ---
 
@@ -241,14 +255,14 @@ ensure it does not re-enter the credit contract during `transfer` /
 | Category | Codes | Count | Dominant SDK recovery |
 | -------- | ----- | ----- | --------------------- |
 | Auth | 1, 2, 32 | 3 | Reconnect wallet / re-deploy with admin init |
-| Lifecycle | 4, 14, 20, 21, 45 | 5 | Await admin action or create new line |
-| Numeric | 5, 7, 12, 33, 34 | 5 | Validate inputs / re-sync ledger view |
-| Limit | 6, 10, 13, 17, 28 | 5 | Reduce amount or repay first |
+| Lifecycle | 4, 14, 20, 21, 51 | 5 | Await admin action or create new line |
+| Numeric | 5, 7, 12, 33, 34, 52 | 6 | Validate inputs / re-sync ledger view |
+| Limit | 6, 10, 13, 17, 28, 45, 47 | 7 | Reduce amount or repay first |
 | Liquidity | 22, 23, 24, 25, 26, 27, 30, 31, 41 | 9 | Replenish allowance / wait for reserve |
 | Risk | 8, 9, 18, 29 | 4 | Clamp inputs / wait for cooldown or unpause |
-| Oracle | 36, 37, 38 | 3 | Await valid price feed |
+| Oracle | 36, 37, 38, 50 | 4 | Await valid price feed |
 | Collateral | 35, 39 | 2 | Reduce withdrawal amount |
-| Block | 16, 19, 40 | 3 | Contact admin or wait for unfreeze / expiry |
+| Block | 16, 19, 40, 46 | 4 | Contact admin or wait for unfreeze / expiry |
 | Reentrancy | 11 | 1 | Do not retry; inspect on-chain state |
-| Misc | 3, 15, 42, 43, 44 | 5 | Create line first / wait for delay |
-| **Total** | 1–45 | **45** | — |
+| Misc | 3, 15, 42, 43, 44, 48, 49 | 7 | Create line first / wait for delay |
+| **Total** | 1–52 | **52** | — |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -47,7 +47,6 @@ Rules enforced by CI (`tests/error_discriminants.rs`):
 | `17` | `DrawExceedsMaxAmount`           | The requested draw amount exceeds the per-transaction cap set via `set_max_draw_amount`. | Split the draw into smaller transactions or request a cap increase from the admin. |
 | `18` | `Paused`                         | The protocol is paused via the emergency circuit breaker; operation is blocked. | Wait for the admin to unpause the protocol via `set_protocol_paused(false)`. `repay_credit` remains active during a pause. |
 | `19` | `DrawsFrozen`                    | Draws are globally frozen during liquidity reserve operations. | Wait for the admin to call `unfreeze_draws`. Repayments remain available. |
-| `41` | `CreditLineFrozen`               | The credit line has an admin freeze with structured reason; draws are blocked. | Wait for admin `unfreeze_credit_line` or resolve the underlying hold. Repayments remain available. |
 | `20` | `CreditLineSuspended`            | A draw was attempted while the credit line status is `Suspended`. | Reinstate the line or resolve the suspension before drawing. |
 | `21` | `CreditLineDefaulted`            | A draw was attempted while the credit line status is `Defaulted`. | Defaulted lines cannot draw; use repayment or liquidation workflows. |
 | `22` | `MissingLiquidityToken`          | `draw_credit` or `repay_credit` requires a liquidity token, but none is configured. | Admin must call `set_liquidity_token` before liquidity-moving operations. |
@@ -56,7 +55,31 @@ Rules enforced by CI (`tests/error_discriminants.rs`):
 | `25` | `LiquidityTokenCallFailed`       | A liquidity token interaction failed where the contract can expose a canonical token-call failure. | Inspect the configured token contract and retry only after the token issue is resolved. |
 | `26` | `InsufficientRepaymentAllowance` | The borrower has not approved enough liquidity token allowance for `repay_credit`. | Approve at least the effective repayment amount for the credit contract. |
 | `27` | `InsufficientRepaymentBalance`   | The borrower's liquidity token balance is below the effective repayment amount. | Transfer or mint enough tokens to the borrower before retrying repayment. |
-| `45` | `AlreadySettled`                 | The liquidation for this (borrower, settlement_id) pair has already been settled. | No action needed — the settlement has already been processed. |
+| `28` | `RepayExceedsMaxAmount`          | The requested repay exceeds the per-transaction cap. | Split into smaller transactions. |
+| `29` | `DrawCooldownActive`             | Borrower attempted to draw before cooldown elapsed. | Wait for the cooldown interval. |
+| `30` | `TreasuryNotSet`                 | Treasury address is not configured. | Admin must call `set_treasury`. |
+| `31` | `ExposureCapExceeded`            | Draw would exceed the global protocol exposure cap. | Reduce draw amount or wait for repayments. |
+| `32` | `AdminNotInitialized`            | Admin address has not been initialized. | Deployer must call `init()` first. |
+| `33` | `TimestampRegression`            | Timestamp regression detected. | Re-sync ledger view and retry. |
+| `34` | `LimitOutOfBounds`               | Credit limit outside configured min/max bounds. | Adjust limit to `[min, max]` range. |
+| `35` | `CollateralRatioBelowMinimum`    | Collateral ratio is below the minimum required. | Reduce withdrawal or add collateral. |
+| `36` | `OraclePriceInvalid`             | Oracle price is zero, negative, or malformed. | Ensure oracle returns a valid positive price. |
+| `37` | `OraclePriceStale`               | Oracle price exceeds `max_age_seconds`. | Wait for oracle price update. |
+| `38` | `OraclePriceDeviation`           | Oracle price deviation exceeds configured maximum. | Do not retry with same price; await new price. |
+| `39` | `InsufficientCollateralBalance`  | Borrower's collateral balance is below the withdrawal amount. | Reduce withdrawal amount. |
+| `40` | `BorrowerFrozen`                 | Borrower's draws are temporarily frozen until expiry. | Wait for freeze expiry or contact admin. |
+| `41` | `BountyNotSet`                   | Bounty pool address is not configured. | Admin must call `set_bounty`. |
+| `42` | `NoPendingTreasuryWithdrawal`    | No pending treasury withdrawal proposal exists. | Create a proposal first via `propose_treasury_withdrawal`. |
+| `43` | `TreasuryTimelockActive`         | The 24-hour treasury timelock has not elapsed. | Wait for timelock. |
+| `44` | `TreasuryProposalExists`         | A treasury withdrawal proposal already exists. | Execute or cancel the existing proposal. |
+| `45` | `CloseFactorAboveMax`            | The supplied close_factor_bps exceeds the protocol maximum. | Reduce close_factor_bps. |
+| `46` | `CreditLineFrozen`               | Credit line draws are frozen by admin (compliance hold). | Wait for admin `unfreeze_credit_line`. |
+| `47` | `DrawReversalWindowExpired`      | Draw reversal attempted after the allowed window expired. | Reversal no longer possible. |
+| `48` | `OriginalDrawNotFound`           | Original draw record not found for reversal. | No matching draw record. |
+| `49` | `AttestationBatchNotFound`       | No attestation batch has been committed. | Admin must commit a batch first. |
+| `50` | `OracleQuorumNotMet`             | Oracle quorum condition not satisfied. | Submit prices from more feeds. |
+| `51` | `AlreadySettled`                 | Liquidation for this (borrower, id) already processed. | No action needed — already settled. |
+| `52` | `InvalidRiskWeight`              | Collateral risk weight exceeds 10 000 bps. | Ensure risk weight is in `0..=10_000`. |
 
 ---
 


### PR DESCRIPTION
## Summary

Group all 52 `ContractError` variants into an 11-category taxonomy with a stable `ContractErrorCategory` enum and comprehensive documentation. This enables SDK clients, indexers, and front-end integrators to handle errors by category instead of matching on individual error codes.

Closes #768

## Changes

### Source code
- **contracts/credit/src/types.rs** — Added `ContractErrorCategory` enum (11 stable `#[repr(u32)]` variants: Auth=1, Lifecycle=2, Numeric=3, Limit=4, Liquidity=5, Risk=6, Oracle=7, Collateral=8, Block=9, Reentrancy=10, Misc=11). Added `ContractError::category()` method mapping all 52 variants. Added 3 new error variants: `OracleQuorumNotMet=50`, `AlreadySettled=51`, `InvalidRiskWeight=52`. Updated discriminant table doc comment.
- **contracts/credit/tests/error_discriminants.rs** — Full rewrite: tests all 52 variant discriminants, 11 category discriminants, every variant-to-category mapping, coverage of all categories.
- **contracts/credit/src/lib.rs** — Fixed stale comment (38 → 52 variants).

### Documentation
- **docs/ERROR_CODES.md** — Complete rewrite with 11-category taxonomy, code tables, SDK recovery actions, and summary.
- **docs/error-taxonomy.md** — Updated for all 52 variants with recovery actions per category.
- **docs/contract-errors.md** — Updated code table (codes 1–52) and category table.
- **docs/errors.md** — Updated error code table to cover all 52 variants.

## File listing

| File | Change |
|------|--------|
| `contracts/credit/src/types.rs` | Added ContractErrorCategory + category() + 3 variants |
| `contracts/credit/src/lib.rs` | Comment fix (38→52) |
| `contracts/credit/tests/error_discriminants.rs` | Full rewrite for 52 variants |
| `docs/ERROR_CODES.md` | Complete rewrite with 11 categories |
| `docs/error-taxonomy.md` | Updated for 52 variants |
| `docs/contract-errors.md` | Updated code + category tables |
| `docs/errors.md` | Updated code table |

## Testing

- `cargo test -p creditra-credit --test error_discriminants` validates all discriminant and category assertions
- Category mapping tests cover every variant-to-category relationship
- Existing integration tests for error paths preserved

## API changes

- **New public enum**: `ContractErrorCategory` (11 variants, published at `creditra_credit::types`)
- **New public method**: `ContractError::category() -> ContractErrorCategory`
- **New error codes**: `OracleQuorumNotMet` (50), `AlreadySettled` (51), `InvalidRiskWeight` (52)