### PR TITLE
test: collateral auth snapshot

### DIFF
--- a/contracts/collateral/Cargo.toml
+++ b/contracts/collateral/Cargo.toml
@@ -19,6 +19,10 @@ creditra-credit = { path = "../credit" }
 name = "admin_cooldown"
 path = "tests/admin_cooldown.rs"
 
+[[test]]
+name = "auth_snap"
+path = "tests/auth_snap.rs"
+
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 creditra-credit = { path = "../credit", features = [] }

--- a/contracts/collateral/README.md
+++ b/contracts/collateral/README.md
@@ -27,3 +27,17 @@ ledger.timestamp >= LastAdminCollateralCriticalActionTs + AdminCollateralCooldow
 Otherwise the contract reverts with `ContractError::AdminCollateralCooldownActive` (`54`).
 
 Implementation: [`src/admin.rs`](./src/admin.rs) (compiled into `creditra-credit`).
+
+## Authorization snapshot
+
+The collateral v7 API has per-entrypoint authorization regression coverage in
+[`tests/auth_snap.rs`](./tests/auth_snap.rs). Each state-changing collateral
+entrypoint records exactly one required signer:
+
+- borrower authorization for deposit, withdrawal, partial release, atomic
+  repay-and-release, and per-token deposit/withdrawal;
+- admin authorization for collateral ratio, risk weight, token allowlist, and
+  admin cooldown configuration.
+
+Collateral queries remain authorization-free. This documents and tests the
+existing public authorization contract; no function signatures changed.

--- a/contracts/collateral/tests/auth_snap.rs
+++ b/contracts/collateral/tests/auth_snap.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+
+//! Per-entrypoint authorization snapshot for the collateral v7 surface.
+//!
+//! These tests pin the signer and authorization count recorded by Soroban for
+//! every state-changing collateral entrypoint. Token transfers may be nested
+//! below the recorded authorization, but they must not add another signer.
+//!
+//! | Entrypoint | Required signer | Auths recorded |
+//! |---|---|---|
+//! | `deposit_collateral` | borrower | 1 |
+//! | `withdraw_collateral` | borrower | 1 |
+//! | `partial_release_collateral` | borrower | 1 |
+//! | `repay_and_release_collateral` | borrower | 1 |
+//! | `deposit_collateral_token` | borrower | 1 |
+//! | `withdraw_collateral_token` | borrower | 1 |
+//! | `set_min_collateral_ratio_bps` | admin | 1 |
+//! | `set_collateral_risk_weight` | admin | 1 |
+//! | `set_collateral_token_allowlist` | admin | 1 |
+//! | `set_admin_collateral_cooldown_seconds` | admin | 1 |
+//!
+//! Read-only collateral entrypoints require no authorization.
+
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec,
+};
+
+const COLLATERAL_AMOUNT: i128 = 1_000;
+
+struct Fixture<'a> {
+    client: CreditClient<'a>,
+    admin: Address,
+    borrower: Address,
+    contract_id: Address,
+    token: Address,
+}
+
+/// Deploy a configured contract and fund a borrower with collateral tokens.
+fn setup(env: &Env) -> Fixture<'_> {
+    env.mock_all_auths();
+
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(env))
+        .address();
+    client.set_liquidity_token(&token);
+    StellarAssetClient::new(env, &token).mint(&borrower, &(COLLATERAL_AMOUNT * 2));
+
+    Fixture {
+        client,
+        admin,
+        borrower,
+        contract_id,
+        token,
+    }
+}
+
+/// Assert that the immediately preceding call required exactly `signer`.
+fn assert_single_auth(env: &Env, signer: &Address, entrypoint: &str) {
+    let auths = env.auths();
+    assert_eq!(
+        auths.len(),
+        1,
+        "{entrypoint} must record exactly one authorization"
+    );
+    assert_eq!(
+        &auths[0].0, signer,
+        "{entrypoint} must require the documented signer"
+    );
+}
+
+#[test]
+fn deposit_collateral_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+
+    fixture
+        .client
+        .deposit_collateral(&fixture.borrower, &COLLATERAL_AMOUNT);
+
+    assert_single_auth(&env, &fixture.borrower, "deposit_collateral");
+}
+
+#[test]
+fn withdraw_collateral_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+    fixture
+        .client
+        .deposit_collateral(&fixture.borrower, &COLLATERAL_AMOUNT);
+
+    fixture
+        .client
+        .withdraw_collateral(&fixture.borrower, &COLLATERAL_AMOUNT);
+
+    assert_single_auth(&env, &fixture.borrower, "withdraw_collateral");
+}
+
+#[test]
+fn partial_release_collateral_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+    fixture
+        .client
+        .deposit_collateral(&fixture.borrower, &COLLATERAL_AMOUNT);
+
+    fixture
+        .client
+        .partial_release_collateral(&fixture.borrower, &1);
+
+    assert_single_auth(&env, &fixture.borrower, "partial_release_collateral");
+}
+
+#[test]
+fn repay_and_release_collateral_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+    StellarAssetClient::new(&env, &fixture.token).mint(&fixture.contract_id, &1_000);
+    fixture
+        .client
+        .open_credit_line(&fixture.borrower, &1_000, &300, &50);
+    fixture
+        .client
+        .deposit_collateral(&fixture.borrower, &COLLATERAL_AMOUNT);
+    fixture.client.draw_credit(&fixture.borrower, &100);
+    TokenClient::new(&env, &fixture.token).approve(
+        &fixture.borrower,
+        &fixture.contract_id,
+        &100,
+        &1_000,
+    );
+
+    fixture
+        .client
+        .repay_and_release_collateral(&fixture.borrower, &1);
+
+    assert_single_auth(&env, &fixture.borrower, "repay_and_release_collateral");
+}
+
+#[test]
+fn deposit_collateral_token_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(fixture.token.clone());
+    fixture.client.set_collateral_token_allowlist(&tokens);
+
+    fixture
+        .client
+        .deposit_collateral_token(&fixture.borrower, &fixture.token, &COLLATERAL_AMOUNT);
+
+    assert_single_auth(&env, &fixture.borrower, "deposit_collateral_token");
+}
+
+#[test]
+fn withdraw_collateral_token_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(fixture.token.clone());
+    fixture.client.set_collateral_token_allowlist(&tokens);
+    fixture
+        .client
+        .deposit_collateral_token(&fixture.borrower, &fixture.token, &COLLATERAL_AMOUNT);
+
+    fixture
+        .client
+        .withdraw_collateral_token(&fixture.borrower, &fixture.token, &COLLATERAL_AMOUNT);
+
+    assert_single_auth(&env, &fixture.borrower, "withdraw_collateral_token");
+}
+
+#[test]
+fn set_min_collateral_ratio_bps_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+
+    fixture.client.set_min_collateral_ratio_bps(&15_000);
+
+    assert_single_auth(&env, &fixture.admin, "set_min_collateral_ratio_bps");
+}
+
+#[test]
+fn set_collateral_risk_weight_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+
+    fixture
+        .client
+        .set_collateral_risk_weight(&fixture.token, &8_000);
+
+    assert_single_auth(&env, &fixture.admin, "set_collateral_risk_weight");
+}
+
+#[test]
+fn set_collateral_token_allowlist_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(fixture.token.clone());
+
+    fixture.client.set_collateral_token_allowlist(&tokens);
+
+    assert_single_auth(&env, &fixture.admin, "set_collateral_token_allowlist");
+}
+
+#[test]
+fn set_admin_collateral_cooldown_seconds_auth_snapshot() {
+    let env = Env::default();
+    let fixture = setup(&env);
+
+    fixture.client.set_admin_collateral_cooldown_seconds(&120);
+
+    assert_single_auth(
+        &env,
+        &fixture.admin,
+        "set_admin_collateral_cooldown_seconds",
+    );
+}
+
+#[test]
+fn collateral_queries_require_no_auth() {
+    let env = Env::default();
+    let fixture = setup(&env);
+
+    let _ = fixture.client.get_collateral(&fixture.borrower);
+    assert!(env.auths().is_empty(), "get_collateral must be auth-free");
+
+    let _ = fixture.client.get_min_collateral_ratio_bps();
+    assert!(
+        env.auths().is_empty(),
+        "get_min_collateral_ratio_bps must be auth-free"
+    );
+
+    let _ = fixture.client.get_admin_collateral_cooldown_seconds();
+    assert!(
+        env.auths().is_empty(),
+        "get_admin_collateral_cooldown_seconds must be auth-free"
+    );
+
+    let _ = fixture
+        .client
+        .get_last_admin_collateral_critical_action_ts();
+    assert!(
+        env.auths().is_empty(),
+        "get_last_admin_collateral_critical_action_ts must be auth-free"
+    );
+
+    let _ = fixture.client.get_collateral_tokens();
+    assert!(
+        env.auths().is_empty(),
+        "get_collateral_tokens must be auth-free"
+    );
+
+    let _ = fixture
+        .client
+        .get_collateral_for_token(&fixture.borrower, &fixture.token);
+    assert!(
+        env.auths().is_empty(),
+        "get_collateral_for_token must be auth-free"
+    );
+}


### PR DESCRIPTION
closes #856 

## Summary                                                                                                        
   Adds per-entrypoint authorization snapshot tests for the collateral v7 surface.                                   
                                                                                                                     
   ## Changes                                                                                                        
   - **contracts/collateral/tests/auth_snap.rs** — 11 tests pinning required signer and auth count for every         
 state-changing collateral entrypoint:                                                                               
     - Borrower-authorized (6): `deposit_collateral`, `withdraw_collateral`, `partial_release_collateral`,           
 `repay_and_release_collateral`, `deposit_collateral_token`, `withdraw_collateral_token`                             
     - Admin-authorized (4): `set_min_collateral_ratio_bps`, `set_collateral_risk_weight`,                           
 `set_collateral_token_allowlist`, `set_admin_collateral_cooldown_seconds`                                           
     - Read-only queries verified auth-free (7): `get_collateral`, `get_min_collateral_ratio_bps`,                   
 `get_admin_collateral_cooldown_seconds`, `get_last_admin_collateral_critical_action_ts`, `get_collateral_tokens`,   
 `get_collateral_for_token`                                                                                          
                                                                                                                     
   - **contracts/collateral/README.md** — Added "Authorization snapshot" section documenting the per-entrypoint auth 
 contract                                                                                                            
                                                                                                                     
   - **contracts/collateral/Cargo.toml** — Registered `auth_snap` test target                                        
                                                                                                                     
   ## Verification                                                                                                   
   - Source code in `contracts/credit/src/collateral.rs` and `contracts/collateral/src/admin.rs` confirms all        
 state-changing entrypoints call `borrower.require_auth()` or `require_admin_auth(env)`                              
   - Tests use `env.mock_all_auths()` + `assert_single_auth()` to pin exactly one recorded authorization per         
 entrypoint                                                                                                                                                     
                                                                                                                     
   ## Notes                                                                                                          
   - Test execution currently blocked by pre-existing merge artifacts in `contracts/credit/src/lib.rs` (unrelated    
 duplicate imports); those require separate cleanup to unblock CI                                                           
 ```                                                                                                                 
