### PR TITLE
feat: collateral get_state view and borrow lifecycle events

### DIFF
--- a/contracts/credit/src/collateral.rs
+++ b/contracts/credit/src/collateral.rs
@@ -57,7 +57,7 @@ use crate::storage::{
     get_collateral_balance, get_collateral_risk_weight_bps, get_collateral_token,
     get_credit_line, get_min_collateral_ratio_bps, set_collateral_balance,
 };
-use crate::types::ContractError;
+use crate::types::{CollateralState, ContractError};
 use soroban_sdk::{token, Address, Env};
 
 /// Deposit collateral tokens from the borrower into the contract.
@@ -156,6 +156,53 @@ pub fn withdraw_collateral(env: &Env, borrower: &Address, amount: i128) {
 /// Read‑only getter for a borrower's collateral balance.
 pub fn get_collateral(env: &Env, borrower: &Address) -> i128 {
     get_collateral_balance(env, borrower)
+}
+
+/// Return a full collateral state snapshot for `borrower`.
+///
+/// Reads the borrower's collateral balance, the protocol-wide minimum
+/// collateral ratio, the configured collateral token, and computes the
+/// current health factor — all in a single read-only call.
+///
+/// # Health factor
+///
+/// ```text
+/// health_factor_bps = balance * 10_000 / utilized_amount
+/// ```
+///
+/// A value at or above `min_ratio_bps` indicates the position is adequately
+/// collateralized. Returns `u32::MAX` when `utilized_amount == 0` (no
+/// outstanding debt).
+///
+/// # Authentication
+///
+/// None required — this is a pure read.
+pub fn get_collateral_state(env: &Env, borrower: &Address) -> CollateralState {
+    let balance = get_collateral_balance(env, borrower);
+    let min_ratio_bps = get_min_collateral_ratio_bps(env).unwrap_or(15_000);
+    let collateral_token = get_collateral_token(env);
+
+    let utilized_amount = get_credit_line(env, borrower)
+        .map(|l| l.utilized_amount)
+        .unwrap_or(0);
+
+    let health_factor_bps: u32 = if utilized_amount == 0 {
+        u32::MAX
+    } else {
+        let hf = balance
+            .checked_mul(10_000_i128)
+            .unwrap_or(i128::MAX)
+            / utilized_amount;
+        u32::try_from(hf).unwrap_or(u32::MAX)
+    };
+
+    CollateralState {
+        borrower: borrower.clone(),
+        balance,
+        min_ratio_bps,
+        collateral_token,
+        health_factor_bps,
+    }
 }
 
 /// Allow a borrower to release a portion of their collateral while keeping

--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -575,6 +575,77 @@ pub fn publish_late_fee_charged_event(env: &Env, event: LateFeeChargedEvent) {
         .publish((symbol_short!("credit"), symbol_short!("late_fee")), event);
 }
 
+/// Emitted when an admin forgives (writes off) a portion of a borrower's accrued interest.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DebtForgivenEvent {
+    /// Borrower whose debt was forgiven.
+    pub borrower: Address,
+    /// Amount of accrued interest written off.
+    pub amount_forgiven: i128,
+    /// Remaining accrued interest after the write-off.
+    pub remaining_accrued_interest: i128,
+    /// Outstanding utilized amount after the write-off.
+    pub new_utilized_amount: i128,
+}
+
+/// Publish a debt forgiven event.
+pub fn publish_debt_forgiven_event(env: &Env, event: DebtForgivenEvent) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "debt_frgv")),
+        event,
+    );
+}
+
+/// Structured borrow lifecycle event emitted at every state-changing borrow operation.
+///
+/// Complements the existing per-operation events (`drawn`, `repay`, `opened`, etc.)
+/// with a single unified payload that captures the full credit-line snapshot at the
+/// moment of the transition. Indexers can subscribe to `("credit", "borrow_lc")` to
+/// reconstruct the complete lifecycle history without joining multiple event streams.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BorrowLifecycleEvent {
+    /// Borrower address.
+    pub borrower: Address,
+    /// Lifecycle phase that triggered this event.
+    pub phase: BorrowLifecyclePhase,
+    /// Credit-line status after the operation.
+    pub status: CreditStatus,
+    /// Outstanding utilized amount after the operation.
+    pub utilized_amount: i128,
+    /// Credit limit at the time of the event.
+    pub credit_limit: i128,
+    /// Effective interest rate in basis points.
+    pub interest_rate_bps: u32,
+    /// Ledger timestamp of the event.
+    pub timestamp: u64,
+}
+
+/// Discriminant for [`BorrowLifecycleEvent`] indicating which operation occurred.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BorrowLifecyclePhase {
+    Opened,
+    Drawn,
+    Repaid,
+    Suspended,
+    Reinstated,
+    Defaulted,
+    Closed,
+    DebtForgiven,
+}
+
+/// Publish a structured borrow lifecycle event.
+///
+/// Topic: `("credit", "borrow_lc")`.
+pub fn publish_borrow_lifecycle_event(env: &Env, event: BorrowLifecycleEvent) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "borrow_lc")),
+        event,
+    );
+}
+
 /// Publish a grace waiver receipt event when a suspended line's accrual uses the grace period.
 pub fn publish_grace_waiver_receipt_event(
     env: &Env,

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -186,6 +186,8 @@ use crate::events::{
     ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent, TreasuryWithdrawalExecutedEvent,
     TreasuryWithdrawalProposedEvent,
+    publish_borrow_lifecycle_event, publish_debt_forgiven_event,
+    BorrowLifecycleEvent, BorrowLifecyclePhase, DebtForgivenEvent,
 };
 use crate::math_utils::{compute_deviation_bps, mul_div, safe_mul_div, Rounding};
 use crate::storage::{
@@ -570,9 +572,21 @@ impl Credit {
         publish_drawn_event(
             &env,
             DrawnEvent {
-                borrower,
+                borrower: borrower.clone(),
                 amount,
                 new_utilized_amount: updated_utilized,
+            },
+        );
+        publish_borrow_lifecycle_event(
+            &env,
+            BorrowLifecycleEvent {
+                borrower: borrower.clone(),
+                phase: BorrowLifecyclePhase::Drawn,
+                status: credit_line.status,
+                utilized_amount: updated_utilized,
+                credit_limit: credit_line.credit_limit,
+                interest_rate_bps: credit_line.interest_rate_bps,
+                timestamp,
             },
         );
         clear_reentrancy_guard(&env);
@@ -722,6 +736,18 @@ impl Credit {
                 borrower: borrower.clone(),
                 amount: effective_repay,
                 new_utilized_amount: new_utilized,
+            },
+        );
+        publish_borrow_lifecycle_event(
+            &env,
+            BorrowLifecycleEvent {
+                borrower: borrower.clone(),
+                phase: BorrowLifecyclePhase::Repaid,
+                status: credit_line.status,
+                utilized_amount: new_utilized,
+                credit_limit: credit_line.credit_limit,
+                interest_rate_bps: credit_line.interest_rate_bps,
+                timestamp: env.ledger().timestamp(),
             },
         );
 
@@ -1574,6 +1600,20 @@ impl Credit {
     pub fn get_collateral(env: Env, borrower: Address) -> i128 {
         crate::collateral::get_collateral(&env, &borrower)
     }
+
+    /// Return a full collateral state snapshot for `borrower`.
+    ///
+    /// Reads balance, minimum collateral ratio, collateral token, and computed
+    /// health factor in a single read-only call. No authentication required.
+    ///
+    /// # Returns
+    /// [`crate::types::CollateralState`] — see field docs for semantics.
+    pub fn get_collateral_state(
+        env: Env,
+        borrower: Address,
+    ) -> crate::types::CollateralState {
+        crate::collateral::get_collateral_state(&env, &borrower)
+    }
     
     /// Set the risk weight for a collateral asset, in basis points (admin only).
     ///
@@ -1855,10 +1895,51 @@ impl Credit {
     }
 
     /// Forgive outstanding debt without transferring tokens (admin only).
+    ///
+    /// Reduces `accrued_interest` (and `utilized_amount`) by up to `amount`.
+    /// Emits [`DebtForgivenEvent`] and [`BorrowLifecycleEvent`] on success.
     pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
         require_admin_auth(&env);
         enforce_borrow_admin_cooldown(&env, &borrower);
-        lifecycle::forgive_debt(env, borrower, amount)
+
+        if amount <= 0 {
+            env.panic_with_error(ContractError::InvalidAmount);
+        }
+
+        let mut credit_line: CreditLineData =
+            crate::storage::get_credit_line(&env, &borrower).unwrap_or_else(|| {
+                env.panic_with_error(ContractError::CreditLineNotFound)
+            });
+
+        let forgiven = amount.min(credit_line.accrued_interest);
+        let previous_utilized = credit_line.utilized_amount;
+        credit_line.accrued_interest = credit_line.accrued_interest.saturating_sub(forgiven);
+        credit_line.utilized_amount = credit_line.utilized_amount.saturating_sub(forgiven);
+
+        persist_credit_line(&env, &borrower, &credit_line, previous_utilized, None);
+
+        let timestamp = env.ledger().timestamp();
+        publish_debt_forgiven_event(
+            &env,
+            DebtForgivenEvent {
+                borrower: borrower.clone(),
+                amount_forgiven: forgiven,
+                remaining_accrued_interest: credit_line.accrued_interest,
+                new_utilized_amount: credit_line.utilized_amount,
+            },
+        );
+        publish_borrow_lifecycle_event(
+            &env,
+            BorrowLifecycleEvent {
+                borrower: borrower.clone(),
+                phase: BorrowLifecyclePhase::DebtForgiven,
+                status: credit_line.status,
+                utilized_amount: credit_line.utilized_amount,
+                credit_limit: credit_line.credit_limit,
+                interest_rate_bps: credit_line.interest_rate_bps,
+                timestamp,
+            },
+        );
     }
 
     /// Apply auction liquidation proceeds to a defaulted credit line (admin only).

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -819,3 +819,24 @@ impl ContractError {
         }
     }
 }
+
+/// Full collateral state snapshot for a borrower, returned by `get_collateral_state`.
+///
+/// All fields are read-only; no authentication is required to call the view.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CollateralState {
+    /// Borrower whose collateral is described.
+    pub borrower: soroban_sdk::Address,
+    /// Current collateral balance held by the contract for this borrower.
+    pub balance: i128,
+    /// Protocol-wide minimum collateral ratio in basis points (default 15 000 = 150 %).
+    /// Zero means the ratio check is disabled.
+    pub min_ratio_bps: u32,
+    /// Configured collateral token address, or `None` when not yet set.
+    pub collateral_token: Option<soroban_sdk::Address>,
+    /// Health factor expressed in basis points: `balance * 10_000 / utilized_amount`.
+    /// A value at or above `min_ratio_bps` indicates adequate collateralization.
+    /// `u32::MAX` when `utilized_amount == 0` (no outstanding debt).
+    pub health_factor_bps: u32,
+}

--- a/contracts/credit/tests/borrow_lifecycle_events.rs
+++ b/contracts/credit/tests/borrow_lifecycle_events.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+#![cfg(test)]
+
+use creditra_credit::events::{BorrowLifecycleEvent, BorrowLifecyclePhase, DebtForgivenEvent};
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    token::StellarAssetClient,
+    Address, Env, IntoVal, Symbol,
+};
+
+fn setup(env: &Env) -> (CreditClient, Address, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&token);
+
+    let token_admin = StellarAssetClient::new(env, &token);
+    token_admin.mint(&borrower, &100_000_i128);
+    token_admin.mint(&token, &100_000_i128);
+
+    (client, admin, borrower, token)
+}
+
+fn find_borrow_lifecycle_events(env: &Env) -> soroban_sdk::Vec<BorrowLifecycleEvent> {
+    let mut result = soroban_sdk::Vec::new(env);
+    for (_, topics, data) in env.events().all().iter() {
+        if topics.len() >= 2 {
+            let t1: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(env);
+            let t2: Result<soroban_sdk::Symbol, _> = topics.get(1).unwrap().try_into_val(env);
+            if let (Ok(a), Ok(b)) = (t1, t2) {
+                if a == soroban_sdk::symbol_short!("credit") && b == Symbol::new(env, "borrow_lc") {
+                    if let Ok(ev) = data.try_into_val(env) {
+                        result.push_back(ev);
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+/// draw_credit emits a BorrowLifecycleEvent with phase Drawn.
+#[test]
+fn draw_credit_emits_borrow_lifecycle_drawn() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10_000, &0, &0);
+    client.deposit_collateral(&borrower, &1_500);
+    client.draw_credit(&borrower, &1_000);
+
+    let events = find_borrow_lifecycle_events(&env);
+    assert!(
+        !events.is_empty(),
+        "expected at least one BorrowLifecycleEvent"
+    );
+
+    let ev = events.last().unwrap();
+    assert_eq!(ev.borrower, borrower);
+    assert!(matches!(ev.phase, BorrowLifecyclePhase::Drawn));
+    assert_eq!(ev.utilized_amount, 1_000);
+}
+
+/// repay_credit emits a BorrowLifecycleEvent with phase Repaid.
+#[test]
+fn repay_credit_emits_borrow_lifecycle_repaid() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10_000, &0, &0);
+    client.deposit_collateral(&borrower, &1_500);
+    client.draw_credit(&borrower, &1_000);
+    client.repay_credit(&borrower, &500);
+
+    let events = find_borrow_lifecycle_events(&env);
+    let repaid_events: soroban_sdk::Vec<BorrowLifecycleEvent> = events
+        .iter()
+        .filter(|e| matches!(e.phase, BorrowLifecyclePhase::Repaid))
+        .collect();
+
+    assert!(
+        !repaid_events.is_empty(),
+        "expected a Repaid lifecycle event"
+    );
+    let ev = repaid_events.last().unwrap();
+    assert_eq!(ev.borrower, borrower);
+    assert_eq!(ev.utilized_amount, 500);
+}
+
+/// forgive_debt emits DebtForgivenEvent and BorrowLifecycleEvent with phase DebtForgiven.
+#[test]
+fn forgive_debt_emits_debt_forgiven_and_lifecycle_events() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10_000, &500, &50);
+    client.deposit_collateral(&borrower, &1_500);
+    client.draw_credit(&borrower, &1_000);
+
+    // Advance time so interest accrues.
+    env.ledger().with_mut(|l| l.timestamp += 365 * 24 * 3600);
+    client.accrue_batch(&soroban_sdk::vec![&env, borrower.clone()]);
+
+    client.forgive_debt(&borrower, &100);
+
+    // Check DebtForgivenEvent.
+    let mut found_forgiven = false;
+    for (_, topics, data) in env.events().all().iter() {
+        if topics.len() >= 2 {
+            let t2: Result<soroban_sdk::Symbol, _> = topics.get(1).unwrap().try_into_val(&env);
+            if let Ok(b) = t2 {
+                if b == Symbol::new(&env, "debt_frgv") {
+                    let ev: DebtForgivenEvent = data.try_into_val(&env).unwrap();
+                    assert_eq!(ev.borrower, borrower);
+                    assert!(ev.amount_forgiven <= 100);
+                    found_forgiven = true;
+                }
+            }
+        }
+    }
+    assert!(found_forgiven, "expected DebtForgivenEvent");
+
+    // Check BorrowLifecycleEvent with DebtForgiven phase.
+    let lc_events = find_borrow_lifecycle_events(&env);
+    let forgiven_lc: soroban_sdk::Vec<BorrowLifecycleEvent> = lc_events
+        .iter()
+        .filter(|e| matches!(e.phase, BorrowLifecyclePhase::DebtForgiven))
+        .collect();
+    assert!(
+        !forgiven_lc.is_empty(),
+        "expected DebtForgiven lifecycle event"
+    );
+}
+
+/// forgive_debt with zero amount reverts.
+#[test]
+#[should_panic(expected = "Error(Contract, #")]
+fn forgive_debt_zero_amount_reverts() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10_000, &0, &0);
+    client.forgive_debt(&borrower, &0);
+}
+
+/// forgive_debt on non-existent line reverts.
+#[test]
+#[should_panic(expected = "Error(Contract, #")]
+fn forgive_debt_no_line_reverts() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.forgive_debt(&borrower, &100);
+}

--- a/contracts/credit/tests/collateral_state_view.rs
+++ b/contracts/credit/tests/collateral_state_view.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+#![cfg(test)]
+
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env};
+
+fn setup(env: &Env) -> (CreditClient, Address, Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&token);
+
+    let token_admin = StellarAssetClient::new(env, &token);
+    token_admin.mint(&borrower, &100_000_i128);
+    token_admin.mint(&token, &100_000_i128);
+
+    (client, admin, borrower, token)
+}
+
+/// No credit line, no deposit: balance = 0, health = u32::MAX.
+#[test]
+fn get_collateral_state_no_line_no_deposit() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    let state = client.get_collateral_state(&borrower);
+
+    assert_eq!(state.borrower, borrower);
+    assert_eq!(state.balance, 0);
+    assert_eq!(state.min_ratio_bps, 15_000);
+    assert_eq!(state.health_factor_bps, u32::MAX);
+}
+
+/// After deposit with no debt, health = u32::MAX.
+#[test]
+fn get_collateral_state_after_deposit_no_debt() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.deposit_collateral(&borrower, &5_000);
+    let state = client.get_collateral_state(&borrower);
+
+    assert_eq!(state.balance, 5_000);
+    assert_eq!(state.health_factor_bps, u32::MAX);
+}
+
+/// With active debt: health_factor_bps = balance * 10_000 / utilized_amount.
+#[test]
+fn get_collateral_state_with_active_debt() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10_000, &0, &0);
+    // 1_500 satisfies the default 150% (15_000 bps) ratio for a 1_000 draw.
+    client.deposit_collateral(&borrower, &1_500);
+    client.draw_credit(&borrower, &1_000);
+
+    let state = client.get_collateral_state(&borrower);
+
+    assert_eq!(state.balance, 1_500);
+    // health = 1_500 * 10_000 / 1_000 = 15_000
+    assert_eq!(state.health_factor_bps, 15_000_u32);
+}
+
+/// After full repayment, health returns to u32::MAX.
+#[test]
+fn get_collateral_state_after_full_repay() {
+    let env = Env::default();
+    let (client, _, borrower, _) = setup(&env);
+
+    client.open_credit_line(&borrower, &10_000, &0, &0);
+    client.deposit_collateral(&borrower, &1_500);
+    client.draw_credit(&borrower, &1_000);
+    client.repay_credit(&borrower, &1_000);
+
+    let state = client.get_collateral_state(&borrower);
+
+    assert_eq!(state.balance, 1_500);
+    assert_eq!(state.health_factor_bps, u32::MAX);
+}
+
+/// collateral_token field matches the configured token address.
+#[test]
+fn get_collateral_state_token_field() {
+    let env = Env::default();
+    let (client, _, borrower, token) = setup(&env);
+
+    let state = client.get_collateral_state(&borrower);
+    assert_eq!(state.collateral_token, Some(token));
+}


### PR DESCRIPTION
## Summary
- Adds `get_collateral_state` — a read-only view returning a full `CollateralState` snapshot (balance, `min_ratio_bps`, `collateral_token`, `health_factor_bps`) for a borrower in one call.
- Adds a structured `BorrowLifecycleEvent`, emitted on `draw_credit`, `repay_credit`, and `forgive_debt`, published under topic `("credit", "borrow_lc")` so indexers can reconstruct the full lifecycle without joining multiple event streams.
- Adds `DebtForgivenEvent` for `forgive_debt`.

Closes #830
Closes #827

## Important note on repo state
While implementing this, I found that `main` (as of `efbaa74`, the `-X theirs` merge for PR #958) currently **fails to build** — `cargo check -p creditra-credit` reports 373 errors, mostly duplicate definitions (`set_credit_limit_bounds`, `get_credit_limit_bounds`, the `oracles`/`limits`/`cross_chain` modules, several `storage.rs` constants, etc. are each defined twice), plus a call to `lifecycle::forgive_debt` in `lib.rs` where that function no longer exists in `lifecycle.rs`.

This PR does not attempt to fix that unrelated breakage (out of scope for #827/#830), but it does restore `forgive_debt`'s write-off logic inline in `lib.rs` (accrued-interest/utilized-amount reduction) since that was the only way to hook the new lifecycle-event emission for debt forgiveness. Because of the pre-existing duplicate-definition errors elsewhere in the crate, I was unable to run `cargo check`/`cargo test` end-to-end to confirm a clean build — the new code and tests are correct by inspection and consistent with existing patterns in the file, but should be re-verified once the duplicate-definition issue is resolved. I'd suggest maintainers treat that merge damage as a separate, high-priority bug.

## Test plan
- [ ] `cargo test -p creditra-credit` (blocked locally by the pre-existing duplicate-definition build errors described above — please re-run in CI/after the merge issue is fixed)
- [x] `contracts/credit/tests/collateral_state_view.rs` — covers no-line/no-deposit, deposit-with-no-debt, active-debt health factor, post-repay reset, and the `collateral_token` field
- [x] `contracts/credit/tests/borrow_lifecycle_events.rs` — covers `Drawn`, `Repaid`, `DebtForgiven` phases and `forgive_debt` revert paths