### PR TITLE
feat: collateral events (v7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,15 @@ name = "creditra-accrual"
 version = "0.1.0"
 dependencies = [
  "creditra-credit",
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "creditra-collateral"
+version = "0.1.0"
+dependencies = [
+ "creditra-credit",
  "soroban-sdk",
 ]
 
@@ -377,14 +386,6 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "soroban-sdk",
-]
-
-[[package]]
-name = "creditra-lifecycle"
-version = "0.1.0"
-dependencies = [
- "creditra-credit",
  "soroban-sdk",
 ]
 

--- a/contracts/collateral/README.md
+++ b/contracts/collateral/README.md
@@ -24,6 +24,6 @@ action requires:
 ledger.timestamp >= LastAdminCollateralCriticalActionTs + AdminCollateralCooldownSeconds
 ```
 
-Otherwise the contract reverts with `ContractError::AdminCollateralCooldownActive` (`54`).
+Otherwise the contract reverts with `ContractError::AdminCollateralCooldownActive` (`56`).
 
 Implementation: [`src/admin.rs`](./src/admin.rs) (compiled into `creditra-credit`).

--- a/contracts/collateral/tests/admin_cooldown.rs
+++ b/contracts/collateral/tests/admin_cooldown.rs
@@ -38,8 +38,8 @@ fn assert_admin_collateral_cooldown_active(result: std::thread::Result<()>, cont
     };
 
     assert!(
-        err_str.contains("Error(Contract, #54)"),
-        "{context}: expected AdminCollateralCooldownActive (#54), got {err_str:?}"
+        err_str.contains("Error(Contract, #56)"),
+        "{context}: expected AdminCollateralCooldownActive (#56), got {err_str:?}"
     );
 }
 

--- a/contracts/credit/src/collateral.rs
+++ b/contracts/credit/src/collateral.rs
@@ -49,15 +49,16 @@
 //! for the full error table.
 
 use crate::events::{
-    publish_collateral_deposited_event, publish_collateral_partial_released_event,
-    publish_collateral_withdrawn_event, CollateralDepositedEvent, CollateralPartialReleasedEvent,
-    CollateralWithdrawnEvent,
+    publish_collateral_deposited_event, publish_collateral_lifecycle_event,
+    publish_collateral_partial_released_event, publish_collateral_withdrawn_event,
+    CollateralDepositedEvent, CollateralPartialReleasedEvent, CollateralWithdrawnEvent,
 };
 use crate::storage::{
-    get_collateral_balance, get_collateral_risk_weight_bps, get_collateral_token,
-    get_credit_line, get_min_collateral_ratio_bps, set_collateral_balance,
+    get_collateral_balance, get_collateral_balance_for_token, get_collateral_risk_weight_bps,
+    get_collateral_token, get_credit_line, get_min_collateral_ratio_bps,
+    is_collateral_token_allowed, set_collateral_balance, set_collateral_balance_for_token,
 };
-use crate::types::ContractError;
+use crate::types::{CollateralEventKind, ContractError};
 use soroban_sdk::{token, Address, Env};
 
 /// Deposit collateral tokens from the borrower into the contract.
@@ -95,6 +96,14 @@ pub fn deposit_collateral(env: &Env, borrower: &Address, amount: i128) {
             amount,
             new_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Deposited,
+        None,
+        amount,
+        new_balance,
     );
 }
 
@@ -150,6 +159,14 @@ pub fn withdraw_collateral(env: &Env, borrower: &Address, amount: i128) {
             amount,
             new_balance: post_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Withdrawn,
+        None,
+        amount,
+        post_balance,
     );
 }
 
@@ -285,6 +302,14 @@ pub fn partial_release_collateral(env: &Env, borrower: &Address, amount: i128) {
             health_factor_bps,
         },
     );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::PartiallyReleased,
+        None,
+        amount,
+        post_balance,
+    );
 }
 
 /// Release collateral tokens to the borrower without requiring auth.
@@ -327,6 +352,14 @@ pub fn release_collateral(env: &Env, borrower: &Address, amount: i128) {
             new_balance: post_balance,
         },
     );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Released,
+        None,
+        amount,
+        post_balance,
+    );
 }
 
 // ── Multi-collateral: per-token deposit / withdraw / query ─────────────────────
@@ -362,6 +395,14 @@ pub fn deposit_collateral_token(env: &Env, borrower: &Address, token_addr: &Addr
             amount,
             new_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Deposited,
+        Some(token_addr.clone()),
+        amount,
+        new_balance,
     );
 }
 
@@ -399,6 +440,14 @@ pub fn withdraw_collateral_token(env: &Env, borrower: &Address, token_addr: &Add
             amount,
             new_balance: post_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Withdrawn,
+        Some(token_addr.clone()),
+        amount,
+        post_balance,
     );
 }
 

--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -467,6 +467,63 @@ pub struct CollateralWithdrawnEvent {
     pub new_balance: i128,
 }
 
+/// Structured, unified lifecycle event covering every collateral state
+/// change (deposit, withdrawal, partial release, internal release).
+///
+/// Emitted **in addition to** the legacy per-action events
+/// ([`CollateralDepositedEvent`], [`CollateralWithdrawnEvent`],
+/// [`CollateralPartialReleasedEvent`]) so existing indexers keep working
+/// unmodified, while new integrators can subscribe to a single topic
+/// (`("credit", "col_lca")`) and disambiguate via [`crate::types::CollateralEventKind`]
+/// instead of tracking multiple topic strings.
+///
+/// # Field notes
+///
+/// - `token` is `None` for the single-token collateral path (`CollateralBalance`
+///   storage) and `Some(token)` for the multi-collateral, per-token path.
+/// - `ledger` / `timestamp` let off-chain consumers order and correlate
+///   events without a separate RPC round-trip to fetch ledger metadata.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CollateralLifecycleEvent {
+    pub borrower: Address,
+    pub kind: crate::types::CollateralEventKind,
+    /// `None` for the single-token collateral balance; `Some(token)` for
+    /// the multi-collateral per-token path.
+    pub token: Option<Address>,
+    /// Amount moved by this action (always positive).
+    pub amount: i128,
+    /// Collateral balance remaining after this action.
+    pub new_balance: i128,
+    /// Ledger sequence at time of the action (for off-chain indexers).
+    pub ledger: u32,
+    /// Ledger timestamp at time of the action.
+    pub timestamp: u64,
+}
+
+/// Publish a [`CollateralLifecycleEvent`] under the unified `("credit", "col_lca")` topic.
+pub fn publish_collateral_lifecycle_event(
+    env: &Env,
+    borrower: &Address,
+    kind: crate::types::CollateralEventKind,
+    token: Option<Address>,
+    amount: i128,
+    new_balance: i128,
+) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "col_lca")),
+        CollateralLifecycleEvent {
+            borrower: borrower.clone(),
+            kind,
+            token,
+            amount,
+            new_balance,
+            ledger: env.ledger().sequence(),
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
 pub fn publish_collateral_deposited_event(env: &Env, event: CollateralDepositedEvent) {
     env.events()
         .publish((symbol_short!("credit"), symbol_short!("col_dep")), event);

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -116,14 +116,12 @@ mod freeze;
 #[cfg(all(not(target_arch = "wasm32"), feature = "instrument"))]
 pub mod instrument;
 mod lifecycle;
-mod oracles;
 mod limits;
 pub mod math_utils;
 mod penalties;
 #[cfg(test)]
 mod penalties_tests;
 mod query;
-pub mod limits;
 mod risk;
 mod views;
 pub use crate::risk::compute_rate_from_score;
@@ -133,21 +131,6 @@ pub mod cross_chain;
 mod scoring;
 mod storage;
 pub mod types;
-
-use soroban_sdk::{
-    contract, contractimpl, symbol_short, token, Address, Env, Symbol,
-};
-
-use events::{
-    publish_credit_line_event, publish_drawn_event, publish_repayment_event,
-    CreditLineEvent, DrawnEvent, RepaymentEvent,
-};
-use types::{ContractError, CreditLineData, CreditStatus, RateChangeConfig};
-use storage::{clear_reentrancy_guard, set_reentrancy_guard, rate_cfg_key, DataKey};
-use auth::require_admin_auth;
-#[cfg(not(target_arch = "wasm32"))]
-pub mod cross_chain;
-
 
 #[cfg(test)]
 mod boundary_tests;
@@ -165,66 +148,52 @@ mod views_tests;
 #[path = "../proofs/prorate_interest.rs"]
 mod prorate_interest_proofs;
 
-use crate::auth::require_admin_auth;
+use crate::auth::{require_admin, require_admin_auth};
 use crate::attestation::AttestationBatch;
-use crate::events::publish_protocol_fee_bps_set_event;
-use crate::events::publish_protocol_fee_bounds_set_event;
-use crate::events::publish_close_factor_bps_set_event;
-use crate::events::publish_paused_event;
-use crate::types::ProofOfReserve;
 use crate::events::{
     publish_admin_rotation_accepted, publish_admin_rotation_proposed,
-    publish_borrower_blocked_event, publish_borrower_frozen_event, publish_close_factor_bps_set_event,
-    publish_contract_upgraded_event, publish_credit_line_event, publish_draw_reversed_event,
-    publish_drawn_event, publish_interest_accrued_event, publish_oracle_config_set_event,
-    publish_oracle_price_accepted_event, publish_paused_event, publish_protocol_fee_bounds_set_event,
-    publish_protocol_fee_bps_set_event, publish_rate_formula_config_event,
-    publish_repayment_event, publish_token_rescued_event,
+    publish_borrower_blocked_event, publish_borrower_frozen_event,
+    publish_close_factor_bps_set_event, publish_contract_upgraded_event,
+    publish_credit_line_event, publish_draw_reversed_event, publish_drawn_event,
+    publish_interest_accrued_event, publish_oracle_config_set_event,
+    publish_oracle_price_accepted_event, publish_oracle_quorum_config_set_event,
+    publish_oracle_quorum_price_set_event, publish_paused_event,
+    publish_protocol_fee_bounds_set_event, publish_protocol_fee_bps_set_event,
+    publish_rate_formula_config_event, publish_repayment_event, publish_token_rescued_event,
     publish_treasury_withdrawal_executed, publish_treasury_withdrawal_proposed,
-    publish_protocol_fee_bps_set_event, publish_protocol_fee_bounds_set_event,
-    publish_close_factor_bps_set_event, publish_paused_event,
-    ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent,
-    InterestAccruedEvent, RepaymentEvent, TreasuryWithdrawalExecutedEvent,
-    TreasuryWithdrawalProposedEvent,
+    ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent, InterestAccruedEvent,
+    RepaymentEvent, TreasuryWithdrawalExecutedEvent, TreasuryWithdrawalProposedEvent,
 };
 use crate::math_utils::{compute_deviation_bps, mul_div, safe_mul_div, Rounding};
+use crate::penalties::LateFeeConfig;
 use crate::storage::{
-    admin_key, assert_not_paused, clear_borrower_frozen, clear_reentrancy_guard,
-    enforce_freeze_cooldown, get_borrower_by_credit_line_id, get_borrower_frozen_until,
-    get_credit_line as storage_get_credit_line, get_last_draw_ts as storage_get_last_draw_ts,
-    get_utilization_cap_bps as storage_get_utilization_cap_bps,
+    admin_key, assert_not_paused, clear_borrower_frozen, clear_pending_treasury_withdrawal,
+    clear_reentrancy_guard, enforce_freeze_cooldown, get_borrower_by_credit_line_id,
+    get_borrower_frozen_until, get_credit_line as storage_get_credit_line,
+    get_last_draw_ts as storage_get_last_draw_ts, get_oracle_config, get_oracle_quorum_config,
+    get_pending_treasury_withdrawal, get_utilization_cap_bps as storage_get_utilization_cap_bps,
     is_borrower_blocked as storage_is_borrower_blocked,
     is_borrower_frozen as storage_is_borrower_frozen, persist_credit_line, proposed_admin_key,
-    proposed_at_key, rate_formula_key, set_borrower_blocked as storage_set_borrower_blocked,
-    set_borrower_frozen_until, set_borrower_unblocked,
-    set_last_draw_ts as storage_set_last_draw_ts, record_freeze_timestamp_if_cooldown,
-    set_reentrancy_guard,
+    proposed_at_key, rate_cfg_key, rate_formula_key, record_freeze_timestamp_if_cooldown,
+    set_borrower_blocked as storage_set_borrower_blocked, set_borrower_frozen_until,
+    set_borrower_unblocked, set_last_draw_ts as storage_set_last_draw_ts, set_oracle_config,
+    set_oracle_quorum_config, set_pending_treasury_withdrawal, set_reentrancy_guard,
     set_utilization_cap_bps as storage_set_utilization_cap_bps, DataKey, MAX_ENUMERATION_LIMIT,
 };
-use crate::storage::{get_oracle_config, set_oracle_config};
-use crate::storage::{get_oracle_quorum_config, set_oracle_quorum_config};
-use crate::oracles::{resolve_quorum_price, MAX_ORACLE_FEEDS};
-use crate::storage::{
-    clear_pending_treasury_withdrawal, get_pending_treasury_withdrawal,
-    set_pending_treasury_withdrawal,
-};
-use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
-    BorrowCapabilities, ContractError, CreditLineData, CreditLinesPage, CreditStatus,
-    GracePeriodConfig, GraceWaiverMode, OracleConfig, ProtocolConfig, ProtocolSummary,
-    ProtocolSummaryView, RateChangeConfig, RateFormulaConfig, TreasuryWithdrawalProposal,
+    BorrowCapabilities, ContractError, CreditLineData, CreditLineSnapshot, CreditLinesPage,
+    CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig, OracleQuorumConfig,
+    ProofOfReserve, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
+    RateFormulaConfig, TreasuryWithdrawalProposal,
 };
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec,
+};
 
 pub const CONTRACT_API_VERSION: (u32, u32, u32) = (1, 0, 0);
 
 /// Maximum allowed protocol fee in basis points (1000 = 10%). Adjust if needed.
 const MAX_PROTOCOL_FEE_BPS: u32 = 1_000;
-
-/// Instance storage key for admin.
-fn admin_key(env: &Env) -> Symbol {
-    Symbol::new(env, "admin")
-}
 
 #[allow(dead_code)]
 const SECONDS_PER_YEAR: u64 = 31_536_000;
@@ -757,16 +726,6 @@ impl Credit {
         risk::set_rate_change_limits(env, max_rate_change_bps, rate_change_min_interval)
     }
 
-    /// Set a per-borrower interest rate floor (admin only).
-    pub fn set_borrower_rate_floor(env: Env, borrower: Address, floor_bps: Option<u32>) {
-        risk::set_borrower_rate_floor(env, borrower, floor_bps)
-    }
-
-    /// Set a per-borrower interest rate ceiling (admin only).
-    pub fn set_borrower_rate_ceiling(env: Env, borrower: Address, ceiling_bps: Option<u32>) {
-        risk::set_borrower_rate_ceiling(env, borrower, ceiling_bps)
-    }
-
     /// Set the penalty surcharge in basis points for delinquent lines (admin only).
     pub fn set_penalty_surcharge_bps(env: Env, bps: u32) {
         risk::set_penalty_surcharge_bps(env, bps)
@@ -1080,7 +1039,7 @@ impl Credit {
     /// - `env`: Soroban environment.
     /// - `borrower`: Borrower address to configure.
     /// - `grace_period_seconds`: Grace period duration in seconds. Pass `0` to remove.
-    pub fn set_per_borrower_liquidation_grace(
+    pub fn set_borrower_liq_grace(
         env: Env,
         borrower: Address,
         grace_period_seconds: u64,
@@ -1089,7 +1048,7 @@ impl Credit {
     }
 
     /// Return the per-borrower liquidation grace period in seconds for `borrower`.
-    pub fn get_per_borrower_liquidation_grace(env: Env, borrower: Address) -> u64 {
+    pub fn get_borrower_liq_grace(env: Env, borrower: Address) -> u64 {
         lifecycle::get_per_borrower_liquidation_grace(&env, borrower)
     }
 
@@ -1610,17 +1569,17 @@ impl Credit {
     /// Set the minimum interval between critical collateral admin actions (admin only).
     ///
     /// Pass `0` to disable the cool-off guard.
-    pub fn set_admin_collateral_cooldown_seconds(env: Env, seconds: u64) {
+    pub fn set_col_admin_cooldown_secs(env: Env, seconds: u64) {
         collateral_admin::set_admin_collateral_cooldown_seconds(&env, seconds);
     }
 
     /// Query the configured admin collateral cool-off interval, if set.
-    pub fn get_admin_collateral_cooldown_seconds(env: Env) -> Option<u64> {
+    pub fn get_col_admin_cooldown_secs(env: Env) -> Option<u64> {
         collateral_admin::get_admin_collateral_cooldown_seconds(&env)
     }
 
     /// Query the ledger timestamp of the last critical collateral admin action.
-    pub fn get_last_admin_collateral_critical_action_ts(env: Env) -> Option<u64> {
+    pub fn get_last_col_admin_action_ts(env: Env) -> Option<u64> {
         collateral_admin::get_last_admin_collateral_critical_action_ts(&env)
     }
 
@@ -1846,12 +1805,6 @@ impl Credit {
         require_admin_auth(&env);
         enforce_borrow_admin_cooldown(&env, &borrower);
         lifecycle::default_credit_line(env, borrower)
-    }
-
-    pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditStatus) {
-        require_admin_auth(&env);
-        enforce_borrow_admin_cooldown(&env, &borrower);
-        lifecycle::reinstate_credit_line(env, borrower, target_status)
     }
 
     /// Forgive outstanding debt without transferring tokens (admin only).
@@ -2147,11 +2100,11 @@ impl Credit {
             env.panic_with_error(ContractError::OraclePriceInvalid)
         });
 
-        if prices.len() > MAX_ORACLE_FEEDS {
+        if prices.len() > oracles::MAX_ORACLE_FEEDS {
             env.panic_with_error(ContractError::OraclePriceInvalid);
         }
 
-        let canonical_price = resolve_quorum_price(&env, &prices, &qcfg);
+        let canonical_price = oracles::resolve_quorum_price(&env, &prices, &qcfg);
         let now = env.ledger().timestamp();
         crate::storage::set_oracle_last_price(&env, canonical_price, now);
         publish_oracle_quorum_price_set_event(&env, canonical_price, qcfg.min_quorum_k, now);
@@ -2434,10 +2387,6 @@ impl Credit {
 
         crate::storage::set_paused(&env, paused);
         publish_paused_event(&env, paused);
-    }
-
-    pub fn set_late_fee_flat(env: Env, fee: i128) {
-        crate::storage::set_late_fee_flat(&env, fee)
     }
 
     pub fn freeze_draws(env: Env) {

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -93,9 +93,9 @@ use crate::events::{
 };
 use crate::risk::{MAX_INTEREST_RATE_BPS, MAX_RISK_SCORE};
 use crate::storage::{
-    assert_not_paused, clear_repayment_schedule, get_repayment_schedule,
-    liquidation_settlement_key, persist_credit_line,
-    set_repayment_schedule as storage_set_repayment_schedule, CREDIT_LINE_TTL_EXTEND_TO,
+    assert_not_paused, assert_ts_monotonic, bump_credit_line_ttl, clear_repayment_schedule,
+    get_repayment_schedule, persist_credit_line,
+    set_repayment_schedule as storage_set_repayment_schedule, DataKey, CREDIT_LINE_TTL_EXTEND_TO,
     CREDIT_LINE_TTL_THRESHOLD,
 };
 use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
@@ -116,16 +116,6 @@ fn liquidation_settlement_key(
         borrower.clone(),
         settlement_id.clone(),
     )
-}
-
-/// Set credit limit bounds (admin only, called through contractimpl).
-///
-/// These bounds are enforced by [`validate_credit_limit_bounds`] during
-/// `open_credit_line` and `update_risk_parameters`.
-pub fn set_credit_limit_bounds(env: Env, min: i128, max: i128) {
-    require_admin_auth(&env);
-    crate::storage::set_min_credit_limit(&env, min);
-    crate::storage::set_max_credit_limit(&env, max);
 }
 
 /// Get the current credit limit bounds, if configured.
@@ -193,56 +183,8 @@ pub fn set_credit_limit_bounds(env: Env, min: i128, max: i128) {
     }
 
     // Store bounds in instance storage
-    set_min_credit_limit(&env, min);
-    set_max_credit_limit(&env, max);
-}
-
-/// Get the configured global credit limit bounds.
-///
-/// Returns the minimum and maximum allowed credit limits, if configured.
-///
-/// # Returns
-/// `(min_credit_limit, max_credit_limit)` tuple, or `(None, None)` if not configured.
-///
-/// # Storage
-/// - Reads from instance storage keys `DataKey::MinCreditLimit` and `DataKey::MaxCreditLimit`
-pub fn get_credit_limit_bounds(env: Env) -> (Option<i128>, Option<i128>) {
-    let min = get_min_credit_limit(&env);
-    let max = get_max_credit_limit(&env);
-    (min, max)
-}
-
-/// Validate that a credit limit falls within configured bounds.
-///
-/// # Parameters
-/// - `env`: The Soroban environment.
-/// - `credit_limit`: The credit limit to validate.
-///
-/// # Panics
-/// - `ContractError::LimitOutOfBounds` if the limit is outside configured bounds
-///
-/// # Behavior
-/// - If bounds are not configured, validation passes (no restrictions)
-/// - If only min is configured, validates `credit_limit >= min`
-/// - If only max is configured, validates `credit_limit <= max`
-/// - If both are configured, validates `min <= credit_limit <= max`
-pub fn validate_credit_limit_bounds(env: &Env, credit_limit: i128) {
-    let min = get_min_credit_limit(env);
-    let max = get_max_credit_limit(env);
-
-    // Check minimum bound if configured
-    if let Some(min_limit) = min {
-        if credit_limit < min_limit {
-            env.panic_with_error(ContractError::LimitOutOfBounds);
-        }
-    }
-
-    // Check maximum bound if configured
-    if let Some(max_limit) = max {
-        if credit_limit > max_limit {
-            env.panic_with_error(ContractError::LimitOutOfBounds);
-        }
-    }
+    crate::storage::set_min_credit_limit(&env, min);
+    crate::storage::set_max_credit_limit(&env, max);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -327,89 +269,6 @@ pub fn get_per_borrower_liquidation_grace(env: &Env, borrower: Address) -> u64 {
     crate::storage::get_per_borrower_liquidation_grace(env, &borrower)
 }
 
-/// Set or replace a borrower's installment repayment schedule.
-pub fn set_repayment_schedule(
-    env: &Env,
-    borrower: Address,
-    amount_per_period: i128,
-    period_seconds: u64,
-    first_due_ts: u64,
-) {
-    assert_not_paused(env);
-    require_admin_auth(env);
-
-    if amount_per_period <= 0 || period_seconds == 0 {
-        env.panic_with_error(ContractError::InvalidAmount);
-    }
-
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
-
-    if stored_line.status == CreditStatus::Closed {
-        env.panic_with_error(ContractError::CreditLineClosed);
-    }
-
-    storage_set_repayment_schedule(
-        env,
-        &borrower,
-        &RepaymentSchedule {
-            amount_per_period,
-            period_seconds,
-            next_due_ts: first_due_ts,
-        },
-    );
-}
-
-/// Advance the next due timestamp when a qualifying repayment covers one or more installments.
-/// Also charges a flat late fee per overdue installment when `LateFeeFlat` is configured.
-pub fn advance_repayment_schedule_after_repay(env: &Env, borrower: &Address, amount: i128) {
-    if amount <= 0 {
-        return;
-    }
-
-    let Some(mut schedule) = storage_get_repayment_schedule(env, borrower) else {
-        return;
-    };
-
-    if schedule.amount_per_period <= 0 || schedule.period_seconds == 0 {
-        return;
-    }
-
-    let installments_paid = (amount / schedule.amount_per_period) as u64;
-    if installments_paid == 0 {
-        return;
-    }
-
-    // ── Late-fee surcharge ──────────────────────────────────────────────────
-    let late_fee = storage_get_late_fee_flat(env);
-    if late_fee > 0 {
-        let now = env.ledger().timestamp();
-        for i in 0_u64..installments_paid {
-            let due_ts = schedule
-                .next_due_ts
-                .saturating_add(i.saturating_mul(schedule.period_seconds));
-            if now > due_ts {
-                storage_add_treasury_balance(env, late_fee);
-                publish_late_fee_charged_event(
-                    env,
-                    LateFeeChargedEvent {
-                        borrower: borrower.clone(),
-                        fee: late_fee,
-                        installment_index: i.saturating_add(1),
-                    },
-                );
-            }
-        }
-    }
-
-    let advance_seconds = schedule.period_seconds.saturating_mul(installments_paid);
-    schedule.next_due_ts = schedule.next_due_ts.saturating_add(advance_seconds);
-    storage_set_repayment_schedule(env, borrower, &schedule);
-}
-
 /// Set the flat late fee per missed installment (admin only).
 ///
 /// When non-zero, this fee is charged to `TreasuryBalance` for each
@@ -427,14 +286,14 @@ pub fn set_late_fee_flat(env: Env, fee: i128) {
     if fee < 0 {
         env.panic_with_error(ContractError::InvalidAmount);
     }
-    storage_set_late_fee_flat(&env, fee);
+    crate::storage::set_late_fee_flat(&env, fee);
 }
 
 /// Get the configured flat late fee per missed installment.
 ///
 /// Returns `0` if not configured (no flat late fee).
 pub fn get_late_fee_flat(env: Env) -> i128 {
-    storage_get_late_fee_flat(&env)
+    crate::storage::get_late_fee_flat(&env)
 }
 
 /// Open a new credit line.
@@ -620,7 +479,7 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
         .persistent()
         .get(&borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
-    let _previous_utilized = credit_line.utilized_amount;
+    let previous_utilized = credit_line.utilized_amount;
 
     // Idempotent: already closed → nothing to do.
     if credit_line.status == CreditStatus::Closed {
@@ -645,7 +504,7 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
         panic!("unauthorized");
     }
 
-    let _previous_status = credit_line.status;
+    let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Closed;
     persist_credit_line(
         &env,
@@ -713,7 +572,7 @@ pub fn default_credit_line(env: Env, borrower: Address) {
         .persistent()
         .get(&borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
-    let _previous_utilized = stored_line.utilized_amount;
+    let previous_utilized = stored_line.utilized_amount;
 
     if stored_line.status == CreditStatus::Closed {
         env.panic_with_error(ContractError::CreditLineClosed);
@@ -749,7 +608,7 @@ pub fn default_credit_line(env: Env, borrower: Address) {
         }
     }
 
-    let _previous_status = credit_line.status;
+    let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Defaulted;
     persist_credit_line(
         &env,
@@ -772,6 +631,45 @@ pub fn default_credit_line(env: Env, borrower: Address) {
     );
 
     publish_default_liquidation_requested_event(&env, &borrower, credit_line.utilized_amount);
+}
+
+/// Write off outstanding debt without transferring tokens (admin only).
+///
+/// Reduces `accrued_interest` first, then `utilized_amount`, by `amount`
+/// (clamped to the outstanding balance). No token movement occurs — this is
+/// pure accounting relief, e.g. for negotiated settlements handled off-chain.
+pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
+    assert_not_paused(&env);
+    require_admin_auth(&env);
+
+    if amount <= 0 {
+        env.panic_with_error(ContractError::InvalidAmount);
+    }
+
+    let stored_line: CreditLineData = env
+        .storage()
+        .persistent()
+        .get(&borrower)
+        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
+    let previous_utilized = stored_line.utilized_amount;
+    let previous_status = stored_line.status;
+
+    // Apply interest accrual before any mutation.
+    let mut credit_line = crate::accrual::apply_accrual(&env, stored_line);
+
+    let forgive_amount = amount.min(credit_line.utilized_amount);
+    let interest_forgiven = forgive_amount.min(credit_line.accrued_interest);
+
+    credit_line.accrued_interest -= interest_forgiven;
+    credit_line.utilized_amount -= forgive_amount;
+
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
 }
 
 pub fn settle_default_liquidation(
@@ -1010,6 +908,28 @@ pub fn advance_repayment_schedule_after_repay(
     let installments_paid = (principal_repaid / schedule.amount_per_period) as u64;
     if installments_paid == 0 {
         return;
+    }
+
+    // ── Late-fee surcharge ──────────────────────────────────────────────────
+    let late_fee = crate::storage::get_late_fee_flat(env);
+    if late_fee > 0 {
+        let now = env.ledger().timestamp();
+        for i in 0_u64..installments_paid {
+            let due_ts = schedule
+                .next_due_ts
+                .saturating_add(i.saturating_mul(schedule.period_seconds));
+            if now > due_ts {
+                crate::storage::add_treasury_balance(env, late_fee);
+                crate::events::publish_late_fee_charged_event(
+                    env,
+                    crate::events::LateFeeChargedEvent {
+                        borrower: borrower.clone(),
+                        fee: late_fee,
+                        installment_index: i.saturating_add(1),
+                    },
+                );
+            }
+        }
     }
 
     let advance_seconds = installments_paid.saturating_mul(schedule.period_seconds);

--- a/contracts/credit/src/oracles.rs
+++ b/contracts/credit/src/oracles.rs
@@ -162,11 +162,11 @@ pub fn get_median_value(env: Env) -> Result<u128, ContractError> {
     }
 
     if total_weight < quorum {
-        return Err(ContractError::QuorumNotMet);
+        return Err(ContractError::OracleQuorumNotMet);
     }
 
     if valid_reports.is_empty() {
-        return Err(ContractError::QuorumNotMet);
+        return Err(ContractError::OracleQuorumNotMet);
     }
 
     // Sort valid reports by value ascending using a simple insertion sort
@@ -409,6 +409,9 @@ mod test {
         // Median should be 150.
         let val = client.get_median_value();
         assert_eq!(val, 150);
+    }
+}
+
 // # Multi-oracle quorum price resolution
 //
 // Implements the quorum-of-K algorithm for combining multiple independent
@@ -675,6 +678,4 @@ mod tests {
         let prices = vec![&env, 1_051i128, 1_000i128];
         resolve_quorum_price(&env, &prices, &cfg(2, 500));
     }
-}
-}
 }

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -166,7 +166,7 @@ pub fn is_delinquent(env: Env, borrower: Address) -> bool {
         return false;
     }
 
-    let Some(schedule) = get_repayment_schedule(env.clone(), borrower) else {
+    let Some(schedule) = get_repayment_schedule(env.clone(), borrower.clone()) else {
         return false;
     };
 

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -89,7 +89,11 @@ use soroban_sdk::{contracttype, Address, Env, Symbol};
 /// Helper functions in this module always pick the correct tier; callers
 /// outside this module should never hit the storage API directly with these
 /// keys.
-#[contracttype]
+// `export = false`: DataKey has grown past the 50-case limit the Soroban
+// contract-spec XDR format (`SCSpecUdtUnionV0.cases<50>`) allows for an
+// exported type spec. This is an internal storage-key type (never crosses
+// the contract ABI), so skipping spec export has no client-visible effect.
+#[contracttype(export = false)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
     /// Address of the liquidity token (SAC or compatible token contract).
@@ -192,7 +196,7 @@ pub enum DataKey {
     /// Minimum ledger seconds between critical collateral admin actions (v7).
     AdminCollateralCooldownSeconds,
     /// Ledger timestamp of the last critical collateral admin action (v7).
-    LastAdminCollateralCriticalActionTs,
+    LastColAdminActionTs,
     /// Per-asset collateral risk weight in basis points (10_000 = 100%, full value).
     /// Absent for an asset means callers should treat it as 10_000 bps (unweighted).
     CollateralRiskWeightBps(Address),
@@ -213,9 +217,6 @@ pub enum DataKey {
     /// Pending treasury withdrawal proposal (at most one at a time).
     /// Stored in instance storage; cleared after successful execution.
     PendingTreasuryWithdrawal,
-    /// Protocol-level max close factor in basis points for partial liquidation settlements.
-    /// Stored in instance storage; defaults to 10_000 (full liquidation) when absent.
-    CloseFactorBps,
     /// Structured reason for the most recent protocol pause (escape-hatch audit trail).
     /// Stored when admin invokes pause with a reason; cleared on unpause.
     PauseReason,
@@ -233,6 +234,12 @@ pub enum DataKey {
     /// Per-borrower liquidation grace period in seconds.
     /// Specifies a grace window before a credit line can be defaulted or liquidated.
     LiquidationGracePeriod(Address),
+    /// Per-borrower absolute exposure cap (i128 amount).
+    BorrowerExposureCap(Address),
+    /// Admin-configured allowlist of accepted multi-collateral token addresses.
+    CollateralTokenAllowlist,
+    /// Per-borrower, per-token collateral balance (multi-collateral path).
+    CollateralBalanceV2(Address, Address),
 }
 
 /// Maximum number of credit lines returned per page.
@@ -259,10 +266,6 @@ pub const MAX_ENUMERATION_LIMIT: u32 = 100;
 // number of TTL writes per active key is at most one per three months.
 pub const LEDGER_BUMP_AMOUNT: u32 = 3_110_400; // ~6 months
 pub const LEDGER_BUMP_THRESHOLD: u32 = 1_555_200; // ~3 months
-
-/// TTL policy used by per-borrower credit-line entries.
-pub const CREDIT_LINE_TTL_EXTEND_TO: u32 = LEDGER_BUMP_AMOUNT;
-pub const CREDIT_LINE_TTL_THRESHOLD: u32 = LEDGER_BUMP_THRESHOLD;
 
 /// Instance storage TTL policy (covers global config like admin/liquidity token).
 pub const INSTANCE_BUMP_AMOUNT: u32 = LEDGER_BUMP_AMOUNT;
@@ -560,14 +563,14 @@ pub fn set_admin_collateral_cooldown_seconds(env: &Env, seconds: u64) {
 pub fn get_last_admin_collateral_critical_action_ts(env: &Env) -> Option<u64> {
     env.storage()
         .instance()
-        .get(&DataKey::LastAdminCollateralCriticalActionTs)
+        .get(&DataKey::LastColAdminActionTs)
 }
 
 /// Record the ledger timestamp of the last critical collateral admin action.
 pub fn set_last_admin_collateral_critical_action_ts(env: &Env, ts: u64) {
     env.storage()
         .instance()
-        .set(&DataKey::LastAdminCollateralCriticalActionTs, &ts);
+        .set(&DataKey::LastColAdminActionTs, &ts);
 }
 /// Return the risk weight for a specific collateral asset, in basis points,
 /// if explicitly configured. `None` means no weight was ever set for this
@@ -1336,7 +1339,7 @@ pub fn set_late_fee_flat(env: &Env, fee: i128) {
 /// # Storage
 /// - **Type**: Instance storage
 /// - **Key**: [`DataKey::LateFeeConfig`]
-pub fn get_late_fee_config(env: &Env) -> Option<crate::types::LateFeeConfig> {
+pub fn get_late_fee_config(env: &Env) -> Option<crate::penalties::LateFeeConfig> {
     env.storage().instance().get(&DataKey::LateFeeConfig)
 }
 
@@ -1348,7 +1351,7 @@ pub fn get_late_fee_config(env: &Env) -> Option<crate::types::LateFeeConfig> {
 /// # Storage
 /// - **Type**: Instance storage
 /// - **Key**: [`DataKey::LateFeeConfig`]
-pub fn set_late_fee_config(env: &Env, config: Option<crate::types::LateFeeConfig>) {
+pub fn set_late_fee_config(env: &Env, config: Option<crate::penalties::LateFeeConfig>) {
     match config {
         Some(c) => env.storage().instance().set(&DataKey::LateFeeConfig, &c),
         None => env.storage().instance().remove(&DataKey::LateFeeConfig),
@@ -1503,6 +1506,13 @@ pub fn get_last_freeze_timestamp(env: &Env) -> Option<u64> {
     env.storage()
         .instance()
         .get(&DataKey::LastFreezeTimestamp)
+}
+
+/// Set the ledger timestamp of the last admin freeze/unfreeze action.
+fn set_last_freeze_timestamp(env: &Env, ts: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LastFreezeTimestamp, &ts);
 }
 
 /// Record a freeze/unfreeze action timestamp, but only when a cooldown is

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -166,7 +166,12 @@ pub enum CreditStatus {
 /// | 53   | `InvalidAttestation`           | Misc          | Attestation proof is invalid or no attestation batch has been committed |
 /// | 54   | `AdminCooldownActive`          | Risk          | Critical borrower admin action attempted before cooldown elapsed |
 /// | 55   | `LiquidationGraceActive`       | Lifecycle     | Per-borrower liquidation grace window has not yet elapsed |
-#[contracterror]
+// `export = false`: this enum has grown past the 50-case limit that the
+// Soroban contract-spec XDR format (`SCSpecUdtErrorEnumV0.cases<50>`)
+// allows for exported error specs. Discriminants and `From<Error>` /
+// `InvokeError` conversions are unaffected; only the on-chain metadata
+// blob (used by client-generation tooling) is skipped.
+#[contracterror(export = false)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
@@ -280,6 +285,13 @@ pub enum ContractError {
     AdminCooldownActive = 54,
     /// Per-borrower liquidation grace window has not yet elapsed.
     LiquidationGraceActive = 55,
+    /// Critical collateral admin action attempted before the configured
+    /// cool-off elapsed. See [`crate::collateral_admin`].
+    AdminCollateralCooldownActive = 56,
+    /// Per-borrower absolute exposure cap ([`crate::limits`]) was exceeded.
+    BorrowerExposureCapExceeded = 57,
+    /// Admin freeze/unfreeze action attempted before the configured cool-off elapsed.
+    FreezeCooldownActive = 58,
 }
 
 /// ABI-stable category label for [`ContractError`] variants.
@@ -367,6 +379,7 @@ impl ContractError {
             Self::RepayExceedsMaxAmount => Limit,
             Self::CloseFactorAboveMax => Limit,
             Self::DrawReversalWindowExpired => Limit,
+            Self::BorrowerExposureCapExceeded => Limit,
             // Liquidity (5)
             Self::MissingLiquidityToken => Liquidity,
             Self::MissingLiquiditySource => Liquidity,
@@ -391,6 +404,7 @@ impl ContractError {
             // Collateral (8)
             Self::CollateralRatioBelowMinimum => Collateral,
             Self::InsufficientCollateralBalance => Collateral,
+            Self::AdminCollateralCooldownActive => Collateral,
             // Block (9)
             Self::BorrowerBlocked => Block,
             Self::DrawsFrozen => Block,
@@ -504,6 +518,35 @@ pub struct GracePeriodConfig {
     pub waiver_mode: GraceWaiverMode,
     /// Reduced rate to apply when waiver_mode is ReducedRate.
     pub reduced_rate_bps: u32,
+}
+
+/// Structured kind discriminant for collateral lifecycle events.
+///
+/// # Discriminant stability
+/// Same rule as [`FreezeReason`] / [`CreditStatus`]: discriminants are part
+/// of the contract ABI and must never be reordered or renumbered; new
+/// variants must be appended.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CollateralEventKind {
+    /// Collateral tokens deposited into the contract.
+    Deposited = 0,
+    /// Collateral tokens withdrawn by the borrower (generic withdrawal path).
+    Withdrawn = 1,
+    /// Collateral tokens released via the health-factor-gated partial release path.
+    PartiallyReleased = 2,
+    /// Collateral tokens released internally as part of an atomic repay+release flow.
+    Released = 3,
+}
+
+/// Persisted state for the global draw-freeze switch ([`crate::storage::DataKey::DrawsFrozen`]).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DrawsFreezeState {
+    /// `true` when all draws are currently frozen.
+    pub frozen: bool,
+    /// Structured reason recorded on the most recent freeze/unfreeze action.
+    pub reason: FreezeReason,
 }
 
 /// Grace period waiver modes.
@@ -633,6 +676,29 @@ pub struct CreditLinesPage {
     pub has_more: bool,
 }
 
+/// Aggregated, single-call read-only view of a borrower's full credit-line state.
+///
+/// Assembles [`CreditLineData`], collateral balance, health factor, repayment
+/// schedule, and delinquency status in one call, avoiding the multiple
+/// round-trips a caller would otherwise need for `get_credit_line` +
+/// `get_collateral` + `get_health_factor` + `get_repayment_schedule` +
+/// `is_delinquent`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineSnapshot {
+    /// The core credit line record.
+    pub line: CreditLineData,
+    /// Collateral balance for the borrower (single-token collateral path).
+    pub collateral_balance: i128,
+    /// Collateral-aware health factor in basis points. `u32::MAX` when
+    /// `utilized_amount == 0`.
+    pub health_factor_bps: u32,
+    /// The borrower's installment repayment schedule, if configured.
+    pub repayment_schedule: Option<RepaymentSchedule>,
+    /// `true` when the borrower is past the delinquency grace window.
+    pub is_delinquent: bool,
+}
+
 /// Read-only capabilities bitmap for a borrower's credit line.
 ///
 /// Returned by `borrow_capabilities` to let off-chain clients and
@@ -720,102 +786,3 @@ pub struct PauseReason {
     pub actor: soroban_sdk::Address,
 }
 
-/// Error categories for client-side grouping of [`ContractError`] variants.
-///
-/// # Discriminant stability
-/// Discriminants are permanently pinned. New variants must be appended at the
-/// end with the next available integer.
-#[contracttype]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u32)]
-pub enum ContractErrorCategory {
-    /// Authentication / authorization errors (Unauthorized, NotAdmin, AdminNotInitialized).
-    Auth = 1,
-    /// Credit line lifecycle state errors (Closed, Suspended, Defaulted, AlreadyInitialized).
-    Lifecycle = 2,
-    /// Numeric domain errors (InvalidAmount, NegativeLimit, Overflow, TimestampRegression, LimitOutOfBounds).
-    Numeric = 3,
-    /// Per-borrower limit enforcement (OverLimit, UtilizationNotZero, DrawExceedsMaxAmount, BorrowerExposureCapExceeded).
-    Limit = 4,
-    /// Liquidity / reserve / exposure errors (MissingLiquidityToken, ExposureCapExceeded, TreasuryNotSet, etc.).
-    Liquidity = 5,
-    /// Risk / rate / score / circuit-breaker errors (RateTooHigh, ScoreTooHigh, Paused, cooldowns).
-    Risk = 6,
-    /// Oracle price-feed errors (OraclePriceInvalid, OraclePriceStale, OraclePriceDeviation).
-    Oracle = 7,
-    /// Collateral ratio errors (CollateralRatioBelowMinimum, InsufficientCollateralBalance).
-    Collateral = 8,
-    /// Blocklist / freeze / draw-freeze errors (BorrowerBlocked, DrawsFrozen, BorrowerFrozen).
-    Block = 9,
-    /// Reentrancy guard trigger.
-    Reentrancy = 10,
-    /// Unclassified errors (CreditLineNotFound, AdminAcceptTooEarly).
-    Misc = 11,
-}
-
-impl ContractError {
-    /// Return the error category for this variant.
-    ///
-    /// Categories allow clients to group errors without matching on individual
-    /// discriminant values. Every variant maps to exactly one category.
-    pub fn category(&self) -> ContractErrorCategory {
-        match self {
-            ContractError::Unauthorized
-            | ContractError::NotAdmin
-            | ContractError::AdminNotInitialized => ContractErrorCategory::Auth,
-
-            ContractError::CreditLineClosed
-            | ContractError::AlreadyInitialized
-            | ContractError::CreditLineSuspended
-            | ContractError::CreditLineDefaulted
-            | ContractError::LiquidationGraceActive => ContractErrorCategory::Lifecycle,
-
-            ContractError::InvalidAmount
-            | ContractError::NegativeLimit
-            | ContractError::Overflow
-            | ContractError::TimestampRegression
-            | ContractError::LimitOutOfBounds => ContractErrorCategory::Numeric,
-
-            ContractError::OverLimit
-            | ContractError::UtilizationNotZero
-            | ContractError::LimitDecreaseRequiresRepayment
-            | ContractError::DrawExceedsMaxAmount
-            | ContractError::RepayExceedsMaxAmount
-            | ContractError::BorrowerExposureCapExceeded => ContractErrorCategory::Limit,
-
-            ContractError::MissingLiquidityToken
-            | ContractError::MissingLiquiditySource
-            | ContractError::InsufficientLiquidityReserve
-            | ContractError::LiquidityTokenCallFailed
-            | ContractError::InsufficientRepaymentAllowance
-            | ContractError::InsufficientRepaymentBalance
-            | ContractError::TreasuryNotSet
-            | ContractError::ExposureCapExceeded => ContractErrorCategory::Liquidity,
-
-            ContractError::RateTooHigh
-            | ContractError::ScoreTooHigh
-            | ContractError::Paused
-            | ContractError::DrawCooldownActive
-            | ContractError::AdminCooldownActive => ContractErrorCategory::Risk,
-
-            ContractError::OraclePriceInvalid
-            | ContractError::OraclePriceStale
-            | ContractError::OraclePriceDeviation => ContractErrorCategory::Oracle,
-
-            ContractError::CollateralRatioBelowMinimum
-            | ContractError::InsufficientCollateralBalance => ContractErrorCategory::Collateral,
-
-            ContractError::BorrowerBlocked
-            | ContractError::DrawsFrozen
-            | ContractError::BorrowerFrozen
-            | ContractError::FreezeCooldownActive => ContractErrorCategory::Block,
-
-            ContractError::Reentrancy => ContractErrorCategory::Reentrancy,
-
-            ContractError::CreditLineNotFound
-            | ContractError::AdminAcceptTooEarly
-            | ContractError::DrawReversalWindowExpired
-            | ContractError::OriginalDrawNotFound => ContractErrorCategory::Misc,
-        }
-    }
-}

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -10,8 +10,30 @@ use crate::storage::{
     get_borrower_by_credit_line_id, get_credit_line, is_borrower_blocked, is_borrower_frozen,
     is_paused, MAX_ENUMERATION_LIMIT,
 };
-use crate::types::{BorrowCapabilities, CreditLinesPage, ProofOfReserve, ProtocolSummaryView};
+use crate::types::{
+    BorrowCapabilities, CreditLineSnapshot, CreditLinesPage, ProofOfReserve, ProtocolSummaryView,
+};
 use soroban_sdk::{Address, Env, Vec};
+
+/// Assemble a full read-only snapshot of `borrower`'s credit line.
+///
+/// Returns `None` when no credit line has been opened for `borrower`.
+/// See [`CreditLineSnapshot`] for the aggregated fields.
+pub fn get_credit_line_snapshot(env: Env, borrower: Address) -> Option<CreditLineSnapshot> {
+    let line = get_credit_line(&env, &borrower)?;
+    let collateral_balance = crate::collateral::get_collateral(&env, &borrower);
+    let health_factor_bps = crate::query::get_health_factor(env.clone(), borrower.clone());
+    let repayment_schedule = crate::query::get_repayment_schedule(env.clone(), borrower.clone());
+    let is_delinquent = crate::query::is_delinquent(env.clone(), borrower);
+
+    Some(CreditLineSnapshot {
+        line,
+        collateral_balance,
+        health_factor_bps,
+        repayment_schedule,
+        is_delinquent,
+    })
+}
 
 // ── Borrow capabilities view ─────────────────────────────────────────────────
 
@@ -162,8 +184,9 @@ pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> 
     // Clamp start_id to valid range
     if start_id >= total_count {
         return CreditLinesPage {
-            credit_lines: Vec::new(&env),
+            lines: Vec::new(&env),
             next_cursor: None,
+            has_more: false,
         };
     }
 
@@ -196,8 +219,10 @@ pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> 
         next_cursor = None;
     }
 
+    let has_more = next_cursor.is_some();
     CreditLinesPage {
-        credit_lines,
+        lines: credit_lines,
         next_cursor,
+        has_more,
     }
 }


### PR DESCRIPTION
Closes #860

## Summary
- Per the "Structured Events (v7)" issue, added a unified `CollateralLifecycleEvent` (topic `("credit", "col_lca")`) tagged with a new `CollateralEventKind` enum (`Deposited` / `Withdrawn` / `PartiallyReleased` / `Released`) plus `ledger`/`timestamp` fields, so indexers can subscribe to one topic instead of tracking `col_dep` / `col_wit` / `col_prel` separately.
- Wired the new event into every collateral state-changing entrypoint — `deposit_collateral`, `withdraw_collateral`, `partial_release_collateral`, `release_collateral`, `deposit_collateral_token`, `withdraw_collateral_token` — as a **dual-publish** alongside the existing per-action events, so no existing indexer breaks.
- While integrating this, `contracts/credit` failed to build on `main` at all: a prior bad merge (PR #955/#958) had left duplicated `mod`/struct/enum/fn declarations and several outright-missing types across `lib.rs`, `types.rs`, `storage.rs`, `lifecycle.rs`, and `oracles.rs`. Repaired these so the crate (and the new events) could actually compile and be tested:
  - Removed duplicate `mod` declarations, duplicate `ContractErrorCategory`/`DataKey` content, and duplicate `set_repayment_schedule` / `advance_repayment_schedule_after_repay` / `reinstate_credit_line` / rate-floor/ceiling entrypoints (kept the more complete/tested variant in each case, e.g. restored the late-fee-charging logic that had been silently dropped from the surviving `advance_repayment_schedule_after_repay`).
  - Added missing `DataKey` variants (`BorrowerExposureCap`, `CollateralTokenAllowlist`, `CollateralBalanceV2`) and missing types (`CreditLineSnapshot`, `DrawsFreezeState`) and implemented `lifecycle::forgive_debt` and `views::get_credit_line_snapshot`, which existed only as dangling call sites.
  - Added missing `ContractError` variants (`AdminCollateralCooldownActive`, `BorrowerExposureCapExceeded`, `FreezeCooldownActive`); since `ContractError` had grown past Soroban's 50-case XDR spec-export limit, marked it (and the now similarly oversized internal-only `DataKey`) `export = false` to skip on-chain spec generation without affecting behavior.
  - Shortened two `#[contractimpl]` entrypoint names that exceeded Soroban's 32-character contract-function-name limit (`set_admin_collateral_cooldown_seconds` → `set_col_admin_cooldown_secs`, `set_per_borrower_liquidation_grace` → `set_borrower_liq_grace`, and their `get_*` counterparts) and updated `contracts/collateral/tests/admin_cooldown.rs` / `contracts/collateral/README.md` to the corrected `AdminCollateralCooldownActive` discriminant (`#56` — `#54` was already taken by an unrelated `AdminCooldownActive` variant).

## Test plan
- [ ] `cargo build -p creditra-credit` — was failing outright on `main`; fixed down to a handful of remaining errors isolated to a leftover duplicate-import issue in `oracles.rs` from the same bad merge (not yet resolved — flagged separately, not part of this PR's scope).
- [ ] `cargo test -p creditra-credit` once the build is fully green, to confirm the existing collateral/event test suites (`tests/collateral.rs`, `tests/events_catalog.rs`, `tests/event_topic_stability.rs`, `contracts/collateral/tests/admin_cooldown.rs`) still pass.
- [ ] Add/extend focused tests asserting `CollateralLifecycleEvent` is emitted with the correct `kind`/`token`/`ledger`/`timestamp` for each collateral entrypoint (not yet written — outstanding for this PR before merge).
- [ ] Update `docs/EVENTS_CATALOG.md` with the new `col_lca` topic (outstanding — not yet done).