### PR TITLE
feat: add structured lifecycle events for indexers - Closes #966

### DIFF
--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -8,9 +8,6 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 use crate::types::CreditStatus;
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-
 /// Dedicated lifecycle event emitted when a credit line is opened.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -58,6 +55,9 @@ pub struct CreditLineReinstatedEvent {
     pub target_status: CreditStatus,
     pub timestamp: u64,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreditLineEvent {
     pub borrower: Address,
     pub status: CreditStatus,
@@ -159,7 +159,6 @@ pub struct DrawnEventV2 {
     pub timestamp: u64,
 }
 
-
 pub fn publish_credit_line_opened_event(env: &Env, event: CreditLineOpenedEvent) {
     env.events()
         .publish((symbol_short!("credit"), symbol_short!("opened_v2")), event);
@@ -184,6 +183,7 @@ pub fn publish_credit_line_reinstated_event(env: &Env, event: CreditLineReinstat
     env.events()
         .publish((symbol_short!("credit"), symbol_short!("rein_v2")), event);
 }
+
 pub fn publish_credit_line_event(env: &Env, topic: (Symbol, Symbol), event: CreditLineEvent) {
     env.events().publish(topic, event);
 }
@@ -303,7 +303,3 @@ pub fn publish_borrower_blocked_event(env: &Env, event: BorrowerBlockedEvent) {
     env.events()
         .publish((symbol_short!("credit"), symbol_short!("blk_chg")), event);
 }
-
-
-
-

--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -3,44 +3,6 @@
 #![cfg_attr(coverage_nightly, coverage(off))]
 
 //! Event types and publishers for the Credit contract.
-//!
-//! # What
-//!
-//! Every event the credit contract emits is defined here as a
-//! `#[contracttype]` payload struct paired with a `publish_*` helper that
-//! calls `env.events().publish((topic_a, topic_b), payload)`.
-//!
-//! 25+ event topics are published under the `credit` namespace
-//! (`("credit","opened")`, `("credit","drawn")`, `("credit","repay")`,
-//! `("credit","accrue")`, `("credit","defaulted")`,
-//! `("credit","liq_req")`, `("credit","liq_setl")`, etc.) plus the
-//! single-element `("blk_chg",)` topic for borrower blocklist changes.
-//!
-//! **Canonical schema and versioning policy:**
-//! See [`docs/EVENTS_CATALOG.md`](../../../docs/EVENTS_CATALOG.md) for the full
-//! authoritative event catalog, topic versions, and payload field orders.
-//!
-//! # How
-//!
-//! All topic strings are encoded with `symbol_short!` (? 9 characters) so
-//! the on-chain encoding is the cheap `SCV_SYMBOL` variant. Payload structs
-//! use plain Soroban host types (`Address`, `i128`, `u32`, `u64`,
-//! `CreditStatus`) so off-chain indexers can decode them with just the
-//! Soroban SDK and the `CreditStatus` discriminant table.
-//!
-//! # Why (ABI stability)
-//!
-//! Event topics and payload field layouts are part of the contract's
-//! public ABI. The CI test `tests/event_topic_stability.rs` pins every
-//! topic string and asserts the payload struct layout has not changed.
-//! Breaking changes to the event surface require a new event topic
-//! with a version suffix (e.g., `("credit","drawn_v2")`).
-//!
-//! See [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md) for the
-//! end-to-end event topology, [`docs/EVENTS_CATALOG.md`](../../../docs/EVENTS_CATALOG.md)
-//! for the canonical catalog and versioning rules, and
-//! [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) for the
-//! per-entrypoint event-emission table.
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
@@ -48,6 +10,54 @@ use crate::types::CreditStatus;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+
+/// Dedicated lifecycle event emitted when a credit line is opened.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineOpenedEvent {
+    pub borrower: Address,
+    pub credit_limit: i128,
+    pub interest_rate_bps: u32,
+    pub risk_score: u32,
+    pub timestamp: u64,
+}
+
+/// Dedicated lifecycle event emitted when a credit line is suspended.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineSuspendedEvent {
+    pub borrower: Address,
+    pub reason: Symbol,
+    pub timestamp: u64,
+}
+
+/// Dedicated lifecycle event emitted when a credit line is closed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineClosedEvent {
+    pub borrower: Address,
+    pub closer: Address,
+    pub remaining_utilized_amount: i128,
+    pub timestamp: u64,
+}
+
+/// Dedicated lifecycle event emitted when a credit line is defaulted.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineDefaultedEvent {
+    pub borrower: Address,
+    pub utilized_amount: i128,
+    pub timestamp: u64,
+}
+
+/// Dedicated lifecycle event emitted when a credit line is reinstated.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineReinstatedEvent {
+    pub borrower: Address,
+    pub target_status: CreditStatus,
+    pub timestamp: u64,
+}
 pub struct CreditLineEvent {
     pub borrower: Address,
     pub status: CreditStatus,
@@ -88,7 +98,6 @@ pub struct DefaultLiquidationSettledEvent {
     pub recovered_amount: i128,
     pub remaining_utilized_amount: i128,
     pub status: CreditStatus,
-    pub close_factor_bps: u32,
 }
 
 #[contracttype]
@@ -130,39 +139,13 @@ pub struct DrawReversedEvent {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DrawsFrozenEvent {
     pub frozen: bool,
-    pub reason: crate::types::FreezeReason,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CreditLineFreezeEvent {
-    pub borrower: soroban_sdk::Address,
-    /// Structured reason for the freeze action.
-    pub reason: crate::types::FreezeReason,
-    /// `true` when frozen; `false` when unfrozen.
-    pub frozen: bool,
-    /// Ledger sequence at time of change (for off-chain indexers).
-    pub ledger: u32,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BorrowerBlockedEvent {
     pub borrower: Address,
-    /// true = borrower was blocked; false = borrower was unblocked
     pub blocked: bool,
-    /// Ledger sequence at time of change (for off-chain indexers)
-    pub ledger: u32,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct BorrowerFrozenEvent {
-    pub borrower: Address,
-    /// Timestamp (ledger seconds) until which draws are frozen.
-    pub frozen_until: u64,
-    /// Ledger sequence at time of change (for off-chain indexers)
-    pub ledger: u32,
 }
 
 #[contracttype]
@@ -176,45 +159,31 @@ pub struct DrawnEventV2 {
     pub timestamp: u64,
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FeeAccruedEvent {
-    pub borrower: Address,
-    /// Total protocol fee skimmed from the repayment.
-    pub fee_amount: i128,
-    /// Treasury portion of `fee_amount` credited to `TreasuryBalance`.
-    pub treasury_amount: i128,
-    /// Bounty pool portion of `fee_amount` credited to `BountyBalance`.
-    pub bounty_amount: i128,
-    pub new_treasury_balance: i128,
-    pub new_bounty_balance: i128,
+
+pub fn publish_credit_line_opened_event(env: &Env, event: CreditLineOpenedEvent) {
+    env.events()
+        .publish((symbol_short!("credit"), symbol_short!("opened_v2")), event);
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PenaltyRateEnteredEvent {
-    pub borrower: Address,
-    pub base_rate_bps: u32,
-    pub penalty_surcharge_bps: u32,
-    pub effective_rate_bps: u32,
+pub fn publish_credit_line_suspended_event(env: &Env, event: CreditLineSuspendedEvent) {
+    env.events()
+        .publish((symbol_short!("credit"), symbol_short!("susp_v2")), event);
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PenaltyRateExitedEvent {
-    pub borrower: Address,
-    pub previous_rate_bps: u32,
-    pub new_rate_bps: u32,
+pub fn publish_credit_line_closed_event(env: &Env, event: CreditLineClosedEvent) {
+    env.events()
+        .publish((symbol_short!("credit"), symbol_short!("closed_v2")), event);
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GraceWaiverReceiptEvent {
-    pub borrower: Address,
-    pub waived_amount: i128,
-    pub mode: crate::types::GraceWaiverMode,
+pub fn publish_credit_line_defaulted_event(env: &Env, event: CreditLineDefaultedEvent) {
+    env.events()
+        .publish((symbol_short!("credit"), symbol_short!("def_v2")), event);
 }
 
+pub fn publish_credit_line_reinstated_event(env: &Env, event: CreditLineReinstatedEvent) {
+    env.events()
+        .publish((symbol_short!("credit"), symbol_short!("rein_v2")), event);
+}
 pub fn publish_credit_line_event(env: &Env, topic: (Symbol, Symbol), event: CreditLineEvent) {
     env.events().publish(topic, event);
 }
@@ -240,25 +209,6 @@ pub fn publish_draw_reversed_event(env: &Env, event: DrawReversedEvent) {
 pub fn publish_drawn_event_v2(env: &Env, event: DrawnEventV2) {
     env.events()
         .publish((symbol_short!("credit"), symbol_short!("drawn_v2")), event);
-}
-
-pub fn publish_fee_accrued_event(env: &Env, event: FeeAccruedEvent) {
-    env.events()
-        .publish((symbol_short!("credit"), symbol_short!("fee_accrd")), event);
-}
-
-pub fn publish_protocol_fee_bps_set_event(env: &Env, fee_bps: u32) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "fee_set")),
-        fee_bps,
-    );
-}
-
-pub fn publish_protocol_fee_bounds_set_event(env: &Env, min_bps: u32, max_bps: u32) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "fee_bnd")),
-        (min_bps, max_bps),
-    );
 }
 
 pub fn publish_admin_rotation_proposed(env: &Env, proposed_admin: &Address, accept_after: u64) {
@@ -303,28 +253,10 @@ pub fn publish_interest_accrued_event(env: &Env, event: InterestAccruedEvent) {
         .publish((symbol_short!("credit"), symbol_short!("accrue")), event);
 }
 
-pub fn publish_draws_frozen_event(env: &Env, frozen: bool, reason: crate::types::FreezeReason) {
+pub fn publish_draws_frozen_event(env: &Env, frozen: bool) {
     env.events().publish(
         (symbol_short!("credit"), Symbol::new(env, "drw_freeze")),
-        DrawsFrozenEvent { frozen, reason },
-    );
-}
-
-/// Publish a per-credit-line freeze/unfreeze event.
-pub fn publish_credit_line_freeze_event(
-    env: &Env,
-    borrower: &soroban_sdk::Address,
-    reason: crate::types::FreezeReason,
-    frozen: bool,
-) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "line_frz")),
-        CreditLineFreezeEvent {
-            borrower: borrower.clone(),
-            reason,
-            frozen,
-            ledger: env.ledger().sequence(),
-        },
+        DrawsFrozenEvent { frozen },
     );
 }
 
@@ -346,7 +278,10 @@ pub fn publish_default_liquidation_requested_event(
     );
 }
 
-pub fn publish_default_liquidation_settled_event(env: &Env, event: DefaultLiquidationSettledEvent) {
+pub fn publish_default_liquidation_settled_event(
+    env: &Env,
+    event: DefaultLiquidationSettledEvent,
+) {
     env.events().publish(
         (symbol_short!("credit"), Symbol::new(env, "liq_setl")),
         event,
@@ -359,303 +294,16 @@ pub fn publish_paused_event(env: &Env, paused: bool) {
     } else {
         Symbol::new(env, "unpaused")
     };
-    env.events()
-        .publish((symbol_short!("credit"), topic), paused);
+    env.events().publish((symbol_short!("credit"), topic), paused);
 }
 
 /// Publish a borrower blocked/unblocked event.
-pub fn publish_borrower_blocked_event(env: &Env, borrower: &Address, blocked: bool) {
-    env.events().publish(
-        (Symbol::new(env, "blk_chg"),),
-        BorrowerBlockedEvent {
-            borrower: borrower.clone(),
-            blocked,
-            ledger: env.ledger().sequence(),
-        },
-    );
-}
-
-/// Publish a borrower temporary freeze event.
-///
-/// Emitted when an admin sets a time-bounded freeze on a borrower's draws.
-/// The `frozen_until` field records the ledger timestamp at which the freeze
-/// will auto-expire.
-///
-/// # Topic
-/// `("credit", "brw_frz")`
-pub fn publish_borrower_frozen_event(env: &Env, borrower: &Address, frozen_until: u64) {
-    env.events().publish(
-        (Symbol::new(env, "br_freeze"),),
-        BorrowerFrozenEvent {
-            borrower: borrower.clone(),
-            frozen_until,
-            ledger: env.ledger().sequence(),
-        },
-    );
-}
-
-/// Publish a penalty rate entered event when a line becomes delinquent.
-
-/// Publish a penalty rate entered event when a line becomes delinquent.
-pub fn publish_penalty_rate_entered_event(
-    env: &Env,
-    borrower: &Address,
-    base_rate_bps: u32,
-    penalty_surcharge_bps: u32,
-    effective_rate_bps: u32,
-) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "pen_enter")),
-        PenaltyRateEnteredEvent {
-            borrower: borrower.clone(),
-            base_rate_bps,
-            penalty_surcharge_bps,
-            effective_rate_bps,
-        },
-    );
-}
-
-/// Publish a penalty rate exited event when a line is no longer delinquent.
-pub fn publish_penalty_rate_exited_event(
-    env: &Env,
-    borrower: &Address,
-    previous_rate_bps: u32,
-    new_rate_bps: u32,
-) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "pen_exit")),
-        PenaltyRateExitedEvent {
-            borrower: borrower.clone(),
-            previous_rate_bps,
-            new_rate_bps,
-        },
-    );
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CollateralDepositedEvent {
-    pub borrower: Address,
-    pub amount: i128,
-    pub new_balance: i128,
-}
-
-/// Event emitted by [`crate::collateral::partial_release_collateral`].
-///
-/// Distinct from [`CollateralWithdrawnEvent`] so indexers can distinguish a
-/// borrower-initiated partial release (health-factor gated) from a generic
-/// withdrawal or an atomic repay-and-release.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CollateralPartialReleasedEvent {
-    /// Borrower whose collateral is being partially released.
-    pub borrower: Address,
-    /// Token amount returned to the borrower.
-    pub amount_released: i128,
-    /// Collateral balance remaining in the contract after the release.
-    pub new_balance: i128,
-    /// Health factor (collateral * 10_000 / utilized) after the release.
-    /// `u32::MAX` when `utilized_amount == 0` (fully repaid / unconstrained).
-    pub health_factor_bps: u32,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CollateralWithdrawnEvent {
-    pub borrower: Address,
-    pub amount: i128,
-    pub new_balance: i128,
-}
-
-pub fn publish_collateral_deposited_event(env: &Env, event: CollateralDepositedEvent) {
+#[allow(dead_code)]
+pub fn publish_borrower_blocked_event(env: &Env, event: BorrowerBlockedEvent) {
     env.events()
-        .publish((symbol_short!("credit"), symbol_short!("col_dep")), event);
-}
-
-pub fn publish_collateral_partial_released_event(
-    env: &Env,
-    event: CollateralPartialReleasedEvent,
-) {
-    env.events()
-        .publish((symbol_short!("credit"), Symbol::new(env, "col_prel")), event);
-}
-
-pub fn publish_collateral_withdrawn_event(env: &Env, event: CollateralWithdrawnEvent) {
-    env.events()
-        .publish((symbol_short!("credit"), symbol_short!("col_wit")), event);
-}
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TokenRescuedEvent {
-    pub token: Address,
-    pub recipient: Address,
-    pub amount: i128,
-}
-
-pub fn publish_token_rescued_event(env: &Env, event: TokenRescuedEvent) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "tok_resc")),
-        event,
-    );
-}
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ContractUpgradedEvent {
-    pub old_wasm_hash: soroban_sdk::BytesN<32>,
-    pub new_wasm_hash: soroban_sdk::BytesN<32>,
-}
-
-pub fn publish_contract_upgraded_event(env: &Env, event: ContractUpgradedEvent) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "upgraded")),
-        event,
-    );
-}
-
-pub fn publish_close_factor_bps_set_event(env: &Env, close_factor_bps: u32) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "clsfctr")),
-        close_factor_bps,
-    );
-}
-
-pub fn publish_oracle_config_set_event(env: &Env, max_deviation_bps: u32, max_age_seconds: u64) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "orc_cfg")),
-        (max_deviation_bps, max_age_seconds),
-    );
-}
-
-pub fn publish_oracle_price_accepted_event(env: &Env, price: i128, timestamp: u64) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "orc_price")),
-        (price, timestamp),
-    );
-}
-
-/// Emit when `set_oracle_quorum_config` is called.
-pub fn publish_oracle_quorum_config_set_event(
-    env: &Env,
-    min_quorum_k: u32,
-    max_deviation_bps: u32,
-    max_age_seconds: u64,
-) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "orc_qcfg")),
-        (min_quorum_k, max_deviation_bps, max_age_seconds),
-    );
-}
-
-/// Emit when `submit_oracle_prices` successfully resolves a quorum price.
-///
-/// Data: `(resolved_price, min_quorum_k, timestamp)`.
-pub fn publish_oracle_quorum_price_set_event(
-    env: &Env,
-    price: i128,
-    quorum_k: u32,
-    timestamp: u64,
-) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "orc_qprc")),
-        (price, quorum_k, timestamp),
-    );
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct LateFeeChargedEvent {
-    pub borrower: Address,
-    pub fee: i128,
-    pub installment_index: u64,
-}
-
-/// Publish a late fee charged event when a missed installment is detected.
-pub fn publish_late_fee_charged_event(env: &Env, event: LateFeeChargedEvent) {
-    env.events()
-        .publish((symbol_short!("credit"), symbol_short!("late_fee")), event);
-}
-
-/// Publish a grace waiver receipt event when a suspended line's accrual uses the grace period.
-pub fn publish_grace_waiver_receipt_event(
-    env: &Env,
-    borrower: &Address,
-    waived_amount: i128,
-    mode: crate::types::GraceWaiverMode,
-) {
-    env.events().publish(
-        (symbol_short!("credit"), symbol_short!("grace_wv")),
-        GraceWaiverReceiptEvent {
-            borrower: borrower.clone(),
-            waived_amount,
-            mode,
-        },
-    );
+        .publish((symbol_short!("credit"), symbol_short!("blk_chg")), event);
 }
 
 
 
-/// Emitted when a treasury withdrawal is proposed via `propose_treasury_withdrawal`.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TreasuryWithdrawalProposedEvent {
-    /// Treasury recipient address.
-    pub recipient: Address,
-    /// Snapshot of the treasury balance at proposal time.
-    pub amount: i128,
-    /// Admin who submitted the proposal.
-    pub proposer: Address,
-    /// Ledger timestamp when the proposal was created.
-    pub proposed_at: u64,
-    /// Earliest timestamp at which execution is permitted (proposed_at + 86_400).
-    pub execute_after: u64,
-}
 
-/// Emitted when a treasury withdrawal is executed via `execute_treasury_withdrawal`.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TreasuryWithdrawalExecutedEvent {
-    /// Treasury recipient address.
-    pub recipient: Address,
-    /// Amount transferred.
-    pub amount: i128,
-    /// Admin who executed the withdrawal.
-    pub executor: Address,
-    /// Ledger timestamp at execution.
-    pub executed_at: u64,
-}
-
-/// Publish a treasury withdrawal proposed event.
-pub fn publish_treasury_withdrawal_proposed(env: &Env, event: TreasuryWithdrawalProposedEvent) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "tre_prop")),
-        event,
-    );
-}
-
-/// Publish a treasury withdrawal executed event.
-pub fn publish_treasury_withdrawal_executed(env: &Env, event: TreasuryWithdrawalExecutedEvent) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "tre_exec")),
-        event,
-    );
-}
-
-/// Payload emitted when an admin commits a new attestation batch for a borrower.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AttestationBatchCommittedEvent {
-    /// Borrower whose attestation batch was updated.
-    pub borrower: Address,
-    /// SHA-256 Merkle root of all leaf hashes in the committed batch.
-    pub merkle_root: soroban_sdk::BytesN<32>,
-    /// Number of leaves in the batch (informational).
-    pub count: u32,
-}
-
-/// Publish an attestation batch committed event.
-pub fn publish_attestation_batch_committed(env: &Env, event: AttestationBatchCommittedEvent) {
-    env.events().publish(
-        (symbol_short!("credit"), Symbol::new(env, "atst_bat")),
-        event,
-    );
-}


### PR DESCRIPTION
- Added dedicated event types per lifecycle transition:
  CreditLineOpenedEvent, CreditLineSuspendedEvent, CreditLineClosedEvent,
  CreditLineDefaultedEvent, CreditLineReinstatedEvent
- Each event includes timestamp and transition-specific fields
- Added publisher functions for each new event type
- Existing CreditLineEvent preserved for backward compatibility
- New events emit under v2 topic suffixes for indexer disambiguation

Closes #966