### PR TITLE
feat: Dutch stepped decay

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/curves.rs
+++ b/gateway-contract/contracts/auction_contract/src/curves.rs
@@ -1,4 +1,25 @@
 // contracts/gateway-auction/src/curves.rs
+//
+//! Standalone price-decay curve primitives for Dutch auctions.
+//!
+//! # Relationship with `compute_dutch_price`
+//!
+//! This module provides low-level curve implementations parameterised by
+//! explicit `rate` / `step_size` / `factor` values (all `u128`).
+//!
+//! The higher-level [`super::compute_dutch_price`] function in the crate
+//! root serves the same purpose but derives those parameters from
+//! `start_price`, `floor_price`, and `duration` (using `i128` arithmetic
+//! to match the Soroban ABI). The two APIs are intentionally distinct:
+//!
+//! * [`DecayCurve`] — suitable for off-chain estimation and standalone
+//!   previews where callers already know the per-tick rates.
+//! * [`super::compute_dutch_price`] — used inside the auction
+//!   entrypoints; fits the `DutchAuctionDecay` contract-type ABI.
+//!
+//! Both must maintain identical mathematical semantics for the same
+//! underlying curve shape. If a bug is found in one, verify that the
+//! other is not also affected.
 
 /// Represents the decay curve used in the Dutch auction
 #[derive(Clone, Debug)]
@@ -45,7 +66,10 @@ pub fn calculate_price(
             Ok(start_price.saturating_sub(decay))
         }
 
-        DecayCurve::Stepped { step_size, interval } => {
+        DecayCurve::Stepped {
+            step_size,
+            interval,
+        } => {
             if *interval == 0 {
                 return Err(CurveError::InvalidInput);
             }
@@ -68,13 +92,288 @@ pub fn calculate_price(
             let mut price = start_price;
 
             for _ in 0..elapsed {
-                price = price
-                    .checked_mul(*factor)
-                    .ok_or(CurveError::Overflow)?
-                    / *scale;
+                price = price.checked_mul(*factor).ok_or(CurveError::Overflow)? / *scale;
             }
 
             Ok(price)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Linear decay tests ──
+
+    #[test]
+    fn linear_zero_elapsed_returns_start_price() {
+        let curve = DecayCurve::Linear { rate: 10 };
+        let price = calculate_price(1000, 0, &curve).unwrap();
+        assert_eq!(price, 1000);
+    }
+
+    #[test]
+    fn linear_basic_decay() {
+        let curve = DecayCurve::Linear { rate: 10 };
+        let price = calculate_price(1000, 5, &curve).unwrap();
+        assert_eq!(price, 950);
+    }
+
+    #[test]
+    fn linear_saturates_at_zero() {
+        let curve = DecayCurve::Linear { rate: 100 };
+        let price = calculate_price(100, 10, &curve).unwrap();
+        assert_eq!(price, 0);
+    }
+
+    #[test]
+    fn linear_no_underflow_below_zero() {
+        let curve = DecayCurve::Linear { rate: 10 };
+        let price = calculate_price(50, 10, &curve).unwrap();
+        assert_eq!(price, 0);
+    }
+
+    #[test]
+    fn linear_price_never_increases() {
+        let curve = DecayCurve::Linear { rate: 5 };
+        let mut prev = calculate_price(1000, 0, &curve).unwrap();
+        for t in 1..=100 {
+            let curr = calculate_price(1000, t, &curve).unwrap();
+            assert!(
+                curr <= prev,
+                "price increased at t={}: {} > {}",
+                t,
+                curr,
+                prev
+            );
+            prev = curr;
+        }
+    }
+
+    #[test]
+    fn linear_large_rate() {
+        let curve = DecayCurve::Linear {
+            rate: u128::MAX / 2,
+        };
+        let price = calculate_price(u128::MAX, 1, &curve).unwrap();
+        assert!(price < u128::MAX);
+    }
+
+    // ── Stepped decay tests ──
+
+    #[test]
+    fn stepped_zero_interval_returns_error() {
+        let curve = DecayCurve::Stepped {
+            step_size: 100,
+            interval: 0,
+        };
+        let result = calculate_price(1000, 10, &curve);
+        assert!(result.is_err());
+        match result {
+            Err(CurveError::InvalidInput) => {}
+            _ => panic!("expected InvalidInput error"),
+        }
+    }
+
+    #[test]
+    fn stepped_basic_price_drop() {
+        let curve = DecayCurve::Stepped {
+            step_size: 100,
+            interval: 10,
+        };
+        // At t=0, no steps completed
+        let p0 = calculate_price(1000, 0, &curve).unwrap();
+        assert_eq!(p0, 1000);
+        // At t=9, still in first step
+        let p1 = calculate_price(1000, 9, &curve).unwrap();
+        assert_eq!(p1, 1000);
+        // At t=10, one step completed
+        let p2 = calculate_price(1000, 10, &curve).unwrap();
+        assert_eq!(p2, 900);
+        // At t=20, two steps completed
+        let p3 = calculate_price(1000, 20, &curve).unwrap();
+        assert_eq!(p3, 800);
+    }
+
+    #[test]
+    fn stepped_holds_price_within_interval() {
+        let curve = DecayCurve::Stepped {
+            step_size: 50,
+            interval: 30,
+        };
+        // All times within the same interval should have the same price
+        let p_at_0 = calculate_price(500, 0, &curve).unwrap();
+        let p_at_15 = calculate_price(500, 15, &curve).unwrap();
+        let p_at_29 = calculate_price(500, 29, &curve).unwrap();
+        assert_eq!(p_at_0, p_at_15);
+        assert_eq!(p_at_0, p_at_29);
+        // But at the next interval boundary, price drops
+        let p_at_30 = calculate_price(500, 30, &curve).unwrap();
+        assert!(p_at_30 < p_at_0);
+        assert_eq!(p_at_30, 450);
+    }
+
+    #[test]
+    fn stepped_saturates_at_zero() {
+        let curve = DecayCurve::Stepped {
+            step_size: 500,
+            interval: 1,
+        };
+        let price = calculate_price(100, 10, &curve).unwrap();
+        assert_eq!(price, 0);
+    }
+
+    #[test]
+    fn stepped_monotonic_non_increasing() {
+        let curve = DecayCurve::Stepped {
+            step_size: 7,
+            interval: 5,
+        };
+        let mut prev = calculate_price(1000, 0, &curve).unwrap();
+        for t in 1..=100 {
+            let curr = calculate_price(1000, t, &curve).unwrap();
+            assert!(
+                curr <= prev,
+                "stepped price increased at t={}: {} > {}",
+                t,
+                curr,
+                prev
+            );
+            prev = curr;
+        }
+    }
+
+    #[test]
+    fn stepped_large_elapsed() {
+        let curve = DecayCurve::Stepped {
+            step_size: 1,
+            interval: 1,
+        };
+        let price = calculate_price(10, u64::MAX, &curve).unwrap();
+        assert_eq!(price, 0);
+    }
+
+    #[test]
+    fn stepped_overflow_protection() {
+        let curve = DecayCurve::Stepped {
+            step_size: u128::MAX,
+            interval: 1,
+        };
+        let result = calculate_price(u128::MAX, 2, &curve);
+        assert!(result.is_err());
+        match result {
+            Err(CurveError::Overflow) => {}
+            _ => panic!("expected Overflow error"),
+        }
+    }
+
+    // ── Exponential decay tests ──
+
+    #[test]
+    fn exponential_zero_scale_returns_error() {
+        let curve = DecayCurve::Exponential {
+            factor: 9900,
+            scale: 0,
+        };
+        let result = calculate_price(1000, 10, &curve);
+        assert!(result.is_err());
+        match result {
+            Err(CurveError::InvalidInput) => {}
+            _ => panic!("expected InvalidInput error"),
+        }
+    }
+
+    #[test]
+    fn exponential_zero_elapsed_returns_start_price() {
+        let curve = DecayCurve::Exponential {
+            factor: 9900,
+            scale: 10000,
+        };
+        let price = calculate_price(1000, 0, &curve).unwrap();
+        assert_eq!(price, 1000);
+    }
+
+    #[test]
+    fn exponential_basic_decay() {
+        let curve = DecayCurve::Exponential {
+            factor: 9900,
+            scale: 10000,
+        };
+        let p0 = calculate_price(1000, 0, &curve).unwrap();
+        let p1 = calculate_price(1000, 1, &curve).unwrap();
+        assert_eq!(p1, 990); // 1000 * 9900 / 10000
+        assert!(p1 < p0);
+    }
+
+    #[test]
+    fn exponential_monotonic_non_increasing() {
+        let curve = DecayCurve::Exponential {
+            factor: 9900,
+            scale: 10000,
+        };
+        let mut prev = calculate_price(10000, 0, &curve).unwrap();
+        for t in 1..=50 {
+            let curr = calculate_price(10000, t, &curve).unwrap();
+            assert!(
+                curr <= prev,
+                "exponential price increased at t={}: {} > {}",
+                t,
+                curr,
+                prev
+            );
+            prev = curr;
+        }
+    }
+
+    #[test]
+    fn exponential_approaches_zero() {
+        let curve = DecayCurve::Exponential {
+            factor: 5000,
+            scale: 10000,
+        };
+        let price = calculate_price(1000, 100, &curve).unwrap();
+        assert!(price < 10); // With 50% decay per tick, after 100 ticks it's near zero
+    }
+
+    // ── Cross-curve comparative tests ──
+
+    #[test]
+    fn all_curves_same_start_at_zero_elapsed() {
+        let curves = vec![
+            DecayCurve::Linear { rate: 10 },
+            DecayCurve::Stepped {
+                step_size: 100,
+                interval: 10,
+            },
+            DecayCurve::Exponential {
+                factor: 9900,
+                scale: 10000,
+            },
+        ];
+        for curve in &curves {
+            let price = calculate_price(500, 0, curve).unwrap();
+            assert_eq!(price, 500);
+        }
+    }
+
+    #[test]
+    fn all_curves_non_increasing_over_short_window() {
+        let curves = vec![
+            DecayCurve::Linear { rate: 10 },
+            DecayCurve::Stepped {
+                step_size: 10,
+                interval: 1,
+            },
+            DecayCurve::Exponential {
+                factor: 9900,
+                scale: 10000,
+            },
+        ];
+        for curve in &curves {
+            let p0 = calculate_price(1000, 0, curve).unwrap();
+            let p5 = calculate_price(1000, 5, curve).unwrap();
+            assert!(p5 <= p0, "curve {:?} increased", curve);
         }
     }
 }

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -1,10 +1,12 @@
 #![cfg_attr(not(test), no_std)]
 
+pub mod curves;
 mod errors;
 mod events;
 mod storage;
 mod types;
 
+pub use curves::{calculate_price, CurveError, DecayCurve};
 pub use errors::AuctionError;
 pub use events::BidRefundedEvent;
 pub use types::{AuctionMode, AuctionState, AuctionStatus, DutchAuctionDecay};
@@ -13,7 +15,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, 
 
 use crate::storage::{
     bump_auction_state_ttl, bump_settlement_marker_ttl, clear_reentrancy_guard,
-    get_factory_contract, set_factory_contract, set_liquidation_grace_window, set_reentrancy_guard,
+    get_factory_contract, set_liquidation_grace_window, set_reentrancy_guard,
 };
 use crate::types::*;
 use events::{
@@ -346,9 +348,7 @@ impl Auction {
 
             AuctionMode::Dutch => {
                 let current_time = env.ledger().timestamp();
-                let elapsed_time = current_time
-                    .checked_sub(state.config.start_time)
-                    .unwrap_or(0);
+                let elapsed_time = current_time.saturating_sub(state.config.start_time);
                 let duration = state
                     .config
                     .end_time

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -9,6 +9,7 @@ mod tests {
 
     use soroban_sdk::testutils::Events as _;
     use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::token::Client as TokenClient;
     use soroban_sdk::token::StellarAssetClient;
     use soroban_sdk::{Address, BytesN, Env, Symbol, TryFromVal, TryIntoVal};
 
@@ -133,7 +134,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -169,7 +170,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -213,7 +214,7 @@ mod tests {
             &1000_u32, // 10% min_increment_bps
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -225,7 +226,7 @@ mod tests {
         assert_eq!(contract_err, AuctionError::BidTooLow.into());
 
         // A bid of 110 should succeed.
-        setup_token(&env, &contract_id, 1000, &[alice.clone()], 1000);
+        setup_token(&env, &contract_id, 1000, std::slice::from_ref(&alice), 1000);
         client.place_bid(&auction_id, &alice, &110_i128);
 
         let stored_after: crate::types::AuctionState = env
@@ -265,7 +266,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -333,7 +334,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -385,7 +386,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -442,7 +443,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.init_auction(
@@ -454,7 +455,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &bidder, &100_i128);
@@ -491,7 +492,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.init_auction(
@@ -503,7 +504,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &bidder, &420_i128);
@@ -543,7 +544,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.close_auction(&auction_id);
@@ -582,7 +583,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.init_auction(
@@ -594,7 +595,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.close_auction(&auction_id);
@@ -679,7 +680,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.close_auction(&auction_id);
@@ -727,7 +728,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -758,7 +759,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &bidder, &420_i128);
@@ -800,7 +801,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &bidder, &420_i128);
@@ -849,7 +850,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &bidder, &420_i128);
@@ -879,7 +880,7 @@ mod tests {
                 &10_001_u32,
                 &None,
                 &None,
-                &DutchAuctionDecay::None,
+                &Some(DutchAuctionDecay::None),
                 &None,
             );
         }));
@@ -903,7 +904,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.init_auction(
@@ -915,7 +916,7 @@ mod tests {
             &10_000_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
     }
@@ -941,7 +942,7 @@ mod tests {
             &100_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &alice, &1_000_i128);
@@ -982,7 +983,7 @@ mod tests {
             &100_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &alice, &1_000_i128);
@@ -1017,7 +1018,7 @@ mod tests {
             &333_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &alice, &1_000_i128);
@@ -1058,7 +1059,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &alice, &500_i128);
@@ -1100,7 +1101,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &winner, &100_i128);
@@ -1122,7 +1123,13 @@ mod tests {
         let contract_id = env.register(Auction, ());
         let client = AuctionClient::new(&env, &contract_id);
         let _factory = setup_factory(&env, &client);
-        setup_token(&env, &contract_id, 1000, &[winner.clone()], 1000);
+        setup_token(
+            &env,
+            &contract_id,
+            1000,
+            std::slice::from_ref(&winner),
+            1000,
+        );
 
         let auction_id = Symbol::new(&env, "claim_double");
 
@@ -1135,7 +1142,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &winner, &100_i128);
@@ -1174,7 +1181,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &winner, &100_i128);
@@ -1207,7 +1214,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.close_auction(&auction_id);
@@ -1228,7 +1235,8 @@ mod tests {
         let contract_id = env.register(Auction, ());
         let client = AuctionClient::new(&env, &contract_id);
         let _factory = setup_factory(&env, &client);
-        let (bid_token, sac) = setup_token(&env, &contract_id, 1000, &[winner.clone()], 0);
+        let (bid_token, _sac) =
+            setup_token(&env, &contract_id, 1000, std::slice::from_ref(&winner), 0);
 
         let auction_id = Symbol::new(&env, "claim_transfer");
 
@@ -1241,15 +1249,16 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &winner, &420_i128);
         client.close_auction(&auction_id);
 
-        let balance_before = sac.balance(&winner);
+        let token_client = TokenClient::new(&env, &bid_token);
+        let balance_before = token_client.balance(&winner);
         client.claim_auction(&auction_id);
-        let balance_after = sac.balance(&winner);
+        let balance_after = token_client.balance(&winner);
 
         assert_eq!(
             balance_after - balance_before,
@@ -1257,7 +1266,7 @@ mod tests {
             "winner must receive the bid amount after claim"
         );
 
-        let contract_balance = sac.balance(&contract_id);
+        let contract_balance = token_client.balance(&contract_id);
         assert_eq!(
             contract_balance, 580_i128,
             "contract balance must decrease by the bid amount"
@@ -1288,7 +1297,7 @@ mod tests {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -1326,7 +1335,7 @@ mod tests {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -1364,7 +1373,7 @@ mod tests {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -1406,7 +1415,7 @@ mod tests {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -1438,7 +1447,7 @@ mod tests {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -1643,7 +1652,7 @@ mod tests {
                 &0_u32,
                 &Some(500_i128),
                 &Some(100_i128),
-                &DutchAuctionDecay::Stepped,
+                &Some(DutchAuctionDecay::Stepped),
                 &None,
             );
         }));
@@ -1670,7 +1679,7 @@ mod tests {
                 &0_u32,
                 &Some(500_i128),
                 &Some(100_i128),
-                &DutchAuctionDecay::Stepped,
+                &Some(DutchAuctionDecay::Stepped),
                 &Some(0_u32),
             );
         }));
@@ -1699,7 +1708,7 @@ mod tests {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Stepped,
+            &Some(DutchAuctionDecay::Stepped),
             &Some(4_u32),
         );
 
@@ -1740,7 +1749,7 @@ mod tests {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -1770,7 +1779,7 @@ mod tests {
             &bps,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
     }
@@ -1881,7 +1890,7 @@ mod tests {
             &10_000_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &alice, &100_i128);
@@ -1998,7 +2007,7 @@ mod reentrancy_exploration {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -2078,7 +2087,7 @@ mod reentrancy_exploration {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &winner, &100_i128);
@@ -2120,7 +2129,7 @@ mod reentrancy_exploration {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -2180,7 +2189,7 @@ mod reentrancy_preservation {
                 &0_u32,
                 &None,
                 &None,
-                &DutchAuctionDecay::None,
+                &Some(DutchAuctionDecay::None),
                 &None,
             );
             cli2.place_bid(&aid2, &Address::generate(&env2), &amount);
@@ -2218,7 +2227,7 @@ mod reentrancy_preservation {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -2255,7 +2264,7 @@ mod reentrancy_preservation {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &alice, &100_i128);
@@ -2286,7 +2295,7 @@ mod reentrancy_preservation {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         cli3.close_auction(&aid3);
@@ -2317,7 +2326,7 @@ mod reentrancy_preservation {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
         client.place_bid(&auction_id, &bidder, &420_i128);
@@ -2369,7 +2378,7 @@ mod liquidation_grace_window {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -2526,7 +2535,7 @@ mod liquidation_grace_window {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -2561,7 +2570,7 @@ mod liquidation_grace_window {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -2600,7 +2609,7 @@ mod liquidation_grace_window {
             &0_u32,
             &Some(500_i128),
             &Some(100_i128),
-            &DutchAuctionDecay::Linear,
+            &Some(DutchAuctionDecay::Linear),
             &None,
         );
 
@@ -2671,7 +2680,7 @@ mod liquidation_grace_window {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 

--- a/gateway-contract/contracts/auction_contract/tests/auth_settle.rs
+++ b/gateway-contract/contracts/auction_contract/tests/auth_settle.rs
@@ -52,7 +52,7 @@ fn setup_auction() -> (Env, Address, Symbol, Address, Address, i128) {
         &0_u32,
         &None,
         &None,
-        &DutchAuctionDecay::None,
+        &Some(DutchAuctionDecay::None),
         &None,
     );
     client.place_bid(&auction_id, &bidder, &420_i128);

--- a/gateway-contract/contracts/auction_contract/tests/factory_auth.rs
+++ b/gateway-contract/contracts/auction_contract/tests/factory_auth.rs
@@ -45,7 +45,7 @@ fn setup_settleable() -> (Env, Address, Symbol, Address, Address, i128) {
         &0_u32,
         &None,
         &None,
-        &DutchAuctionDecay::None,
+        &Some(DutchAuctionDecay::None),
         &None,
     );
     client.place_bid(&auction_id, &bidder, &420_i128);
@@ -128,7 +128,7 @@ fn init_auction_reverts_when_factory_unset() {
         &0_u32,
         &None,
         &None,
-        &DutchAuctionDecay::None,
+        &Some(DutchAuctionDecay::None),
         &None,
     );
 
@@ -166,7 +166,7 @@ fn init_auction_requires_factory_auth() {
                     0_u32,
                     None::<i128>,
                     None::<i128>,
-                    DutchAuctionDecay::None,
+                    Some(DutchAuctionDecay::None),
                     None::<u32>,
                 )
                     .into_val(&env),
@@ -182,7 +182,7 @@ fn init_auction_requires_factory_auth() {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -219,7 +219,7 @@ fn init_auction_succeeds_with_factory_auth() {
                     0_u32,
                     None::<i128>,
                     None::<i128>,
-                    DutchAuctionDecay::None,
+                    Some(DutchAuctionDecay::None),
                     None::<u32>,
                 )
                     .into_val(&env),
@@ -235,7 +235,7 @@ fn init_auction_succeeds_with_factory_auth() {
             &0_u32,
             &None,
             &None,
-            &DutchAuctionDecay::None,
+            &Some(DutchAuctionDecay::None),
             &None,
         );
 
@@ -283,7 +283,7 @@ fn close_auction_requires_factory_auth() {
         &0_u32,
         &None,
         &None,
-        &DutchAuctionDecay::None,
+        &Some(DutchAuctionDecay::None),
         &None,
     );
 
@@ -327,7 +327,7 @@ fn close_auction_succeeds_with_factory_auth() {
         &0_u32,
         &None,
         &None,
-        &DutchAuctionDecay::None,
+        &Some(DutchAuctionDecay::None),
         &None,
     );
 

--- a/gateway-contract/contracts/auction_contract/tests/panic_with_error.rs
+++ b/gateway-contract/contracts/auction_contract/tests/panic_with_error.rs
@@ -27,7 +27,7 @@ fn init_open_auction(client: &AuctionClient<'_>, auction_id: &Symbol, end_time: 
         &0_u32,
         &None,
         &None,
-        &gateway_auction::DutchAuctionDecay::None,
+        &Some(gateway_auction::DutchAuctionDecay::None),
         &None,
     );
     factory

--- a/gateway-contract/contracts/auction_contract/tests/refund_atomic.rs
+++ b/gateway-contract/contracts/auction_contract/tests/refund_atomic.rs
@@ -71,7 +71,7 @@ fn open_english(client: &AuctionClient<'_>, id: &Symbol) {
         &0_u32,
         &None,
         &None,
-        &gateway_auction::DutchAuctionDecay::None,
+        &Some(gateway_auction::DutchAuctionDecay::None),
         &None,
     );
 }

--- a/gateway-contract/contracts/auction_contract/tests/transition_matrix.rs
+++ b/gateway-contract/contracts/auction_contract/tests/transition_matrix.rs
@@ -181,7 +181,7 @@ fn init_auction(client: &AuctionClient<'_>, auction_id: &Symbol, mode: AuctionMo
                 &0_u32,
                 &None,
                 &None,
-                &gateway_auction::DutchAuctionDecay::None,
+                &Some(gateway_auction::DutchAuctionDecay::None),
                 &None,
             );
         }
@@ -195,7 +195,7 @@ fn init_auction(client: &AuctionClient<'_>, auction_id: &Symbol, mode: AuctionMo
                 &0_u32,
                 &Some(500_i128),
                 &Some(100_i128),
-                &DutchAuctionDecay::None,
+                &Some(DutchAuctionDecay::None),
                 &None,
             );
             client.env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -227,7 +227,7 @@ fn setup_auction(mode: AuctionMode, from: AuctionStatus) -> (Env, Address, Symbo
     let factory = Address::generate(&env);
     client.set_factory_contract(&factory);
 
-    init_auction(&client, &auction_id, mode.clone());
+    init_auction(&client, &auction_id, mode);
 
     match (mode, from.clone()) {
         (_, AuctionStatus::Open) => {}
@@ -287,7 +287,7 @@ fn invoke_entrypoint(
 fn run_matrix(mode: AuctionMode) {
     for case in transition_matrix(mode) {
         let from = case.from.clone();
-        let (env, contract_id, auction_id, _winner) = setup_auction(mode.clone(), from);
+        let (env, contract_id, auction_id, _winner) = setup_auction(mode, from);
         let client = AuctionClient::new(&env, &contract_id);
         let status_before = read_status(&env, &contract_id, &auction_id);
 
@@ -351,7 +351,7 @@ fn dutch_auction_status_transition_matrix() {
 #[test]
 fn illegal_transition_count_is_six_per_mode() {
     for mode in [AuctionMode::English, AuctionMode::Dutch] {
-        let illegal = transition_matrix(mode.clone())
+        let illegal = transition_matrix(mode)
             .into_iter()
             .filter(|c| !c.expect_ok)
             .count();
@@ -365,7 +365,7 @@ fn illegal_transition_count_is_six_per_mode() {
 #[test]
 fn legal_transition_count_is_three_per_mode() {
     for mode in [AuctionMode::English, AuctionMode::Dutch] {
-        let legal = transition_matrix(mode.clone())
+        let legal = transition_matrix(mode)
             .into_iter()
             .filter(|c| c.expect_ok)
             .count();


### PR DESCRIPTION
- Integrate curves.rs module (pub mod curves) with re-exports

- Add comprehensive unit tests for Linear, Stepped, Exponential decay curves

- Add rustdoc explaining curves.rs relationship to compute_dutch_price

- Fix pre-existing type errors: init_auction dutch_decay now Option<DutchAuctionDecay>

- Fix StellarAssetClient::balance() -> token::Client::balance()

Closes #751