### PR TITLE
docs: rustdoc gateway-auction

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -206,6 +206,23 @@ pub enum AuctionKey {
 
 #[contractimpl]
 impl Auction {
+    /// Initializes a new auction.
+    ///
+    /// # Parameters
+    /// - `env`: The execution environment.
+    /// - `auction_id`: The unique identifier for the auction.
+    /// - `mode`: The mode of the auction (e.g., English or Dutch).
+    /// - `start_time`: The timestamp when the auction starts.
+    /// - `end_time`: The timestamp when the auction ends.
+    /// - `min_bid`: The minimum initial bid (English) or floor price equivalent logic.
+    /// - `min_increment_bps`: The minimum bid increment in basis points (max 10000).
+    /// - `dutch_start_price`: The starting price for a Dutch auction.
+    /// - `dutch_floor_price`: The lowest possible price for a Dutch auction.
+    /// - `dutch_decay`: The price decay configuration for a Dutch auction.
+    /// - `dutch_step_count`: Required steps if decay is `Stepped`.
+    ///
+    /// # Panics
+    /// Panics if `start_time >= end_time`, if `min_increment_bps > 10_000`, or if Dutch auction parameters are invalid.
     pub fn init_auction(
         env: Env,
         auction_id: Symbol,
@@ -269,11 +286,31 @@ impl Auction {
         bump_auction_state_ttl(&env, &auction_id);
     }
 
+    /// Sets the factory contract address.
+    ///
+    /// # Authorization
+    /// Requires `require_auth` from the factory itself.
     pub fn set_factory_contract(env: Env, factory: Address) {
         factory.require_auth();
         storage::set_factory_contract(&env, &factory);
     }
 
+    /// Places a bid on an active auction.
+    ///
+    /// # Authorization
+    /// Requires `require_auth` from the `bidder`.
+    ///
+    /// # Parameters
+    /// - `env`: The execution environment.
+    /// - `auction_id`: The unique identifier of the auction.
+    /// - `bidder`: The address placing the bid.
+    /// - `amount`: The amount of the bid token being bid.
+    ///
+    /// # Panics
+    /// * [`AuctionError::BidTooLow`] - Bid amount is not strictly positive, or does not meet minimum threshold/current Dutch price.
+    /// * [`AuctionError::NotFound`] - Auction state not found.
+    /// * [`AuctionError::AuctionNotOpen`] - Auction is not in `Open` status or end time has passed.
+    /// * [`AuctionError::GracePeriodActive`] - Attempting to bid during the liquidation grace window.
     pub fn place_bid(env: Env, auction_id: Symbol, bidder: Address, amount: i128) {
         bidder.require_auth();
 
@@ -411,6 +448,22 @@ impl Auction {
         bump_auction_state_ttl(&env, &auction_id);
     }
 
+    /// Settles an auction that ended in default or completes the liquidation process.
+    ///
+    /// Transfers the highest bid amount (if any) to the credit contract.
+    ///
+    /// # Authorization
+    /// Requires `require_auth` from the factory contract.
+    ///
+    /// # Returns
+    /// The `highest_bid` amount that was settled.
+    ///
+    /// # Panics
+    /// * [`AuctionError::NoFactoryContract`] - Factory contract not set.
+    /// * [`AuctionError::Unauthorized`] - Caller is not the factory contract.
+    /// * [`AuctionError::NotFound`] - Auction not found.
+    /// * [`AuctionError::NotClosed`] - Auction is not in the `Closed` state.
+    /// * [`AuctionError::AlreadySettled`] - Auction has already been settled.
     pub fn settle_default_liquidation(
         env: Env,
         auction_id: Symbol,
@@ -479,6 +532,18 @@ impl Auction {
         state.highest_bid
     }
 
+    /// Claims the proceeds or assets of a closed auction by the winning bidder.
+    ///
+    /// # Authorization
+    /// Requires `require_auth` from the winning bidder.
+    ///
+    /// # Panics
+    /// * [`AuctionError::NotFound`] - Auction not found.
+    /// * [`AuctionError::AuctionNotClosed`] - Auction is not in `Closed` status.
+    /// * [`AuctionError::AlreadySettled`] - Auction has already been liquidated/settled.
+    /// * [`AuctionError::NoWinner`] - There is no winning bidder.
+    /// * [`AuctionError::AlreadyClaimed`] - Auction was already claimed.
+    /// * [`AuctionError::InvalidState`] - Bid token not found in storage.
     pub fn claim_auction(env: Env, auction_id: Symbol) {
         let state: AuctionState = env
             .storage()
@@ -574,20 +639,19 @@ impl Auction {
         bump_auction_state_ttl(&env, &auction_id);
     }
 
-    /// Set the liquidation grace window (in seconds) for newly created auctions.
-    ///
-    /// # Authorization
-    /// Requires [`require_auth`] from the registered factory contract.
-    ///
-    /// Return the configured liquidation grace window in seconds.
+    /// Returns the configured liquidation grace window in seconds.
     ///
     /// Returns `0` if never configured (no grace period enforced).
     pub fn get_liquidation_grace_window(env: Env) -> u64 {
         storage::get_liquidation_grace_window(&env)
     }
 
-    /// When non-zero, bidders cannot place bids before
-    /// `auction.start_time + grace_window` has elapsed.
+    /// Sets the liquidation grace window (in seconds) for newly created auctions.
+    ///
+    /// When non-zero, bidders cannot place bids before `auction.start_time + grace_window` has elapsed.
+    ///
+    /// # Authorization
+    /// Requires [`require_auth`] from the registered factory contract.
     pub fn set_liquidation_grace_window(env: Env, seconds: u64) {
         let factory = get_factory_contract(&env)
             .unwrap_or_else(|| env.panic_with_error(AuctionError::NoFactoryContract));


### PR DESCRIPTION
Closes #914
## Description
This PR resolves the issue for the GrantFox FWC26 campaign (Stellar Wave) by adding comprehensive NatSpec-style rustdocs to every public function in the `gateway-auction` contract. 

## Changes Made
- Added NatSpec-style rustdocs (`///`) to the following public entrypoints in `contracts/auction_contract/src/lib.rs`:
  - `init_auction`
  - `set_factory_contract`
  - `place_bid`
  - `settle_default_liquidation`
  - `claim_auction`
  - `get_liquidation_grace_window`
  - `set_liquidation_grace_window`
- Documented parameter details, panic conditions, authorizations, and return types using the proper conventions.

## Context
These changes satisfy the campaign requirements by ensuring all public APIs are properly documented. No logic changes were made, and safety parameters remain intact.

## Acceptance Criteria
- [x] Implementation matches the description (NatSpec-style docs added)
- [x] Code review ready
- [x] Docs updated