### PR TITLE
feat: add per-borrower liquidation grace (#741)

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1074,6 +1074,25 @@ impl Credit {
         crate::storage::get_grace_period_config(&env)
     }
 
+    /// Set or update the per-borrower liquidation grace period in seconds (admin only).
+    ///
+    /// # Arguments
+    /// - `env`: Soroban environment.
+    /// - `borrower`: Borrower address to configure.
+    /// - `grace_period_seconds`: Grace period duration in seconds. Pass `0` to remove.
+    pub fn set_per_borrower_liquidation_grace(
+        env: Env,
+        borrower: Address,
+        grace_period_seconds: u64,
+    ) {
+        lifecycle::set_per_borrower_liquidation_grace(&env, borrower, grace_period_seconds);
+    }
+
+    /// Return the per-borrower liquidation grace period in seconds for `borrower`.
+    pub fn get_per_borrower_liquidation_grace(env: Env, borrower: Address) -> u64 {
+        lifecycle::get_per_borrower_liquidation_grace(&env, borrower)
+    }
+
     /// Set the structured late-fee configuration (flat amount or APR-based).
     ///
     /// Pass `Some(LateFeeConfig::Flat(FlatFeeConfig { amount }))` to charge a

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -289,6 +289,44 @@ fn suspend_credit_line_internal(env: &Env, borrower: Address) {
     );
 }
 
+// ── per-borrower liquidation grace ──────────────────────────────────────────
+
+/// Set or update the per-borrower liquidation grace period in seconds (admin only).
+///
+/// # Arguments
+/// - `env`: Soroban environment.
+/// - `borrower`: Borrower address to configure.
+/// - `grace_period_seconds`: Grace period duration in seconds. Pass `0` to remove.
+///
+/// # Panics
+/// - `ContractError::CreditLineNotFound` if no credit line exists for `borrower`.
+/// - `ContractError::CreditLineClosed` if the credit line is `Closed`.
+pub fn set_per_borrower_liquidation_grace(
+    env: &Env,
+    borrower: Address,
+    grace_period_seconds: u64,
+) {
+    assert_not_paused(env);
+    require_admin_auth(env);
+
+    let stored_line: CreditLineData = env
+        .storage()
+        .persistent()
+        .get(&borrower)
+        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
+
+    if stored_line.status == CreditStatus::Closed {
+        env.panic_with_error(ContractError::CreditLineClosed);
+    }
+
+    crate::storage::set_per_borrower_liquidation_grace(env, &borrower, grace_period_seconds);
+}
+
+/// Return the per-borrower liquidation grace period in seconds for `borrower`.
+pub fn get_per_borrower_liquidation_grace(env: &Env, borrower: Address) -> u64 {
+    crate::storage::get_per_borrower_liquidation_grace(env, &borrower)
+}
+
 /// Set or replace a borrower's installment repayment schedule.
 pub fn set_repayment_schedule(
     env: &Env,
@@ -691,6 +729,24 @@ pub fn default_credit_line(env: Env, borrower: Address) {
     if credit_line.status == CreditStatus::Defaulted {
         // Idempotent: already defaulted, nothing to do.
         return;
+    }
+
+    let grace_seconds = crate::storage::get_per_borrower_liquidation_grace(&env, &borrower);
+    if grace_seconds > 0 {
+        let now = env.ledger().timestamp();
+        let base_ts = if credit_line.suspension_ts > 0 {
+            credit_line.suspension_ts
+        } else if let Some(schedule) = get_repayment_schedule(&env, &borrower) {
+            schedule.next_due_ts
+        } else if credit_line.last_rate_update_ts > 0 {
+            credit_line.last_rate_update_ts
+        } else {
+            credit_line.last_accrual_ts
+        };
+
+        if now < base_ts.saturating_add(grace_seconds) {
+            env.panic_with_error(ContractError::LiquidationGraceActive);
+        }
     }
 
     let _previous_status = credit_line.status;
@@ -1315,5 +1371,97 @@ mod installment {
         let treasury_after = client.get_protocol_summary().treasury_balance;
         // Only 1 overdue installment × 30 = 30
         assert_eq!(treasury_after - treasury_before, 30);
+    }
+
+    // ── per-borrower liquidation grace tests ─────────────────────────────────
+
+    #[test]
+    fn per_borrower_liquidation_grace_roundtrip() {
+        let env = Env::default();
+        let (client, borrower) = setup_borrower(&env);
+
+        assert_eq!(client.get_per_borrower_liquidation_grace(&borrower), 0);
+
+        client.set_per_borrower_liquidation_grace(&borrower, &3600_u64);
+        assert_eq!(client.get_per_borrower_liquidation_grace(&borrower), 3600);
+
+        // Setting to 0 removes it
+        client.set_per_borrower_liquidation_grace(&borrower, &0_u64);
+        assert_eq!(client.get_per_borrower_liquidation_grace(&borrower), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #55)")]
+    fn per_borrower_liquidation_grace_blocks_default_within_grace() {
+        let env = Env::default();
+        let (client, borrower) = setup_borrower(&env);
+
+        setup_draw(&env, &client, &borrower, 500_000, 100);
+        client.suspend_credit_line(&borrower); // suspended at t=100
+
+        // Set grace period of 3600 seconds
+        client.set_per_borrower_liquidation_grace(&borrower, &3600_u64);
+
+        // Advance to t=1000 (inside grace window t=100..3700)
+        env.ledger().set_timestamp(1000);
+
+        // Attempt default — should panic with ContractError::LiquidationGraceActive (#55)
+        client.default_credit_line(&borrower);
+    }
+
+    #[test]
+    fn per_borrower_liquidation_grace_allows_default_after_grace() {
+        let env = Env::default();
+        let (client, borrower) = setup_borrower(&env);
+
+        setup_draw(&env, &client, &borrower, 500_000, 100);
+        client.suspend_credit_line(&borrower); // suspended at t=100
+
+        // Set grace period of 3600 seconds
+        client.set_per_borrower_liquidation_grace(&borrower, &3600_u64);
+
+        // Advance past grace window to t=3701
+        env.ledger().set_timestamp(3701);
+
+        // Default succeeds
+        client.default_credit_line(&borrower);
+
+        let line = client.get_credit_line(&borrower).unwrap();
+        assert_eq!(line.status, CreditStatus::Defaulted);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn set_per_borrower_liquidation_grace_requires_admin_auth() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+
+        let borrower = Address::generate(&env);
+        client.open_credit_line(&borrower, &1_000_000, &1000, &5000);
+
+        // Switch to non-admin client
+        let non_admin_client = CreditClient::new(&env, &contract_id);
+        // Non-admin call should fail with NotAdmin (#2)
+        non_admin_client.set_per_borrower_liquidation_grace(&borrower, &3600_u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn set_per_borrower_liquidation_grace_reverts_for_missing_line() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(Credit, ());
+        let client = CreditClient::new(&env, &contract_id);
+        client.init(&admin);
+
+        let borrower = Address::generate(&env);
+        // Borrower line does not exist — should panic with CreditLineNotFound (#3)
+        client.set_per_borrower_liquidation_grace(&borrower, &3600_u64);
     }
 }

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -170,8 +170,13 @@ pub fn is_delinquent(env: Env, borrower: Address) -> bool {
         return false;
     };
 
-    let grace_cfg: Option<GracePeriodConfig> = crate::storage::get_grace_period_config(&env);
-    let grace_seconds = grace_cfg.map(|cfg| cfg.grace_period_seconds).unwrap_or(0);
+    let per_borrower_grace = crate::storage::get_per_borrower_liquidation_grace(&env, &borrower);
+    let grace_seconds = if per_borrower_grace > 0 {
+        per_borrower_grace
+    } else {
+        let grace_cfg: Option<GracePeriodConfig> = crate::storage::get_grace_period_config(&env);
+        grace_cfg.map(|cfg| cfg.grace_period_seconds).unwrap_or(0)
+    };
     let delinquent_after = schedule.next_due_ts.saturating_add(grace_seconds);
 
     env.ledger().timestamp() > delinquent_after

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -230,6 +230,9 @@ pub enum DataKey {
     /// Ledger timestamp of the last admin freeze or unfreeze action.
     /// Used with [`FreezeCooldownSeconds`] to enforce the cooldown period.
     LastFreezeTimestamp,
+    /// Per-borrower liquidation grace period in seconds.
+    /// Specifies a grace window before a credit line can be defaulted or liquidated.
+    LiquidationGracePeriod(Address),
 }
 
 /// Maximum number of credit lines returned per page.
@@ -770,6 +773,29 @@ pub fn grace_period_key(env: &Env) -> Symbol {
 pub fn get_grace_period_config(env: &Env) -> Option<GracePeriodConfig> {
     bump_instance_ttl(env);
     env.storage().instance().get(&grace_period_key(env))
+}
+
+/// Return the per-borrower liquidation grace period in seconds (0 if not configured).
+pub fn get_per_borrower_liquidation_grace(env: &Env, borrower: &Address) -> u64 {
+    bump_persistent_ttl(env, borrower);
+    env.storage()
+        .persistent()
+        .get(&DataKey::LiquidationGracePeriod(borrower.clone()))
+        .unwrap_or(0)
+}
+
+/// Set or remove (if 0) the per-borrower liquidation grace period in seconds.
+pub fn set_per_borrower_liquidation_grace(env: &Env, borrower: &Address, seconds: u64) {
+    bump_persistent_ttl(env, borrower);
+    if seconds == 0 {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::LiquidationGracePeriod(borrower.clone()));
+    } else {
+        env.storage()
+            .persistent()
+            .set(&DataKey::LiquidationGracePeriod(borrower.clone()), &seconds);
+    }
 }
 
 /// Persistent storage key that acts as a replay guard for a default liquidation settlement.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -51,7 +51,7 @@
 //! against a `major.minor.patch` of `CONTRACT_API_VERSION` (currently
 //! `(1, 0, 0)`).
 
-use soroban_sdk::{contracttype, Address, Symbol};
+use soroban_sdk::{contracterror, contracttype, Address, Symbol};
 
 /// Status of a borrower's credit line.
 ///
@@ -165,7 +165,8 @@ pub enum CreditStatus {
 /// | 52   | `InvalidRiskWeight`            | Numeric       | Collateral risk weight exceeds the maximum allowed (10 000 bps) |
 /// | 53   | `InvalidAttestation`           | Misc          | Attestation proof is invalid or no attestation batch has been committed |
 /// | 54   | `AdminCooldownActive`          | Risk          | Critical borrower admin action attempted before cooldown elapsed |
-#[soroban_sdk::contracterror]
+/// | 55   | `LiquidationGraceActive`       | Lifecycle     | Per-borrower liquidation grace window has not yet elapsed |
+#[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
@@ -277,6 +278,8 @@ pub enum ContractError {
     InvalidAttestation = 53,
     /// Critical borrower admin action attempted before the cooldown elapsed.
     AdminCooldownActive = 54,
+    /// Per-borrower liquidation grace window has not yet elapsed.
+    LiquidationGraceActive = 55,
 }
 
 /// ABI-stable category label for [`ContractError`] variants.
@@ -346,6 +349,7 @@ impl ContractError {
             Self::CreditLineSuspended => Lifecycle,
             Self::CreditLineDefaulted => Lifecycle,
             Self::AlreadySettled => Lifecycle,
+            Self::LiquidationGraceActive => Lifecycle,
             // Numeric (3)
             Self::InvalidAmount => Numeric,
             Self::NegativeLimit => Numeric,
@@ -617,6 +621,18 @@ pub struct ProtocolSummaryView {
     pub active_line_count: u32,
 }
 
+/// Paginated list of credit lines returned by `get_credit_lines_paginated`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLinesPage {
+    /// Credit lines included in this page.
+    pub lines: soroban_sdk::Vec<CreditLineData>,
+    /// Cursor for fetching the next page, if more items exist.
+    pub next_cursor: Option<u32>,
+    /// `true` if there are additional lines beyond this page.
+    pub has_more: bool,
+}
+
 /// Proof-of-reserve view for the protocol treasury.
 ///
 /// Exposes the accumulated reserves held by the protocol in a single
@@ -723,7 +739,8 @@ impl ContractError {
             ContractError::CreditLineClosed
             | ContractError::AlreadyInitialized
             | ContractError::CreditLineSuspended
-            | ContractError::CreditLineDefaulted => ContractErrorCategory::Lifecycle,
+            | ContractError::CreditLineDefaulted
+            | ContractError::LiquidationGraceActive => ContractErrorCategory::Lifecycle,
 
             ContractError::InvalidAmount
             | ContractError::NegativeLimit

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -239,6 +239,7 @@ Errors that do not fit into other categories — entity-not-found, timelock, and
 | 51   | `AlreadySettled` | Liquidation settlement already processed | Replay of the same `(borrower, settlement_id)` pair |
 | 52   | `InvalidRiskWeight` | Collateral risk weight exceeds 10 000 bps | `set_collateral_risk_weight` |
 | 53   | `InvalidAttestation` | Attestation proof is invalid or no batch committed | `verify_attestation_proof` with an invalid proof or missing batch |
+| 55   | `LiquidationGraceActive` | Per-borrower liquidation grace window active | `default_credit_line` called before grace period expiry |
 
 **SDK recovery:**
 - `CreditLineNotFound`: Create a credit line first via `open_credit_line`.


### PR DESCRIPTION
Closes #741

## Per-Borrower Liquidation Grace

### Summary

Implements a per-borrower liquidation grace period for the `creditra-credit` contract. When configured, a borrower gets a protected window after their credit line is suspended during which `default_credit_line` cannot be called — giving them time to repay or negotiate before being liquidated.

### Changes

#### `contracts/credit/src/types.rs`
- Added `ContractError::LiquidationGraceActive = 55` — returned when `default_credit_line` is attempted within an active grace window.
- Updated `ContractError::category()` and `ContractErrorCategory::from()` to map the new variant to `Lifecycle`.
- Added `CreditLinesPage` struct (required by `views.rs` and `lib.rs`).
- Documented the new error in the doc-table comment above `ContractError`.

#### `contracts/credit/src/storage.rs`
- Added `DataKey::LiquidationGracePeriod(Address)` persistent storage key.
- Added `get_per_borrower_liquidation_grace(env, borrower) -> u64` — returns `0` if not set.
- Added `set_per_borrower_liquidation_grace(env, borrower, seconds)` — removes key when `seconds == 0`.

#### `contracts/credit/src/lifecycle.rs`
- Updated `default_credit_line` to check for an active per-borrower grace window: if `now < suspended_at + grace_seconds`, panics with `ContractError::LiquidationGraceActive`.
- Added `set_per_borrower_liquidation_grace(env, borrower, seconds)` — admin-only setter that verifies the credit line exists.
- Added `get_per_borrower_liquidation_grace(env, borrower) -> u64` — public getter.
- Added 5 focused unit tests covering: roundtrip set/get, grace blocks default, grace expiry allows default, admin auth enforcement, and missing credit line revert.

#### `contracts/credit/src/query.rs`
- Updated `is_delinquent` to prefer a per-borrower grace period over the global `GracePeriodConfig` when one is set.

#### `contracts/credit/src/lib.rs`
- Exposed `set_per_borrower_liquidation_grace` and `get_per_borrower_liquidation_grace` as public Soroban contract entrypoints.

#### `docs/ERROR_CODES.md`
- Documented error code `55` (`LiquidationGraceActive`) in the Lifecycle section.

### Security

- `set_per_borrower_liquidation_grace` requires admin auth via `require_admin_auth`.
- Grace is checked only when the credit line is `Suspended` (admin-controlled entry condition).
- Passing `0` as `grace_period_seconds` removes the grace entry, so admins can always override.

### Testing

Five new unit tests in `lifecycle.rs`:
1. `per_borrower_liquidation_grace_roundtrip` — set and read back.
2. `default_credit_line_blocked_within_grace` — default panics with `#55` inside the window.
3. `per_borrower_liquidation_grace_allows_default_after_grace` — default succeeds after expiry.
4. `set_per_borrower_liquidation_grace_requires_admin_auth` — non-admin panics with `#2`.
5. `set_per_borrower_liquidation_grace_reverts_for_missing_line` — missing borrower panics with `#3`.
