### PR TITLE
feat(lifecycle): bump TTL on lifecycle storage reads

### DIFF
--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -59,6 +59,8 @@
 //! - **Borrower credit lines**: Persistent storage (independent TTL per borrower).
 //!   - Key: `borrower: Address` (via `DataKey::CreditLineIdByBorrower`)
 //!   - Value: `CreditLineData`
+//!   - Hot reads use [`crate::storage::get_credit_line`] to refresh TTL when
+//!     the remaining lifetime falls below the configured threshold.
 //! - **Liquidation settlement markers**: Persistent storage (replay protection).
 //!   - Key: `(Symbol("liq_seen"), borrower, settlement_id)`
 //!   - Value: `bool` (presence = settled; replay reverts
@@ -93,10 +95,9 @@ use crate::events::{
 };
 use crate::risk::{MAX_INTEREST_RATE_BPS, MAX_RISK_SCORE};
 use crate::storage::{
-    assert_not_paused, clear_repayment_schedule, get_repayment_schedule,
-    liquidation_settlement_key, persist_credit_line,
-    set_repayment_schedule as storage_set_repayment_schedule, CREDIT_LINE_TTL_EXTEND_TO,
-    CREDIT_LINE_TTL_THRESHOLD,
+    assert_not_paused, bump_credit_line_ttl, clear_repayment_schedule, get_credit_line,
+    get_repayment_schedule, liquidation_settlement_key, persist_credit_line,
+    set_repayment_schedule as storage_set_repayment_schedule,
 };
 use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
 use soroban_sdk::{symbol_short, Address, Env, Symbol};
@@ -248,10 +249,7 @@ pub fn validate_credit_limit_bounds(env: &Env, credit_limit: i128) {
 // ──────────────────────────────────────────────────────────────────────────────
 
 fn suspend_credit_line_internal(env: &Env, borrower: Address) {
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let stored_line = get_credit_line(env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
 
@@ -309,10 +307,7 @@ pub fn set_per_borrower_liquidation_grace(
     assert_not_paused(env);
     require_admin_auth(env);
 
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let stored_line = get_credit_line(env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
 
     if stored_line.status == CreditStatus::Closed {
@@ -342,10 +337,7 @@ pub fn set_repayment_schedule(
         env.panic_with_error(ContractError::InvalidAmount);
     }
 
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let stored_line = get_credit_line(env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
 
     if stored_line.status == CreditStatus::Closed {
@@ -465,11 +457,9 @@ pub fn open_credit_line(
     // Validate credit limit is within configured bounds
     validate_credit_limit_bounds(&env, credit_limit);
 
-    if let Some(existing) = env
-        .storage()
-        .persistent()
-        .get::<Address, CreditLineData>(&borrower)
-    {
+    let existing_line = get_credit_line(&env, &borrower);
+
+    if let Some(existing) = existing_line.as_ref() {
         if existing.status == CreditStatus::Active {
             env.panic_with_error(ContractError::AlreadyInitialized);
         }
@@ -478,10 +468,7 @@ pub fn open_credit_line(
         require_admin_auth(&env);
     }
 
-    let previous_utilized = env
-        .storage()
-        .persistent()
-        .get::<Address, CreditLineData>(&borrower)
+    let previous_utilized = existing_line
         .map(|existing| existing.utilized_amount)
         .unwrap_or(0);
 
@@ -530,11 +517,8 @@ pub fn open_credit_line(
 pub fn suspend_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
     require_admin_auth(&env);
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .expect("Credit line not found");
+    let mut credit_line =
+        get_credit_line(&env, &borrower).unwrap_or_else(|| panic!("Credit line not found"));
 
     if credit_line.status != CreditStatus::Active {
         panic!("Only active credit lines can be suspended");
@@ -615,10 +599,7 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
     let admin: Address = require_admin(&env);
 
     // Load the credit line; revert if it does not exist.
-    let mut credit_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let mut credit_line = get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let _previous_utilized = credit_line.utilized_amount;
 
@@ -708,10 +689,7 @@ pub fn close_credit_lines_batch(env: Env, borrowers: soroban_sdk::Vec<Address>) 
 pub fn default_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
     require_admin_auth(&env);
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let stored_line = get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let _previous_utilized = stored_line.utilized_amount;
 
@@ -801,10 +779,7 @@ pub fn settle_default_liquidation(
         env.panic_with_error(ContractError::AlreadySettled);
     }
 
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let stored_line = get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
     let previous_status = stored_line.status;
@@ -892,10 +867,7 @@ pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditS
         env.panic_with_error(ContractError::InvalidAmount);
     }
 
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    let stored_line = get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
     let previous_status = stored_line.status;
@@ -956,7 +928,7 @@ pub fn set_repayment_schedule(
         env.panic_with_error(ContractError::InvalidAmount);
     }
 
-    if !env.storage().persistent().has(&borrower) {
+    if get_credit_line(env, &borrower).is_none() {
         env.panic_with_error(ContractError::CreditLineNotFound);
     }
 
@@ -966,10 +938,6 @@ pub fn set_repayment_schedule(
         next_due_ts: first_due_ts,
     };
     storage_set_repayment_schedule(env, &borrower, &schedule);
-    // Setting a schedule is an interaction with the credit line, so keep the
-    // credit-line entry live as well (the schedule entry is bumped by the
-    // storage setter itself).
-    bump_credit_line_ttl(env, &borrower);
 }
 
 /// Advance a borrower's installment schedule after a repayment.

--- a/contracts/credit/tests/storage_ttl.rs
+++ b/contracts/credit/tests/storage_ttl.rs
@@ -6,7 +6,10 @@
 //! These entries must have their TTL extended on frequently-invoked read/write
 //! paths so that active credit lines are not silently archived by the network.
 
-use creditra_credit::storage::{DataKey, LEDGER_BUMP_AMOUNT, LEDGER_BUMP_THRESHOLD};
+use creditra_credit::storage::{
+    DataKey, CREDIT_LINE_TTL_EXTEND_TO, CREDIT_LINE_TTL_THRESHOLD, LEDGER_BUMP_AMOUNT,
+    LEDGER_BUMP_THRESHOLD,
+};
 use creditra_credit::types::{CreditLineData, CreditStatus, GracePeriodConfig, GraceWaiverMode};
 use creditra_credit::{Credit, CreditClient};
 use soroban_sdk::testutils::storage::{Instance as _, Persistent as _};
@@ -226,5 +229,29 @@ fn accrual_path_bumps_instance_ttl_for_accrual_reads() {
     assert!(
         ttl_after >= LEDGER_BUMP_AMOUNT,
         "instance TTL not extended for accrual reads: initial={initial_ttl} after={ttl_after}"
+    );
+}
+
+#[test]
+fn already_closed_credit_line_read_bumps_ttl() {
+    let env = Env::default();
+    let (contract_id, client, admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+    client.close_credit_line(&borrower, &admin);
+
+    let initial_ttl = ttl_for_key(&env, &contract_id, &borrower);
+    let target_remaining = CREDIT_LINE_TTL_THRESHOLD.saturating_sub(1);
+    advance_ledgers(&env, initial_ttl.saturating_sub(target_remaining));
+
+    // The already-closed path returns early, but its storage read must still
+    // refresh the persistent credit-line TTL.
+    client.close_credit_line(&borrower, &admin);
+
+    let ttl_after = ttl_for_key(&env, &contract_id, &borrower);
+    assert!(
+        ttl_after >= CREDIT_LINE_TTL_EXTEND_TO,
+        "credit-line TTL not bumped on idempotent close: initial={initial_ttl} after={ttl_after}"
     );
 }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -9,4 +9,7 @@
 //! discriminants relevant to the v7 lifecycle subsystem for CI stability
 //! guards. See [`tests/err_stab.rs`] for the pinning assertions.
 
+//! Lifecycle hot reads refresh persistent credit-line TTL without changing
+//! contract entrypoints, parameters, return values, events, or error codes.
+
 pub use creditra_credit::*;


### PR DESCRIPTION
## Summary

Adds TTL refreshes to lifecycle hot-read paths so active borrower credit-line records are not archived while still being accessed.

Lifecycle functions now use the existing TTL-aware `get_credit_line` storage helper instead of reading borrower credit lines directly from persistent storage.

Closes #908.

## Changes

* Replaced direct borrower credit-line storage reads in lifecycle operations with `get_credit_line`.
* Covered lifecycle paths including:

  * opening a credit line
  * suspending a credit line
  * closing a credit line
  * defaulting a credit line
  * reinstating a credit line
  * configuring repayment schedules
  * configuring borrower liquidation grace
  * settling default liquidations
* Reused a previously loaded credit line in `open_credit_line` to avoid a duplicate storage read.
* Removed a redundant manual TTL bump after repayment schedule persistence.
* Preserved the existing missing-credit-line panic behaviour in `suspend_credit_line`.
* Added lifecycle storage documentation describing the TTL refresh behaviour.

## Focused regression test

Added `already_closed_credit_line_read_bumps_ttl`.

The test:

1. Opens and closes a borrower credit line.
2. Advances the ledger until the record is below the configured TTL threshold.
3. Calls the idempotent close path again.
4. Verifies that the lifecycle read refreshes the credit-line TTL.

The already-closed path returns before persisting the record, ensuring the test specifically validates the TTL-aware read rather than a later write.

## API and visible behaviour

No contract API changes were introduced.

This PR does not change:

* entrypoint names or signatures
* parameters or return values
* emitted events
* error codes
* authentication requirements

The only visible behavioural change is that lifecycle access to an existing borrower credit line refreshes its persistent-storage TTL when it falls below the configured threshold.

## Security and correctness

* Uses the existing central TTL helper rather than duplicating TTL logic.
* Existing authentication checks remain in place on all touched state-changing paths.
* Introduces no new production `unwrap()` or `expect()` calls.
* Introduces no unchecked arithmetic.
* Test ledger calculations use `saturating_sub`.
* Does not modify unrelated liquidation replay-marker storage reads.

## Validation

Passed:

```text
git diff --check
```

The newly added regression test section is also `rustfmt`-clean.

A scan confirmed there are no remaining direct borrower credit-line `persistent().get`, `persistent().has`, or typed `CreditLineData` reads in the lifecycle implementation. The remaining persistent `has` call checks a liquidation settlement replay marker and is intentionally unchanged.

## Upstream test-suite limitation

The focused test and full workspace suite could not execute because the current upstream base fails compilation before tests are reached.

The failures are caused by pre-existing duplicate definitions unrelated to this PR, including duplicate lifecycle functions, modules, and credit-line TTL constants.

Examples include duplicate definitions of:

* `set_credit_limit_bounds`
* `get_credit_limit_bounds`
* `validate_credit_limit_bounds`
* `set_repayment_schedule`
* `CREDIT_LINE_TTL_THRESHOLD`
* `CREDIT_LINE_TTL_EXTEND_TO`

These duplicates are present in both parents of the current upstream merge commit and were not introduced by this branch.

Because the workspace cannot compile, repository-wide test coverage, including the requested 95% threshold, cannot currently be measured. This PR remains limited to the TTL lifecycle-read scope described in #908.
