### PR TITLE
docs: document get_protocol_summary_view in protocol spec

### DIFF
--- a/docs/PROTOCOL_SPEC.md
+++ b/docs/PROTOCOL_SPEC.md
@@ -406,6 +406,7 @@ See `contracts/credit/src/fees.rs`.
 | `get_protocol_fee_bps()`                                         | `Option<u32>`                                                                                            |
 | `get_collateral(borrower)`                                       | `i128`                                                                                                   |
 | `get_health_factor(borrower)`                                    | `u32` (bps-scaled, `u32::MAX` when no debt; `< 10_000` = liquidatable; see `query.rs:get_health_factor`) |
+| `get_protocol_summary_view()`                                    | `ProtocolSummaryView { total_utilized, total_collateral, active_line_count }` — active-line-only aggregate view built for the GrantFox campaign; see `views.rs:get_protocol_summary_view` |
 
 Reads with persistent borrower data invoke `bump_credit_line_ttl` (a write,
 but cheap and idempotent — see `storage.rs:146`).


### PR DESCRIPTION
## What changed

Documented `get_protocol_summary_view` in `docs/PROTOCOL_SPEC.md` §2.10 (Read-only queries).

## Why

Closes #782.

Before implementing anything, I verified the feature described in this issue ("Add protocol summary view — return totals") was already implemented and tested in the live crate:

- Implementation: `contracts/credit/src/views.rs::get_protocol_summary_view`
- Wired as a contract entrypoint: `contracts/credit/src/lib.rs`
- Explicitly built for this campaign — its own doc comment reads: *"Protocol summary returned by the specific query view for GrantFox campaign."*
- Test coverage already exists: `contracts/credit/src/views_tests.rs::test_protocol_summary_view_active_lines`, covering zero-state, incremental active-line counting across multiple borrowers, and count decrementing on suspend/default.

The one genuine gap was documentation: neither `get_protocol_summary_view` nor its sibling `get_protocol_summary`/`get_proof_of_reserve` appeared in `docs/PROTOCOL_SPEC.md`'s read-only query table. This PR adds the missing row for `get_protocol_summary_view`.

Note: the issue's suggested implementation path (`contracts/creditra-credit/src/views.rs`) does not correspond to a workspace member — `Cargo.toml`'s `members` list only includes `contracts/credit`, `contracts/accrual`, `contracts/collateral`, and `gateway-contract/contracts/auction_contract`. The real, live crate is `contracts/credit`.

## How it was tested

The existing test `test_protocol_summary_view_active_lines` appears correct on inspection (covers empty state, incremental counting, suspend/default transitions) but **could not be executed**, because `contracts/credit` currently fails to compile independent of this change.

Confirmed via stash comparison that this is pre-existing and unrelated:
- With this PR's one-line doc change: 530 compile errors
- On a clean checkout with the change stashed out: 534 compile errors
- Same root cause in both cases (e.g. non-exhaustive `DataKey::CloseFactorBps` match in `storage.rs`, unrelated to protocol summary)

This PR does not attempt to fix that pre-existing breakage, as it's out of scope for #782 — flagging for maintainer visibility.

## Limitations / things I noticed but left out of scope

- `contracts/credit` fails to compile on a clean checkout (530+ errors) — pre-existing, unrelated to this change.
- `contracts/creditra-credit` exists in the repo but is not a Cargo workspace member; its contents (a CosmWasm-style crate, distinct from the Soroban `contracts/credit`) appear unrelated to the active codebase.
- Sibling queries `get_protocol_summary` and `get_proof_of_reserve` are also undocumented in `PROTOCOL_SPEC.md` — out of scope here, but worth a follow-up doc pass.