### PR TITLE
docs: fix event schema docs (#766)

### DIFF
--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -382,7 +382,7 @@ pub fn publish_borrower_blocked_event(env: &Env, borrower: &Address, blocked: bo
 /// will auto-expire.
 ///
 /// # Topic
-/// `("credit", "brw_frz")`
+/// `("br_freeze",)`
 pub fn publish_borrower_frozen_event(env: &Env, borrower: &Address, frozen_until: u64) {
     env.events().publish(
         (Symbol::new(env, "br_freeze"),),

--- a/contracts/credit/tests/events_catalog.rs
+++ b/contracts/credit/tests/events_catalog.rs
@@ -46,7 +46,7 @@ fn second_topic(env: &Env, index: u32) -> Symbol {
 fn credit_line_event_shape() {
     let (env, borrower, _admin) = env_and_addresses();
 
-    for suffix in ["opened", "suspend", "closed", "default", "reinstate"] {
+    for suffix in ["opened", "suspend", "closed", "defaulted", "reinstate"] {
         let ev = CreditLineEvent {
             borrower: borrower.clone(),
             status: CreditStatus::Active,

--- a/docs/EVENTS_CATALOG.md
+++ b/docs/EVENTS_CATALOG.md
@@ -1,9 +1,9 @@
 # Events Catalog
 
-**Version:** 1.0  
+**Version:** 1.1  
 **Status:** Authoritative for `main` at the time of writing  
-**Scope:** `creditra-credit` (`contracts/credit/`) and `gateway-auction` (`gateway-contract/contracts/auction_contract/`)  
-**Last updated:** 2026-07-24
+**Scope:** `creditra-credit` (`contracts/credit/`), `gateway-auction` (`gateway-contract/contracts/auction_contract/`), `creditra-accrual` (`contracts/accrual/`), and `creditra-credit` CosmWasm (`contracts/creditra-credit/`)  
+**Last updated:** 2026-07-25
 
 ---
 
@@ -76,7 +76,7 @@ noted. Publishers live in `contracts/credit/src/events.rs`.
 | `"opened"` | `CreditLineEvent` | 1. `borrower: Address`, 2. `status: CreditStatus`, 3. `credit_limit: i128`, 4. `interest_rate_bps: u32`, 5. `risk_score: u32` | 1.0.0 | Stable |
 | `"suspend"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
 | `"closed"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
-| `"default"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
+| `"defaulted"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
 | `"reinstate"` | `CreditLineEvent` | Same as `opened` | 1.0.0 | Stable |
 
 ### 4.2 Draw and repayment events
@@ -103,7 +103,6 @@ noted. Publishers live in `contracts/credit/src/events.rs`.
 | `"risk_upd"` | `RiskParametersUpdatedEvent` | 1. `borrower: Address`, 2. `credit_limit: i128`, 3. `interest_rate_bps: u32`, 4. `risk_score: u32` | 1.0.0 | Stable |
 | `"drw_freeze"` | `DrawsFrozenEvent` | 1. `frozen: bool`, 2. `reason: FreezeReason` | 1.0.0 | Stable |
 | `"line_frz"` | `CreditLineFreezeEvent` | 1. `borrower: Address`, 2. `reason: FreezeReason`, 3. `frozen: bool`, 4. `ledger: u32` | 1.0.0 | Stable |
-| `"br_freeze"` | `BorrowerFrozenEvent` | 1. `borrower: Address`, 2. `frozen_until: u64`, 3. `ledger: u32` | 1.0.0 | Stable |
 | `"pen_enter"` | `PenaltyRateEnteredEvent` | 1. `borrower: Address`, 2. `base_rate_bps: u32`, 3. `penalty_surcharge_bps: u32`, 4. `effective_rate_bps: u32` | 1.0.0 | Stable |
 | `"pen_exit"` | `PenaltyRateExitedEvent` | 1. `borrower: Address`, 2. `previous_rate_bps: u32`, 3. `new_rate_bps: u32` | 1.0.0 | Stable |
 | `"grace_wv"` | `GraceWaiverReceiptEvent` | 1. `borrower: Address`, 2. `waived_amount: i128`, 3. `mode: GraceWaiverMode` | 1.0.0 | Stable |
@@ -123,9 +122,11 @@ noted. Publishers live in `contracts/credit/src/events.rs`.
 | Topic | Payload struct | Field order & types | Version added | Stability |
 |---|---|---|---|---|
 | `("blk_chg",)` | `BorrowerBlockedEvent` | 1. `borrower: Address`, 2. `blocked: bool`, 3. `ledger: u32` | 1.0.0 | Stable |
+| `("br_freeze",)` | `BorrowerFrozenEvent` | 1. `borrower: Address`, 2. `frozen_until: u64`, 3. `ledger: u32` | 1.0.0 | Stable |
 
 > Note: `BorrowerBlockedEvent` is emitted on a single-element topic tuple
-> `("blk_chg",)`.
+> `("blk_chg",)`. `BorrowerFrozenEvent` is also a single-element topic
+> `("br_freeze",)`.
 
 ### 4.7 Collateral events
 
@@ -171,24 +172,43 @@ noted. Publishers live in `contracts/credit/src/events.rs`.
 
 ---
 
-## 5. Auction Contract Event Catalog
+## 5. Accrual Contract Event Catalog
+
+All topics are published under the `("accrual", ...)` namespace by the separate
+Soroban accrual contract (`contracts/accrual/src/events.rs`).
+
+### 5.1 Batch accrual events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"batch"` | `AccrualBatchCompletedEvent` | 1. `borrowers_processed: u32`, 2. `lines_accrued: u32`, 3. `total_interest_accrued: i128`, 4. `timestamp: u64` | 1.0.0 | Stable |
+
+### 5.2 Per-borrower interest events
+
+| Second topic | Payload struct | Field order & types | Version added | Stability |
+|---|---|---|---|---|
+| `"accrue"` | `accrual::InterestAccruedEvent` | 1. `borrower: Address`, 2. `accrued_amount: i128`, 3. `new_utilized_amount: i128`, 4. `new_accrued_interest: i128`, 5. `elapsed_seconds: u64`, 6. `timestamp: u64` | 1.0.0 | Stable |
+
+---
+
+## 6. Auction Contract Event Catalog
 
 All topics are published under the `gateway-auction` contract. Publishers live in
 `gateway-contract/contracts/auction_contract/src/events.rs`.
 
-### 5.1 English auction events
+### 6.1 English auction events
 
 | First topic | Second topic | Payload struct | Field order & types | Version added | Stability |
 |---|---|---|---|---|---|
 | `"BID_RFDN"` | `"auction"` | `BidRefundedEvent` | 1. `prev_bidder: Address`, 2. `amount: i128` | 1.0.0 | Stable |
 
-### 5.2 Auction close event
+### 6.2 Auction close event
 
 | First topic | Second topic | Payload struct | Field order & types | Version added | Stability |
 |---|---|---|---|---|---|
 | `"AUC_CLOSE"` | `"auction"` | `AuctionClosedEvent` | 1. `auction_id: Symbol`, 2. `winner: Option<Address>`, 3. `amount: i128` | 1.0.0 | Stable |
 
-### 5.3 Default liquidation settlement event
+### 6.3 Default liquidation settlement event
 
 | First topic | Second topic | Payload struct | Field order & types | Version added | Stability |
 |---|---|---|---|---|---|
@@ -196,7 +216,25 @@ All topics are published under the `gateway-auction` contract. Publishers live i
 
 ---
 
-## 6. Stability Matrix
+## 7. CosmWasm Contract Event Catalog
+
+All events are emitted by the CosmWasm `creditra-credit` contract
+(`contracts/creditra-credit/src/contract.rs`). Events use CosmWasm's standard
+`wasm` event wrapper with attributes set via `Response::add_attribute`.
+
+| Action | Entrypoint | Attributes | Auth |
+|---|---|---|---|
+| `"create_credit_line"` | `execute_create_credit_line` | `action`, `credit_line_id` | owner |
+| `"create_draw"` | `execute_create_draw` | `action`, `credit_line_id`, `draw_id` | borrower |
+| `"repay_draw"` | `execute_repay_draw` | `action`, `credit_line_id`, `draw_id` | drawer |
+| `"add_audit_memo"` | `execute_add_audit_memo` | `action`, `credit_line_id`, `draw_id` | owner |
+| `"update_protocol_version"` | `execute_update_protocol_version` | `action`, `major`, `minor` | owner |
+| `"set_oracle_quorum_config"` | `execute_set_oracle_quorum_config` | `action`, `min_quorum_k`, `max_deviation_bps`, `max_age_seconds` | owner |
+| `"submit_oracle_prices"` | `execute_submit_oracle_prices` | `action`, `canonical_price`, `min_quorum_k`, `timestamp` | owner |
+
+---
+
+## 8. Stability Matrix
 
 | Event topic | Stable since | Deprecated | Removal target | Notes |
 |---|---|---|---|---|
@@ -211,7 +249,7 @@ All topics are published under the `gateway-auction` contract. Publishers live i
 | `("credit","risk_upd")` | 1.0.0 | No | — | |
 | `("credit","drw_freeze")` | 1.0.0 | No | — | Global toggle |
 | `("credit","line_frz")` | 1.0.0 | No | — | Per-borrower toggle |
-| `("credit","br_freeze")` | 1.0.0 | No | — | Time-bounded per-borrower freeze |
+| `("br_freeze",)` | 1.0.0 | No | — | Time-bounded per-borrower freeze, single-element topic |
 | `("credit","pen_enter")` | 1.0.0 | No | — | |
 | `("credit","pen_exit")` | 1.0.0 | No | — | |
 | `("credit","grace_wv")` | 1.0.0 | No | — | |
@@ -241,26 +279,30 @@ All topics are published under the `gateway-auction` contract. Publishers live i
 | `("BID_RFDN","auction")` | 1.0.0 | No | — | |
 | `("AUC_CLOSE","auction")` | 1.0.0 | No | — | |
 | `("LIQ_SETL","auction")` | 1.0.0 | No | — | |
+| `("accrual","batch")` | 1.0.0 | No | — | Accrual contract, batch-level |
+| `("accrual","accrue")` | 1.0.0 | No | — | Accrual contract, per-borrower |
+| CosmWasm `wasm` events | 1.0.0 | No | — | 7 entrypoints, see §7 |
 
 ---
 
-## 7. Type Definitions
+## 9. Type Definitions
 
 All payload structs are defined in `contracts/credit/src/events.rs` or
 `gateway-contract/contracts/auction_contract/src/events.rs` with `#[contracttype]`.
 
 Shared types referenced in events:
 
-- `CreditStatus` — `Active = 0`, `Suspended = 1`, `Defaulted = 2`, `Closed = 3`
+- `CreditStatus` — `Active = 0`, `Suspended = 1`, `Defaulted = 2`, `Closed = 3`, `Restricted = 4`
   (defined in `contracts/credit/src/types.rs`).
 - `FreezeReason` — enum for freeze source (defined in
-  `contracts/credit/src/types.rs`).
+  `contracts/credit/src/types.rs`): `LiquidityReserve = 0`, `Compliance = 1`,
+  `RiskInvestigation = 2`, `OperationalMaintenance = 3`, `BorrowerRequest = 4`.
 - `GraceWaiverMode` — `FullWaiver`, `ReducedRate` (defined in
   `contracts/credit/src/types.rs`).
 
 ---
 
-## 8. Publisher Reference
+## 10. Publisher Reference
 
 All publisher functions live in `contracts/credit/src/events.rs` (credit) and
 `gateway-contract/contracts/auction_contract/src/events.rs` (auction). Each
@@ -269,7 +311,7 @@ publisher takes `&Env` plus the event-specific payload fields and calls
 
 | Publisher function | Event topic |
 |---|---|
-| `publish_credit_line_event` | `("credit", "opened"\|"suspend"\|"closed"\|"default"\|"reinstate")` |
+| `publish_credit_line_event` | `("credit", "opened"\|"suspend"\|"closed"\|"defaulted"\|"reinstate")` |
 | `publish_drawn_event` | `("credit", "drawn")` |
 | `publish_drawn_event_v2` | `("credit", "drawn_v2")` |
 | `publish_repayment_event` | `("credit", "repay")` |
@@ -309,10 +351,12 @@ publisher takes `&Env` plus the event-specific payload fields and calls
 | `publish_bid_refunded_event` | `("BID_RFDN", "auction")` |
 | `publish_auction_closed_event` | `("AUC_CLOSE", "auction")` |
 | `publish_default_liquidation_settlement_event` | `("LIQ_SETL", "auction")` |
+| `publish_accrual_batch_completed` | `("accrual", "batch")` |
+| `publish_interest_accrued` | `("accrual", "accrue")` |
 
 ---
 
-## 9. API / Visible Changes Log
+## 11. API / Visible Changes Log
 
 | Date | Change | Impact |
 |---|---|---|
@@ -320,10 +364,11 @@ publisher takes `&Env` plus the event-specific payload fields and calls
 | 2026-06-28 | Added `AttestationBatchCommittedEvent` and `publish_attestation_batch_committed` to `contracts/credit/src/events.rs` | Fixed broken import in `contracts/credit/src/attestation.rs`. No contract ABI change; event was already emitted by `commit_attestation_batch` but the struct and publisher were missing. |
 | 2026-06-28 | Added `contracts/credit/tests/events_catalog.rs` | New integration test verifying every cataloged event is emitted with the correct topic and payload shape. |
 | 2026-07-24 | Added `DrawReversedEvent`, `CollateralPartialReleasedEvent`, oracle quorum events (`orc_qcfg`, `orc_qprc`) to catalog | Catalog was missing 4 events present in `contracts/credit/src/events.rs`. Fixed `GraceWaiverAppliedEvent` → `GraceWaiverReceiptEvent` naming to match code. Added corresponding tests. |
+| 2026-07-25 | Added accrual contract events (`contracts/accrual/`), CosmWasm contract events (`contracts/creditra-credit/`). Fixed `"default"` → `"defaulted"` lifecycle topic. Fixed `BorrowerFrozenEvent` topic from `("credit","br_freeze")` to `("br_freeze",)`. Added `Restricted = 4` to `CreditStatus`. Expanded `FreezeReason` with all 5 variants. Updated doc comment in `events.rs`. | Schema v1.0 → v1.1 |
 
 ---
 
-## 10. Related Documentation
+## 12. Related Documentation
 
 - [`docs/events-schema.md`](./events-schema.md) — legacy schema reference (superseded by this file).
 - [`docs/indexer-integration.md`](./indexer-integration.md) — decoder patterns and RPC examples.

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -1,9 +1,9 @@
 # Event Schema Documentation
 
-**Version:** 1.0  
+**Version:** 1.1  
 **Status:** Authoritative  
-**Scope:** `creditra-credit` (`contracts/credit/`) and `gateway-auction` (`gateway-contract/contracts/auction_contract/`)  
-**Last updated:** 2026-06-29
+**Scope:** `creditra-credit` (`contracts/credit/`), `gateway-auction` (`gateway-contract/contracts/auction_contract/`), `creditra-accrual` (`contracts/accrual/`), and `creditra-credit` CosmWasm (`contracts/creditra-credit/`)  
+**Last updated:** 2026-07-25
 
 ---
 
@@ -55,7 +55,7 @@ Topics are Soroban `Symbol` values chosen to use the cheap `SCV_SYMBOL` on-chain
 | `symbol_short!` macro | ≤ 9 characters |
 | `Symbol::new` | Up to 32 characters |
 
-The first topic in every published tuple is either `"credit"` (credit contract) or a short identifier such as `"blk_chg"` or `"BID_RFDN"`.
+The first topic in every published tuple is either `"credit"` (credit contract), `"accrual"` (accrual contract), or a short identifier such as `"blk_chg"` or `"BID_RFDN"`.
 
 ---
 
@@ -67,13 +67,13 @@ All credit contract events are published under the `("credit", "...")` namespace
 
 #### Event: Credit Line State Changes
 
-**Topic:** `("credit", "opened")`, `("credit", "suspend")`, `("credit", "closed")`, `("credit", "default")`, `("credit", "reinstate")`
+**Topic:** `("credit", "opened")`, `("credit", "suspend")`, `("credit", "closed")`, `("credit", "defaulted")`, `("credit", "reinstate")`
 
 **Payload Struct:** `CreditLineEvent`
 
 **Fields:**
 1. `borrower: Address` - The borrower whose credit line state changed
-2. `status: CreditStatus` - New status of the credit line (Active=0, Suspended=1, Defaulted=2, Closed=3)
+2. `status: CreditStatus` - New status of the credit line (Active=0, Suspended=1, Defaulted=2, Closed=3, Restricted=4)
 3. `credit_limit: i128` - Maximum credit limit
 4. `interest_rate_bps: u32` - Interest rate in basis points
 5. `risk_score: u32` - Risk assessment score
@@ -716,6 +716,48 @@ All credit contract events are published under the `("credit", "...")` namespace
 
 ---
 
+### 4.12 Accrual Contract Events
+
+These events are emitted by the separate `contracts/accrual/` Soroban contract under the `("accrual", ...)` namespace.
+
+#### Event: Accrual Batch Completed
+
+**Topic:** `("accrual", "batch")`
+
+**Payload Struct:** `AccrualBatchCompletedEvent`
+
+**Fields:**
+1. `borrowers_processed: u32` - Number of borrower addresses submitted in the batch
+2. `lines_accrued: u32` - Number of credit lines that actually accrued interest
+3. `total_interest_accrued: i128` - Total interest capitalized across all lines
+4. `timestamp: u64` - Ledger timestamp at execution
+
+**Version Added:** 1.0.0  
+**Stability:** Stable  
+**Publisher:** `publish_accrual_batch_completed`
+
+---
+
+#### Event: Interest Accrued (per-borrower)
+
+**Topic:** `("accrual", "accrue")`
+
+**Payload Struct:** `accrual::InterestAccruedEvent`
+
+**Fields:**
+1. `borrower: Address` - Borrower whose credit line was accrued
+2. `accrued_amount: i128` - Interest amount capitalized in this step
+3. `new_utilized_amount: i128` - `utilized_amount` after capitalizing interest
+4. `new_accrued_interest: i128` - `accrued_interest` after this step
+5. `elapsed_seconds: u64` - Seconds elapsed since last accrual
+6. `timestamp: u64` - Ledger timestamp at time of accrual
+
+**Version Added:** 1.0.0  
+**Stability:** Stable  
+**Publisher:** `publish_interest_accrued`
+
+---
+
 ## 5. Auction Contract Events
 
 All auction contract events are published under the `gateway-auction` contract. Publishers live in `gateway-contract/contracts/auction_contract/src/events.rs`.
@@ -778,7 +820,117 @@ All auction contract events are published under the `gateway-auction` contract. 
 
 ---
 
-## 6. Type Definitions
+## 6. CosmWasm Contract Events
+
+All events are emitted by the CosmWasm `creditra-credit` contract (`contracts/creditra-credit/src/contract.rs`) via the standard CosmWasm `wasm` event wrapper. Entrypoints return `Result<Response, ContractError>` with `.add_attribute("key", "value")` calls on the `Response`.
+
+### 6.1 Credit Line Created
+
+**Action:** `"create_credit_line"`  
+**Entrypoint:** `execute` via `ExecuteMsg::CreateCreditLine`  
+**Authorization:** Contract owner
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"create_credit_line"` |
+| `credit_line_id` | `u64` | Auto-incremented credit line counter |
+
+---
+
+### 6.2 Draw Created
+
+**Action:** `"create_draw"`  
+**Entrypoint:** `execute` via `ExecuteMsg::CreateDraw`  
+**Authorization:** Borrower of the credit line
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"create_draw"` |
+| `credit_line_id` | `u64` | Parent credit line ID |
+| `draw_id` | `u64` | Auto-incremented draw counter per credit line |
+
+---
+
+### 6.3 Draw Repaid
+
+**Action:** `"repay_draw"`  
+**Entrypoint:** `execute` via `ExecuteMsg::RepayDraw`  
+**Authorization:** Original drawer
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"repay_draw"` |
+| `credit_line_id` | `u64` | Parent credit line ID |
+| `draw_id` | `u64` | Draw being repaid |
+
+---
+
+### 6.4 Audit Memo Added
+
+**Action:** `"add_audit_memo"`  
+**Entrypoint:** `execute` via `ExecuteMsg::AddAuditMemo`  
+**Authorization:** Contract owner
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"add_audit_memo"` |
+| `credit_line_id` | `u64` | Parent credit line ID |
+| `draw_id` | `u64` | Draw receiving the memo |
+
+---
+
+### 6.5 Protocol Version Updated
+
+**Action:** `"update_protocol_version"`  
+**Entrypoint:** `execute` via `ExecuteMsg::UpdateProtocolVersion`  
+**Authorization:** Contract owner
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"update_protocol_version"` |
+| `major` | `u32` | New major version |
+| `minor` | `u32` | New minor version |
+
+---
+
+### 6.6 Oracle Quorum Config Set
+
+**Action:** `"set_oracle_quorum_config"`  
+**Entrypoint:** `execute` via `ExecuteMsg::SetOracleQuorumConfig`  
+**Authorization:** Contract owner
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"set_oracle_quorum_config"` |
+| `min_quorum_k` | `u32` | Minimum quorum size |
+| `max_deviation_bps` | `u32` | Maximum allowed deviation |
+| `max_age_seconds` | `u64` | Maximum oracle price age |
+
+---
+
+### 6.7 Oracle Prices Submitted
+
+**Action:** `"submit_oracle_prices"`  
+**Entrypoint:** `execute` via `ExecuteMsg::SubmitOraclePrices`  
+**Authorization:** Contract owner
+
+**Attributes:**
+| Name | Type | Description |
+|---|---|---|
+| `action` | `string` | Always `"submit_oracle_prices"` |
+| `canonical_price` | `i128` | Resolved quorum price |
+| `min_quorum_k` | `u32` | Quorum size used |
+| `timestamp` | `u64` | Block timestamp |
+
+---
+
+## 7. Type Definitions
 
 ### Shared Types
 
@@ -787,8 +939,14 @@ All auction contract events are published under the `gateway-auction` contract. 
   - `Suspended = 1`
   - `Defaulted = 2`
   - `Closed = 3`
+  - `Restricted = 4`
 
-- **FreezeReason** - Enum defined in `contracts/credit/src/types.rs` for freeze source.
+- **FreezeReason** - Enum defined in `contracts/credit/src/types.rs` for freeze source:
+  - `LiquidityReserve = 0`
+  - `Compliance = 1`
+  - `RiskInvestigation = 2`
+  - `OperationalMaintenance = 3`
+  - `BorrowerRequest = 4`
 
 - **GraceWaiverMode** - Enum defined in `contracts/credit/src/types.rs`:
   - `FullWaiver`
@@ -796,7 +954,7 @@ All auction contract events are published under the `gateway-auction` contract. 
 
 ---
 
-## 7. Stability Matrix
+## 8. Stability Matrix
 
 | Event topic | Stable since | Deprecated | Removal target | Notes |
 |---|---|---|---|---|
@@ -839,10 +997,13 @@ All auction contract events are published under the `gateway-auction` contract. 
 | `("BID_RFDN","auction")` | 1.0.0 | No | — | |
 | `("AUC_CLOSE","auction")` | 1.0.0 | No | — | |
 | `("LIQ_SETL","auction")` | 1.0.0 | No | — | |
+| `("accrual","batch")` | 1.0.0 | No | — | Accrual contract, batch-level |
+| `("accrual","accrue")` | 1.0.0 | No | — | Accrual contract, per-borrower |
+| CosmWasm `wasm` events | 1.0.0 | No | — | 7 entrypoints, see §6 |
 
 ---
 
-## 8. Publisher Reference
+## 9. Publisher Reference
 
 ### Credit Contract Publishers
 
@@ -850,7 +1011,7 @@ All credit contract publishers live in `contracts/credit/src/events.rs`:
 
 | Publisher function | Event topic |
 |---|---|
-| `publish_credit_line_event` | `("credit", "opened"\|"suspend"\|"closed"\|"default"\|"reinstate")` |
+| `publish_credit_line_event` | `("credit", "opened"\|"suspend"\|"closed"\|"defaulted"\|"reinstate")` |
 | `publish_drawn_event` | `("credit", "drawn")` |
 | `publish_drawn_event_v2` | `("credit", "drawn_v2")` |
 | `publish_repayment_event` | `("credit", "repay")` |
@@ -897,9 +1058,32 @@ All auction contract publishers live in `gateway-contract/contracts/auction_cont
 | `publish_auction_closed_event` | `("AUC_CLOSE", "auction")` |
 | `publish_default_liquidation_settlement_event` | `("LIQ_SETL", "auction")` |
 
+### Accrual Contract Publishers
+
+All accrual contract publishers live in `contracts/accrual/src/events.rs`:
+
+| Publisher function | Event topic |
+|---|---|
+| `publish_accrual_batch_completed` | `("accrual", "batch")` |
+| `publish_interest_accrued` | `("accrual", "accrue")` |
+
+### CosmWasm Credit Contract Entrypoints
+
+All CosmWasm events are emitted from `contracts/creditra-credit/src/contract.rs` via `Response::add_attribute`:
+
+| Entrypoint function | Action attribute |
+|---|---|
+| `execute_create_credit_line` | `"create_credit_line"` |
+| `execute_create_draw` | `"create_draw"` |
+| `execute_repay_draw` | `"repay_draw"` |
+| `execute_add_audit_memo` | `"add_audit_memo"` |
+| `execute_update_protocol_version` | `"update_protocol_version"` |
+| `execute_set_oracle_quorum_config` | `"set_oracle_quorum_config"` |
+| `execute_submit_oracle_prices` | `"submit_oracle_prices"` |
+
 ---
 
-## 9. Related Documentation
+## 10. Related Documentation
 
 - [`docs/EVENTS_CATALOG.md`](./EVENTS_CATALOG.md) — Authoritative event catalog with stability status
 - [`docs/events-schema.md`](./events-schema.md) — Legacy schema reference (superseded)


### PR DESCRIPTION
Closes #766. 
Fixes discrepancies between event schema docs and actual contract code:
"default" to "defaulted" lifecycle topic (code uses "defaulted")
BorrowerFrozenEvent topic ("credit","br_freeze") to ("br_freeze",) (single-element topic)
Added Restricted = 4 to CreditStatus, expanded FreezeReason with all 5 variants
Added accrual contract events (contracts/accrual/) and CosmWasm contract events (contracts/creditra-credit/)
Fixed doc comment in events.rs to match code
Updated version to 1.1, renumbered sections, updated all tables and publisher refs