### PR TITLE
fix: bump TTL on accrual hot-read paths

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -2300,6 +2300,11 @@ impl Credit {
     }
 
     /// Admin-only bounded reversal for an erroneous draw.
+    ///
+    /// # Storage
+    /// Loads the credit line via `storage_get_credit_line`, which bumps the
+    /// entry's persistent TTL on read — independent of whether the call goes
+    /// on to mutate and persist the line.
     pub fn reverse_draw(
         env: Env,
         borrower: Address,
@@ -2319,10 +2324,9 @@ impl Credit {
             env.panic_with_error(ContractError::DrawReversalWindowExpired);
         }
 
-        let mut credit_line: CreditLineData = env
-            .storage()
-            .persistent()
-            .get(&borrower)
+        // Bump TTL on read: this is a hot accrual read path, so an active
+        // borrower's entry must never be archived independently of draw/repay.
+        let mut credit_line: CreditLineData = storage_get_credit_line(&env, &borrower)
             .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
         credit_line = accrual::apply_accrual(&env, credit_line);
 

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -248,10 +248,9 @@ pub fn validate_credit_limit_bounds(env: &Env, credit_limit: i128) {
 // ──────────────────────────────────────────────────────────────────────────────
 
 fn suspend_credit_line_internal(env: &Env, borrower: Address) {
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    // Bump TTL on read: this is a hot accrual read path, so an active
+    // borrower's entry must never be archived independently of draw/repay.
+    let stored_line: CreditLineData = crate::storage::get_credit_line(env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
 
@@ -563,6 +562,11 @@ pub fn suspend_credit_line(env: Env, borrower: Address) {
 /// This is a borrower safety control that blocks future draws while leaving
 /// repayments available. Reactivation still requires a separate admin-controlled
 /// workflow.
+///
+/// # Storage
+/// Loads the credit line via [`crate::storage::get_credit_line`], which bumps
+/// the entry's persistent TTL on read — independent of whether the call goes
+/// on to mutate and persist the line.
 pub fn self_suspend_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
     borrower.require_auth();
@@ -705,13 +709,17 @@ pub fn close_credit_lines_batch(env: Env, borrowers: soroban_sdk::Vec<Address>) 
 ///
 /// # Events
 /// Emits a `("credit", "default")` [`CreditLineEvent`].
+///
+/// # Storage
+/// Loads the credit line via [`crate::storage::get_credit_line`], which bumps
+/// the entry's persistent TTL on read — independent of whether the call goes
+/// on to mutate and persist the line.
 pub fn default_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
     require_admin_auth(&env);
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    // Bump TTL on read: this is a hot accrual read path, so an active
+    // borrower's entry must never be archived independently of draw/repay.
+    let stored_line: CreditLineData = crate::storage::get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let _previous_utilized = stored_line.utilized_amount;
 
@@ -774,6 +782,12 @@ pub fn default_credit_line(env: Env, borrower: Address) {
     publish_default_liquidation_requested_event(&env, &borrower, credit_line.utilized_amount);
 }
 
+/// Accounting half of a default-liquidation settlement (admin only).
+///
+/// # Storage
+/// Loads the credit line via [`crate::storage::get_credit_line`], which bumps
+/// the entry's persistent TTL on read — independent of whether the call goes
+/// on to mutate and persist the line.
 pub fn settle_default_liquidation(
     env: Env,
     borrower: Address,
@@ -801,10 +815,9 @@ pub fn settle_default_liquidation(
         env.panic_with_error(ContractError::AlreadySettled);
     }
 
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    // Bump TTL on read: this is a hot accrual read path, so an active
+    // borrower's entry must never be archived independently of draw/repay.
+    let stored_line: CreditLineData = crate::storage::get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
     let previous_status = stored_line.status;
@@ -883,6 +896,11 @@ pub fn settle_default_liquidation(
 ///
 /// # Events
 /// Emits a `("credit", "reinstate")` [`CreditLineEvent`].
+///
+/// # Storage
+/// Loads the credit line via [`crate::storage::get_credit_line`], which bumps
+/// the entry's persistent TTL on read — independent of whether the call goes
+/// on to mutate and persist the line.
 pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditStatus) {
     assert_not_paused(&env);
     require_admin_auth(&env);
@@ -892,10 +910,9 @@ pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditS
         env.panic_with_error(ContractError::InvalidAmount);
     }
 
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
+    // Bump TTL on read: this is a hot accrual read path, so an active
+    // borrower's entry must never be archived independently of draw/repay.
+    let stored_line: CreditLineData = crate::storage::get_credit_line(&env, &borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
     let previous_utilized = stored_line.utilized_amount;
     let previous_status = stored_line.status;

--- a/contracts/credit/tests/storage_ttl.rs
+++ b/contracts/credit/tests/storage_ttl.rs
@@ -11,7 +11,7 @@ use creditra_credit::types::{CreditLineData, CreditStatus, GracePeriodConfig, Gr
 use creditra_credit::{Credit, CreditClient};
 use soroban_sdk::testutils::storage::{Instance as _, Persistent as _};
 use soroban_sdk::testutils::{Address as _, Ledger};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Symbol};
 
 fn setup(env: &Env) -> (Address, CreditClient, Address) {
     env.mock_all_auths();
@@ -226,5 +226,131 @@ fn accrual_path_bumps_instance_ttl_for_accrual_reads() {
     assert!(
         ttl_after >= LEDGER_BUMP_AMOUNT,
         "instance TTL not extended for accrual reads: initial={initial_ttl} after={ttl_after}"
+    );
+}
+
+// ── Lifecycle entrypoints that load a credit line ahead of `apply_accrual` ──
+//
+// Each of these previously read the credit line via a raw
+// `env.storage().persistent().get(&borrower)` call, bypassing
+// `storage::get_credit_line`'s TTL bump. A borrower who only ever interacts
+// through one of these paths (e.g. is suspended, defaulted, or reinstated but
+// never draws or repays) would have their entry silently drift toward
+// archival. These regression tests drain the entry's TTL below the refresh
+// threshold and assert that invoking each path bumps it back up.
+
+/// Drain `borrower`'s credit-line TTL down to just below the refresh
+/// threshold so the next accrual read must perform a real bump.
+fn drain_credit_line_ttl(env: &Env, contract_id: &Address, borrower: &Address) {
+    let ttl_initial = ttl_for_key(env, contract_id, borrower);
+    let target_remaining = LEDGER_BUMP_THRESHOLD.saturating_sub(1);
+    advance_ledgers(env, ttl_initial.saturating_sub(target_remaining));
+}
+
+#[test]
+fn self_suspend_bumps_credit_line_ttl_on_accrual_read() {
+    let env = Env::default();
+    let (contract_id, client, _admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+    drain_credit_line_ttl(&env, &contract_id, &borrower);
+
+    client.self_suspend_credit_line(&borrower);
+
+    let ttl_after = ttl_for_key(&env, &contract_id, &borrower);
+    assert!(
+        ttl_after >= LEDGER_BUMP_AMOUNT,
+        "credit-line TTL not bumped on self_suspend_credit_line: {ttl_after}"
+    );
+}
+
+#[test]
+fn default_credit_line_bumps_credit_line_ttl_on_accrual_read() {
+    let env = Env::default();
+    let (contract_id, client, _admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+    drain_credit_line_ttl(&env, &contract_id, &borrower);
+
+    client.default_credit_line(&borrower);
+
+    let ttl_after = ttl_for_key(&env, &contract_id, &borrower);
+    assert!(
+        ttl_after >= LEDGER_BUMP_AMOUNT,
+        "credit-line TTL not bumped on default_credit_line: {ttl_after}"
+    );
+}
+
+#[test]
+fn reinstate_credit_line_bumps_credit_line_ttl_on_accrual_read() {
+    let env = Env::default();
+    let (contract_id, client, _admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+    client.default_credit_line(&borrower);
+
+    drain_credit_line_ttl(&env, &contract_id, &borrower);
+
+    client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+
+    let ttl_after = ttl_for_key(&env, &contract_id, &borrower);
+    assert!(
+        ttl_after >= LEDGER_BUMP_AMOUNT,
+        "credit-line TTL not bumped on reinstate_credit_line: {ttl_after}"
+    );
+}
+
+#[test]
+fn settle_default_liquidation_bumps_credit_line_ttl_on_accrual_read() {
+    let env = Env::default();
+    let (contract_id, client, _admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+    client.default_credit_line(&borrower);
+
+    drain_credit_line_ttl(&env, &contract_id, &borrower);
+
+    let settlement_id = Symbol::new(&env, "settle1");
+    client.settle_default_liquidation(&borrower, &500_i128, &settlement_id, &10_000_u32, &None);
+
+    let ttl_after = ttl_for_key(&env, &contract_id, &borrower);
+    assert!(
+        ttl_after >= LEDGER_BUMP_AMOUNT,
+        "credit-line TTL not bumped on settle_default_liquidation: {ttl_after}"
+    );
+}
+
+#[test]
+fn reverse_draw_bumps_credit_line_ttl_on_accrual_read() {
+    let env = Env::default();
+    let (contract_id, client, _admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &300_u32, &70_u32);
+
+    // Record a draw-audit entry directly (bypassing token transfer machinery,
+    // which is irrelevant to this TTL regression test) so `reverse_draw` can
+    // find an original draw to reverse.
+    let original_ts = env.ledger().timestamp();
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::DrawAudit(borrower.clone(), original_ts), &200_i128);
+    });
+
+    drain_credit_line_ttl(&env, &contract_id, &borrower);
+
+    client.reverse_draw(&borrower, &100_i128, &original_ts, &1_u32);
+
+    let ttl_after = ttl_for_key(&env, &contract_id, &borrower);
+    assert!(
+        ttl_after >= LEDGER_BUMP_AMOUNT,
+        "credit-line TTL not bumped on reverse_draw: {ttl_after}"
     );
 }

--- a/docs/storage-tiers.md
+++ b/docs/storage-tiers.md
@@ -131,6 +131,22 @@ below `LEDGER_BUMP_THRESHOLD` (~3 months) to `LEDGER_BUMP_AMOUNT` (~6 months).
 > that need these entries to survive beyond the ~6-month window without a draw
 > or repay should call `bump_persistent_ttl` explicitly on the relevant key.
 
+> **✅ Accrual hot-read paths now bump on read (Closes #949)**
+>
+> `self_suspend_credit_line` (via `suspend_credit_line_internal`),
+> `default_credit_line`, `reinstate_credit_line`, `settle_default_liquidation`,
+> and `reverse_draw` previously loaded the borrower's `CreditLineData` with a
+> raw `env.storage().persistent().get(&borrower)` call ahead of
+> `accrual::apply_accrual`, bypassing the TTL bump. A borrower who only ever
+> interacted through one of these read paths — without an intervening
+> `draw_credit` / `repay_credit` — would have their entry's TTL silently drift
+> toward the archival threshold, since (unlike `persist_credit_line`, which
+> always bumps on write) some of these paths return early without persisting
+> (idempotent no-ops, guard-clause reverts). All five now load the line via
+> `storage::get_credit_line`, so the TTL bump happens unconditionally on read,
+> before any status check or early return. See
+> `contracts/credit/tests/storage_ttl.rs` for the regression tests.
+
 ---
 
 ## Summary — Bump Coverage by Variant


### PR DESCRIPTION
## Summary

Closes #949.

Five lifecycle entrypoints that call `accrual::apply_accrual` loaded the borrower's `CreditLineData` via a raw `env.storage().persistent().get(&borrower)` read, bypassing `storage::get_credit_line`'s TTL-bump logic:

- `self_suspend_credit_line` (via `suspend_credit_line_internal`)
- `default_credit_line`
- `reinstate_credit_line`
- `settle_default_liquidation`
- `reverse_draw`

Unlike `persist_credit_line` (which always bumps TTL on write), several of these paths return early without writing — idempotent no-ops (e.g. `default_credit_line` on an already-`Defaulted` line) and guard-clause reverts (e.g. `reinstate_credit_line` when the line isn't `Defaulted`). A borrower who only ever exercised one of these read-mostly entrypoints, without an intervening `draw_credit`/`repay_credit`, could have their credit-line entry's TTL drift toward the archival threshold with nothing refreshing it.

All five now load the credit line through `storage::get_credit_line`, so the TTL bump happens unconditionally on read — before any status check or early return. `draw_credit`, `repay_credit`, and `update_risk_parameters` already went through this helper and are unchanged.

## Changes

- `contracts/credit/src/lifecycle.rs` — route `suspend_credit_line_internal`, `default_credit_line`, `settle_default_liquidation`, `reinstate_credit_line` through `storage::get_credit_line`; add `# Storage` rustdoc notes.
- `contracts/credit/src/lib.rs` — route `reverse_draw` through `storage_get_credit_line`; add `# Storage` rustdoc note.
- `contracts/credit/tests/storage_ttl.rs` — five new regression tests, one per fixed entrypoint, draining the credit-line TTL below the refresh threshold and asserting the call re-extends it to `LEDGER_BUMP_AMOUNT`.
- `docs/storage-tiers.md` — document the fix against the pre-existing "unbumped persistent keys" note that flagged this exact gap.

No public API or signature changes — this is purely an internal storage-access fix.

## ⚠️ Pre-existing build break on `main` (unrelated to this change)

`contracts/credit` currently fails to compile on `main` (~350 errors from an earlier bad merge — duplicated `DataKey` variants, duplicated function bodies e.g. `reinstate_credit_line` defined twice, `ContractError` not resolving from `types`, duplicate TTL constants, etc.). This predates this PR and is unrelated to the accrual/TTL change. I confirmed my specific edits are drop-in replacements of the exact same `Option<CreditLineData>`-returning read (verified the surrounding types and call sites by hand) and don't add any new distinct error class, but I could not get `cargo test` green end-to-end because of this pre-existing breakage. Flagging here since CI on this PR will likely fail through no fault of this diff — happy to help untangle that corruption in a separate PR if useful.

## Test plan
- [x] Added 5 new tests in `contracts/credit/tests/storage_ttl.rs` covering each fixed entrypoint
- [ ] `cargo test -p creditra-credit` — blocked by the pre-existing compile break described above; tests are written against the intended (post-fix-of-main) API and follow the existing file's conventions exactly