### PR TITLE
test: freeze auth snapshot (#866)

### DIFF
--- a/contracts/credit/tests/freeze_auth_snap.rs
+++ b/contracts/credit/tests/freeze_auth_snap.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT
+
+//! Per-entrypoint auth snapshot for the freeze subsystem (#866, v7).
+//!
+//! `unauthorized_matrix.rs` proves a *wrong* signer reverts. This file goes
+//! one step further and pins the exact authorization *shape* the Soroban
+//! host records for a **successful**, admin-signed call to every
+//! state-changing freeze entrypoint. A future change that silently drops
+//! `require_auth`, requires an extra signer, or authorizes the wrong
+//! address will fail one of the snapshot assertions below even though
+//! `mock_all_auths` would otherwise paper over the regression.
+//!
+//! # Snapshot (v7 freeze surface)
+//!
+//! | Entrypoint              | Required signer | Auths recorded | Sub-invocations |
+//! |--------------------------|------------------|----------------|------------------|
+//! | `freeze_draws`           | admin            | 1              | 0                |
+//! | `unfreeze_draws`         | admin            | 1              | 0                |
+//! | `freeze_credit_line`     | admin            | 1              | 0                |
+//! | `unfreeze_credit_line`   | admin            | 1              | 0                |
+//! | `is_draws_frozen`        | none (read-only) | 0              | —                |
+//! | `is_credit_line_frozen`  | none (read-only) | 0              | —                |
+//!
+//! # Rules
+//! - Never weaken an existing assertion (e.g. loosening `auths().len()`).
+//! - If a freeze entrypoint gains a second required signer or a
+//!   sub-invocation, update the table above alongside the assertion.
+//!
+//! # See also
+//! - `creditra_credit::freeze` — the freeze/unfreeze implementation.
+//! - `contracts/credit/tests/unauthorized_matrix.rs` — the negative-only
+//!   caller matrix this file complements.
+
+use creditra_credit::{Credit, CreditClient, FreezeReason};
+use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::{Address, Env, IntoVal};
+
+/// Deploys a fresh contract, initializes `admin`, and opens a credit line
+/// for `borrower`, with `mock_all_auths` enabled for the whole env.
+///
+/// Because `mock_all_auths` still records what was authorized (it only
+/// skips signature verification), `env.auths()` after the call under test
+/// reflects exactly what that call — and nothing from setup — required.
+fn setup(env: &Env) -> (CreditClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &50_u32);
+    (client, admin, borrower)
+}
+
+/// Same as [`setup`] but *without* `mock_all_auths`, for negative tests.
+/// `init` and `open_credit_line` do not currently enforce `require_auth`,
+/// so both calls succeed here without any mocked signer.
+fn setup_no_mock(env: &Env) -> (CreditClient<'_>, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &50_u32);
+    (client, contract_id, admin, borrower)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 1 — Positive snapshot: exactly one auth, held by admin
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn freeze_draws_auth_snapshot() {
+    let env = Env::default();
+    let (client, admin, _borrower) = setup(&env);
+
+    client.freeze_draws();
+
+    let auths = env.auths();
+    assert_eq!(
+        auths.len(),
+        1,
+        "freeze_draws must record exactly one authorization"
+    );
+    assert_eq!(
+        auths[0].0, admin,
+        "freeze_draws must be authorized by the admin"
+    );
+}
+
+#[test]
+fn unfreeze_draws_auth_snapshot() {
+    let env = Env::default();
+    let (client, admin, _borrower) = setup(&env);
+    client.freeze_draws();
+
+    client.unfreeze_draws();
+
+    let auths = env.auths();
+    assert_eq!(
+        auths.len(),
+        1,
+        "unfreeze_draws must record exactly one authorization"
+    );
+    assert_eq!(
+        auths[0].0, admin,
+        "unfreeze_draws must be authorized by the admin"
+    );
+}
+
+#[test]
+fn freeze_credit_line_auth_snapshot() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup(&env);
+
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+
+    let auths = env.auths();
+    assert_eq!(
+        auths.len(),
+        1,
+        "freeze_credit_line must record exactly one authorization"
+    );
+    assert_eq!(
+        auths[0].0, admin,
+        "freeze_credit_line must be authorized by the admin"
+    );
+}
+
+#[test]
+fn unfreeze_credit_line_auth_snapshot() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup(&env);
+    client.freeze_credit_line(&borrower, &FreezeReason::RiskInvestigation);
+
+    client.unfreeze_credit_line(&borrower);
+
+    let auths = env.auths();
+    assert_eq!(
+        auths.len(),
+        1,
+        "unfreeze_credit_line must record exactly one authorization"
+    );
+    assert_eq!(
+        auths[0].0, admin,
+        "unfreeze_credit_line must be authorized by the admin"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 2 — Negative: entrypoint reverts with zero signers mocked
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic]
+fn freeze_draws_reverts_without_auth() {
+    let env = Env::default();
+    let (client, _contract_id, _admin, _borrower) = setup_no_mock(&env);
+    client.freeze_draws();
+}
+
+#[test]
+#[should_panic]
+fn unfreeze_draws_reverts_without_auth() {
+    let env = Env::default();
+    let (client, contract_id, admin, _borrower) = setup_no_mock(&env);
+
+    // Legitimately freeze first, authorizing only this one call.
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "freeze_draws",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .freeze_draws();
+
+    // No signer mocked for this call — must revert.
+    client.unfreeze_draws();
+}
+
+#[test]
+#[should_panic]
+fn freeze_credit_line_reverts_without_auth() {
+    let env = Env::default();
+    let (client, _contract_id, _admin, borrower) = setup_no_mock(&env);
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+}
+
+#[test]
+#[should_panic]
+fn unfreeze_credit_line_reverts_without_auth() {
+    let env = Env::default();
+    let (client, contract_id, admin, borrower) = setup_no_mock(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "freeze_credit_line",
+                args: (borrower.clone(), FreezeReason::Compliance).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .freeze_credit_line(&borrower, &FreezeReason::Compliance);
+
+    client.unfreeze_credit_line(&borrower);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 3 — Edge case: a non-admin signer is rejected, not just "no signer"
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic]
+fn freeze_draws_wrong_signer_reverts() {
+    let env = Env::default();
+    let (client, contract_id, _admin, _borrower) = setup_no_mock(&env);
+    let attacker = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "freeze_draws",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .freeze_draws();
+}
+
+#[test]
+#[should_panic]
+fn freeze_credit_line_wrong_signer_reverts() {
+    let env = Env::default();
+    let (client, contract_id, _admin, borrower) = setup_no_mock(&env);
+    let attacker = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "freeze_credit_line",
+                args: (borrower.clone(), FreezeReason::Compliance).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .freeze_credit_line(&borrower, &FreezeReason::Compliance);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 4 — Edge case: read-only freeze queries require no authorization
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn is_draws_frozen_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, _borrower) = setup(&env);
+    client.freeze_draws();
+
+    let _ = client.is_draws_frozen();
+
+    assert!(
+        env.auths().is_empty(),
+        "is_draws_frozen must not require any authorization"
+    );
+}
+
+#[test]
+fn is_credit_line_frozen_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup(&env);
+    client.freeze_credit_line(&borrower, &FreezeReason::Compliance);
+
+    let _ = client.is_credit_line_frozen(&borrower);
+
+    assert!(
+        env.auths().is_empty(),
+        "is_credit_line_frozen must not require any authorization"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #866. Adds a per-entrypoint auth snapshot for the freeze subsystem: `contracts/credit/tests/freeze_auth_snap.rs`.

For every state-changing freeze entrypoint (`freeze_draws`, `unfreeze_draws`, `freeze_credit_line`, `unfreeze_credit_line`) the snapshot pins:
- exactly **one** authorization is recorded per call, held by the **admin** (via `env.auths()` after a `mock_all_auths` call, so the check reflects what the entrypoint itself required, not test setup)
- the call **reverts with zero signers mocked**
- the call **reverts when a non-admin address is the only mocked signer** (distinguishes "no auth" from "wrong auth")
- read-only queries (`is_draws_frozen`, `is_credit_line_frozen`) require **no** authorization

This complements `unauthorized_matrix.rs` (negative-only) by also pinning the *positive* shape of a successful, correctly-authorized call, so a future change that silently drops `require_auth`, adds a second required signer, or authorizes the wrong address will fail a snapshot assertion.

## Notes on scope

- The issue's suggested path (`contracts/freeze/tests/auth_snap.rs`) assumes freeze lives in its own crate; in this repo freeze is a module inside `creditra-credit` (`contracts/credit/src/freeze.rs`), so the test was added alongside its siblings at `contracts/credit/tests/freeze_auth_snap.rs`, matching `freeze_draws.rs` / `freeze_reason.rs` / `unauthorized_matrix.rs`.
- No production code was touched — this PR is test-only, matching the pattern of the other recently-merged v7 snapshot PRs (e.g. #930).

## Pre-existing issues found (out of scope, not fixed here)

While verifying entrypoint signatures against existing tests I found the credit contract's test suite currently has unrelated compile blockers on `main`:
- `contracts/credit/tests/unauthorized_matrix.rs` has its entire body duplicated verbatim (duplicate fn definitions).
- `contracts/credit/tests/freeze_draws.rs` and `freeze_reason.rs` call `client.freeze_draws(&FreezeReason::...)`, but the live entrypoint (`contracts/credit/src/lib.rs`) declares `freeze_draws(env: Env)` with no reason parameter.
- `contracts/credit/src/lib.rs`'s inline `test_draw_freeze::freeze_is_per_contract_instance` test contains stray lines referencing an undefined `client`/`assert_utilization_invariants`.

Since Cargo compiles each integration-test file as an independent binary, the new `freeze_auth_snap.rs` is unaffected by these and compiles/runs on its own, but a full `cargo test -p creditra-credit` will still fail on the above until they're addressed separately. Flagging here rather than expanding this PR's scope to fix unrelated files.

## Test plan

- [ ] `cargo test -p creditra-credit --test freeze_auth_snap` (I could not run this locally: this sandbox has no MSVC linker installed and the available MinGW toolchain fails to link due to a space in its own install path, unrelated to the repo. Please run in CI / locally before merge.)
- [x] Manual review of every call against the real entrypoint signatures in `contracts/credit/src/freeze.rs` and `contracts/credit/src/lib.rs`.
- [x] `should_panic` tests cover: no signer, wrong signer, per state-changing entrypoint.
