### PR TITLE
feat: cross-contract version handshake negotiation (close #797)

### DIFF
--- a/contracts/creditra-credit/src/contract.rs
+++ b/contracts/creditra-credit/src/contract.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
 };
 
 use crate::error::ContractError;
+use crate::handshake::{self, ProtocolVersion};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{
     Config, CreditLine, Draw, DrawAction, DrawAuditEntry, CONFIG, CREDIT_LINE_COUNT, CREDIT_LINES,
@@ -22,6 +23,7 @@ pub fn instantiate(
     let config = Config { owner };
     CONFIG.save(deps.storage, &config)?;
     CREDIT_LINE_COUNT.save(deps.storage, &0)?;
+    handshake::initialize_version(deps.storage)?;
     Ok(Response::default())
 }
 
@@ -63,6 +65,9 @@ pub fn execute(
             draw_id,
             memo,
         } => execute_add_audit_memo(deps, env, info, credit_line_id, draw_id, memo),
+        ExecuteMsg::UpdateProtocolVersion { major, minor } => {
+            execute_update_protocol_version(deps, info, major, minor)
+        }
     }
 }
 
@@ -215,6 +220,24 @@ pub fn execute_add_audit_memo(
         .add_attribute("draw_id", draw_id.to_string()))
 }
 
+pub fn execute_update_protocol_version(
+    deps: DepsMut,
+    info: MessageInfo,
+    major: u32,
+    minor: u32,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+    let version = ProtocolVersion { major, minor };
+    handshake::set_protocol_version(deps, version)?;
+    Ok(Response::default()
+        .add_attribute("action", "update_protocol_version")
+        .add_attribute("major", major.to_string())
+        .add_attribute("minor", minor.to_string()))
+}
+
 fn append_audit_entry(
     deps: DepsMut,
     env: Env,
@@ -255,6 +278,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             let resp = views::query_draw_audit_trail(deps, credit_line_id, draw_id)
                 .map_err(|e| StdError::generic_err(e.to_string()))?;
             to_json_binary(&resp)
+        }
+        QueryMsg::ProtocolVersion {} => {
+            let version = handshake::query_protocol_version(deps)?;
+            to_json_binary(&version)
         }
     }
 }

--- a/contracts/creditra-credit/src/handshake.rs
+++ b/contracts/creditra-credit/src/handshake.rs
@@ -1,0 +1,288 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Deps, DepsMut, StdResult, Storage};
+use cw_storage_plus::Item;
+
+/// Protocol version for cross-contract handshake negotiation.
+///
+/// Uses a (major, minor) scheme where major version changes
+/// indicate breaking protocol changes and minor version bumps
+/// indicate backward-compatible additions.
+#[cw_serde]
+#[derive(Copy, Eq, Ord, PartialOrd)]
+pub struct ProtocolVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl ProtocolVersion {
+    /// Check whether two versions share a common major version,
+    /// meaning they *may* be wire-compatible.
+    pub fn is_compatible_with(&self, other: &ProtocolVersion) -> bool {
+        self.major == other.major
+    }
+
+    /// Check whether `self` meets or exceeds a minimum version floor.
+    /// Major must match and minor must be >= the minimum.
+    pub fn meets_minimum(&self, min: &ProtocolVersion) -> bool {
+        self.major == min.major && self.minor >= min.minor
+    }
+
+    /// Negotiate a mutually supported protocol version between two peers.
+    ///
+    /// # Conditions
+    ///
+    /// 1. Both sides must share the same major version.
+    /// 2. `our_version` must meet `their_min_compat` (we are recent enough for them).
+    /// 3. `their_version` must meet `our_min_compat` (they are recent enough for us).
+    ///
+    /// When all conditions are satisfied the negotiated version is the
+    /// *lower* of the two actual versions, ensuring both sides can
+    /// communicate under that protocol revision.
+    pub fn negotiate(
+        our_version: &ProtocolVersion,
+        their_version: &ProtocolVersion,
+        our_min_compat: &ProtocolVersion,
+        their_min_compat: &ProtocolVersion,
+    ) -> Option<ProtocolVersion> {
+        if our_version.major != their_version.major {
+            return None;
+        }
+        if !our_version.meets_minimum(their_min_compat) {
+            return None;
+        }
+        if !their_version.meets_minimum(our_min_compat) {
+            return None;
+        }
+        Some(ProtocolVersion {
+            major: our_version.major,
+            minor: our_version.minor.min(their_version.minor),
+        })
+    }
+}
+
+/// The current protocol version of this contract.
+pub const CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion { major: 1, minor: 0 };
+
+/// The minimum protocol version this contract can interoperate with.
+pub const MIN_COMPATIBLE_VERSION: ProtocolVersion = ProtocolVersion { major: 1, minor: 0 };
+
+/// Storage item for the on-chain protocol version.
+pub const PROTOCOL_VERSION: Item<ProtocolVersion> = Item::new("protocol_version");
+
+/// Initialize the stored protocol version on first deploy.
+/// Idempotent – safe to call on re-instantiation.
+pub fn initialize_version(storage: &mut dyn Storage) -> StdResult<()> {
+    if PROTOCOL_VERSION.may_load(storage)?.is_none() {
+        PROTOCOL_VERSION.save(storage, &CURRENT_PROTOCOL_VERSION)?;
+    }
+    Ok(())
+}
+
+/// Return the stored protocol version.
+pub fn query_protocol_version(deps: Deps) -> StdResult<ProtocolVersion> {
+    PROTOCOL_VERSION.load(deps.storage)
+}
+
+/// Overwrite the stored protocol version.  Use during upgrades.
+pub fn set_protocol_version(deps: DepsMut, version: ProtocolVersion) -> StdResult<ProtocolVersion> {
+    PROTOCOL_VERSION.save(deps.storage, &version)?;
+    Ok(version)
+}
+
+/// Verify that two versions are mutually compatible.
+///
+/// Each version must be wire-compatible with the other
+/// (same major version in both directions).
+pub fn verify_peer_version(
+    our_version: &ProtocolVersion,
+    peer_version: &ProtocolVersion,
+) -> bool {
+    our_version.is_compatible_with(peer_version) && peer_version.is_compatible_with(our_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::mock_dependencies;
+
+    fn v(major: u32, minor: u32) -> ProtocolVersion {
+        ProtocolVersion { major, minor }
+    }
+
+    mod is_compatible_with {
+        use super::*;
+
+        #[test]
+        fn same_major() {
+            assert!(v(1, 0).is_compatible_with(&v(1, 5)));
+            assert!(v(2, 3).is_compatible_with(&v(2, 0)));
+        }
+
+        #[test]
+        fn different_major() {
+            assert!(!v(1, 0).is_compatible_with(&v(2, 0)));
+            assert!(!v(3, 1).is_compatible_with(&v(2, 9)));
+        }
+
+        #[test]
+        fn equal_versions() {
+            assert!(v(1, 0).is_compatible_with(&v(1, 0)));
+        }
+    }
+
+    mod meets_minimum {
+        use super::*;
+
+        #[test]
+        fn exactly_at_minimum() {
+            assert!(v(1, 0).meets_minimum(&v(1, 0)));
+        }
+
+        #[test]
+        fn above_minimum() {
+            assert!(v(1, 5).meets_minimum(&v(1, 3)));
+        }
+
+        #[test]
+        fn below_minimum() {
+            assert!(!v(1, 2).meets_minimum(&v(1, 5)));
+        }
+
+        #[test]
+        fn different_major_even_with_high_minor() {
+            assert!(!v(2, 99).meets_minimum(&v(1, 0)));
+        }
+    }
+
+    mod negotiate {
+        use super::*;
+
+        #[test]
+        fn both_sides_meet_minimums() {
+            let result = ProtocolVersion::negotiate(&v(1, 5), &v(1, 3), &v(1, 1), &v(1, 0));
+            assert_eq!(result, Some(v(1, 3)));
+        }
+
+        #[test]
+        fn incompatible_major_versions() {
+            let result = ProtocolVersion::negotiate(&v(1, 0), &v(2, 0), &v(1, 0), &v(2, 0));
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn our_version_too_low_for_their_minimum() {
+            let result = ProtocolVersion::negotiate(&v(1, 0), &v(1, 5), &v(1, 0), &v(1, 2));
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn their_version_too_low_for_our_minimum() {
+            let result = ProtocolVersion::negotiate(&v(1, 5), &v(1, 0), &v(1, 3), &v(1, 0));
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn picks_lower_of_two_versions() {
+            let result = ProtocolVersion::negotiate(&v(1, 5), &v(1, 3), &v(1, 0), &v(1, 0));
+            assert_eq!(result, Some(v(1, 3)));
+
+            let result = ProtocolVersion::negotiate(&v(1, 2), &v(1, 7), &v(1, 0), &v(1, 0));
+            assert_eq!(result, Some(v(1, 2)));
+        }
+
+        #[test]
+        fn equal_versions_negotiate_to_self() {
+            let result = ProtocolVersion::negotiate(&v(1, 0), &v(1, 0), &v(1, 0), &v(1, 0));
+            assert_eq!(result, Some(v(1, 0)));
+        }
+
+        #[test]
+        fn both_sides_exactly_at_each_others_minimum() {
+            let result = ProtocolVersion::negotiate(&v(1, 2), &v(1, 3), &v(1, 1), &v(1, 0));
+            assert_eq!(result, Some(v(1, 2)));
+        }
+
+        #[test]
+        fn zero_version() {
+            let result = ProtocolVersion::negotiate(&v(0, 0), &v(0, 0), &v(0, 0), &v(0, 0));
+            assert_eq!(result, Some(v(0, 0)));
+        }
+
+        #[test]
+        fn version_zero_and_one_different_major() {
+            let result = ProtocolVersion::negotiate(&v(0, 5), &v(1, 0), &v(0, 0), &v(1, 0));
+            assert_eq!(result, None);
+        }
+    }
+
+    mod verify_peer_version {
+        use super::*;
+
+        #[test]
+        fn same_major_is_compatible() {
+            assert!(verify_peer_version(&v(1, 0), &v(1, 2)));
+            assert!(verify_peer_version(&v(2, 5), &v(2, 0)));
+        }
+
+        #[test]
+        fn different_major_is_incompatible() {
+            assert!(!verify_peer_version(&v(1, 0), &v(2, 0)));
+            assert!(!verify_peer_version(&v(3, 1), &v(2, 9)));
+        }
+    }
+
+    mod storage {
+        use super::*;
+
+        #[test]
+        fn initialize_version_sets_default() {
+            let mut deps = mock_dependencies();
+            initialize_version(deps.as_mut().storage).unwrap();
+            let stored = PROTOCOL_VERSION.load(deps.as_ref().storage).unwrap();
+            assert_eq!(stored, CURRENT_PROTOCOL_VERSION);
+        }
+
+        #[test]
+        fn initialize_version_is_idempotent() {
+            let mut deps = mock_dependencies();
+            initialize_version(deps.as_mut().storage).unwrap();
+
+            let custom = v(2, 0);
+            PROTOCOL_VERSION.save(deps.as_mut().storage, &custom).unwrap();
+
+            initialize_version(deps.as_mut().storage).unwrap();
+            let stored = PROTOCOL_VERSION.load(deps.as_ref().storage).unwrap();
+            assert_eq!(stored, custom);
+        }
+
+        #[test]
+        fn query_protocol_version_returns_stored() {
+            let mut deps = mock_dependencies();
+            initialize_version(deps.as_mut().storage).unwrap();
+
+            let queried = query_protocol_version(deps.as_ref()).unwrap();
+            assert_eq!(queried, CURRENT_PROTOCOL_VERSION);
+        }
+
+        #[test]
+        fn set_protocol_version_overwrites() {
+            let mut deps = mock_dependencies();
+            initialize_version(deps.as_mut().storage).unwrap();
+
+            let new_ver = v(2, 1);
+            let returned = set_protocol_version(deps.as_mut(), new_ver).unwrap();
+            assert_eq!(returned, new_ver);
+
+            let stored = PROTOCOL_VERSION.load(deps.as_ref().storage).unwrap();
+            assert_eq!(stored, new_ver);
+        }
+
+        #[test]
+        fn set_protocol_version_returns_new_version() {
+            let mut deps = mock_dependencies();
+            let ver = v(3, 0);
+            let result = set_protocol_version(deps.as_mut(), ver).unwrap();
+            assert_eq!(result, ver);
+        }
+    }
+}

--- a/contracts/creditra-credit/src/lib.rs
+++ b/contracts/creditra-credit/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod error;
+pub mod handshake;
 pub mod msg;
 pub mod state;
 pub mod views;

--- a/contracts/creditra-credit/src/msg.rs
+++ b/contracts/creditra-credit/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Timestamp};
 
+use crate::handshake::ProtocolVersion;
 use crate::state::DrawAuditEvent;
 
 #[cw_serde]
@@ -31,6 +32,10 @@ pub enum ExecuteMsg {
         draw_id: u64,
         memo: String,
     },
+    UpdateProtocolVersion {
+        major: u32,
+        minor: u32,
+    },
 }
 
 #[cw_serde]
@@ -41,6 +46,8 @@ pub enum QueryMsg {
         credit_line_id: u64,
         draw_id: Option<u64>,
     },
+    #[returns(ProtocolVersion)]
+    ProtocolVersion {},
 }
 
 #[cw_serde]


### PR DESCRIPTION
## Summary

Implements cross-contract protocol version negotiation for the `creditra-credit` CosmWasm contract, as specified in #797. Allows peer contracts to query, verify, and negotiate a mutually supported protocol version before engaging in cross-contract calls.

## Changes

### New file: `contracts/creditra-credit/src/handshake.rs`

Core version negotiation module:

| Export | Purpose |
|---|---|
| `ProtocolVersion { major, minor }` | Semver-like version struct with `Copy`, `Eq`, `Ord` |
| `ProtocolVersion::is_compatible_with()` | Same-major compatibility check |
| `ProtocolVersion::meets_minimum()` | Version meets a required floor |
| `ProtocolVersion::negotiate()` | Two-sided mutual negotiation – checks major alignment, both min-compat constraints, returns the lower common version |
| `CURRENT_PROTOCOL_VERSION` | Constant `{ 1, 0 }` |
| `MIN_COMPATIBLE_VERSION` | Constant `{ 1, 0 }` |
| `initialize_version()` | Idempotent storage init (safe on re-instantiation) |
| `query_protocol_version()` | Read from on-chain storage |
| `set_protocol_version()` | Write to on-chain storage |
| `verify_peer_version()` | Two-way mutual wire-compatibility predicate |

### Modified files

| File | Change |
|---|---|
| `contracts/creditra-credit/src/lib.rs` | Added `pub mod handshake;` |
| `contracts/creditra-credit/src/msg.rs` | New `ExecuteMsg::UpdateProtocolVersion { major, minor }` and `QueryMsg::ProtocolVersion {}` |
| `contracts/creditra-credit/src/contract.rs` | Version initialized on instantiate; `execute_update_protocol_version` handler with owner-only auth; version query branch in `query` |

### Security

- `execute_update_protocol_version` requires `info.sender == config.owner` (owner-only)
- No `unwrap()` in any production path
- No unsafe math – only comparisons on `u32` fields
- `initialize_version` is idempotent (uses `may_load` + `is_none`)

### Tests (23 unit tests)

```
handshake::tests
├── is_compatible_with (3): same major, different major, equal
├── meets_minimum (4): at/above/below floor, different major rejection
├── negotiate (9): success, incompatible major, both low-side edges, picks lower, equal, at-min boundaries, zero versions, cross-major zero
├── verify_peer_version (2): compatible and incompatible
└── storage (5): init sets default, init is idempotent, query returns stored, set overwrites, set returns value
```

## How to verify

```sh
cd contracts/creditra-credit
cargo test
cargo clippy -- -D warnings
```

## Closes

Closes #797