### PR TITLE
feat: admin freeze cooldown for critical actions (v7)

### DIFF
--- a/contracts/credit/src/freeze.rs
+++ b/contracts/credit/src/freeze.rs
@@ -29,7 +29,9 @@
 
 use crate::auth::require_admin_auth;
 use crate::events::{publish_credit_line_freeze_event, publish_draws_frozen_event};
-use crate::storage::{get_credit_line, DataKey};
+use crate::storage::{
+    enforce_freeze_cooldown, get_credit_line, record_freeze_timestamp_if_cooldown, DataKey,
+};
 use crate::types::{ContractError, DrawsFreezeState, FreezeReason};
 use soroban_sdk::{Address, Env};
 
@@ -46,6 +48,7 @@ use soroban_sdk::{Address, Env};
 /// Emits [`DrawsFrozenEvent`] with `frozen = true` and the supplied `reason`.
 pub fn freeze_draws(env: Env, reason: FreezeReason) {
     require_admin_auth(&env);
+    enforce_freeze_cooldown(&env);
     env.storage().instance().set(
         &DataKey::DrawsFrozen,
         &DrawsFreezeState {
@@ -54,6 +57,7 @@ pub fn freeze_draws(env: Env, reason: FreezeReason) {
         },
     );
     publish_draws_frozen_event(&env, true, reason);
+    record_freeze_timestamp_if_cooldown(&env);
 }
 
 /// Unfreeze draws globally (admin only).
@@ -65,6 +69,7 @@ pub fn freeze_draws(env: Env, reason: FreezeReason) {
 /// (defaults to [`FreezeReason::LiquidityReserve`] when never frozen before).
 pub fn unfreeze_draws(env: Env) {
     require_admin_auth(&env);
+    enforce_freeze_cooldown(&env);
     let reason = get_draws_freeze_state(&env)
         .map(|state| state.reason)
         .unwrap_or(FreezeReason::LiquidityReserve);
@@ -76,6 +81,7 @@ pub fn unfreeze_draws(env: Env) {
         },
     );
     publish_draws_frozen_event(&env, false, reason);
+    record_freeze_timestamp_if_cooldown(&env);
 }
 
 /// Returns `true` when draws are globally frozen.
@@ -104,6 +110,7 @@ pub fn get_draws_freeze_reason(env: &Env) -> Option<FreezeReason> {
 /// Emits [`CreditLineFreezeEvent`] on `("credit", "line_frz")` with `frozen = true`.
 pub fn freeze_credit_line(env: Env, borrower: Address, reason: FreezeReason) {
     require_admin_auth(&env);
+    enforce_freeze_cooldown(&env);
     if get_credit_line(&env, &borrower).is_none() {
         env.panic_with_error(ContractError::CreditLineNotFound);
     }
@@ -111,6 +118,7 @@ pub fn freeze_credit_line(env: Env, borrower: Address, reason: FreezeReason) {
         .persistent()
         .set(&DataKey::CreditLineFreeze(borrower.clone()), &reason);
     publish_credit_line_freeze_event(&env, &borrower, reason, true);
+    record_freeze_timestamp_if_cooldown(&env);
 }
 
 /// Lift a per-credit-line draw freeze (admin only).
@@ -121,6 +129,7 @@ pub fn freeze_credit_line(env: Env, borrower: Address, reason: FreezeReason) {
 /// Emits [`CreditLineFreezeEvent`] with `frozen = false` when a freeze record existed.
 pub fn unfreeze_credit_line(env: Env, borrower: Address) {
     require_admin_auth(&env);
+    enforce_freeze_cooldown(&env);
     let key = DataKey::CreditLineFreeze(borrower.clone());
     let Some(reason) = env
         .storage()
@@ -131,6 +140,7 @@ pub fn unfreeze_credit_line(env: Env, borrower: Address) {
     };
     env.storage().persistent().remove(&key);
     publish_credit_line_freeze_event(&env, &borrower, reason, false);
+    record_freeze_timestamp_if_cooldown(&env);
 }
 
 /// Returns `true` when a credit line has an active admin freeze.

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -188,14 +188,15 @@ use crate::events::{
 use crate::math_utils::{compute_deviation_bps, mul_div, safe_mul_div, Rounding};
 use crate::storage::{
     admin_key, assert_not_paused, clear_borrower_frozen, clear_reentrancy_guard,
-    get_borrower_by_credit_line_id, get_borrower_frozen_until,
+    enforce_freeze_cooldown, get_borrower_by_credit_line_id, get_borrower_frozen_until,
     get_credit_line as storage_get_credit_line, get_last_draw_ts as storage_get_last_draw_ts,
     get_utilization_cap_bps as storage_get_utilization_cap_bps,
     is_borrower_blocked as storage_is_borrower_blocked,
     is_borrower_frozen as storage_is_borrower_frozen, persist_credit_line, proposed_admin_key,
     proposed_at_key, rate_formula_key, set_borrower_blocked as storage_set_borrower_blocked,
     set_borrower_frozen_until, set_borrower_unblocked,
-    set_last_draw_ts as storage_set_last_draw_ts, set_reentrancy_guard,
+    set_last_draw_ts as storage_set_last_draw_ts, record_freeze_timestamp_if_cooldown,
+    set_reentrancy_guard,
     set_utilization_cap_bps as storage_set_utilization_cap_bps, DataKey, MAX_ENUMERATION_LIMIT,
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
@@ -1187,6 +1188,29 @@ impl Credit {
     /// Get the configured minimum draw interval between borrower draws.
     pub fn get_draw_min_interval(env: Env) -> Option<u64> {
         crate::storage::get_draw_min_interval(&env)
+    }
+
+    /// Set the admin freeze cooldown duration in seconds.
+    ///
+    /// When set to a non-zero value, admin freeze/unfreeze actions
+    /// (global draws freeze, per-credit-line freeze, borrower freeze)
+    /// must wait at least `seconds` between successive calls.
+    /// Pass `0` to disable the cooldown.
+    ///
+    /// # Authorization
+    /// Requires admin privileges.
+    pub fn set_freeze_cooldown(env: Env, seconds: u64) {
+        assert_not_paused(&env);
+        require_admin_auth(&env);
+        crate::storage::set_freeze_cooldown_seconds(&env, seconds);
+    }
+
+    /// Get the configured admin freeze cooldown duration in seconds.
+    ///
+    /// Returns `None` when no cooldown is configured (or when it has been
+    /// disabled by passing `0` to `set_freeze_cooldown`).
+    pub fn get_freeze_cooldown(env: Env) -> Option<u64> {
+        crate::storage::get_freeze_cooldown_seconds(&env)
     }
 
     /// Set protocol fee in basis points (applied to interest portion of repayments).
@@ -2379,6 +2403,7 @@ impl Credit {
     pub fn freeze_borrower_until(env: Env, admin: Address, borrower: Address, expiry_ts: u64) {
         admin.require_auth();
         require_admin_auth(&env);
+        enforce_freeze_cooldown(&env);
 
         let now = env.ledger().timestamp();
         if expiry_ts <= now {
@@ -2387,6 +2412,7 @@ impl Credit {
 
         set_borrower_frozen_until(&env, &borrower, expiry_ts);
         publish_borrower_frozen_event(&env, &borrower, expiry_ts);
+        record_freeze_timestamp_if_cooldown(&env);
     }
 
     /// Check whether a borrower's draws are currently frozen.
@@ -2417,7 +2443,9 @@ impl Credit {
     pub fn unfreeze_borrower(env: Env, admin: Address, borrower: Address) {
         admin.require_auth();
         require_admin_auth(&env);
+        enforce_freeze_cooldown(&env);
         clear_borrower_frozen(&env, &borrower);
+        record_freeze_timestamp_if_cooldown(&env);
     }
 
     /// Returns all global protocol configuration in a single call.

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -215,6 +215,13 @@ pub enum DataKey {
     /// When set, draw_credit enforces: utilized_amount <= max_borrower_exposure.
     /// Pass 0 to remove the cap for this borrower.
     MaxBorrowerExposure(Address),
+    /// Admin freeze cooldown duration in seconds.
+    /// When set to a non-zero value, admin freeze/unfreeze actions are gated
+    /// by a minimum interval between successive calls.
+    FreezeCooldownSeconds,
+    /// Ledger timestamp of the last admin freeze or unfreeze action.
+    /// Used with [`FreezeCooldownSeconds`] to enforce the cooldown period.
+    LastFreezeTimestamp,
 }
 
 /// Maximum number of credit lines returned per page.
@@ -1359,4 +1366,68 @@ pub fn set_collateral_token_allowlist(env: &Env, tokens: &soroban_sdk::Vec<Addre
 /// Return `true` when `token` is in the collateral allowlist.
 pub fn is_collateral_token_allowed(env: &Env, token: &Address) -> bool {
     get_collateral_token_allowlist(env).contains(token.clone())
+}
+
+// ── Freeze cooldown helpers ─────────────────────────────────────────────────
+
+/// Get the configured freeze cooldown duration in seconds.
+///
+/// Returns `None` when not configured, meaning no cooldown is enforced.
+/// A value of `0` also means the cooldown is disabled.
+pub fn get_freeze_cooldown_seconds(env: &Env) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&DataKey::FreezeCooldownSeconds)
+        .filter(|&secs: &u64| secs > 0)
+}
+
+/// Set the freeze cooldown duration in seconds.
+///
+/// Pass `0` or `None`-equivalent behaviour: remove the key entirely,
+/// effectively disabling the cooldown.
+pub fn set_freeze_cooldown_seconds(env: &Env, seconds: u64) {
+    if seconds == 0 {
+        env.storage()
+            .instance()
+            .remove(&DataKey::FreezeCooldownSeconds);
+    } else {
+        env.storage()
+            .instance()
+            .set(&DataKey::FreezeCooldownSeconds, &seconds);
+    }
+}
+
+/// Return the ledger timestamp of the last admin freeze/unfreeze action, if any.
+pub fn get_last_freeze_timestamp(env: &Env) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&DataKey::LastFreezeTimestamp)
+}
+
+/// Record a freeze/unfreeze action timestamp, but only when a cooldown is
+/// configured. When no cooldown is set, this is a no-op so that timestamps
+/// recorded before cooldown was enabled never retroactively block actions.
+pub fn record_freeze_timestamp_if_cooldown(env: &Env) {
+    if get_freeze_cooldown_seconds(env).is_some() {
+        set_last_freeze_timestamp(env, env.ledger().timestamp());
+    }
+}
+
+/// Check and enforce the admin freeze cooldown.
+///
+/// If a cooldown is configured and the last freeze action was less than
+/// `cooldown_seconds` ago, this function reverts with
+/// [`crate::types::ContractError::FreezeCooldownActive`].
+///
+/// Call this at the start of every admin freeze/unfreeze entrypoint.
+pub fn enforce_freeze_cooldown(env: &Env) {
+    let Some(cooldown_secs) = get_freeze_cooldown_seconds(env) else {
+        return;
+    };
+    if let Some(last_ts) = get_last_freeze_timestamp(env) {
+        let now = env.ledger().timestamp();
+        if now < last_ts.saturating_add(cooldown_secs) {
+            env.panic_with_error(crate::types::ContractError::FreezeCooldownActive);
+        }
+    }
 }

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -164,6 +164,7 @@ pub enum CreditStatus {
 /// | 51   | `AlreadySettled`               | Lifecycle     | Liquidation settlement already processed for this (borrower, id) pair |
 /// | 52   | `InvalidRiskWeight`            | Numeric       | Collateral risk weight exceeds the maximum allowed (10 000 bps) |
 | 53   | `InvalidAttestation`           | Misc          | Attestation proof is invalid or no attestation batch has been committed |
+| 54   | `FreezeCooldownActive`         | Block         | Admin freeze cooldown has not yet elapsed |
 #[soroban_sdk::contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -274,6 +275,8 @@ pub enum ContractError {
     InvalidRiskWeight = 52,
     /// Attestation proof is invalid or no attestation batch has been committed.
     InvalidAttestation = 53,
+    /// Admin freeze cooldown period has not yet elapsed.
+    FreezeCooldownActive = 54,
 }
 
 /// ABI-stable category label for [`ContractError`] variants.
@@ -388,6 +391,7 @@ impl ContractError {
             Self::DrawsFrozen => Block,
             Self::BorrowerFrozen => Block,
             Self::CreditLineFrozen => Block,
+            Self::FreezeCooldownActive => Block,
             // Reentrancy (10)
             Self::Reentrancy => Reentrancy,
             // Misc (11)
@@ -756,7 +760,8 @@ impl ContractError {
 
             ContractError::BorrowerBlocked
             | ContractError::DrawsFrozen
-            | ContractError::BorrowerFrozen => ContractErrorCategory::Block,
+            | ContractError::BorrowerFrozen
+            | ContractError::FreezeCooldownActive => ContractErrorCategory::Block,
 
             ContractError::Reentrancy => ContractErrorCategory::Reentrancy,
 

--- a/contracts/credit/tests/error_discriminants.rs
+++ b/contracts/credit/tests/error_discriminants.rs
@@ -68,6 +68,7 @@ fn error_discriminants_are_stable() {
     assert_eq!(ContractError::AlreadySettled as u32, 51);
     assert_eq!(ContractError::InvalidRiskWeight as u32, 52);
     assert_eq!(ContractError::InvalidAttestation as u32, 53);
+    assert_eq!(ContractError::FreezeCooldownActive as u32, 54);
 }
 
 /// Verify no two variants share the same discriminant.
@@ -129,6 +130,7 @@ fn no_duplicate_discriminants() {
         ContractError::AlreadySettled as u32,
         ContractError::InvalidRiskWeight as u32,
         ContractError::InvalidAttestation as u32,
+        ContractError::FreezeCooldownActive as u32,
     ];
 
     let unique: HashSet<u32> = codes.iter().cloned().collect();
@@ -142,7 +144,7 @@ fn no_duplicate_discriminants() {
 /// Verify the total variant count matches expectations.
 #[test]
 fn variant_count_is_known() {
-    const EXPECTED_VARIANT_COUNT: usize = 53;
+    const EXPECTED_VARIANT_COUNT: usize = 54;
 
     let codes = [
         ContractError::Unauthorized as u32,
@@ -198,6 +200,7 @@ fn variant_count_is_known() {
         ContractError::AlreadySettled as u32,
         ContractError::InvalidRiskWeight as u32,
         ContractError::InvalidAttestation as u32,
+        ContractError::FreezeCooldownActive as u32,
     ];
 
     assert_eq!(
@@ -506,6 +509,11 @@ fn category_mappings_are_stable() {
         ContractError::InvalidAttestation.category(),
         ContractErrorCategory::Misc
     );
+    // Block (9)
+    assert_eq!(
+        ContractError::FreezeCooldownActive.category(),
+        ContractErrorCategory::Block
+    );
 }
 
 /// Verify every ContractError variant has a known category and that all 11
@@ -568,6 +576,7 @@ fn every_variant_has_known_category() {
         ContractError::AlreadySettled.category(),
         ContractError::InvalidRiskWeight.category(),
         ContractError::InvalidAttestation.category(),
+        ContractError::FreezeCooldownActive.category(),
     ];
 
     let unique: HashSet<ContractErrorCategory> = all_variants.iter().cloned().collect();
@@ -576,7 +585,7 @@ fn every_variant_has_known_category() {
         11,
         "Not all 11 categories are covered by variant mappings"
     );
-    assert_eq!(all_variants.len(), 53, "Expected 53 ContractError variants");
+    assert_eq!(all_variants.len(), 54, "Expected 54 ContractError variants");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contracts/credit/tests/freeze_cooldown.rs
+++ b/contracts/credit/tests/freeze_cooldown.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: MIT
+
+//! Admin freeze cooldown tests for the Credit contract.
+//!
+//! # Coverage
+//! - Cooldown is disabled by default (no `set_freeze_cooldown` call)
+//! - Setting a cooldown and verifying it blocks rapid freeze actions
+//! - Cooldown applies to all freeze/unfreeze entrypoints:
+//!   - freeze_draws
+//!   - unfreeze_draws
+//!   - freeze_credit_line
+//!   - unfreeze_credit_line
+//!   - freeze_borrower_until
+//!   - unfreeze_borrower
+//! - Setting cooldown to 0 disables it
+//! - Cooldown resets after the configured interval elapses
+//! - Cooldown is not retroactive (first action always succeeds)
+//! - get_freeze_cooldown returns None when not configured
+//! - Cooldown is shared across all freeze action types
+
+use creditra_credit::{Credit, CreditClient, FreezeReason};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, Env};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    (env, admin, contract_id)
+}
+
+fn setup_with_token() -> (Env, Address, Address, Address) {
+    let (env, admin, contract_id) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_address = token_id.address();
+    let client = CreditClient::new(&env, &contract_id);
+    client.set_liquidity_token(&token_address);
+    (env, admin, contract_id, token_address)
+}
+
+// ── Cooldown defaults ────────────────────────────────────────────────────────
+
+#[test]
+fn freeze_cooldown_disabled_by_default() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    let cooldown = client.get_freeze_cooldown();
+    assert!(cooldown.is_none(), "cooldown should be None by default");
+}
+
+#[test]
+fn freeze_actions_succeed_when_cooldown_disabled() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Both actions should succeed without any cooldown
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+    client.freeze_draws(&FreezeReason::Compliance);
+    // No panic = success
+}
+
+// ── Cooldown enforcement ─────────────────────────────────────────────────────
+
+#[test]
+fn freeze_draws_blocked_within_cooldown() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&3600); // 1 hour cooldown
+
+    // First freeze succeeds
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // Second freeze within cooldown fails
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.freeze_draws(&FreezeReason::Compliance);
+    }));
+    assert!(
+        result.is_err(),
+        "second freeze_draws must fail within cooldown"
+    );
+}
+
+#[test]
+fn unfreeze_draws_blocked_within_cooldown() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&3600);
+
+    // First action succeeds
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // Unfreeze within cooldown fails
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.unfreeze_draws();
+    }));
+    assert!(
+        result.is_err(),
+        "unfreeze_draws must fail within cooldown"
+    );
+}
+
+#[test]
+fn freeze_credit_line_blocked_within_cooldown() {
+    let (env, _admin, contract_id, _token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+    let borrower2 = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    client.open_credit_line(&borrower2, &1_000, &300, &50);
+
+    client.set_freeze_cooldown(&3600);
+
+    // First freeze succeeds
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+
+    // Second freeze within cooldown fails
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.freeze_credit_line(&borrower2, &FreezeReason::RiskInvestigation);
+    }));
+    assert!(
+        result.is_err(),
+        "second freeze_credit_line must fail within cooldown"
+    );
+}
+
+#[test]
+fn unfreeze_credit_line_blocked_within_cooldown() {
+    let (env, _admin, contract_id, _token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+
+    client.set_freeze_cooldown(&3600);
+
+    // First unfreeze succeeds
+    client.unfreeze_credit_line(&borrower);
+
+    // Second unfreeze within cooldown fails
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.unfreeze_credit_line(&borrower);
+    }));
+    assert!(
+        result.is_err(),
+        "second unfreeze_credit_line must fail within cooldown"
+    );
+}
+
+#[test]
+fn freeze_borrower_until_blocked_within_cooldown() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+    let admin = _admin.clone();
+    let borrower = Address::generate(&env);
+    let borrower2 = Address::generate(&env);
+
+    client.set_freeze_cooldown(&3600);
+
+    let now = env.ledger().timestamp();
+    let future = now + 86_400; // 24 hours from now
+
+    // First freeze succeeds
+    client.freeze_borrower_until(&admin, &borrower, &future);
+
+    // Second freeze within cooldown fails
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.freeze_borrower_until(&admin, &borrower2, &future);
+    }));
+    assert!(
+        result.is_err(),
+        "second freeze_borrower_until must fail within cooldown"
+    );
+}
+
+#[test]
+fn unfreeze_borrower_blocked_within_cooldown() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+    let admin = _admin.clone();
+    let borrower = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let future = now + 86_400;
+    client.freeze_borrower_until(&admin, &borrower, &future);
+
+    client.set_freeze_cooldown(&3600);
+
+    // First unfreeze succeeds
+    client.unfreeze_borrower(&admin, &borrower);
+
+    // Second unfreeze within cooldown fails
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.unfreeze_borrower(&admin, &borrower);
+    }));
+    assert!(
+        result.is_err(),
+        "second unfreeze_borrower must fail within cooldown"
+    );
+}
+
+// ── Cross-entrypoint cooldown sharing ────────────────────────────────────────
+
+#[test]
+fn cooldown_is_shared_across_freeze_types() {
+    let (env, _admin, contract_id, _token_address) = setup_with_token();
+    let client = CreditClient::new(&env, &contract_id);
+    let admin = _admin.clone();
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &1_000, &300, &50);
+
+    client.set_freeze_cooldown(&3600);
+
+    // Freeze draws (global)
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // Try to freeze credit line within cooldown - must fail
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+    }));
+    assert!(
+        result.is_err(),
+        "freeze_credit_line must fail within cooldown after freeze_draws"
+    );
+
+    // Try to freeze borrower within cooldown - must fail
+    let now = env.ledger().timestamp();
+    let future = now + 86_400;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.freeze_borrower_until(&admin, &borrower, &future);
+    }));
+    assert!(
+        result.is_err(),
+        "freeze_borrower_until must fail within cooldown after freeze_draws"
+    );
+}
+
+// ── Cooldown expiry ──────────────────────────────────────────────────────────
+
+#[test]
+fn freeze_action_succeeds_after_cooldown_expires() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&60); // 60 second cooldown
+
+    // First freeze
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // Advance time past the cooldown
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 61);
+
+    // Second freeze should succeed
+    client.freeze_draws(&FreezeReason::Compliance);
+    // No panic = success
+}
+
+#[test]
+fn freeze_action_succeeds_at_exact_cooldown_boundary() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&60);
+
+    // First freeze
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // Advance time exactly to the cooldown boundary
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + 60);
+
+    // Should succeed at exact boundary (now >= last_ts + cooldown)
+    client.freeze_draws(&FreezeReason::Compliance);
+}
+
+// ── Disabling cooldown ───────────────────────────────────────────────────────
+
+#[test]
+fn setting_cooldown_to_zero_disables_it() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&3600);
+
+    // First freeze with cooldown active
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // Disable cooldown
+    client.set_freeze_cooldown(&0);
+    assert!(client.get_freeze_cooldown().is_none());
+
+    // Second freeze should succeed immediately
+    client.freeze_draws(&FreezeReason::Compliance);
+}
+
+// ── Error discriminant ───────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #54)")]
+fn freeze_cooldown_active_error_has_correct_discriminant() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&3600);
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+
+    // This should panic with #54 (FreezeCooldownActive)
+    client.freeze_draws(&FreezeReason::Compliance);
+}
+
+// ── First action always succeeds ─────────────────────────────────────────────
+
+#[test]
+fn first_freeze_action_always_succeeds_even_with_cooldown() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    client.set_freeze_cooldown(&3600);
+
+    // Very first action after setting cooldown should succeed
+    client.freeze_draws(&FreezeReason::LiquidityReserve);
+    // No panic = success
+}
+
+// ── get_freeze_cooldown ──────────────────────────────────────────────────────
+
+#[test]
+fn get_freeze_cooldown_returns_configured_value() {
+    let (env, _admin, contract_id) = setup();
+    let client = CreditClient::new(&env, &contract_id);
+
+    assert!(client.get_freeze_cooldown().is_none());
+
+    client.set_freeze_cooldown(&7200);
+    assert_eq!(client.get_freeze_cooldown(), Some(7200));
+
+    client.set_freeze_cooldown(&300);
+    assert_eq!(client.get_freeze_cooldown(), Some(300));
+}
+
+// ── set_freeze_cooldown requires admin auth ──────────────────────────────────
+
+#[test]
+#[should_panic]
+fn set_freeze_cooldown_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+    client.set_freeze_cooldown(&3600);
+}


### PR DESCRIPTION
# feat(credit): admin freeze cooldown for critical actions (v7)

## Summary

Implements an admin cooldown gating all freeze/unfreeze critical actions in the Credit contract. When configured, successive admin freeze operations (global draw freeze, per-credit-line freeze, and borrower temporary freeze — including both freeze and unfreeze variants) must wait a minimum interval between calls. This prevents rapid toggle abuse by a compromised or careless admin while preserving immediate action capability when the cooldown is disabled (the default).

Closes #873

---

## What Changed

### 1. New error variant — `FreezeCooldownActive = 54`

**`contracts/credit/src/types.rs`**

- Added `FreezeCooldownActive = 54` to `ContractError` with doc comment `/// Admin freeze cooldown period has not yet elapsed.`
- Added to the discriminant table comment (row 54, category Block)
- Mapped to `ContractErrorCategory::Block` in **both** `category()` implementations (the `Self`-pattern version and the `ContractError`-path version)
- Updated the Block arm in the second implementation to include `FreezeCooldownActive` alongside existing `CreditLineFrozen`

### 2. Storage — two new instance keys + six helpers

**`contracts/credit/src/storage.rs`** (+71 lines)

**New `DataKey` variants:**
- `FreezeCooldownSeconds` — admin-configurable cooldown duration in seconds. Instance storage.
- `LastFreezeTimestamp` — ledger timestamp of the most recent freeze/unfreeze action. Instance storage.

**New helpers:**

| Function | Purpose |
|---|---|
| `get_freeze_cooldown_seconds(env)` | Returns `Some(secs)` when cooldown > 0 is configured; `None` otherwise |
| `set_freeze_cooldown_seconds(env, seconds)` | Stores the duration; removes the key when `seconds == 0` |
| `get_last_freeze_timestamp(env)` | Returns the last freeze/unfreeze action timestamp, if any |
| `set_last_freeze_timestamp(env, ts)` | Low-level timestamp setter |
| `record_freeze_timestamp_if_cooldown(env)` | **Conditional** recorder — only stores the current ledger timestamp when a cooldown is configured (prevents retroactive blocking from timestamps recorded before cooldown was enabled) |
| `enforce_freeze_cooldown(env)` | Panics with `FreezeCooldownActive` when `now < last_ts + cooldown_secs`; a no-op when cooldown is disabled or no previous action exists |

### 3. Freeze module — cooldown enforcement on all four entrypoints

**`contracts/credit/src/freeze.rs`** (+11 lines net)

Updated imports to pull `enforce_freeze_cooldown` and `record_freeze_timestamp_if_cooldown` from `crate::storage`.

Every freeze/unfreeze function now follows the same pattern:

```
require_admin_auth(&env);       // existing
enforce_freeze_cooldown(&env);  // NEW — check before action
... perform action ...          // existing
record_freeze_timestamp_if_cooldown(&env); // NEW — record after success
```

**Functions updated:**
- `freeze_draws` — global draw freeze
- `unfreeze_draws` — global draw unfreeze
- `freeze_credit_line` — per-credit-line freeze
- `unfreeze_credit_line` — per-credit-line unfreeze

### 4. Contract entrypoints — borrower freeze + cooldown config

**`contracts/credit/src/lib.rs`** (+32 lines)

**Extended cooldown enforcement to borrower freeze entrypoints:**
- `freeze_borrower_until` — now calls `enforce_freeze_cooldown` before the action and `record_freeze_timestamp_if_cooldown` after
- `unfreeze_borrower` — same pattern

**New entrypoints:**

| Entrypoint | Signature | Auth | Notes |
|---|---|---|---|
| `set_freeze_cooldown` | `(env, seconds: u64)` | Admin, pause-gated | Pass `0` to disable |
| `get_freeze_cooldown` | `(env) -> Option<u64>` | None | Returns `None` when disabled |

`set_freeze_cooldown` is pause-gated (`assert_not_paused`) consistent with `set_draw_min_interval` and other admin configuration entrypoints.

### 5. Error discriminant stability tests

**`contracts/credit/tests/error_discriminants.rs`** (+13 lines, −2 lines)

- Added `FreezeCooldownActive as u32 == 54` assertion to `error_discriminants_are_stable`
- Added variant to `no_duplicate_discriminants` vector
- Bumped `EXPECTED_VARIANT_COUNT` from 53 → 54
- Added variant to `variant_count_is_known` array
- Added category mapping assertion: `FreezeCooldownActive.category() == Block`
- Added variant to `every_variant_has_known_category` list
- Updated expected variant count assertion to 54

### 6. New test file — freeze cooldown

**`contracts/credit/tests/freeze_cooldown.rs`** (new, ~300 lines, 16 tests)

| # | Test | Category |
|---|---|---|
| 1 | `freeze_cooldown_disabled_by_default` | Defaults |
| 2 | `freeze_actions_succeed_when_cooldown_disabled` | Defaults |
| 3 | `freeze_draws_blocked_within_cooldown` | Enforcement |
| 4 | `unfreeze_draws_blocked_within_cooldown` | Enforcement |
| 5 | `freeze_credit_line_blocked_within_cooldown` | Enforcement |
| 6 | `unfreeze_credit_line_blocked_within_cooldown` | Enforcement |
| 7 | `freeze_borrower_until_blocked_within_cooldown` | Enforcement |
| 8 | `unfreeze_borrower_blocked_within_cooldown` | Enforcement |
| 9 | `cooldown_is_shared_across_freeze_types` | Cross-entrypoint |
| 10 | `freeze_action_succeeds_after_cooldown_expires` | Expiry |
| 11 | `freeze_action_succeeds_at_exact_cooldown_boundary` | Boundary |
| 12 | `setting_cooldown_to_zero_disables_it` | Disable |
| 13 | `freeze_cooldown_active_error_has_correct_discriminant` | Error code |
| 14 | `first_freeze_action_always_succeeds_even_with_cooldown` | Semantics |
| 15 | `get_freeze_cooldown_returns_configured_value` | Getter |
| 16 | `set_freeze_cooldown_requires_admin_auth` | Auth |

---

## Design Decisions

### 1. Cooldown is shared across all freeze entrypoint types

A `freeze_draws` (global) call blocks a subsequent `freeze_credit_line` (per-borrower) call within the same cooldown window. This prevents an attacker from circumventing the cooldown by switching freeze mechanisms. All six freeze/unfreeze entrypoints participate in the same cooldown clock.

### 2. Conditional timestamp recording

Timestamps are **only recorded when a cooldown is actively configured**. If an admin performs a freeze action while the cooldown is disabled, no `LastFreezeTimestamp` is stored. This prevents the following attack vector:

1. Admin freezes a credit line (no cooldown configured)
2. Governance votes to enable cooldown
3. The old freeze timestamp retroactively blocks all new freeze actions

With conditional recording, step 1 leaves no timestamp, so step 3 does not block anything.

### 3. Cooldown disabled by default

`get_freeze_cooldown` returns `None` until explicitly set by an admin. A zero value also counts as disabled and removes the instance storage key entirely.

### 4. `set_freeze_cooldown` is pause-gated

Consistent with `set_draw_min_interval`, `set_max_draw_amount`, and other admin configuration entrypoints. The circuit breaker (`Paused`) must be off before reconfiguring the cooldown.

### 5. First action after enabling cooldown always succeeds

When the cooldown is first enabled, there is no previous `LastFreezeTimestamp`, so `enforce_freeze_cooldown` has nothing to compare against. The first freeze action after enabling cooldown is always allowed; subsequent actions within the window are blocked.

### 6. Unfreeze is also gated

Both freeze AND unfreeze entrypoints are subject to the cooldown. This prevents rapid freeze/unfreeze toggling which could be used to perform denial-of-service on the draw path while burning minimal gas.

---

## API / Visible Changes

| Change | Type | Notes |
|---|---|---|
| `ContractError::FreezeCooldownActive = 54` | New error | Block category; panics when cooldown is active |
| `set_freeze_cooldown(env, seconds)` | New entrypoint | Admin-only, pause-gated |
| `get_freeze_cooldown(env) -> Option<u64>` | New entrypoint | Read-only, no auth |
| `freeze_draws` / `unfreeze_draws` | Modified | Now may revert with `FreezeCooldownActive` |
| `freeze_credit_line` / `unfreeze_credit_line` | Modified | Now may revert with `FreezeCooldownActive` |
| `freeze_borrower_until` / `unfreeze_borrower` | Modified | Now may revert with `FreezeCooldownActive` |

**Backward compatibility:** When no freeze cooldown is configured (the default), all existing freeze entrypoints behave identically — no new reverts are introduced. Enabling the cooldown is an opt-in admin action.

---

## Security Notes

### Threat model

**What this protects against:**
- A compromised admin key performing rapid freeze/unfreeze cycles to disrupt the draw path (DoS)
- An admin accidentally or maliciously toggling freeze state faster than governance can respond

**What this does NOT protect against:**
- A compromised admin key can still freeze draws permanently (cooldown only limits frequency, not duration)
- A compromised admin can disable the cooldown (`set_freeze_cooldown(0)`) and then freeze/unfreeze freely — this is inherent to admin-key trust

### Trust boundary

The admin key is assumed to belong to a trusted off-chain system, multisig, or governance DAO. The cooldown adds a **time buffer** that gives operators and governance a window to detect and respond to anomalous freeze activity, but it does not replace admin-key security.

### Storage safety

- `FreezeCooldownSeconds` and `LastFreezeTimestamp` use **instance storage** (shared TTL with all global config)
- `LastFreezeTimestamp` is only written when a cooldown is actively configured — no unnecessary storage writes
- The `enforce_freeze_cooldown` check uses `saturating_add` to prevent overflow in the `last_ts + cooldown` computation

### Arithmetic

- All timestamp arithmetic uses `saturating_add` (not `checked_add`) — overflow is impossible with `u64` ledger timestamps in any foreseeable ledger era
- No `unwrap()` or `expect()` calls in the cooldown enforcement path — all `Option` handling uses `?`-style early returns or `if let Some`

---

## Error Code Reference

| Code | Variant | Category | Revert Condition |
|---|---|---|---|
| 54 | `FreezeCooldownActive` | Block (9) | `now < last_freeze_ts + freeze_cooldown_seconds` |

---

## Test Coverage

- **15 unit tests** in `tests/freeze_cooldown.rs` covering defaults, enforcement across all 6 freeze entrypoints, cross-entrypoint cooldown sharing, expiry/boundary semantics, disable, error discriminant, first-action semantics, getter, and auth
- **Error discriminant tests** updated in `tests/error_discriminants.rs` — 8 assertion sites updated for the new variant
- **Existing freeze tests** (`tests/freeze_draws.rs`, `tests/freeze_reason.rs`) remain passing — cooldown is disabled by default so no existing tests are affected

---

## Checklist

- [x] Implementation matches the description
- [x] Tests added and passing (15 new cooldown-specific tests; error discriminant tests updated)
- [x] `require_auth` on every state-changing entrypoint (`set_freeze_cooldown`)
- [x] Overflow-safe math (`saturating_add`)
- [x] No `unwrap()` in production paths
- [x] Clear NatSpec-style `///` rustdoc on all public functions
- [x] ABI-stable error discriminants (54, appended at end)
- [x] Category mapping consistent across both `category()` implementations
- [x] Cooldown disabled by default — backward compatible

---

## Files Changed

| File | + | − | Description |
|---|---|---|---|
| `contracts/credit/src/types.rs` | +7 | −2 | New error variant + category mapping |
| `contracts/credit/src/storage.rs` | +71 | 0 | Two DataKey variants + 6 helpers |
| `contracts/credit/src/freeze.rs` | +12 | −1 | Cooldown enforcement on 4 entrypoints |
| `contracts/credit/src/lib.rs` | +32 | 0 | Borrower freeze + 2 config entrypoints |
| `contracts/credit/tests/error_discriminants.rs` | +13 | −2 | Discriminant 54 stability |
| `contracts/credit/tests/freeze_cooldown.rs` | +269 | 0 | New test file (16 tests) |
| **Total** | **+404** | **−5** | |
