### PR TITLE
Task/wasm size guard

### DIFF
--- a/.github/workflows/wasm-size-guard.yml
+++ b/.github/workflows/wasm-size-guard.yml
@@ -1,0 +1,43 @@
+name: WASM Size Budget
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - feature/**
+
+concurrency:
+  group: wasm-size-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm-size-guard:
+    name: WASM size budget (±5 KB)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-budget-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-budget-
+
+      - name: Run baseline check tests
+        run: bash scripts/test_check_wasm_size.sh
+
+      - name: Build and verify WASM size budget
+        run: bash scripts/check-wasm-baseline.sh

--- a/scripts/check-wasm-baseline.sh
+++ b/scripts/check-wasm-baseline.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Build Soroban contracts to WASM and assert each is within ±5 KB of the
+# checked-in baseline (scripts/wasm-size-baseline.txt).
+#
+# Usage:
+#   scripts/check-wasm-baseline.sh              # build + check
+#   scripts/check-wasm-baseline.sh --check-only # check existing artifacts only
+#
+# Exit codes:
+#   0  All builds within tolerance
+#   1  One or more builds exceed the baseline + tolerance
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BASELINE_FILE="scripts/wasm-size-baseline.txt"
+TOLERANCE_BYTES="${TOLERANCE_BYTES:-5120}"  # ±5 KB
+WASM_DIR="${WASM_DIR:-target/wasm32-unknown-unknown/release}"
+
+CHECK_ONLY=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check-only)
+            CHECK_ONLY=1
+            shift
+            ;;
+        -h | --help)
+            sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            echo "usage: scripts/check-wasm-baseline.sh [--check-only]" >&2
+            exit 64
+            ;;
+    esac
+done
+
+if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "::error::Baseline file not found: $BASELINE_FILE" >&2
+    exit 1
+fi
+
+file_size_bytes() {
+    local path="$1"
+    if stat --format="%s" "$path" >/dev/null 2>&1; then
+        stat --format="%s" "$path"
+    elif stat -f "%z" "$path" >/dev/null 2>&1; then
+        stat -f "%z" "$path"
+    else
+        wc -c <"$path" | tr -d '[:space:]'
+    fi
+}
+
+# Build all workspace contracts unless --check-only
+if [[ "$CHECK_ONLY" -eq 0 ]]; then
+    scripts/build_wasm.sh all
+fi
+
+if [[ ! -d "$WASM_DIR" ]]; then
+    echo "::error::WASM directory not found: $WASM_DIR" >&2
+    exit 1
+fi
+
+echo "Tolerance: ±${TOLERANCE_BYTES} bytes ($((TOLERANCE_BYTES / 1024)) KB)"
+echo
+
+fail=0
+warn=0
+count=0
+
+while IFS=' ' read -r crate_name size_bytes; do
+    # Skip comments and blank lines
+    [[ "$crate_name" =~ ^#.*$ || -z "$crate_name" ]] && continue
+
+    count=$((count + 1))
+    baseline="$size_bytes"
+    wasm_path="${WASM_DIR}/${crate_name//-/_}.wasm"
+
+    if [[ ! -f "$wasm_path" ]]; then
+        echo "::error::WASM artifact not found for ${crate_name} at ${wasm_path}" >&2
+        fail=1
+        continue
+    fi
+
+    actual_bytes="$(file_size_bytes "$wasm_path")"
+    upper=$((baseline + TOLERANCE_BYTES))
+    lower=$((baseline - TOLERANCE_BYTES))
+    # Prevent underflow for small baselines
+    [[ "$lower" -lt 0 ]] && lower=0
+
+    echo "${crate_name}:"
+    echo "  baseline: ${baseline} bytes ($((baseline / 1024)) KB)"
+    echo "  current:  ${actual_bytes} bytes ($((actual_bytes / 1024)) KB)"
+    echo "  range:    [${lower}, ${upper}] bytes"
+
+    if [[ "$actual_bytes" -gt "$upper" ]]; then
+        echo "  status:   FAIL (over budget by $((actual_bytes - upper)) bytes)" >&2
+        echo "::error::${crate_name} WASM size ${actual_bytes} exceeds baseline ${baseline} + tolerance ${TOLERANCE_BYTES}" >&2
+        fail=1
+    elif [[ "$actual_bytes" -lt "$lower" ]]; then
+        echo "  status:   WARN (under budget by $((lower - actual_bytes)) bytes — update baseline?)"
+        warn=1
+    else
+        echo "  status:   OK"
+    fi
+    echo
+done < "$BASELINE_FILE"
+
+if [[ "$count" -eq 0 ]]; then
+    echo "::error::No baselines found in $BASELINE_FILE" >&2
+    exit 1
+fi
+
+if [[ "$warn" -ne 0 ]]; then
+    echo "::notice::Some contracts are under budget. Consider updating the baseline."
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "::error::One or more contracts exceed the size budget. CI FAILED." >&2
+    exit 1
+fi
+
+echo "All ${count} contract(s) within ±${TOLERANCE_BYTES} byte tolerance of baseline."

--- a/scripts/wasm-size-baseline.txt
+++ b/scripts/wasm-size-baseline.txt
@@ -1,0 +1,6 @@
+# WASM Size Baseline
+# Format: <crate-name> <size-in-bytes>
+# Update after significant code changes that affect contract size.
+# The CI workflow (wasm-size-guard.yml) asserts builds are within ±5 KB of these values.
+creditra-credit 35000
+gateway-auction 15000


### PR DESCRIPTION
## Summary

Adds a CI workflow that builds Soroban contracts to WASM and asserts each is within **±5 KB** of a checked-in baseline file.

## Changes

| File | Description |
|------|-------------|
| `scripts/wasm-size-baseline.txt` | Per-crate size baselines (credit: 35 KB, auction: 15 KB) |
| `scripts/check-wasm-baseline.sh` | Build + compare script (bash 3.2 compatible) |
| `.github/workflows/wasm-size-guard.yml` | CI workflow triggered on PRs and pushes to main/feature branches |

## How It Works

1. **Build**: `cargo build --target wasm32-unknown-unknown --profile release` for all workspace crates
2. **Compare**: Each `.wasm` artifact size is compared against the baseline in `scripts/wasm-size-baseline.txt`
3. **Result**:
   - **Within ±5 KB**: ✅ PASS
   - **Over budget**: ❌ FAIL CI
   - **Under budget**: ⚠️ WARN (suggest updating baseline)

Closes #492