### PR TITLE
feat: Dutch stepped decay

### DIFF
--- a/gateway-contract/contracts/auction_contract/auction.md
+++ b/gateway-contract/contracts/auction_contract/auction.md
@@ -399,6 +399,14 @@ Integration coverage: `tests/panic_with_error.rs`.
 
 Defined in `errors.rs`:
 
+## DecayCurve helper
+
+The crate includes a small `src/curves.rs` helper exposing `DecayCurve` and
+`calculate_price`. A new `DutchStepped` variant is available which splits the
+total drop between `start_price` and `floor_price` across equal-duration
+buckets; see `tests/dutch_stepped_variant.rs` for examples and expected
+behaviour.
+
 - `NotWinner`
 - `AlreadyClaimed`
 - `NotClosed`

--- a/gateway-contract/contracts/auction_contract/src/curves.rs
+++ b/gateway-contract/contracts/auction_contract/src/curves.rs
@@ -8,7 +8,18 @@ pub enum DecayCurve {
 
     /// Stepped decay: price reduces every interval
     /// price = start_price - (steps * step_size)
+
     Stepped { step_size: u128, interval: u64 },
+
+    /// Dutch-style stepped decay that splits the total drop from
+    /// `start_price` down to `floor_price` across `steps` equal-duration
+    /// buckets. The price is constant within a bucket and only drops at
+    /// bucket boundaries.
+    ///
+    /// The variant stores the `floor_price` and `steps` (number of buckets).
+    /// `duration` is provided to `calculate_price` via the variant to allow
+    /// computing bucket indices safely inside the curve implementation.
+    DutchStepped { floor_price: u128, steps: u128, duration: u64 },
 
     /// Exponential decay using fixed-point factor
     /// price = start_price * factor^time (scaled)
@@ -57,6 +68,32 @@ pub fn calculate_price(
                 .ok_or(CurveError::Overflow)?;
 
             Ok(start_price.saturating_sub(decay))
+        }
+
+        DecayCurve::DutchStepped { floor_price, steps, duration } => {
+            if *duration == 0 || *steps == 0 {
+                return Err(CurveError::InvalidInput);
+            }
+
+            // total drop from start to floor
+            let total_drop = start_price.saturating_sub(*floor_price);
+
+            // elapsed steps = floor(elapsed * steps / duration)
+            let elapsed_steps = (elapsed as u128)
+                .checked_mul(*steps)
+                .ok_or(CurveError::Overflow)?
+                / (*duration as u128);
+
+            let q = total_drop / *steps;
+            let r = total_drop % *steps;
+
+            let drop = q
+                .checked_mul(elapsed_steps)
+                .ok_or(CurveError::Overflow)?
+                .checked_add((r.checked_mul(elapsed_steps).ok_or(CurveError::Overflow)? / *steps))
+                .ok_or(CurveError::Overflow)?;
+
+            Ok(start_price.saturating_sub(drop))
         }
 
         DecayCurve::Exponential { factor, scale } => {

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -4,10 +4,12 @@ mod errors;
 mod events;
 mod storage;
 mod types;
+mod curves;
 
 pub use errors::AuctionError;
 pub use events::BidRefundedEvent;
 pub use types::{AuctionMode, AuctionState, AuctionStatus, DutchAuctionDecay};
+pub use curves::{DecayCurve, calculate_price, CurveError};
 
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env, Symbol};
 

--- a/gateway-contract/contracts/auction_contract/tests/dutch_stepped_variant.rs
+++ b/gateway-contract/contracts/auction_contract/tests/dutch_stepped_variant.rs
@@ -1,0 +1,29 @@
+use gateway_auction::{calculate_price, CurveError, DecayCurve};
+
+#[test]
+fn test_dutch_stepped_boundary_prices() {
+    let start = 1200u128;
+    let floor = 600u128;
+    let duration = 3600u64;
+    let steps = 6u128;
+
+    let curve = DecayCurve::DutchStepped { floor_price: floor, steps, duration };
+
+    assert_eq!(calculate_price(start, 0, &curve).unwrap(), 1200);
+    assert_eq!(calculate_price(start, 599, &curve).unwrap(), 1200);
+    assert_eq!(calculate_price(start, 600, &curve).unwrap(), 1100);
+    assert_eq!(calculate_price(start, 3599, &curve).unwrap(), 700);
+    assert_eq!(calculate_price(start, 3600, &curve).unwrap(), 600);
+}
+
+#[test]
+fn test_dutch_stepped_invalid_inputs() {
+    let start = 1000u128;
+    // zero steps is invalid
+    let curve = DecayCurve::DutchStepped { floor_price: 500, steps: 0, duration: 100 };
+    assert!(matches!(calculate_price(start, 10, &curve), Err(CurveError::InvalidInput)));
+
+    // zero duration is invalid
+    let curve2 = DecayCurve::DutchStepped { floor_price: 500, steps: 5, duration: 0 };
+    assert!(matches!(calculate_price(start, 10, &curve2), Err(CurveError::InvalidInput)));
+}


### PR DESCRIPTION
Closes #751

---

Implements a Dutch-stepped decay price curve variant and adds focused tests and docs.

Changes:
- `DecayCurve::DutchStepped` in `src/curves.rs` with safe arithmetic and input validation.
- Re-export `DecayCurve`, `calculate_price`, and `CurveError` from crate root.
- Tests: `tests/dutch_stepped_variant.rs` covering boundary behavior and invalid inputs.
- Docs: brief note in `auction.md`.

All changes are on branch `feature/dutch-stepped` in fork `Lazaruster/Creditra-Contracts`. Please run CI to validate.