### PR TITLE
fix: collateral TTL bump (#831)

### DIFF
--- a/contracts/credit/src/collateral_ttl.rs
+++ b/contracts/credit/src/collateral_ttl.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+
+//! TTL bump regression tests for collateral persistent storage keys.
+//!
+//! The credit contract stores per-borrower collateral balances in persistent
+//! storage entries (`CollateralBalance(borrower)` and
+//! `CollateralBalanceV2(borrower, token)`).
+//! These entries must have their TTL extended on every read/write path
+//! (deposit, withdraw, partial release, get_collateral query) so that active
+//! borrowers' collateral is not silently archived by the network.
+//!
+//! Tests here exercise the storage helpers directly via `env.as_contract` so
+//! we can focus on TTL behaviour without requiring a fully configured token
+//! transfer environment.
+
+#[cfg(test)]
+mod test {
+    use crate::storage::{DataKey, LEDGER_BUMP_AMOUNT, LEDGER_BUMP_THRESHOLD};
+    use crate::{Credit, CreditClient};
+    use soroban_sdk::testutils::storage::Persistent as _;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, Env};
+
+    fn setup(env: &Env) -> (Address, CreditClient) {
+        env.mock_all_auths();
+        let admin = Address::generate(env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(env, &contract_id);
+        client.init(&admin);
+        (contract_id, client)
+    }
+
+    fn advance_ledgers(env: &Env, delta: u32) {
+        env.ledger().with_mut(|li| {
+            li.sequence_number = li.sequence_number.saturating_add(delta);
+        });
+    }
+
+    fn ttl_for_key<K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>>(
+        env: &Env,
+        contract_id: &Address,
+        key: &K,
+    ) -> u32 {
+        env.as_contract(contract_id, || env.storage().persistent().get_ttl(key))
+    }
+
+    /// Helper: drain the TTL of a persistent key to just below the bump
+    /// threshold so the next read/write path must perform a real bump.
+    fn advance_past_ttl_threshold<K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>>(
+        env: &Env,
+        contract_id: &Address,
+        key: &K,
+    ) {
+        let initial = ttl_for_key(env, contract_id, key);
+        let target = LEDGER_BUMP_THRESHOLD.saturating_sub(1);
+        let delta = initial.saturating_sub(target);
+        advance_ledgers(env, delta);
+    }
+
+    // ── Single-token collateral balance TTL tests ────────────────────────────
+
+    #[test]
+    fn set_collateral_balance_bumps_ttl_on_write() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+        let balance_key = DataKey::CollateralBalance(borrower.clone());
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 500_i128);
+        });
+
+        let initial_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            initial_ttl >= LEDGER_BUMP_AMOUNT,
+            "first set must set TTL >= bump amount; got {initial_ttl}"
+        );
+
+        advance_past_ttl_threshold(&env, &contract_id, &balance_key);
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 700_i128);
+        });
+
+        let after_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            after_ttl >= LEDGER_BUMP_AMOUNT,
+            "set must extend TTL; after={after_ttl}"
+        );
+    }
+
+    #[test]
+    fn get_collateral_balance_bumps_ttl_on_read() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+        let balance_key = DataKey::CollateralBalance(borrower.clone());
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 1_000_i128);
+        });
+
+        advance_past_ttl_threshold(&env, &contract_id, &balance_key);
+
+        let balance = env.as_contract(&contract_id, || {
+            crate::storage::get_collateral_balance(&env, &borrower)
+        });
+        assert_eq!(balance, 1_000_i128);
+
+        let after_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            after_ttl >= LEDGER_BUMP_AMOUNT,
+            "get_collateral_balance read must extend TTL; after={after_ttl}"
+        );
+    }
+
+    #[test]
+    fn get_collateral_balance_absent_key_returns_zero_without_panic() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+
+        let balance = env.as_contract(&contract_id, || {
+            crate::storage::get_collateral_balance(&env, &borrower)
+        });
+        assert_eq!(balance, 0_i128);
+    }
+
+    #[test]
+    fn set_collateral_balance_bumps_ttl_on_balance_reduction() {
+        // set_collateral_balance reads the previous value directly from
+        // storage (rather than calling get_collateral_balance) to avoid a
+        // redundant TTL bump on the read side.  This test confirms the
+        // function bumps TTL correctly even when reducing the balance.
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+        let balance_key = DataKey::CollateralBalance(borrower.clone());
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 500_i128);
+        });
+
+        let balance = env.as_contract(&contract_id, || {
+            crate::storage::get_collateral_balance(&env, &borrower)
+        });
+        assert_eq!(balance, 500_i128);
+
+        advance_past_ttl_threshold(&env, &contract_id, &balance_key);
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 300_i128);
+        });
+
+        let after_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            after_ttl >= LEDGER_BUMP_AMOUNT,
+            "set must extend TTL even when reducing balance; after={after_ttl}"
+        );
+
+        let balance = env.as_contract(&contract_id, || {
+            crate::storage::get_collateral_balance(&env, &borrower)
+        });
+        assert_eq!(balance, 300_i128);
+    }
+
+    #[test]
+    fn set_collateral_balance_zero_adjusts_total_collateral_accumulator() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 500_i128);
+        });
+
+        let total_before = env.as_contract(&contract_id, || {
+            crate::storage::get_total_collateral(&env)
+        });
+        assert_eq!(total_before, 500_i128);
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance(&env, &borrower, 0_i128);
+        });
+
+        let total_after = env.as_contract(&contract_id, || {
+            crate::storage::get_total_collateral(&env)
+        });
+        assert_eq!(total_after, 0_i128);
+    }
+
+    // ── Multi-collateral token balance TTL tests ─────────────────────────────
+
+    #[test]
+    fn set_collateral_balance_for_token_bumps_ttl_on_write() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+        let token = Address::generate(&env);
+        let balance_key =
+            DataKey::CollateralBalanceV2(borrower.clone(), token.clone());
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance_for_token(
+                &env, &borrower, &token, 500_i128,
+            );
+        });
+
+        let initial_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            initial_ttl >= LEDGER_BUMP_AMOUNT,
+            "first token set must set TTL >= bump amount; got {initial_ttl}"
+        );
+
+        advance_past_ttl_threshold(&env, &contract_id, &balance_key);
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance_for_token(
+                &env, &borrower, &token, 700_i128,
+            );
+        });
+
+        let after_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            after_ttl >= LEDGER_BUMP_AMOUNT,
+            "token set must extend TTL; after={after_ttl}"
+        );
+    }
+
+    #[test]
+    fn get_collateral_balance_for_token_bumps_ttl_on_read() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+        let token = Address::generate(&env);
+        let balance_key =
+            DataKey::CollateralBalanceV2(borrower.clone(), token.clone());
+
+        env.as_contract(&contract_id, || {
+            crate::storage::set_collateral_balance_for_token(
+                &env, &borrower, &token, 1_000_i128,
+            );
+        });
+
+        advance_past_ttl_threshold(&env, &contract_id, &balance_key);
+
+        let balance = env.as_contract(&contract_id, || {
+            crate::storage::get_collateral_balance_for_token(
+                &env, &borrower, &token,
+            )
+        });
+        assert_eq!(balance, 1_000_i128);
+
+        let after_ttl = ttl_for_key(&env, &contract_id, &balance_key);
+        assert!(
+            after_ttl >= LEDGER_BUMP_AMOUNT,
+            "get_collateral_balance_for_token read must extend TTL; after={after_ttl}"
+        );
+    }
+
+    #[test]
+    fn get_collateral_balance_for_token_absent_key_returns_zero() {
+        let env = Env::default();
+        let (contract_id, _client) = setup(&env);
+        let borrower = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        let balance = env.as_contract(&contract_id, || {
+            crate::storage::get_collateral_balance_for_token(
+                &env, &borrower, &token,
+            )
+        });
+        assert_eq!(balance, 0_i128);
+    }
+}

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -6710,3 +6710,5 @@ mod test_max_draw_amount {
 
 #[cfg(test)]
 mod test_ttl;
+#[cfg(test)]
+mod collateral_ttl;

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -484,20 +484,36 @@ pub fn persist_credit_line(
     }
 }
 
-/// Return a borrower's collateral balance without bumping unrelated TTL.
+/// Return a borrower's collateral balance and bump its persistent TTL.
+///
+/// The collateral balance is stored in a separate persistent entry from the
+/// credit line, so its TTL must be independently refreshed on every read path
+/// (deposit, withdraw, partial release, draw-credit ratio check, and the
+/// `get_collateral` query). Without a bump the entry would be archived
+/// independently of the credit-line entry, causing the borrower's collateral
+/// to appear as zero.
 pub fn get_collateral_balance(env: &Env, borrower: &Address) -> i128 {
-    env.storage()
-        .persistent()
-        .get(&DataKey::CollateralBalance(borrower.clone()))
-        .unwrap_or(0)
+    let key = DataKey::CollateralBalance(borrower.clone());
+    if env.storage().persistent().has(&key) {
+        bump_persistent_ttl(env, &key);
+    }
+    env.storage().persistent().get(&key).unwrap_or(0)
 }
 
 /// Persist a borrower collateral balance and update the global accumulator.
+///
+/// Bumps the TTL of the persistent `CollateralBalance(borrower)` entry so an
+/// active borrower's collateral is never archived independently of the credit
+/// line.
+///
+/// Note: the previous balance is read directly from storage (not via
+/// [`get_collateral_balance`]) to avoid a redundant TTL bump on the read
+/// path; the write path bumps TTL immediately after the set.
 pub fn set_collateral_balance(env: &Env, borrower: &Address, balance: i128) {
-    let previous_balance = get_collateral_balance(env, borrower);
-    env.storage()
-        .persistent()
-        .set(&DataKey::CollateralBalance(borrower.clone()), &balance);
+    let key = DataKey::CollateralBalance(borrower.clone());
+    let previous_balance = env.storage().persistent().get(&key).unwrap_or(0);
+    env.storage().persistent().set(&key, &balance);
+    bump_persistent_ttl(env, &key);
     adjust_total_collateral(env, previous_balance, balance);
 }
 
@@ -1388,13 +1404,14 @@ pub fn clear_borrower_frozen(env: &Env, borrower: &Address) {
 
 // ── Multi-collateral (per-borrower, per-token) ────────────────────────────────
 
-/// Return a borrower's balance for a specific collateral token.
+/// Return a borrower's balance for a specific collateral token and bump
+/// the persistent entry's TTL so it remains live alongside the credit line.
 pub fn get_collateral_balance_for_token(env: &Env, borrower: &Address, token: &Address) -> i128 {
     let key = DataKey::CollateralBalanceV2(borrower.clone(), token.clone());
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(0)
+    if env.storage().persistent().has(&key) {
+        bump_persistent_ttl(env, &key);
+    }
+    env.storage().persistent().get(&key).unwrap_or(0)
 }
 
 /// Persist a borrower's balance for a specific collateral token and update the global accumulator.


### PR DESCRIPTION
## Summary

Adds TTL (Time-To-Live) bump calls to collateral persistent storage keys in the credit contract. Previously, per-borrower collateral balance entries (`CollateralBalance` and `CollateralBalanceV2`) could be archived by the Soroban network independently of the credit line, causing a borrower's collateral to silently appear as zero. This PR proactively extends TTL on every read/write path.

Closes #831

---

## Problem

The credit contract stores per-borrower collateral balances in persistent storage entries separate from the credit line entry:

- `DataKey::CollateralBalance(borrower)` — single-token collateral balance
- `DataKey::CollateralBalanceV2(borrower, token)` — multi-token per-asset balance

While the credit line entry (`CreditLineData`) has its TTL bumped on every interaction via `bump_credit_line_ttl`, the collateral balance entries were **never bumped**. On Soroban, persistent entries with expired TTL are archived — their values revert to the default (zero). Without a bump, an active borrower's collateral could silently disappear, breaking:

- Collateral ratio checks in `draw_credit`
- `withdraw_collateral` / `partial_release_collateral` balance checks
- `get_collateral` / `get_health_factor` queries
- `adjust_total_collateral` global accumulator consistency

---

## Solution

Three storage helpers in `contracts/credit/src/storage.rs` now bump TTL:

| Function | Change | Pattern |
|---|---|---|
| `get_collateral_balance` | Added `has` -> `bump_persistent_ttl` -> `get` | Mirrors `get_repayment_schedule` |
| `set_collateral_balance` | Added `bump_persistent_ttl` after `set`; reads previous balance directly to avoid redundant bump | Mirrors `set_collateral_balance_for_token` |
| `get_collateral_balance_for_token` | Added `has` -> `bump_persistent_ttl` -> `get` | Same read-path pattern |

The write path for `set_collateral_balance_for_token` already bumped TTL (pre-existing), so the read path was the only gap there.

### Key design decisions

- **Direct read in `set_collateral_balance`**: The function reads the previous balance directly from storage rather than calling `get_collateral_balance`. This avoids a redundant TTL bump since the write path immediately calls `bump_persistent_ttl`. A clarifying doc comment explains this.
- **TTL policy reuse**: Uses the existing `LEDGER_BUMP_AMOUNT` (~6 months) and `LEDGER_BUMP_THRESHOLD` (~3 months) constants. The `extend_ttl` call is idempotent — it only writes when remaining TTL drops below the threshold.
- **Entrypoints benefiting**: Every user-facing path that reads or writes collateral now bumps TTL:
  - `deposit_collateral` -> read + write
  - `withdraw_collateral` -> read + write
  - `partial_release_collateral` -> read + write
  - `get_collateral` -> read
  - `draw_credit` (collateral ratio check) -> read
  - `get_health_factor` -> read
  - Multi-token variants via `deposit_collateral_token` / `withdraw_collateral_token` / `get_collateral_for_token`

---

## Files Changed

| File | Change |
|---|---|
| `contracts/credit/src/storage.rs` | Added TTL bump to `get_collateral_balance`, `set_collateral_balance`, `get_collateral_balance_for_token` |
| `contracts/credit/src/collateral_ttl.rs` | **New** — 8 unit tests exercising TTL bump behavior |
| `contracts/credit/src/lib.rs` | Added `#[cfg(test)] mod collateral_ttl;` module registration |

---

## Tests

8 focused unit tests in `contracts/credit/src/collateral_ttl.rs`, testing the storage layer directly via `env.as_contract`:

### Single-token balance (`CollateralBalance`)
- `set_collateral_balance_bumps_ttl_on_write` — first write and subsequent writes after TTL drain
- `get_collateral_balance_bumps_ttl_on_read` — read path extends TTL when below threshold
- `get_collateral_balance_absent_key_returns_zero_without_panic` — safety for never-written keys
- `set_collateral_balance_bumps_ttl_on_balance_reduction` — TTL extended even when decreasing balance
- `set_collateral_balance_zero_adjusts_total_collateral_accumulator` — accumulator integrity

### Multi-token balance (`CollateralBalanceV2`)
- `set_collateral_balance_for_token_bumps_ttl_on_write` — first and subsequent writes
- `get_collateral_balance_for_token_bumps_ttl_on_read` — read path extends TTL
- `get_collateral_balance_for_token_absent_key_returns_zero` — absent key safety

---

## Security Considerations

- **No auth changes**: The TTL bump is a passive storage extension — no authorization boundaries are modified
- **No state mutation beyond TTL**: `bump_persistent_ttl` only calls Soroban's `extend_ttl`, which is a ledger-level TTL extension
- **No new attack surface**: The `has` check before `bump_persistent_ttl` means non-existent keys never trigger unnecessary storage writes
- **Overflow safety**: All collateral math continues to use `checked_*` primitives

---

## Backward Compatibility

Fully backward-compatible. No storage schema changes, no API changes, no event signature changes. The change is purely behavioral: collateral entries that were previously at risk of silent archival now have their TTL extended alongside credit-line entries.

---

## How to Verify

```bash
cargo test -p creditra-credit collateral_ttl
cargo test -p creditra-credit
```
