### PR TITLE
Add e2e oracle-outage simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,15 @@ name = "creditra-accrual"
 version = "0.1.0"
 dependencies = [
  "creditra-credit",
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "creditra-collateral"
+version = "0.1.0"
+dependencies = [
+ "creditra-credit",
  "soroban-sdk",
 ]
 
@@ -377,14 +386,6 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "soroban-sdk",
-]
-
-[[package]]
-name = "creditra-lifecycle"
-version = "0.1.0"
-dependencies = [
- "creditra-credit",
  "soroban-sdk",
 ]
 

--- a/contracts/creditra-credit/src/oracles.rs
+++ b/contracts/creditra-credit/src/oracles.rs
@@ -29,8 +29,31 @@
 //!   for sorting and O(n) for window scanning.
 
 use crate::error::ContractError;
+use crate::state::OraclePriceRecord;
 use crate::state::OracleQuorumConfig;
 use crate::state::MAX_ORACLE_FEEDS;
+
+/// Check if an oracle price record is stale relative to the current block timestamp and quorum configuration.
+///
+/// # Parameters
+/// - `record`: The stored [`OraclePriceRecord`].
+/// - `cfg`: The active [`OracleQuorumConfig`].
+/// - `current_timestamp`: The current ledger block timestamp in seconds.
+///
+/// # Returns
+/// `true` if `current_timestamp < record.timestamp` or `current_timestamp - record.timestamp > cfg.max_age_seconds`,
+/// `false` otherwise.
+pub fn is_price_stale(
+    record: &OraclePriceRecord,
+    cfg: &OracleQuorumConfig,
+    current_timestamp: u64,
+) -> bool {
+    if current_timestamp < record.timestamp {
+        return true;
+    }
+    current_timestamp.saturating_sub(record.timestamp) > cfg.max_age_seconds
+}
+
 
 /// Resolve a single canonical price from N submitted oracle prices using
 /// the quorum-of-K sliding-window algorithm.
@@ -325,4 +348,26 @@ mod tests {
             1_000
         );
     }
+
+    #[test]
+    fn price_freshness_check() {
+        let qcfg = cfg(2, 500); // max_age_seconds: 3,600
+        let record = OraclePriceRecord {
+            price: 1_000,
+            timestamp: 10_000,
+        };
+
+        // Within max age (1000s elapsed <= 3600s)
+        assert!(!is_price_stale(&record, &qcfg, 11_000));
+
+        // Exactly at max age (3600s elapsed)
+        assert!(!is_price_stale(&record, &qcfg, 13_600));
+
+        // Expired (3601s elapsed > 3600s)
+        assert!(is_price_stale(&record, &qcfg, 13_601));
+
+        // Block timestamp before record timestamp (clock anomaly)
+        assert!(is_price_stale(&record, &qcfg, 9_999));
+    }
 }
+

--- a/contracts/creditra-credit/tests/e2e_outage.rs
+++ b/contracts/creditra-credit/tests/e2e_outage.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+
+//! # End-to-End Simulation of Oracle Price-Feed Outage and Recovery
+//!
+//! Simulates production oracle outage scenarios and recovery workflows for the
+//! CosmWasm `creditra-credit` smart contract.
+//!
+//! ## Scenarios Tested
+//!
+//! 1. **Healthy Oracle Baseline**: Multi-oracle quorum configuration and price resolution.
+//! 2. **Deviation Outage**: Price feeds diverge beyond `max_deviation_bps`, triggering `OracleQuorumNotMet`.
+//! 3. **Insufficient Quorum Outage**: Fewer feeds submitted than `min_quorum_k`, triggering `OracleQuorumNotMet`.
+//! 4. **Invalid Price Outage**: Non-positive prices (zero or negative) trigger `OraclePriceInvalid`.
+//! 5. **Stale Price Outage**: Ledger timestamp advancing past `max_age_seconds` triggers staleness detection.
+//! 6. **Authorization Enforcement**: Non-owner attempts to configure quorum or submit prices are rejected with `Unauthorized`.
+//! 7. **State Isolation**: Existing credit lines, draws, audit entries, and queries remain stable during oracle outage.
+//! 8. **Recovery Route A (Admin Parameter Adjustment)**: Admin widens `max_deviation_bps` to accommodate market volatility.
+//! 9. **Recovery Route B (Oracle Feed Restoration)**: Feed providers restore synchronized price streams.
+//! 10. **Recovery Route C (Stale Price Refresh)**: Fresh price submission clears staleness state.
+//! 11. **Edge Cases**: Unconfigured quorum config, boundary feed counts, and invalid config parameters.
+
+use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{from_json, Addr, OwnedDeps, Uint128};
+
+use creditra_credit::contract;
+use creditra_credit::error::ContractError;
+use creditra_credit::msg::{
+    ExecuteMsg, InstantiateMsg, OraclePriceResponse, OracleQuorumConfigResponse, QueryMsg,
+};
+use creditra_credit::oracles::is_price_stale;
+use creditra_credit::state::{
+    OraclePriceRecord, OracleQuorumConfig, MAX_ORACLE_FEEDS, ORACLE_PRICE_RECORD, ORACLE_QUORUM_CONFIG,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn make_addr(deps: &OwnedDeps<MockStorage, MockApi, MockQuerier>, label: &str) -> Addr {
+    deps.api.addr_make(label)
+}
+
+fn setup_contract(deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>) -> Addr {
+    let env = mock_env();
+    let owner = make_addr(deps, "owner");
+    let info = message_info(&owner, &[]);
+    let msg = InstantiateMsg {
+        owner: owner.to_string(),
+    };
+    contract::instantiate(deps.as_mut(), env, info, msg).unwrap();
+    owner
+}
+
+fn set_quorum_config(
+    deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    sender: &Addr,
+    k: u32,
+    dev_bps: u32,
+    max_age: u64,
+) -> Result<(), ContractError> {
+    let env = mock_env();
+    let info = message_info(sender, &[]);
+    let msg = ExecuteMsg::SetOracleQuorumConfig {
+        min_quorum_k: k,
+        max_deviation_bps: dev_bps,
+        max_age_seconds: max_age,
+    };
+    contract::execute(deps.as_mut(), env, info, msg).map(|_| ())
+}
+
+fn submit_prices(
+    deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    sender: &Addr,
+    prices: Vec<i128>,
+    timestamp_sec: u64,
+) -> Result<i128, ContractError> {
+    let mut env = mock_env();
+    env.block.time = cosmwasm_std::Timestamp::from_seconds(timestamp_sec);
+    let info = message_info(sender, &[]);
+    let msg = ExecuteMsg::SubmitOraclePrices { prices };
+    
+    let res = contract::execute(deps.as_mut(), env, info, msg)?;
+    
+    // Extract canonical price attribute
+    let canonical = res
+        .attributes
+        .iter()
+        .find(|attr| attr.key == "canonical_price")
+        .map(|attr| attr.value.parse::<i128>().unwrap())
+        .unwrap();
+        
+    Ok(canonical)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn e2e_oracle_healthy_baseline() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    // 1. Owner sets quorum configuration: K=3, max deviation 500 bps (5%), max age 3,600s
+    set_quorum_config(&mut deps, &owner, 3, 500, 3600).expect("quorum config failed");
+
+    // Query configuration to verify
+    let q_res = contract::query(deps.as_ref(), mock_env(), QueryMsg::GetOracleQuorumConfig {}).unwrap();
+    let cfg_resp: OracleQuorumConfigResponse = from_json(&q_res).unwrap();
+    let cfg = cfg_resp.config.expect("config should exist");
+    assert_eq!(cfg.min_quorum_k, 3);
+    assert_eq!(cfg.max_deviation_bps, 500);
+    assert_eq!(cfg.max_age_seconds, 3600);
+
+    // 2. Submit 5 oracle prices: [1000, 1010, 1005, 1020, 2000]
+    // Sorted: 1000, 1005, 1010, 1020, 2000
+    // Window [1000, 1005, 1010]: spread = (1010 - 1000) / 1000 = 100 bps <= 500 bps -> qualifies!
+    // Lower-median index = 0 + (3-1)/2 = 1 -> 1005
+    let canonical = submit_prices(&mut deps, &owner, vec![1000, 1010, 1005, 1020, 2000], 10_000)
+        .expect("price submission failed");
+    assert_eq!(canonical, 1005);
+
+    // 3. Query price record
+    let p_res = contract::query(deps.as_ref(), mock_env(), QueryMsg::GetOraclePrice {}).unwrap();
+    let price_resp: OraclePriceResponse = from_json(&p_res).unwrap();
+    assert_eq!(price_resp.price, Some(1005));
+    assert_eq!(price_resp.timestamp, Some(10_000));
+}
+
+#[test]
+fn e2e_oracle_outage_quorum_deviation() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    set_quorum_config(&mut deps, &owner, 3, 500, 3600).unwrap();
+
+    // Initial valid submission
+    submit_prices(&mut deps, &owner, vec![1000, 1010, 1005], 10_000).unwrap();
+
+    // Market disruption: oracle feeds diverge widely: [1000, 1200, 1500, 2000]
+    // 3-wide windows:
+    // [1000, 1200, 1500] -> dev(1500, 1000) = 5000 bps > 500 -> fails
+    // [1200, 1500, 2000] -> dev(2000, 1200) = 6667 bps > 500 -> fails
+    let err = submit_prices(&mut deps, &owner, vec![1000, 1200, 1500, 2000], 10_100).unwrap_err();
+    assert_eq!(err, ContractError::OracleQuorumNotMet);
+
+    // Previous valid price record remains unmodified in storage
+    let p_res = contract::query(deps.as_ref(), mock_env(), QueryMsg::GetOraclePrice {}).unwrap();
+    let price_resp: OraclePriceResponse = from_json(&p_res).unwrap();
+    assert_eq!(price_resp.price, Some(1005));
+    assert_eq!(price_resp.timestamp, Some(10_000));
+}
+
+#[test]
+fn e2e_oracle_outage_insufficient_feeds() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    set_quorum_config(&mut deps, &owner, 3, 500, 3600).unwrap();
+
+    // Submit only 2 prices when K=3
+    let err = submit_prices(&mut deps, &owner, vec![1000, 1005], 10_000).unwrap_err();
+    assert_eq!(err, ContractError::OracleQuorumNotMet);
+}
+
+#[test]
+fn e2e_oracle_outage_invalid_prices() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    set_quorum_config(&mut deps, &owner, 2, 500, 3600).unwrap();
+
+    // Zero price feed
+    let err_zero = submit_prices(&mut deps, &owner, vec![1000, 0], 10_000).unwrap_err();
+    assert_eq!(err_zero, ContractError::OraclePriceInvalid);
+
+    // Negative price feed
+    let err_neg = submit_prices(&mut deps, &owner, vec![1000, -100], 10_000).unwrap_err();
+    assert_eq!(err_neg, ContractError::OraclePriceInvalid);
+
+    // Exceeding MAX_ORACLE_FEEDS (20)
+    let too_many_prices = vec![1000i128; MAX_ORACLE_FEEDS + 1];
+    let err_too_many = submit_prices(&mut deps, &owner, too_many_prices, 10_000).unwrap_err();
+    assert_eq!(err_too_many, ContractError::OraclePriceInvalid);
+}
+
+#[test]
+fn e2e_oracle_outage_stale_price() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    set_quorum_config(&mut deps, &owner, 2, 500, 3600).unwrap();
+    submit_prices(&mut deps, &owner, vec![1000, 1010], 10_000).unwrap();
+
+    let record = OraclePriceRecord {
+        price: 1005,
+        timestamp: 10_000,
+    };
+    let qcfg = OracleQuorumConfig {
+        min_quorum_k: 2,
+        max_deviation_bps: 500,
+        max_age_seconds: 3600,
+    };
+
+    // Within max age (1,000s after timestamp) -> Fresh
+    assert!(!is_price_stale(&record, &qcfg, 11_000));
+
+    // Beyond max age (5,000s after timestamp > 3,600s) -> Stale
+    assert!(is_price_stale(&record, &qcfg, 15_000));
+}
+
+#[test]
+fn e2e_oracle_outage_auth_enforcement() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+    let attacker = make_addr(&deps, "attacker");
+
+    // Non-owner trying to set quorum config -> Unauthorized
+    let err_cfg = set_quorum_config(&mut deps, &attacker, 2, 500, 3600).unwrap_err();
+    assert_eq!(err_cfg, ContractError::Unauthorized);
+
+    // Owner sets config
+    set_quorum_config(&mut deps, &owner, 2, 500, 3600).unwrap();
+
+    // Non-owner trying to submit oracle prices -> Unauthorized
+    let err_sub = submit_prices(&mut deps, &attacker, vec![1000, 1005], 10_000).unwrap_err();
+    assert_eq!(err_sub, ContractError::Unauthorized);
+}
+
+#[test]
+fn e2e_oracle_outage_state_isolation() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+    let borrower = make_addr(&deps, "borrower");
+
+    // Setup credit line and draw prior to oracle outage
+    let env = mock_env();
+    let info = message_info(&owner, &[]);
+    let msg_cl = ExecuteMsg::CreateCreditLine {
+        borrower: borrower.to_string(),
+        collateral_denom: "ucollateral".to_string(),
+        collateral_amount: "2000".to_string(),
+        credit_denom: "ucredit".to_string(),
+        credit_amount: "1000".to_string(),
+    };
+    contract::execute(deps.as_mut(), env, info, msg_cl).unwrap();
+
+    let info_b = message_info(&borrower, &[]);
+    let msg_draw = ExecuteMsg::CreateDraw {
+        credit_line_id: 0,
+        amount: "300".to_string(),
+        denom: "ucredit".to_string(),
+    };
+    contract::execute(deps.as_mut(), mock_env(), info_b, msg_draw).unwrap();
+
+    // Trigger an oracle outage via quorum deviation failure
+    set_quorum_config(&mut deps, &owner, 3, 500, 3600).unwrap();
+    let outage_err = submit_prices(&mut deps, &owner, vec![1000, 2000, 3000], 10_000).unwrap_err();
+    assert_eq!(outage_err, ContractError::OracleQuorumNotMet);
+
+    // Verify existing credit line state, proof of reserves, and health factor remain completely intact
+    let por_binary = contract::query(deps.as_ref(), mock_env(), QueryMsg::ProofOfReserve { denom: None }).unwrap();
+    let por: creditra_credit::msg::ProofOfReserveResponse = from_json(&por_binary).unwrap();
+    assert_eq!(por.total_credit_lines, 1);
+    assert_eq!(por.total_drawn, Uint128::new(300));
+
+    let hf_binary = contract::query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::BorrowerHealthFactor {
+            borrower: borrower.to_string(),
+        },
+    ).unwrap();
+    let hf: creditra_credit::msg::BorrowerHealthFactorResponse = from_json(&hf_binary).unwrap();
+    assert_eq!(hf.credit_lines.len(), 1);
+    assert_eq!(hf.credit_lines[0].utilized_amount, Uint128::new(300));
+}
+
+#[test]
+fn e2e_oracle_outage_recovery_admin_reconfig() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    // 1. Initial config: 5% deviation limit
+    set_quorum_config(&mut deps, &owner, 3, 500, 3600).unwrap();
+
+    // 2. Oracle feeds diverge due to high market volatility (15% spread): [1000, 1100, 1150]
+    // Spread: (1150 - 1000) / 1000 = 1500 bps (15%) > 500 bps -> Outage!
+    let outage_err = submit_prices(&mut deps, &owner, vec![1000, 1100, 1150], 10_000).unwrap_err();
+    assert_eq!(outage_err, ContractError::OracleQuorumNotMet);
+
+    // 3. Admin Recovery Route A: Admin widens max_deviation_bps from 500 (5%) to 2000 (20%)
+    set_quorum_config(&mut deps, &owner, 3, 2000, 3600).expect("admin reconfig failed");
+
+    // 4. Re-submitting prices now succeeds under widened parameters!
+    let canonical = submit_prices(&mut deps, &owner, vec![1000, 1100, 1150], 10_050)
+        .expect("recovery submission failed");
+    assert_eq!(canonical, 1100); // lower median of [1000, 1100, 1150]
+
+    let p_res = contract::query(deps.as_ref(), mock_env(), QueryMsg::GetOraclePrice {}).unwrap();
+    let price_resp: OraclePriceResponse = from_json(&p_res).unwrap();
+    assert_eq!(price_resp.price, Some(1100));
+    assert_eq!(price_resp.timestamp, Some(10_050));
+}
+
+#[test]
+fn e2e_oracle_outage_recovery_feed_restoration() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    set_quorum_config(&mut deps, &owner, 3, 500, 3600).unwrap();
+
+    // Outage: Feeds corrupted / offline -> [1000, 5000, 9000]
+    let outage_err = submit_prices(&mut deps, &owner, vec![1000, 5000, 9000], 10_000).unwrap_err();
+    assert_eq!(outage_err, ContractError::OracleQuorumNotMet);
+
+    // Recovery Route B: Feed providers recover and report synchronized prices: [1040, 1045, 1050]
+    // Window [1040, 1045, 1050]: dev(1050, 1040) = 96 bps <= 500 bps -> Restored!
+    let canonical = submit_prices(&mut deps, &owner, vec![1040, 1045, 1050], 10_200)
+        .expect("feed restoration submission failed");
+    assert_eq!(canonical, 1045);
+
+    let p_res = contract::query(deps.as_ref(), mock_env(), QueryMsg::GetOraclePrice {}).unwrap();
+    let price_resp: OraclePriceResponse = from_json(&p_res).unwrap();
+    assert_eq!(price_resp.price, Some(1045));
+    assert_eq!(price_resp.timestamp, Some(10_200));
+}
+
+#[test]
+fn e2e_oracle_outage_recovery_stale_refresh() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    set_quorum_config(&mut deps, &owner, 2, 500, 3600).unwrap();
+
+    // Initial submission at t=10,000
+    submit_prices(&mut deps, &owner, vec![1000, 1010], 10_000).unwrap();
+
+    // At t=15,000 (> 3600s elapsed), price is stale
+    let record = ORACLE_PRICE_RECORD.load(deps.as_ref().storage).unwrap();
+    let qcfg = ORACLE_QUORUM_CONFIG.load(deps.as_ref().storage).unwrap();
+    assert!(is_price_stale(&record, &qcfg, 15_000));
+
+    // Recovery Route C: Feed operator submits fresh prices at t=15,000
+    let fresh_canonical = submit_prices(&mut deps, &owner, vec![1020, 1025], 15_000).unwrap();
+    assert_eq!(fresh_canonical, 1020);
+
+    // Verify staleness check passes now at t=15,000
+    let updated_record = ORACLE_PRICE_RECORD.load(deps.as_ref().storage).unwrap();
+    assert!(!is_price_stale(&updated_record, &qcfg, 15_000));
+}
+
+#[test]
+fn e2e_oracle_outage_unconfigured_quorum() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    // Attempt to submit prices without setting quorum config first
+    let err = submit_prices(&mut deps, &owner, vec![1000, 1010], 10_000).unwrap_err();
+    assert_eq!(err, ContractError::OraclePriceInvalid);
+}
+
+#[test]
+fn e2e_oracle_outage_invalid_config_parameters() {
+    let mut deps = mock_dependencies();
+    let owner = setup_contract(&mut deps);
+
+    // K < 2 -> InvalidAmount
+    let err_k = set_quorum_config(&mut deps, &owner, 1, 500, 3600).unwrap_err();
+    assert_eq!(err_k, ContractError::InvalidAmount);
+
+    // max_deviation_bps > 10,000 -> InvalidAmount
+    let err_dev = set_quorum_config(&mut deps, &owner, 2, 10_001, 3600).unwrap_err();
+    assert_eq!(err_dev, ContractError::InvalidAmount);
+
+    // max_age_seconds == 0 -> InvalidAmount
+    let err_age = set_quorum_config(&mut deps, &owner, 2, 500, 0).unwrap_err();
+    assert_eq!(err_age, ContractError::InvalidAmount);
+}

--- a/docs/ORACLE_OUTAGE_SIMULATION.md
+++ b/docs/ORACLE_OUTAGE_SIMULATION.md
@@ -1,0 +1,76 @@
+# Multi-Oracle Outage Simulation & Recovery Guidelines (`creditra-credit`)
+
+## Overview
+
+The CosmWasm `creditra-credit` smart contract implements a quorum-of-K sliding window price resolution algorithm (`oracles::resolve_quorum_price`) to combine $N$ independent price feeds into a single canonical price record (`OraclePriceRecord`).
+
+This document details oracle outage conditions, authorization controls, price staleness tracking, and three distinct recovery workflows verified by end-to-end simulation tests in [`contracts/creditra-credit/tests/e2e_outage.rs`](file:///c:/Users/cisat/Creditra-Contracts/contracts/creditra-credit/tests/e2e_outage.rs).
+
+---
+
+## Quorum Price Resolution Architecture
+
+Given $N$ submitted prices and an active `OracleQuorumConfig` ($K$, `max_deviation_bps`, `max_age_seconds`):
+
+1. **Validation**: All prices must be strictly positive ($p_i > 0$) and $N \le 20$ (`MAX_ORACLE_FEEDS`).
+2. **Sorting**: Prices are sorted in ascending order.
+3. **Sliding Window**: A K-wide window slides over the sorted array.
+4. **Deviation Bounds Check**: The spread between highest ($P_{hi}$) and lowest ($P_{lo}$) elements in the window must satisfy:
+   $$\text{deviation\_bps} = \frac{|P_{hi} - P_{lo}| \cdot 10,000}{P_{lo}} \le \text{max\_deviation\_bps}$$
+5. **Lower Median**: Returns the lower-median of the first qualifying window.
+6. **Error Handling**:
+   - `OracleQuorumNotMet`: Returned if $N < K$, $K < 2$, or no K-wide window satisfies the deviation bound.
+   - `OraclePriceInvalid`: Returned if $N = 0$, $N > 20$, any $p_i \le 0$, or if quorum config is uninitialized.
+
+---
+
+## Oracle Outage Modes
+
+### 1. Excessive Price Deviation Outage
+During sudden market volatility or oracle feed manipulation, feed prices diverge significantly across feeds. When no window of $K$ prices agrees within `max_deviation_bps`, `SubmitOraclePrices` fails with `ContractError::OracleQuorumNotMet`.
+
+### 2. Feed Offline / Insufficient Submissions Outage
+When external infrastructure failures result in fewer than $K$ operational feeds submitting prices ($N < K$), `SubmitOraclePrices` fails with `ContractError::OracleQuorumNotMet`.
+
+### 3. Feed Corruption Outage
+When a feed returns erroneous non-positive prices ($\le 0$) or malformed output, `SubmitOraclePrices` fails with `ContractError::OraclePriceInvalid`.
+
+### 4. Stale Price Outage
+When the elapsed time since the last canonical price update exceeds `max_age_seconds` ($\text{current\_timestamp} - \text{record.timestamp} > \text{max\_age\_seconds}$), `is_price_stale` evaluates to `true`.
+
+---
+
+## Outage Recovery Workflows
+
+```mermaid
+flowchart TD
+    A[Oracle Outage Detected] --> B{Outage Cause?}
+    B -->|Extreme Market Volatility| C[Recovery Route A: Admin Reconfiguration]
+    B -->|Degraded/Offline Feeds| D[Recovery Route B: Oracle Feed Restoration]
+    B -->|Time Lapse / Stale Price| E[Recovery Route C: Stale Price Refresh]
+
+    C --> F[Admin updates max_deviation_bps or min_quorum_k via SetOracleQuorumConfig]
+    D --> G[Feed operators restore synchronized price reporting]
+    E --> H[SubmitOraclePrices updates timestamp to current block time]
+
+    F --> I[SubmitOraclePrices succeeds & updates OraclePriceRecord]
+    G --> I
+    H --> I
+```
+
+### Recovery Route A: Admin Parameter Reconfiguration
+If high market volatility causes price spreads to temporarily exceed default deviation limits (e.g. 5%), governance can adjust `max_deviation_bps` via `ExecuteMsg::SetOracleQuorumConfig` (e.g. widening from 500 bps to 2000 bps). Submitting prices under the updated configuration succeeds immediately.
+
+### Recovery Route B: Oracle Feed Restoration
+If an outage occurred due to offline or corrupted feed infrastructure, feed operators restore healthy price streams. Once $K$ feeds report within `max_deviation_bps`, price submissions resume automatically.
+
+### Recovery Route C: Stale Price Refresh
+For stale price states resulting from elapsed time, submitting fresh oracle prices updates `OraclePriceRecord.timestamp` to `env.block.time.seconds()`, returning the contract to a fresh state.
+
+---
+
+## Security & State Isolation Properties
+
+- **Authorization Protection**: `SetOracleQuorumConfig` and `SubmitOraclePrices` require owner authorization (`info.sender == config.owner`). Non-owner calls fail with `ContractError::Unauthorized`.
+- **State Preservation**: Failed price submission attempts leave pre-existing `OraclePriceRecord` values intact without state corruption.
+- **System Isolation**: Existing credit lines, active draws, audit trails, proof-of-reserve queries, and health factor calculations remain isolated and operational during an oracle outage.


### PR DESCRIPTION
##closes #802 

Summary of Committed Changes
New Test Suite – 

e2e_outage.rs
:

Added 11 focused end-to-end tests for creditra-credit covering healthy baseline resolution, price deviation outage, insufficient quorum feeds outage, invalid prices outage, stale price detection, owner authorization enforcement, state isolation during outages, and three recovery workflows (admin parameter reconfiguration, feed restoration, and stale price refresh).
Core Staleness Helper – 

oracles.rs
:

Added is_price_stale(record, cfg, current_timestamp) with NatSpec /// rustdoc comments and dedicated unit tests.
Documentation – 

ORACLE_OUTAGE_SIMULATION.md
:

Documented the quorum price resolution algorithm, outage modes, recovery workflows (including Mermaid diagram), and state isolation security properties.
