### PR TITLE
feat(Creditra-Contracts): add-capabilities-view-for-risk-v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contracts/credit",
     "contracts/accrual",
     "contracts/collateral",
+    "contracts/risk",
     "gateway-contract/contracts/auction_contract",
 ]
 

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -125,6 +125,8 @@ mod penalties_tests;
 mod query;
 pub mod limits;
 mod risk;
+#[path = "../../risk/src/views.rs"]
+mod risk_views;
 mod views;
 pub use crate::risk::compute_rate_from_score;
 pub use crate::types::FreezeReason;
@@ -211,6 +213,7 @@ use crate::storage::{
 use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
     BorrowCapabilities, ContractError, CreditLineData, CreditLinesPage, CreditStatus,
+    RiskCapabilities,
     GracePeriodConfig, GraceWaiverMode, OracleConfig, ProtocolConfig, ProtocolSummary,
     ProtocolSummaryView, RateChangeConfig, RateFormulaConfig, TreasuryWithdrawalProposal,
 };
@@ -1561,6 +1564,19 @@ impl Credit {
     /// - `can_self_suspend` — self-suspend pre-flight checks pass
     pub fn borrow_capabilities(env: Env, borrower: Address) -> BorrowCapabilities {
         views::borrow_capabilities(env, borrower)
+    }
+
+    /// Return a borrower's current risk capabilities bitmap.
+    ///
+    /// Read-only view that reports whether risk-parameter updates, interest-rate
+    /// cadence changes, and VRF commitments are currently permitted for the
+    /// borrower. Value-dependent checks (limit bounds, rate delta caps, score
+    /// vs VRF hash) are not evaluated.
+    ///
+    /// # Authentication
+    /// No authentication required. This is a pure read-only query.
+    pub fn risk_capabilities(env: Env, borrower: Address) -> RiskCapabilities {
+        risk_views::capabilities(env, borrower)
     }
 
     pub fn deposit_collateral(env: Env, borrower: Address, amount: i128) {

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -661,6 +661,28 @@ pub struct BorrowCapabilities {
     pub can_self_suspend: bool,
 }
 
+/// Read-only capabilities bitmap for risk mutations on a borrower's line.
+///
+/// Returned by `risk_capabilities` (implemented in `contracts/risk/src/views.rs`)
+/// so off-chain scorers and admin tooling can inspect which risk operations
+/// are currently permitted without simulating full entrypoints.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RiskCapabilities {
+    /// Whether `update_risk_parameters` state pre-checks pass (credit line
+    /// exists, protocol not paused, borrow admin cooldown elapsed). Does not
+    /// validate proposed limit, rate, or score values.
+    pub can_update_risk_parameters: bool,
+    /// Whether an interest-rate change would pass the cadence guard in
+    /// [`RateChangeConfig`]. Rate delta caps are not evaluated because the
+    /// intended new rate is unknown. Limit-only updates may still succeed when
+    /// this field is `false`.
+    pub can_change_rate: bool,
+    /// Whether `commit_vrf_output` state pre-checks pass (protocol not paused,
+    /// no existing VRF commitment for this borrower).
+    pub can_commit_vrf: bool,
+}
+
 /// Proof-of-reserve view for the protocol treasury.
 ///
 /// Exposes the accumulated reserves held by the protocol in a single

--- a/contracts/credit/src/views_tests.rs
+++ b/contracts/credit/src/views_tests.rs
@@ -604,3 +604,108 @@ fn borrow_caps_unblock_restores_draws() {
     let caps = client.borrow_capabilities(&borrower);
     assert!(caps.can_draw, "unblocked → can draw again");
 }
+
+// ── Risk capabilities tests ───────────────────────────────────────────────────
+
+fn setup_risk_caps_test(env: &Env) -> (CreditClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 10_000);
+
+    let admin = Address::generate(env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let borrower = Address::generate(env);
+    client.open_credit_line(&borrower, &10_000, &500, &50);
+
+    (client, admin, borrower)
+}
+
+#[test]
+fn risk_caps_no_line() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let stranger = Address::generate(&env);
+    let caps = client.risk_capabilities(&stranger);
+    assert!(!caps.can_update_risk_parameters);
+    assert!(!caps.can_change_rate);
+    assert!(caps.can_commit_vrf, "VRF commit does not require a credit line");
+}
+
+#[test]
+fn risk_caps_active_line() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_risk_caps_test(&env);
+
+    let caps = client.risk_capabilities(&borrower);
+    assert!(caps.can_update_risk_parameters);
+    assert!(caps.can_change_rate);
+    assert!(caps.can_commit_vrf);
+}
+
+#[test]
+fn risk_caps_protocol_paused() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_risk_caps_test(&env);
+
+    client.set_protocol_paused(&true);
+
+    let caps = client.risk_capabilities(&borrower);
+    assert!(!caps.can_update_risk_parameters);
+    assert!(!caps.can_change_rate);
+    assert!(!caps.can_commit_vrf);
+}
+
+#[test]
+fn risk_caps_admin_cooldown_blocks_update() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_risk_caps_test(&env);
+
+    client.set_borrow_admin_cooldown(&300);
+    client.update_risk_parameters(&borrower, &11_000, &500, &50);
+
+    let caps = client.risk_capabilities(&borrower);
+    assert!(!caps.can_update_risk_parameters);
+    assert!(!caps.can_change_rate);
+
+    env.ledger().with_mut(|li| li.timestamp = 10_300);
+    let caps = client.risk_capabilities(&borrower);
+    assert!(caps.can_update_risk_parameters);
+    assert!(caps.can_change_rate);
+}
+
+#[test]
+fn risk_caps_rate_interval_blocks_rate_only() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_risk_caps_test(&env);
+
+    client.set_rate_change_limits(&100, &600);
+    client.update_risk_parameters(&borrower, &10_000, &600, &50);
+
+    let caps = client.risk_capabilities(&borrower);
+    assert!(caps.can_update_risk_parameters, "limit-only update still allowed");
+    assert!(!caps.can_change_rate, "cadence guard active");
+
+    env.ledger().with_mut(|li| li.timestamp = 10_600);
+    let caps = client.risk_capabilities(&borrower);
+    assert!(caps.can_change_rate);
+}
+
+#[test]
+fn risk_caps_existing_vrf_commitment() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_risk_caps_test(&env);
+
+    let hash = soroban_sdk::BytesN::from_array(&env, &[7u8; 32]);
+    client.commit_vrf_output(&borrower, &hash);
+
+    let caps = client.risk_capabilities(&borrower);
+    assert!(!caps.can_commit_vrf);
+    assert!(caps.can_update_risk_parameters);
+}

--- a/contracts/risk/Cargo.toml
+++ b/contracts/risk/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "creditra-risk"
+version = "0.1.0"
+edition = "2021"
+description = "Creditra risk v7 capabilities view tests"
+license = "MIT"
+keywords = ["soroban", "stellar", "risk", "credit", "smart-contract"]
+categories = ["cryptography::cryptocurrencies", "finance", "no-std"]
+readme = "../../README.md"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+creditra-credit = { path = "../credit" }
+
+[[test]]
+name = "capabilities"
+path = "tests/capabilities.rs"
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+creditra-credit = { path = "../credit", features = [] }

--- a/contracts/risk/src/lib.rs
+++ b/contracts/risk/src/lib.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+#![cfg_attr(not(test), no_std)]
+
+//! Creditra risk v7 — read-only capabilities bitmap for the risk subsystem.
+//!
+//! The view implementation lives in `contracts/risk/src/views.rs`, compiled
+//! into [`creditra_credit`] via `#[path]`. This crate anchors focused
+//! integration tests for the v7 risk capabilities guard.
+
+pub use creditra_credit::*;

--- a/contracts/risk/src/views.rs
+++ b/contracts/risk/src/views.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+//! Read-only risk capabilities views for the Creditra credit contract.
+
+use crate::risk::get_rate_change_limits;
+use crate::scoring::get_vrf_commitment;
+use crate::storage::{
+    get_borrow_admin_cooldown, get_credit_line, get_last_borrow_admin_action_ts, is_paused,
+};
+use crate::types::RiskCapabilities;
+use soroban_sdk::{Address, Env};
+
+// ── Risk capabilities view ───────────────────────────────────────────────────
+
+/// Return a borrower's current risk capabilities bitmap.
+///
+/// Read-only view for off-chain risk engines and admin tooling. Evaluates the
+/// same state-dependent pre-flight checks used by `update_risk_parameters`,
+/// `commit_vrf_output`, and rate cadence guards, except for value-dependent
+/// validation (proposed limit, rate delta, or score vs VRF commitment).
+///
+/// # Parameters
+/// - `borrower`: The borrower address to query.
+///
+/// # Returns
+/// A [`RiskCapabilities`] struct describing which risk mutations should
+/// succeed assuming valid admin authorization and parameters.
+pub fn capabilities(env: Env, borrower: Address) -> RiskCapabilities {
+    let paused = is_paused(&env);
+    let credit_line = get_credit_line(&env, &borrower);
+
+    let cooldown_blocks = borrow_admin_cooldown_blocks(&env, &borrower);
+
+    let can_update_risk_parameters = credit_line
+        .as_ref()
+        .is_some_and(|_| !paused && !cooldown_blocks);
+
+    let can_change_rate = credit_line
+        .as_ref()
+        .is_some_and(|line| {
+            if paused || cooldown_blocks {
+                return false;
+            }
+            match get_rate_change_limits(env.clone()) {
+                None => true,
+                Some(cfg) => {
+                    if cfg.rate_change_min_interval == 0 || line.last_rate_update_ts == 0 {
+                        true
+                    } else {
+                        let elapsed = env
+                            .ledger()
+                            .timestamp()
+                            .saturating_sub(line.last_rate_update_ts);
+                        elapsed >= cfg.rate_change_min_interval
+                    }
+                }
+            }
+        });
+
+    let can_commit_vrf = !paused && get_vrf_commitment(&env, &borrower).is_none();
+
+    RiskCapabilities {
+        can_update_risk_parameters,
+        can_change_rate,
+        can_commit_vrf,
+    }
+}
+
+/// Returns `true` when the configured borrow admin cooldown would reject an update.
+fn borrow_admin_cooldown_blocks(env: &Env, borrower: &Address) -> bool {
+    let Some(cooldown_seconds) = get_borrow_admin_cooldown(env) else {
+        return false;
+    };
+    if cooldown_seconds == 0 {
+        return false;
+    }
+
+    let now = env.ledger().timestamp();
+    if let Some(last_ts) = get_last_borrow_admin_action_ts(env, borrower) {
+        now < last_ts.saturating_add(cooldown_seconds)
+    } else {
+        false
+    }
+}

--- a/contracts/risk/tests/capabilities.rs
+++ b/contracts/risk/tests/capabilities.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for the risk v7 capabilities view (`contracts/risk/src/views.rs`).
+
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+#[test]
+fn risk_capabilities_view_matches_credit_entrypoint() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &5_000_i128, &400_u32, &60_u32);
+
+    let caps = client.risk_capabilities(&borrower);
+    assert!(caps.can_update_risk_parameters);
+    assert!(caps.can_change_rate);
+    assert!(caps.can_commit_vrf);
+}

--- a/docs/PROTOCOL_SPEC.md
+++ b/docs/PROTOCOL_SPEC.md
@@ -407,6 +407,7 @@ See `contracts/credit/src/fees.rs`.
 | `get_collateral(borrower)`                                       | `i128`                                                                                                   |
 | `get_health_factor(borrower)`                                    | `u32` (bps-scaled, `u32::MAX` when no debt; `< 10_000` = liquidatable; see `query.rs:get_health_factor`) |
 | `get_protocol_summary_view()`                                    | `ProtocolSummaryView { total_utilized, total_collateral, active_line_count }` — active-line-only aggregate view built for the GrantFox campaign; see `views.rs:get_protocol_summary_view` |
+| `risk_capabilities(borrower)`                                    | `RiskCapabilities { can_update_risk_parameters, can_change_rate, can_commit_vrf }` — read-only risk mutation pre-flight bitmap; see `contracts/risk/src/views.rs` |
 
 Reads with persistent borrower data invoke `bump_credit_line_ttl` (a write,
 but cheap and idempotent — see `storage.rs:146`).


### PR DESCRIPTION
Closes #891

## Summary
- Add capabilities() view for risk (v7)

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths