### PR TITLE
feat: borrow capabilities view

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -210,9 +210,9 @@ use crate::storage::{
 };
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
-    ContractError, CreditLineData, CreditLinesPage, CreditStatus, GracePeriodConfig, GraceWaiverMode,
-    OracleConfig, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
-    RateFormulaConfig, TreasuryWithdrawalProposal,
+    BorrowCapabilities, ContractError, CreditLineData, CreditLinesPage, CreditStatus,
+    GracePeriodConfig, GraceWaiverMode, OracleConfig, ProtocolConfig, ProtocolSummary,
+    ProtocolSummaryView, RateChangeConfig, RateFormulaConfig, TreasuryWithdrawalProposal,
 };
 use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Symbol, Vec};
 
@@ -1523,6 +1523,25 @@ impl Credit {
     /// ```
     pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> CreditLinesPage {
         views::get_credit_lines_paginated(env, cursor, limit)
+    }
+
+    /// Return a borrower's current borrow capabilities bitmap.
+    ///
+    /// Read-only view that reports whether the borrower can draw, repay,
+    /// or self-suspend, based on the current protocol state and the
+    /// borrower's credit line status. Amount-dependent checks (limit,
+    /// collateral ratio, cooldown, exposure caps) are not evaluated.
+    ///
+    /// # Authentication
+    /// No authentication required. This is a pure read-only query.
+    ///
+    /// # Returns
+    /// A [`BorrowCapabilities`] struct with three bool fields:
+    /// - `can_draw` — draw pre-flight checks pass
+    /// - `can_repay` — repay pre-flight checks pass
+    /// - `can_self_suspend` — self-suspend pre-flight checks pass
+    pub fn borrow_capabilities(env: Env, borrower: Address) -> BorrowCapabilities {
+        views::borrow_capabilities(env, borrower)
     }
 
     pub fn deposit_collateral(env: Env, borrower: Address, amount: i128) {

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -617,6 +617,34 @@ pub struct ProtocolSummaryView {
     pub active_line_count: u32,
 }
 
+/// Read-only capabilities bitmap for a borrower's credit line.
+///
+/// Returned by `borrow_capabilities` to let off-chain clients and
+/// on-chain integrators inspect which operations are currently
+/// permitted for a borrower, without needing to simulate the full
+/// entrypoint logic.
+///
+/// Each `bool` field represents a single operation; `true` means the
+/// operation should succeed assuming valid parameters (amount, etc.).
+/// Amount-dependent checks (credit limit, collateral ratio, draw
+/// cooldown, exposure caps) are NOT evaluated because this view does
+/// not know the intended draw amount.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BorrowCapabilities {
+    /// Whether the borrower can draw credit. False when the credit line
+    /// does not exist, the protocol is paused, draws are frozen, the
+    /// borrower is blocked/frozen, or the credit-line status is not
+    /// draw-allowed (Active/Restricted).
+    pub can_draw: bool,
+    /// Whether the borrower can repay credit. False when the credit line
+    /// does not exist or is permanently Closed.
+    pub can_repay: bool,
+    /// Whether the borrower can self-suspend their credit line. True
+    /// only when the credit line exists and is currently Active.
+    pub can_self_suspend: bool,
+}
+
 /// Proof-of-reserve view for the protocol treasury.
 ///
 /// Exposes the accumulated reserves held by the protocol in a single

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -6,9 +6,74 @@
 //! no authentication required. TTL may be bumped by `get_credit_line` via the
 //! storage layer when the persistent entry nears expiry.
 
-use crate::storage::{get_borrower_by_credit_line_id, get_credit_line, MAX_ENUMERATION_LIMIT};
-use crate::types::{CreditLinesPage, ProofOfReserve, ProtocolSummaryView};
-use soroban_sdk::{Env, Vec};
+use crate::storage::{
+    get_borrower_by_credit_line_id, get_credit_line, is_borrower_blocked, is_borrower_frozen,
+    is_paused, MAX_ENUMERATION_LIMIT,
+};
+use crate::types::{BorrowCapabilities, CreditLinesPage, ProofOfReserve, ProtocolSummaryView};
+use soroban_sdk::{Address, Env, Vec};
+
+// ── Borrow capabilities view ─────────────────────────────────────────────────
+
+/// Return a borrower's current capabilities bitmap.
+///
+/// This is a read-only, no-auth view that reports which operations are
+/// currently permitted for a given borrower. It evaluates the same
+/// pre-flight checks that `draw_credit`, `repay_credit`, and
+/// `self_suspend_credit_line` perform, EXCEPT for amount-dependent
+/// checks (credit limit, collateral ratio, cooldown, exposure caps)
+/// because this view does not know the intended draw/repay amount.
+///
+/// # Parameters
+/// - `borrower`: The borrower address to query.
+///
+/// # Returns
+/// A [`BorrowCapabilities`] struct with three bool fields:
+/// - `can_draw` — draw pre-flight checks pass
+/// - `can_repay` — repay pre-flight checks pass
+/// - `can_self_suspend` — self-suspend pre-flight checks pass
+///
+/// # Security
+/// This is a pure read-only query. It does not require authentication
+/// and does not mutate any state. TTL may be bumped if the borrower's
+/// persistent entry is near expiry, but this does not change logical state.
+pub fn borrow_capabilities(env: Env, borrower: Address) -> BorrowCapabilities {
+    let credit_line = get_credit_line(&env, &borrower);
+
+    let can_draw = credit_line
+        .as_ref()
+        .map(|line| {
+            // Credit status must allow draws
+            crate::borrow::draw_status_error(line.status).is_none()
+                // Protocol must not be paused
+                && !is_paused(&env)
+                // Global draws must not be frozen
+                && !crate::freeze::is_draws_frozen(&env)
+                // Borrower must not be blocked
+                && !is_borrower_blocked(&env, &borrower)
+                // Borrower must not be temporarily frozen
+                && !is_borrower_frozen(&env, &borrower)
+                // Credit line must not be admin-frozen
+                && !crate::freeze::is_credit_line_frozen(&env, &borrower)
+        })
+        .unwrap_or(false);
+
+    let can_repay = credit_line
+        .as_ref()
+        .map(|line| line.status != crate::types::CreditStatus::Closed)
+        .unwrap_or(false);
+
+    let can_self_suspend = credit_line
+        .as_ref()
+        .map(|line| line.status == crate::types::CreditStatus::Active)
+        .unwrap_or(false);
+
+    BorrowCapabilities {
+        can_draw,
+        can_repay,
+        can_self_suspend,
+    }
+}
 
 // ── Protocol-level views ─────────────────────────────────────────────────────
 

--- a/contracts/credit/src/views_tests.rs
+++ b/contracts/credit/src/views_tests.rs
@@ -368,3 +368,239 @@ fn test_credit_lines_paginated_cursor_continuation() {
     assert!(all_limits.contains(&3000));
     assert!(all_limits.contains(&4000));
 }
+
+// ── Borrow capabilities tests ─────────────────────────────────────────────────
+
+fn setup_caps_test(env: &Env) -> (CreditClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(env, &contract_id);
+
+    let token = Address::generate(env);
+    let source = Address::generate(env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    let borrower = Address::generate(env);
+    client.open_credit_line(&borrower, &10_000, &500, &50);
+
+    (client, admin, borrower)
+}
+
+/// No credit line exists → all capabilities are false.
+#[test]
+fn borrow_caps_no_line() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let stranger = Address::generate(&env);
+    let caps = client.borrow_capabilities(&stranger);
+    assert!(!caps.can_draw, "no line → cannot draw");
+    assert!(!caps.can_repay, "no line → cannot repay");
+    assert!(!caps.can_self_suspend, "no line → cannot self-suspend");
+}
+
+/// Active credit line with no restrictions → all capabilities true.
+#[test]
+fn borrow_caps_active_line() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(caps.can_draw, "active line → can draw");
+    assert!(caps.can_repay, "active line → can repay");
+    assert!(caps.can_self_suspend, "active line → can self-suspend");
+}
+
+/// Suspended credit line → draw and self-suspend blocked, repay still allowed.
+#[test]
+fn borrow_caps_suspended() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    client.suspend_credit_line(&borrower);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "suspended → cannot draw");
+    assert!(caps.can_repay, "suspended → can repay");
+    assert!(!caps.can_self_suspend, "suspended → cannot self-suspend");
+}
+
+/// Defaulted credit line → draw and self-suspend blocked, repay allowed.
+#[test]
+fn borrow_caps_defaulted() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    client.default_credit_line(&borrower);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "defaulted → cannot draw");
+    assert!(caps.can_repay, "defaulted → can repay");
+    assert!(!caps.can_self_suspend, "defaulted → cannot self-suspend");
+}
+
+/// Closed credit line → all capabilities false.
+#[test]
+fn borrow_caps_closed() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup_caps_test(&env);
+
+    client.close_credit_line(&borrower, &admin);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "closed → cannot draw");
+    assert!(!caps.can_repay, "closed → cannot repay");
+    assert!(!caps.can_self_suspend, "closed → cannot self-suspend");
+}
+
+/// Self-suspended credit line → draws blocked, repay allowed, self-suspend blocked.
+#[test]
+fn borrow_caps_self_suspended() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    client.self_suspend_credit_line(&borrower);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "self-suspended → cannot draw");
+    assert!(caps.can_repay, "self-suspended → can repay");
+    assert!(!caps.can_self_suspend, "already suspended → cannot self-suspend again");
+}
+
+/// Protocol paused → draws blocked, repay and self-suspend still allowed.
+#[test]
+fn borrow_caps_protocol_paused() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    client.set_protocol_paused(&true);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "paused → cannot draw");
+    assert!(caps.can_repay, "paused → can repay");
+    assert!(caps.can_self_suspend, "paused → can self-suspend");
+}
+
+/// Global draws frozen → draws blocked, repay and self-suspend still allowed.
+#[test]
+fn borrow_caps_global_draws_frozen() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    client.freeze_draws();
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "draws frozen → cannot draw");
+    assert!(caps.can_repay, "draws frozen → can repay");
+    assert!(caps.can_self_suspend, "draws frozen → can self-suspend");
+}
+
+/// Borrower blocked → draws blocked, repay and self-suspend still allowed.
+#[test]
+fn borrow_caps_borrower_blocked() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup_caps_test(&env);
+
+    client.block_borrower(&admin, &borrower);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "blocked → cannot draw");
+    assert!(caps.can_repay, "blocked → can repay");
+    assert!(caps.can_self_suspend, "blocked → can self-suspend");
+}
+
+/// Borrower temporarily frozen → draws blocked, repay and self-suspend still allowed.
+#[test]
+fn borrow_caps_borrower_frozen() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup_caps_test(&env);
+
+    // Freeze until far in the future
+    client.freeze_borrower_until(&admin, &borrower, &1_000_000);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "frozen → cannot draw");
+    assert!(caps.can_repay, "frozen → can repay");
+    assert!(caps.can_self_suspend, "frozen → can self-suspend");
+}
+
+/// Credit line admin-frozen → draws blocked, repay and self-suspend still allowed.
+#[test]
+fn borrow_caps_credit_line_frozen() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_caps_test(&env);
+
+    client.freeze_credit_line(&borrower, &crate::FreezeReason::Compliance);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "line frozen → cannot draw");
+    assert!(caps.can_repay, "line frozen → can repay");
+    assert!(caps.can_self_suspend, "line frozen → can self-suspend");
+}
+
+/// Temporary freeze expiry → draws re-enabled.
+#[test]
+fn borrow_caps_freeze_expires() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup_caps_test(&env);
+
+    // Freeze until timestamp 2000
+    client.freeze_borrower_until(&admin, &borrower, &2000);
+
+    // Still frozen at t=1500
+    env.ledger().with_mut(|li| li.timestamp = 1500);
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "before expiry → cannot draw");
+
+    // Expired at t=2000
+    env.ledger().with_mut(|li| li.timestamp = 2000);
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(caps.can_draw, "at expiry → can draw");
+
+    // Well past expiry at t=3000
+    env.ledger().with_mut(|li| li.timestamp = 3000);
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(caps.can_draw, "after expiry → can draw");
+}
+
+/// Multiple blocking conditions: the most restrictive one applies.
+#[test]
+fn borrow_caps_multiple_blocks() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup_caps_test(&env);
+
+    // Paused + blocked + frozen = still just can_draw false
+    client.set_protocol_paused(&true);
+    client.block_borrower(&admin, &borrower);
+
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "multiple blocks → cannot draw");
+    assert!(caps.can_repay, "multiple blocks → still can repay");
+    assert!(caps.can_self_suspend, "multiple blocks → still can self-suspend");
+}
+
+/// After unblocking, draws are restored.
+#[test]
+fn borrow_caps_unblock_restores_draws() {
+    let env = Env::default();
+    let (client, admin, borrower) = setup_caps_test(&env);
+
+    client.block_borrower(&admin, &borrower);
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(!caps.can_draw, "blocked → cannot draw");
+
+    client.unblock_borrower(&admin, &borrower);
+    let caps = client.borrow_capabilities(&borrower);
+    assert!(caps.can_draw, "unblocked → can draw again");
+}


### PR DESCRIPTION
Adds a read-only  entrypoint that returns
a  bitmap with three bool fields:
-  — pre-flight checks for draw_credit pass
-  — credit line exists and is not Closed
-  — credit line exists and is Active

Evaluates the same status/freeze/block/pause checks the mutating entrypoints enforce, but skips amount-dependent checks (limit, collateral ratio, cooldown, exposure caps) since the view has no knowledge of the intended draw/repay amount.

Closes #851