### PR TITLE
feat: InsufficientCollateralBalance

### DIFF
--- a/contracts/creditra-credit/src/error.rs
+++ b/contracts/creditra-credit/src/error.rs
@@ -24,6 +24,15 @@ pub enum ContractError {
     #[error("CollateralInsufficient")]
     CollateralInsufficient,
 
+    /// Borrower's collateral balance is below the requested withdrawal amount.
+    ///
+    /// Raised when a borrower attempts to withdraw more collateral than their
+    /// current deposited balance. Distinct from `CollateralInsufficient` (which
+    /// covers general insufficiency) and `CollateralRatioBelowMinimum` (which
+    /// covers health-factor constraints).
+    #[error("InsufficientCollateralBalance")]
+    InsufficientCollateralBalance,
+
     /// The requested amount is invalid (e.g., zero or negative where positive is expected).
     #[error("InvalidAmount")]
     InvalidAmount,
@@ -87,5 +96,22 @@ mod tests {
         assert_eq!(err.to_string(), "InvalidAmount");
         assert_eq!(err, ContractError::InvalidAmount);
         assert_ne!(err, ContractError::Unauthorized);
+    }
+
+    #[test]
+    fn insufficient_collateral_balance_display_and_equality() {
+        let err = ContractError::InsufficientCollateralBalance;
+        assert_eq!(err.to_string(), "InsufficientCollateralBalance");
+        assert_eq!(err, ContractError::InsufficientCollateralBalance);
+        assert_ne!(err, ContractError::CollateralInsufficient);
+        assert_ne!(err, ContractError::Unauthorized);
+    }
+
+    #[test]
+    fn insufficient_collateral_balance_is_distinct_from_collateral_insufficient() {
+        let balance_err = ContractError::InsufficientCollateralBalance;
+        let insufficient_err = ContractError::CollateralInsufficient;
+        assert_ne!(balance_err, insufficient_err);
+        assert_ne!(balance_err.to_string(), insufficient_err.to_string());
     }
 }


### PR DESCRIPTION
## Summary

Closes #770

Adds `ContractError::InsufficientCollateralBalance` as a distinct error code to the CosmWasm `creditra-credit` package, matching the existing Soroban contract's error variant.

## Changes

### `contracts/creditra-credit/src/error.rs`
- **Added `InsufficientCollateralBalance` variant** to `ContractError` enum
  - NatSpec-documented as distinct from `CollateralInsufficient` (general insufficiency) and `CollateralRatioBelowMinimum` (health-factor constraints)
  - Display string: `"InsufficientCollateralBalance"`
- **Added 2 focused tests**:
  - `insufficient_collateral_balance_display_and_equality` — verifies display string, self-equality, and inequality with `CollateralInsufficient` and `Unauthorized`
  - `insufficient_collateral_balance_is_distinct_from_collateral_insufficient` — explicit distinctness assertion between the two collateral errors

### `contracts/creditra-credit/src/errors.rs`
- No changes needed — already re-exports `ContractError` via `pub use crate::error::ContractError`

## Context

The Soroban contract (`contracts/credit/src/types.rs`) already defines `InsufficientCollateralBalance = 39` (discriminant 39, category `Collateral`). This PR adds the corresponding variant to the CosmWasm package for parity.

## Verification

Tests added follow the existing pattern in the test module (display string, equality, distinctness assertions).