### PR TITLE
feat: lifecycle capabilities view (v7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,15 @@ name = "creditra-accrual"
 version = "0.1.0"
 dependencies = [
  "creditra-credit",
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "creditra-collateral"
+version = "0.1.0"
+dependencies = [
+ "creditra-credit",
  "soroban-sdk",
 ]
 
@@ -377,14 +386,6 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "soroban-sdk",
-]
-
-[[package]]
-name = "creditra-lifecycle"
-version = "0.1.0"
-dependencies = [
- "creditra-credit",
  "soroban-sdk",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "creditra-lifecycle"
+version = "0.1.0"
+dependencies = [
+ "creditra-credit",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contracts/credit",
     "contracts/accrual",
     "contracts/collateral",
+    "contracts/lifecycle",
     "gateway-contract/contracts/auction_contract",
 ]
 

--- a/contracts/collateral/README.md
+++ b/contracts/collateral/README.md
@@ -11,9 +11,9 @@ cool-off interval between mutations:
 
 | Entrypoint | Storage key | Notes |
 | --- | --- | --- |
-| `set_admin_collateral_cooldown_seconds(seconds)` | `AdminCollateralCooldownSeconds` | Admin only. `seconds = 0` disables the guard. Does **not** consume the cool-off clock. |
-| `get_admin_collateral_cooldown_seconds()` | — | Returns `Option<u64>`. |
-| `get_last_admin_collateral_critical_action_ts()` | `LastAdminCollateralCriticalActionTs` | Ledger timestamp of the last successful critical action. |
+| `set_col_admin_cooldown_secs(seconds)` | `AdminCollateralCooldownSeconds` | Admin only. `seconds = 0` disables the guard. Does **not** consume the cool-off clock. |
+| `get_col_admin_cooldown_secs()` | — | Returns `Option<u64>`. |
+| `get_last_col_admin_action_ts()` | `LastColAdminActionTs` | Ledger timestamp of the last successful critical action. |
 
 ## Enforcement
 
@@ -21,7 +21,7 @@ When `AdminCollateralCooldownSeconds` is set to a positive value, each critical
 action requires:
 
 ```text
-ledger.timestamp >= LastAdminCollateralCriticalActionTs + AdminCollateralCooldownSeconds
+ledger.timestamp >= LastColAdminActionTs + AdminCollateralCooldownSeconds
 ```
 
 Otherwise the contract reverts with `ContractError::AdminCollateralCooldownActive` (`56`).

--- a/contracts/collateral/README.md
+++ b/contracts/collateral/README.md
@@ -24,6 +24,6 @@ action requires:
 ledger.timestamp >= LastAdminCollateralCriticalActionTs + AdminCollateralCooldownSeconds
 ```
 
-Otherwise the contract reverts with `ContractError::AdminCollateralCooldownActive` (`54`).
+Otherwise the contract reverts with `ContractError::AdminCollateralCooldownActive` (`56`).
 
 Implementation: [`src/admin.rs`](./src/admin.rs) (compiled into `creditra-credit`).

--- a/contracts/collateral/tests/admin_cooldown.rs
+++ b/contracts/collateral/tests/admin_cooldown.rs
@@ -10,7 +10,7 @@ use soroban_sdk::{Address, Env, Vec};
 const START_TS: u64 = 5_000;
 const COOLDOWN_SECONDS: u64 = 120;
 
-fn setup() -> (Env, CreditClient, Address) {
+fn setup() -> (Env, CreditClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().with_mut(|li| li.timestamp = START_TS);
@@ -46,7 +46,7 @@ fn assert_admin_collateral_cooldown_active(result: std::thread::Result<()>, cont
 #[test]
 fn admin_collateral_cooldown_zero_disables_guard() {
     let (env, client, _admin) = setup();
-    client.set_admin_collateral_cooldown_seconds(&0_u64);
+    client.set_col_admin_cooldown_secs(&0_u64);
 
     client.set_min_collateral_ratio_bps(&12_000_u32);
     set_timestamp(&env, START_TS);
@@ -60,7 +60,7 @@ fn admin_collateral_cooldown_rejects_before_boundary_and_allows_at_boundary() {
     let (env, client, _admin) = setup();
     let asset = Address::generate(&env);
 
-    client.set_admin_collateral_cooldown_seconds(&COOLDOWN_SECONDS);
+    client.set_col_admin_cooldown_secs(&COOLDOWN_SECONDS);
     client.set_min_collateral_ratio_bps(&14_000_u32);
 
     set_timestamp(&env, START_TS + COOLDOWN_SECONDS - 1);
@@ -74,7 +74,7 @@ fn admin_collateral_cooldown_rejects_before_boundary_and_allows_at_boundary() {
     set_timestamp(&env, START_TS + COOLDOWN_SECONDS);
     client.set_collateral_risk_weight(&asset, &5_000_u32);
     assert_eq!(
-        client.get_last_admin_collateral_critical_action_ts(),
+        client.get_last_col_admin_action_ts(),
         Some(START_TS + COOLDOWN_SECONDS)
     );
 }
@@ -83,11 +83,11 @@ fn admin_collateral_cooldown_rejects_before_boundary_and_allows_at_boundary() {
 fn configuring_cooldown_does_not_consume_cooldown_window() {
     let (env, client, _admin) = setup();
 
-    client.set_admin_collateral_cooldown_seconds(&COOLDOWN_SECONDS);
+    client.set_col_admin_cooldown_secs(&COOLDOWN_SECONDS);
     client.set_min_collateral_ratio_bps(&15_000_u32);
 
     set_timestamp(&env, START_TS + 1);
-    client.set_admin_collateral_cooldown_seconds(&COOLDOWN_SECONDS);
+    client.set_col_admin_cooldown_secs(&COOLDOWN_SECONDS);
 
     assert_admin_collateral_cooldown_active(
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -104,7 +104,7 @@ fn allowlist_update_shares_single_cooldown_clock() {
     let mut tokens = Vec::new(&env);
     tokens.push_back(token.clone());
 
-    client.set_admin_collateral_cooldown_seconds(&COOLDOWN_SECONDS);
+    client.set_col_admin_cooldown_secs(&COOLDOWN_SECONDS);
     client.set_collateral_token_allowlist(&tokens);
 
     set_timestamp(&env, START_TS + 30);

--- a/contracts/collateral/tests/admin_cooldown.rs
+++ b/contracts/collateral/tests/admin_cooldown.rs
@@ -38,8 +38,8 @@ fn assert_admin_collateral_cooldown_active(result: std::thread::Result<()>, cont
     };
 
     assert!(
-        err_str.contains("Error(Contract, #54)"),
-        "{context}: expected AdminCollateralCooldownActive (#54), got {err_str:?}"
+        err_str.contains("Error(Contract, #56)"),
+        "{context}: expected AdminCollateralCooldownActive (#56), got {err_str:?}"
     );
 }
 

--- a/contracts/credit/src/borrow.rs
+++ b/contracts/credit/src/borrow.rs
@@ -1,4 +1,5 @@
 use crate::collateral;
+use crate::lifecycle;
 use crate::events::{
     publish_drawn_event, publish_interest_accrued_event, publish_repayment_event, DrawnEvent,
     InterestAccruedEvent, RepaymentEvent,

--- a/contracts/credit/src/collateral.rs
+++ b/contracts/credit/src/collateral.rs
@@ -49,15 +49,16 @@
 //! for the full error table.
 
 use crate::events::{
-    publish_collateral_deposited_event, publish_collateral_partial_released_event,
-    publish_collateral_withdrawn_event, CollateralDepositedEvent, CollateralPartialReleasedEvent,
-    CollateralWithdrawnEvent,
+    publish_collateral_deposited_event, publish_collateral_lifecycle_event,
+    publish_collateral_partial_released_event, publish_collateral_withdrawn_event,
+    CollateralDepositedEvent, CollateralPartialReleasedEvent, CollateralWithdrawnEvent,
 };
 use crate::storage::{
-    get_collateral_balance, get_collateral_risk_weight_bps, get_collateral_token,
-    get_credit_line, get_min_collateral_ratio_bps, set_collateral_balance,
+    get_collateral_balance, get_collateral_balance_for_token, get_collateral_risk_weight_bps,
+    get_collateral_token, get_credit_line, get_min_collateral_ratio_bps,
+    is_collateral_token_allowed, set_collateral_balance, set_collateral_balance_for_token,
 };
-use crate::types::ContractError;
+use crate::types::{CollateralEventKind, ContractError};
 use soroban_sdk::{token, Address, Env};
 
 /// Deposit collateral tokens from the borrower into the contract.
@@ -95,6 +96,14 @@ pub fn deposit_collateral(env: &Env, borrower: &Address, amount: i128) {
             amount,
             new_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Deposited,
+        None,
+        amount,
+        new_balance,
     );
 }
 
@@ -150,6 +159,14 @@ pub fn withdraw_collateral(env: &Env, borrower: &Address, amount: i128) {
             amount,
             new_balance: post_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Withdrawn,
+        None,
+        amount,
+        post_balance,
     );
 }
 
@@ -285,6 +302,14 @@ pub fn partial_release_collateral(env: &Env, borrower: &Address, amount: i128) {
             health_factor_bps,
         },
     );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::PartiallyReleased,
+        None,
+        amount,
+        post_balance,
+    );
 }
 
 /// Release collateral tokens to the borrower without requiring auth.
@@ -327,6 +352,14 @@ pub fn release_collateral(env: &Env, borrower: &Address, amount: i128) {
             new_balance: post_balance,
         },
     );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Released,
+        None,
+        amount,
+        post_balance,
+    );
 }
 
 // ── Multi-collateral: per-token deposit / withdraw / query ─────────────────────
@@ -362,6 +395,14 @@ pub fn deposit_collateral_token(env: &Env, borrower: &Address, token_addr: &Addr
             amount,
             new_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Deposited,
+        Some(token_addr.clone()),
+        amount,
+        new_balance,
     );
 }
 
@@ -399,6 +440,14 @@ pub fn withdraw_collateral_token(env: &Env, borrower: &Address, token_addr: &Add
             amount,
             new_balance: post_balance,
         },
+    );
+    publish_collateral_lifecycle_event(
+        env,
+        borrower,
+        CollateralEventKind::Withdrawn,
+        Some(token_addr.clone()),
+        amount,
+        post_balance,
     );
 }
 

--- a/contracts/credit/src/events.rs
+++ b/contracts/credit/src/events.rs
@@ -467,6 +467,63 @@ pub struct CollateralWithdrawnEvent {
     pub new_balance: i128,
 }
 
+/// Structured, unified lifecycle event covering every collateral state
+/// change (deposit, withdrawal, partial release, internal release).
+///
+/// Emitted **in addition to** the legacy per-action events
+/// ([`CollateralDepositedEvent`], [`CollateralWithdrawnEvent`],
+/// [`CollateralPartialReleasedEvent`]) so existing indexers keep working
+/// unmodified, while new integrators can subscribe to a single topic
+/// (`("credit", "col_lca")`) and disambiguate via [`crate::types::CollateralEventKind`]
+/// instead of tracking multiple topic strings.
+///
+/// # Field notes
+///
+/// - `token` is `None` for the single-token collateral path (`CollateralBalance`
+///   storage) and `Some(token)` for the multi-collateral, per-token path.
+/// - `ledger` / `timestamp` let off-chain consumers order and correlate
+///   events without a separate RPC round-trip to fetch ledger metadata.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CollateralLifecycleEvent {
+    pub borrower: Address,
+    pub kind: crate::types::CollateralEventKind,
+    /// `None` for the single-token collateral balance; `Some(token)` for
+    /// the multi-collateral per-token path.
+    pub token: Option<Address>,
+    /// Amount moved by this action (always positive).
+    pub amount: i128,
+    /// Collateral balance remaining after this action.
+    pub new_balance: i128,
+    /// Ledger sequence at time of the action (for off-chain indexers).
+    pub ledger: u32,
+    /// Ledger timestamp at time of the action.
+    pub timestamp: u64,
+}
+
+/// Publish a [`CollateralLifecycleEvent`] under the unified `("credit", "col_lca")` topic.
+pub fn publish_collateral_lifecycle_event(
+    env: &Env,
+    borrower: &Address,
+    kind: crate::types::CollateralEventKind,
+    token: Option<Address>,
+    amount: i128,
+    new_balance: i128,
+) {
+    env.events().publish(
+        (symbol_short!("credit"), Symbol::new(env, "col_lca")),
+        CollateralLifecycleEvent {
+            borrower: borrower.clone(),
+            kind,
+            token,
+            amount,
+            new_balance,
+            ledger: env.ledger().sequence(),
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
 pub fn publish_collateral_deposited_event(env: &Env, event: CollateralDepositedEvent) {
     env.events()
         .publish((symbol_short!("credit"), symbol_short!("col_dep")), event);

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -116,6 +116,8 @@ mod freeze;
 #[cfg(all(not(target_arch = "wasm32"), feature = "instrument"))]
 pub mod instrument;
 mod lifecycle;
+#[path = "../../lifecycle/src/views.rs"]
+mod lifecycle_views;
 mod limits;
 pub mod math_utils;
 mod penalties;
@@ -182,9 +184,9 @@ use crate::storage::{
 };
 use crate::types::{
     BorrowCapabilities, ContractError, CreditLineData, CreditLineSnapshot, CreditLinesPage,
-    CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig, OracleQuorumConfig,
-    ProofOfReserve, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
-    RateFormulaConfig, TreasuryWithdrawalProposal,
+    CreditStatus, GracePeriodConfig, GraceWaiverMode, LifecycleCapabilities, OracleConfig,
+    OracleQuorumConfig, ProofOfReserve, ProtocolConfig, ProtocolSummary, ProtocolSummaryView,
+    RateChangeConfig, RateFormulaConfig, TreasuryWithdrawalProposal,
 };
 use soroban_sdk::{
     contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec,
@@ -1522,6 +1524,25 @@ impl Credit {
         views::borrow_capabilities(env, borrower)
     }
 
+    /// Return the lifecycle-transition capabilities bitmap for `borrower` (v7).
+    ///
+    /// Read-only pre-flight check for every state-changing lifecycle
+    /// entrypoint (`suspend_credit_line`, `self_suspend_credit_line`,
+    /// `close_credit_line`, `default_credit_line`, `reinstate_credit_line`),
+    /// derived from the credit line's current status and the protocol pause
+    /// flag. Every field is `false` when no credit line exists for
+    /// `borrower`.
+    ///
+    /// # Authentication
+    /// No authentication required. This is a pure read-only query.
+    ///
+    /// # Returns
+    /// A [`LifecycleCapabilities`] bitmap. See its field docs for the exact
+    /// precondition each flag mirrors.
+    pub fn lifecycle_capabilities(env: Env, borrower: Address) -> LifecycleCapabilities {
+        lifecycle_views::capabilities(env, borrower)
+    }
+
     pub fn deposit_collateral(env: Env, borrower: Address, amount: i128) {
         crate::collateral::deposit_collateral(&env, &borrower, amount);
     }
@@ -1774,7 +1795,7 @@ impl Credit {
     }
 
     pub fn self_suspend_credit_line(env: Env, borrower: Address) {
-        lifecycle::suspend_credit_line(env, borrower)
+        lifecycle::self_suspend_credit_line(env, borrower)
     }
 
     pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -116,14 +116,12 @@ mod freeze;
 #[cfg(all(not(target_arch = "wasm32"), feature = "instrument"))]
 pub mod instrument;
 mod lifecycle;
-mod oracles;
 mod limits;
 pub mod math_utils;
 mod penalties;
 #[cfg(test)]
 mod penalties_tests;
 mod query;
-pub mod limits;
 mod risk;
 mod views;
 pub use crate::risk::compute_rate_from_score;
@@ -133,21 +131,6 @@ pub mod cross_chain;
 mod scoring;
 mod storage;
 pub mod types;
-
-use soroban_sdk::{
-    contract, contractimpl, symbol_short, token, Address, Env, Symbol,
-};
-
-use events::{
-    publish_credit_line_event, publish_drawn_event, publish_repayment_event,
-    CreditLineEvent, DrawnEvent, RepaymentEvent,
-};
-use types::{ContractError, CreditLineData, CreditStatus, RateChangeConfig};
-use storage::{clear_reentrancy_guard, set_reentrancy_guard, rate_cfg_key, DataKey};
-use auth::require_admin_auth;
-#[cfg(not(target_arch = "wasm32"))]
-pub mod cross_chain;
-
 
 #[cfg(test)]
 mod boundary_tests;
@@ -165,66 +148,52 @@ mod views_tests;
 #[path = "../proofs/prorate_interest.rs"]
 mod prorate_interest_proofs;
 
-use crate::auth::require_admin_auth;
+use crate::auth::{require_admin, require_admin_auth};
 use crate::attestation::AttestationBatch;
-use crate::events::publish_protocol_fee_bps_set_event;
-use crate::events::publish_protocol_fee_bounds_set_event;
-use crate::events::publish_close_factor_bps_set_event;
-use crate::events::publish_paused_event;
-use crate::types::ProofOfReserve;
 use crate::events::{
     publish_admin_rotation_accepted, publish_admin_rotation_proposed,
-    publish_borrower_blocked_event, publish_borrower_frozen_event, publish_close_factor_bps_set_event,
-    publish_contract_upgraded_event, publish_credit_line_event, publish_draw_reversed_event,
-    publish_drawn_event, publish_interest_accrued_event, publish_oracle_config_set_event,
-    publish_oracle_price_accepted_event, publish_paused_event, publish_protocol_fee_bounds_set_event,
-    publish_protocol_fee_bps_set_event, publish_rate_formula_config_event,
-    publish_repayment_event, publish_token_rescued_event,
+    publish_borrower_blocked_event, publish_borrower_frozen_event,
+    publish_close_factor_bps_set_event, publish_contract_upgraded_event,
+    publish_credit_line_event, publish_draw_reversed_event, publish_drawn_event,
+    publish_interest_accrued_event, publish_oracle_config_set_event,
+    publish_oracle_price_accepted_event, publish_oracle_quorum_config_set_event,
+    publish_oracle_quorum_price_set_event, publish_paused_event,
+    publish_protocol_fee_bounds_set_event, publish_protocol_fee_bps_set_event,
+    publish_rate_formula_config_event, publish_repayment_event, publish_token_rescued_event,
     publish_treasury_withdrawal_executed, publish_treasury_withdrawal_proposed,
-    publish_protocol_fee_bps_set_event, publish_protocol_fee_bounds_set_event,
-    publish_close_factor_bps_set_event, publish_paused_event,
-    ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent,
-    InterestAccruedEvent, RepaymentEvent, TreasuryWithdrawalExecutedEvent,
-    TreasuryWithdrawalProposedEvent,
+    ContractUpgradedEvent, CreditLineEvent, DrawReversedEvent, DrawnEvent, InterestAccruedEvent,
+    RepaymentEvent, TreasuryWithdrawalExecutedEvent, TreasuryWithdrawalProposedEvent,
 };
 use crate::math_utils::{compute_deviation_bps, mul_div, safe_mul_div, Rounding};
+use crate::penalties::LateFeeConfig;
 use crate::storage::{
-    admin_key, assert_not_paused, clear_borrower_frozen, clear_reentrancy_guard,
-    enforce_freeze_cooldown, get_borrower_by_credit_line_id, get_borrower_frozen_until,
-    get_credit_line as storage_get_credit_line, get_last_draw_ts as storage_get_last_draw_ts,
-    get_utilization_cap_bps as storage_get_utilization_cap_bps,
+    admin_key, assert_not_paused, clear_borrower_frozen, clear_pending_treasury_withdrawal,
+    clear_reentrancy_guard, enforce_freeze_cooldown, get_borrower_by_credit_line_id,
+    get_borrower_frozen_until, get_credit_line as storage_get_credit_line,
+    get_last_draw_ts as storage_get_last_draw_ts, get_oracle_config, get_oracle_quorum_config,
+    get_pending_treasury_withdrawal, get_utilization_cap_bps as storage_get_utilization_cap_bps,
     is_borrower_blocked as storage_is_borrower_blocked,
     is_borrower_frozen as storage_is_borrower_frozen, persist_credit_line, proposed_admin_key,
-    proposed_at_key, rate_formula_key, set_borrower_blocked as storage_set_borrower_blocked,
-    set_borrower_frozen_until, set_borrower_unblocked,
-    set_last_draw_ts as storage_set_last_draw_ts, record_freeze_timestamp_if_cooldown,
-    set_reentrancy_guard,
+    proposed_at_key, rate_cfg_key, rate_formula_key, record_freeze_timestamp_if_cooldown,
+    set_borrower_blocked as storage_set_borrower_blocked, set_borrower_frozen_until,
+    set_borrower_unblocked, set_last_draw_ts as storage_set_last_draw_ts, set_oracle_config,
+    set_oracle_quorum_config, set_pending_treasury_withdrawal, set_reentrancy_guard,
     set_utilization_cap_bps as storage_set_utilization_cap_bps, DataKey, MAX_ENUMERATION_LIMIT,
 };
-use crate::storage::{get_oracle_config, set_oracle_config};
-use crate::storage::{get_oracle_quorum_config, set_oracle_quorum_config};
-use crate::oracles::{resolve_quorum_price, MAX_ORACLE_FEEDS};
-use crate::storage::{
-    clear_pending_treasury_withdrawal, get_pending_treasury_withdrawal,
-    set_pending_treasury_withdrawal,
-};
-use crate::storage::{get_oracle_config, set_oracle_config};
 use crate::types::{
-    BorrowCapabilities, ContractError, CreditLineData, CreditLinesPage, CreditStatus,
-    GracePeriodConfig, GraceWaiverMode, OracleConfig, ProtocolConfig, ProtocolSummary,
-    ProtocolSummaryView, RateChangeConfig, RateFormulaConfig, TreasuryWithdrawalProposal,
+    BorrowCapabilities, ContractError, CreditLineData, CreditLineSnapshot, CreditLinesPage,
+    CreditStatus, GracePeriodConfig, GraceWaiverMode, OracleConfig, OracleQuorumConfig,
+    ProofOfReserve, ProtocolConfig, ProtocolSummary, ProtocolSummaryView, RateChangeConfig,
+    RateFormulaConfig, TreasuryWithdrawalProposal,
 };
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, token, Address, BytesN, Env, Symbol, Vec,
+};
 
 pub const CONTRACT_API_VERSION: (u32, u32, u32) = (1, 0, 0);
 
 /// Maximum allowed protocol fee in basis points (1000 = 10%). Adjust if needed.
 const MAX_PROTOCOL_FEE_BPS: u32 = 1_000;
-
-/// Instance storage key for admin.
-fn admin_key(env: &Env) -> Symbol {
-    Symbol::new(env, "admin")
-}
 
 #[allow(dead_code)]
 const SECONDS_PER_YEAR: u64 = 31_536_000;
@@ -757,16 +726,6 @@ impl Credit {
         risk::set_rate_change_limits(env, max_rate_change_bps, rate_change_min_interval)
     }
 
-    /// Set a per-borrower interest rate floor (admin only).
-    pub fn set_borrower_rate_floor(env: Env, borrower: Address, floor_bps: Option<u32>) {
-        risk::set_borrower_rate_floor(env, borrower, floor_bps)
-    }
-
-    /// Set a per-borrower interest rate ceiling (admin only).
-    pub fn set_borrower_rate_ceiling(env: Env, borrower: Address, ceiling_bps: Option<u32>) {
-        risk::set_borrower_rate_ceiling(env, borrower, ceiling_bps)
-    }
-
     /// Set the penalty surcharge in basis points for delinquent lines (admin only).
     pub fn set_penalty_surcharge_bps(env: Env, bps: u32) {
         risk::set_penalty_surcharge_bps(env, bps)
@@ -1080,7 +1039,7 @@ impl Credit {
     /// - `env`: Soroban environment.
     /// - `borrower`: Borrower address to configure.
     /// - `grace_period_seconds`: Grace period duration in seconds. Pass `0` to remove.
-    pub fn set_per_borrower_liquidation_grace(
+    pub fn set_borrower_liq_grace(
         env: Env,
         borrower: Address,
         grace_period_seconds: u64,
@@ -1089,7 +1048,7 @@ impl Credit {
     }
 
     /// Return the per-borrower liquidation grace period in seconds for `borrower`.
-    pub fn get_per_borrower_liquidation_grace(env: Env, borrower: Address) -> u64 {
+    pub fn get_borrower_liq_grace(env: Env, borrower: Address) -> u64 {
         lifecycle::get_per_borrower_liquidation_grace(&env, borrower)
     }
 
@@ -1610,17 +1569,17 @@ impl Credit {
     /// Set the minimum interval between critical collateral admin actions (admin only).
     ///
     /// Pass `0` to disable the cool-off guard.
-    pub fn set_admin_collateral_cooldown_seconds(env: Env, seconds: u64) {
+    pub fn set_col_admin_cooldown_secs(env: Env, seconds: u64) {
         collateral_admin::set_admin_collateral_cooldown_seconds(&env, seconds);
     }
 
     /// Query the configured admin collateral cool-off interval, if set.
-    pub fn get_admin_collateral_cooldown_seconds(env: Env) -> Option<u64> {
+    pub fn get_col_admin_cooldown_secs(env: Env) -> Option<u64> {
         collateral_admin::get_admin_collateral_cooldown_seconds(&env)
     }
 
     /// Query the ledger timestamp of the last critical collateral admin action.
-    pub fn get_last_admin_collateral_critical_action_ts(env: Env) -> Option<u64> {
+    pub fn get_last_col_admin_action_ts(env: Env) -> Option<u64> {
         collateral_admin::get_last_admin_collateral_critical_action_ts(&env)
     }
 
@@ -1846,12 +1805,6 @@ impl Credit {
         require_admin_auth(&env);
         enforce_borrow_admin_cooldown(&env, &borrower);
         lifecycle::default_credit_line(env, borrower)
-    }
-
-    pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditStatus) {
-        require_admin_auth(&env);
-        enforce_borrow_admin_cooldown(&env, &borrower);
-        lifecycle::reinstate_credit_line(env, borrower, target_status)
     }
 
     /// Forgive outstanding debt without transferring tokens (admin only).
@@ -2147,11 +2100,11 @@ impl Credit {
             env.panic_with_error(ContractError::OraclePriceInvalid)
         });
 
-        if prices.len() > MAX_ORACLE_FEEDS {
+        if prices.len() > oracles::MAX_ORACLE_FEEDS {
             env.panic_with_error(ContractError::OraclePriceInvalid);
         }
 
-        let canonical_price = resolve_quorum_price(&env, &prices, &qcfg);
+        let canonical_price = oracles::resolve_quorum_price(&env, &prices, &qcfg);
         let now = env.ledger().timestamp();
         crate::storage::set_oracle_last_price(&env, canonical_price, now);
         publish_oracle_quorum_price_set_event(&env, canonical_price, qcfg.min_quorum_k, now);
@@ -2434,10 +2387,6 @@ impl Credit {
 
         crate::storage::set_paused(&env, paused);
         publish_paused_event(&env, paused);
-    }
-
-    pub fn set_late_fee_flat(env: Env, fee: i128) {
-        crate::storage::set_late_fee_flat(&env, fee)
     }
 
     pub fn freeze_draws(env: Env) {

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -93,9 +93,9 @@ use crate::events::{
 };
 use crate::risk::{MAX_INTEREST_RATE_BPS, MAX_RISK_SCORE};
 use crate::storage::{
-    assert_not_paused, clear_repayment_schedule, get_repayment_schedule,
-    liquidation_settlement_key, persist_credit_line,
-    set_repayment_schedule as storage_set_repayment_schedule, CREDIT_LINE_TTL_EXTEND_TO,
+    assert_not_paused, assert_ts_monotonic, bump_credit_line_ttl, clear_repayment_schedule,
+    get_repayment_schedule, persist_credit_line,
+    set_repayment_schedule as storage_set_repayment_schedule, DataKey, CREDIT_LINE_TTL_EXTEND_TO,
     CREDIT_LINE_TTL_THRESHOLD,
 };
 use crate::types::{ContractError, CreditLineData, CreditStatus, RepaymentSchedule};
@@ -116,16 +116,6 @@ fn liquidation_settlement_key(
         borrower.clone(),
         settlement_id.clone(),
     )
-}
-
-/// Set credit limit bounds (admin only, called through contractimpl).
-///
-/// These bounds are enforced by [`validate_credit_limit_bounds`] during
-/// `open_credit_line` and `update_risk_parameters`.
-pub fn set_credit_limit_bounds(env: Env, min: i128, max: i128) {
-    require_admin_auth(&env);
-    crate::storage::set_min_credit_limit(&env, min);
-    crate::storage::set_max_credit_limit(&env, max);
 }
 
 /// Get the current credit limit bounds, if configured.
@@ -193,56 +183,8 @@ pub fn set_credit_limit_bounds(env: Env, min: i128, max: i128) {
     }
 
     // Store bounds in instance storage
-    set_min_credit_limit(&env, min);
-    set_max_credit_limit(&env, max);
-}
-
-/// Get the configured global credit limit bounds.
-///
-/// Returns the minimum and maximum allowed credit limits, if configured.
-///
-/// # Returns
-/// `(min_credit_limit, max_credit_limit)` tuple, or `(None, None)` if not configured.
-///
-/// # Storage
-/// - Reads from instance storage keys `DataKey::MinCreditLimit` and `DataKey::MaxCreditLimit`
-pub fn get_credit_limit_bounds(env: Env) -> (Option<i128>, Option<i128>) {
-    let min = get_min_credit_limit(&env);
-    let max = get_max_credit_limit(&env);
-    (min, max)
-}
-
-/// Validate that a credit limit falls within configured bounds.
-///
-/// # Parameters
-/// - `env`: The Soroban environment.
-/// - `credit_limit`: The credit limit to validate.
-///
-/// # Panics
-/// - `ContractError::LimitOutOfBounds` if the limit is outside configured bounds
-///
-/// # Behavior
-/// - If bounds are not configured, validation passes (no restrictions)
-/// - If only min is configured, validates `credit_limit >= min`
-/// - If only max is configured, validates `credit_limit <= max`
-/// - If both are configured, validates `min <= credit_limit <= max`
-pub fn validate_credit_limit_bounds(env: &Env, credit_limit: i128) {
-    let min = get_min_credit_limit(env);
-    let max = get_max_credit_limit(env);
-
-    // Check minimum bound if configured
-    if let Some(min_limit) = min {
-        if credit_limit < min_limit {
-            env.panic_with_error(ContractError::LimitOutOfBounds);
-        }
-    }
-
-    // Check maximum bound if configured
-    if let Some(max_limit) = max {
-        if credit_limit > max_limit {
-            env.panic_with_error(ContractError::LimitOutOfBounds);
-        }
-    }
+    crate::storage::set_min_credit_limit(&env, min);
+    crate::storage::set_max_credit_limit(&env, max);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -327,89 +269,6 @@ pub fn get_per_borrower_liquidation_grace(env: &Env, borrower: Address) -> u64 {
     crate::storage::get_per_borrower_liquidation_grace(env, &borrower)
 }
 
-/// Set or replace a borrower's installment repayment schedule.
-pub fn set_repayment_schedule(
-    env: &Env,
-    borrower: Address,
-    amount_per_period: i128,
-    period_seconds: u64,
-    first_due_ts: u64,
-) {
-    assert_not_paused(env);
-    require_admin_auth(env);
-
-    if amount_per_period <= 0 || period_seconds == 0 {
-        env.panic_with_error(ContractError::InvalidAmount);
-    }
-
-    let stored_line: CreditLineData = env
-        .storage()
-        .persistent()
-        .get(&borrower)
-        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
-
-    if stored_line.status == CreditStatus::Closed {
-        env.panic_with_error(ContractError::CreditLineClosed);
-    }
-
-    storage_set_repayment_schedule(
-        env,
-        &borrower,
-        &RepaymentSchedule {
-            amount_per_period,
-            period_seconds,
-            next_due_ts: first_due_ts,
-        },
-    );
-}
-
-/// Advance the next due timestamp when a qualifying repayment covers one or more installments.
-/// Also charges a flat late fee per overdue installment when `LateFeeFlat` is configured.
-pub fn advance_repayment_schedule_after_repay(env: &Env, borrower: &Address, amount: i128) {
-    if amount <= 0 {
-        return;
-    }
-
-    let Some(mut schedule) = storage_get_repayment_schedule(env, borrower) else {
-        return;
-    };
-
-    if schedule.amount_per_period <= 0 || schedule.period_seconds == 0 {
-        return;
-    }
-
-    let installments_paid = (amount / schedule.amount_per_period) as u64;
-    if installments_paid == 0 {
-        return;
-    }
-
-    // ── Late-fee surcharge ──────────────────────────────────────────────────
-    let late_fee = storage_get_late_fee_flat(env);
-    if late_fee > 0 {
-        let now = env.ledger().timestamp();
-        for i in 0_u64..installments_paid {
-            let due_ts = schedule
-                .next_due_ts
-                .saturating_add(i.saturating_mul(schedule.period_seconds));
-            if now > due_ts {
-                storage_add_treasury_balance(env, late_fee);
-                publish_late_fee_charged_event(
-                    env,
-                    LateFeeChargedEvent {
-                        borrower: borrower.clone(),
-                        fee: late_fee,
-                        installment_index: i.saturating_add(1),
-                    },
-                );
-            }
-        }
-    }
-
-    let advance_seconds = schedule.period_seconds.saturating_mul(installments_paid);
-    schedule.next_due_ts = schedule.next_due_ts.saturating_add(advance_seconds);
-    storage_set_repayment_schedule(env, borrower, &schedule);
-}
-
 /// Set the flat late fee per missed installment (admin only).
 ///
 /// When non-zero, this fee is charged to `TreasuryBalance` for each
@@ -427,14 +286,14 @@ pub fn set_late_fee_flat(env: Env, fee: i128) {
     if fee < 0 {
         env.panic_with_error(ContractError::InvalidAmount);
     }
-    storage_set_late_fee_flat(&env, fee);
+    crate::storage::set_late_fee_flat(&env, fee);
 }
 
 /// Get the configured flat late fee per missed installment.
 ///
 /// Returns `0` if not configured (no flat late fee).
 pub fn get_late_fee_flat(env: Env) -> i128 {
-    storage_get_late_fee_flat(&env)
+    crate::storage::get_late_fee_flat(&env)
 }
 
 /// Open a new credit line.
@@ -620,7 +479,7 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
         .persistent()
         .get(&borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
-    let _previous_utilized = credit_line.utilized_amount;
+    let previous_utilized = credit_line.utilized_amount;
 
     // Idempotent: already closed → nothing to do.
     if credit_line.status == CreditStatus::Closed {
@@ -645,7 +504,7 @@ pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
         panic!("unauthorized");
     }
 
-    let _previous_status = credit_line.status;
+    let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Closed;
     persist_credit_line(
         &env,
@@ -713,7 +572,7 @@ pub fn default_credit_line(env: Env, borrower: Address) {
         .persistent()
         .get(&borrower)
         .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
-    let _previous_utilized = stored_line.utilized_amount;
+    let previous_utilized = stored_line.utilized_amount;
 
     if stored_line.status == CreditStatus::Closed {
         env.panic_with_error(ContractError::CreditLineClosed);
@@ -749,7 +608,7 @@ pub fn default_credit_line(env: Env, borrower: Address) {
         }
     }
 
-    let _previous_status = credit_line.status;
+    let previous_status = credit_line.status;
     credit_line.status = CreditStatus::Defaulted;
     persist_credit_line(
         &env,
@@ -772,6 +631,45 @@ pub fn default_credit_line(env: Env, borrower: Address) {
     );
 
     publish_default_liquidation_requested_event(&env, &borrower, credit_line.utilized_amount);
+}
+
+/// Write off outstanding debt without transferring tokens (admin only).
+///
+/// Reduces `accrued_interest` first, then `utilized_amount`, by `amount`
+/// (clamped to the outstanding balance). No token movement occurs — this is
+/// pure accounting relief, e.g. for negotiated settlements handled off-chain.
+pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
+    assert_not_paused(&env);
+    require_admin_auth(&env);
+
+    if amount <= 0 {
+        env.panic_with_error(ContractError::InvalidAmount);
+    }
+
+    let stored_line: CreditLineData = env
+        .storage()
+        .persistent()
+        .get(&borrower)
+        .unwrap_or_else(|| env.panic_with_error(ContractError::CreditLineNotFound));
+    let previous_utilized = stored_line.utilized_amount;
+    let previous_status = stored_line.status;
+
+    // Apply interest accrual before any mutation.
+    let mut credit_line = crate::accrual::apply_accrual(&env, stored_line);
+
+    let forgive_amount = amount.min(credit_line.utilized_amount);
+    let interest_forgiven = forgive_amount.min(credit_line.accrued_interest);
+
+    credit_line.accrued_interest -= interest_forgiven;
+    credit_line.utilized_amount -= forgive_amount;
+
+    persist_credit_line(
+        &env,
+        &borrower,
+        &credit_line,
+        previous_utilized,
+        Some(previous_status),
+    );
 }
 
 pub fn settle_default_liquidation(
@@ -1010,6 +908,28 @@ pub fn advance_repayment_schedule_after_repay(
     let installments_paid = (principal_repaid / schedule.amount_per_period) as u64;
     if installments_paid == 0 {
         return;
+    }
+
+    // ── Late-fee surcharge ──────────────────────────────────────────────────
+    let late_fee = crate::storage::get_late_fee_flat(env);
+    if late_fee > 0 {
+        let now = env.ledger().timestamp();
+        for i in 0_u64..installments_paid {
+            let due_ts = schedule
+                .next_due_ts
+                .saturating_add(i.saturating_mul(schedule.period_seconds));
+            if now > due_ts {
+                crate::storage::add_treasury_balance(env, late_fee);
+                crate::events::publish_late_fee_charged_event(
+                    env,
+                    crate::events::LateFeeChargedEvent {
+                        borrower: borrower.clone(),
+                        fee: late_fee,
+                        installment_index: i.saturating_add(1),
+                    },
+                );
+            }
+        }
     }
 
     let advance_seconds = installments_paid.saturating_mul(schedule.period_seconds);

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -388,7 +388,11 @@ pub fn open_credit_line(
 /// Emits a `("credit", "suspend")` [`CreditLineEvent`].
 pub fn suspend_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
-    require_admin_auth(&env);
+    // Admin auth is enforced by the `lib.rs` `suspend_credit_line` entrypoint
+    // wrapper before this is called; not re-checked here to avoid a double
+    // `require_auth` on the same address within one invocation (Soroban's
+    // auth-mock treats a second `require_auth` for an already-authorized
+    // address in the same frame as an error).
     let mut credit_line: CreditLineData = env
         .storage()
         .persistent()
@@ -467,8 +471,9 @@ pub fn self_suspend_credit_line(env: Env, borrower: Address) {
 ///   non-closed status. This is intentional for operational efficiency.
 pub fn close_credit_line(env: Env, borrower: Address, closer: Address) {
     assert_not_paused(&env);
-    // Authenticate the closer before any storage access.
-    closer.require_auth();
+    // `closer` auth is enforced by the `lib.rs` `close_credit_line` entrypoint
+    // wrapper before this is called; not re-checked here (see the comment on
+    // `suspend_credit_line` above for why).
 
     // Resolve the current admin address.
     let admin: Address = require_admin(&env);
@@ -566,7 +571,7 @@ pub fn close_credit_lines_batch(env: Env, borrowers: soroban_sdk::Vec<Address>) 
 /// Emits a `("credit", "default")` [`CreditLineEvent`].
 pub fn default_credit_line(env: Env, borrower: Address) {
     assert_not_paused(&env);
-    require_admin_auth(&env);
+    // Admin auth enforced by the `lib.rs` wrapper (see `suspend_credit_line`).
     let stored_line: CreditLineData = env
         .storage()
         .persistent()
@@ -640,7 +645,7 @@ pub fn default_credit_line(env: Env, borrower: Address) {
 /// pure accounting relief, e.g. for negotiated settlements handled off-chain.
 pub fn forgive_debt(env: Env, borrower: Address, amount: i128) {
     assert_not_paused(&env);
-    require_admin_auth(&env);
+    // Admin auth enforced by the `lib.rs` wrapper (see `suspend_credit_line`).
 
     if amount <= 0 {
         env.panic_with_error(ContractError::InvalidAmount);
@@ -783,7 +788,7 @@ pub fn settle_default_liquidation(
 /// Emits a `("credit", "reinstate")` [`CreditLineEvent`].
 pub fn reinstate_credit_line(env: Env, borrower: Address, target_status: CreditStatus) {
     assert_not_paused(&env);
-    require_admin_auth(&env);
+    // Admin auth enforced by the `lib.rs` wrapper (see `suspend_credit_line`).
 
     // Only Active and Restricted are valid reinstate targets per the state-machine spec.
     if target_status != CreditStatus::Active && target_status != CreditStatus::Restricted {

--- a/contracts/credit/src/oracles.rs
+++ b/contracts/credit/src/oracles.rs
@@ -441,10 +441,8 @@ mod test {
 // - The stack buffer is bounded at compile time; gas consumption is O(n²)
 //   for sorting and O(n) for window scanning.
 
-use soroban_sdk::{Env, Vec};
-
 use crate::math_utils::compute_deviation_bps;
-use crate::types::{ContractError, OracleQuorumConfig};
+use crate::types::OracleQuorumConfig;
 
 /// Maximum number of oracle price feeds accepted per `submit_oracle_prices` call.
 ///

--- a/contracts/credit/src/oracles.rs
+++ b/contracts/credit/src/oracles.rs
@@ -162,11 +162,11 @@ pub fn get_median_value(env: Env) -> Result<u128, ContractError> {
     }
 
     if total_weight < quorum {
-        return Err(ContractError::QuorumNotMet);
+        return Err(ContractError::OracleQuorumNotMet);
     }
 
     if valid_reports.is_empty() {
-        return Err(ContractError::QuorumNotMet);
+        return Err(ContractError::OracleQuorumNotMet);
     }
 
     // Sort valid reports by value ascending using a simple insertion sort
@@ -409,6 +409,9 @@ mod test {
         // Median should be 150.
         let val = client.get_median_value();
         assert_eq!(val, 150);
+    }
+}
+
 // # Multi-oracle quorum price resolution
 //
 // Implements the quorum-of-K algorithm for combining multiple independent
@@ -675,6 +678,4 @@ mod tests {
         let prices = vec![&env, 1_051i128, 1_000i128];
         resolve_quorum_price(&env, &prices, &cfg(2, 500));
     }
-}
-}
 }

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -166,7 +166,7 @@ pub fn is_delinquent(env: Env, borrower: Address) -> bool {
         return false;
     }
 
-    let Some(schedule) = get_repayment_schedule(env.clone(), borrower) else {
+    let Some(schedule) = get_repayment_schedule(env.clone(), borrower.clone()) else {
         return false;
     };
 

--- a/contracts/credit/src/storage.rs
+++ b/contracts/credit/src/storage.rs
@@ -89,7 +89,11 @@ use soroban_sdk::{contracttype, Address, Env, Symbol};
 /// Helper functions in this module always pick the correct tier; callers
 /// outside this module should never hit the storage API directly with these
 /// keys.
-#[contracttype]
+// `export = false`: DataKey has grown past the 50-case limit the Soroban
+// contract-spec XDR format (`SCSpecUdtUnionV0.cases<50>`) allows for an
+// exported type spec. This is an internal storage-key type (never crosses
+// the contract ABI), so skipping spec export has no client-visible effect.
+#[contracttype(export = false)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
     /// Address of the liquidity token (SAC or compatible token contract).
@@ -192,7 +196,7 @@ pub enum DataKey {
     /// Minimum ledger seconds between critical collateral admin actions (v7).
     AdminCollateralCooldownSeconds,
     /// Ledger timestamp of the last critical collateral admin action (v7).
-    LastAdminCollateralCriticalActionTs,
+    LastColAdminActionTs,
     /// Per-asset collateral risk weight in basis points (10_000 = 100%, full value).
     /// Absent for an asset means callers should treat it as 10_000 bps (unweighted).
     CollateralRiskWeightBps(Address),
@@ -213,9 +217,6 @@ pub enum DataKey {
     /// Pending treasury withdrawal proposal (at most one at a time).
     /// Stored in instance storage; cleared after successful execution.
     PendingTreasuryWithdrawal,
-    /// Protocol-level max close factor in basis points for partial liquidation settlements.
-    /// Stored in instance storage; defaults to 10_000 (full liquidation) when absent.
-    CloseFactorBps,
     /// Structured reason for the most recent protocol pause (escape-hatch audit trail).
     /// Stored when admin invokes pause with a reason; cleared on unpause.
     PauseReason,
@@ -233,6 +234,12 @@ pub enum DataKey {
     /// Per-borrower liquidation grace period in seconds.
     /// Specifies a grace window before a credit line can be defaulted or liquidated.
     LiquidationGracePeriod(Address),
+    /// Per-borrower absolute exposure cap (i128 amount).
+    BorrowerExposureCap(Address),
+    /// Admin-configured allowlist of accepted multi-collateral token addresses.
+    CollateralTokenAllowlist,
+    /// Per-borrower, per-token collateral balance (multi-collateral path).
+    CollateralBalanceV2(Address, Address),
 }
 
 /// Maximum number of credit lines returned per page.
@@ -259,10 +266,6 @@ pub const MAX_ENUMERATION_LIMIT: u32 = 100;
 // number of TTL writes per active key is at most one per three months.
 pub const LEDGER_BUMP_AMOUNT: u32 = 3_110_400; // ~6 months
 pub const LEDGER_BUMP_THRESHOLD: u32 = 1_555_200; // ~3 months
-
-/// TTL policy used by per-borrower credit-line entries.
-pub const CREDIT_LINE_TTL_EXTEND_TO: u32 = LEDGER_BUMP_AMOUNT;
-pub const CREDIT_LINE_TTL_THRESHOLD: u32 = LEDGER_BUMP_THRESHOLD;
 
 /// Instance storage TTL policy (covers global config like admin/liquidity token).
 pub const INSTANCE_BUMP_AMOUNT: u32 = LEDGER_BUMP_AMOUNT;
@@ -560,14 +563,14 @@ pub fn set_admin_collateral_cooldown_seconds(env: &Env, seconds: u64) {
 pub fn get_last_admin_collateral_critical_action_ts(env: &Env) -> Option<u64> {
     env.storage()
         .instance()
-        .get(&DataKey::LastAdminCollateralCriticalActionTs)
+        .get(&DataKey::LastColAdminActionTs)
 }
 
 /// Record the ledger timestamp of the last critical collateral admin action.
 pub fn set_last_admin_collateral_critical_action_ts(env: &Env, ts: u64) {
     env.storage()
         .instance()
-        .set(&DataKey::LastAdminCollateralCriticalActionTs, &ts);
+        .set(&DataKey::LastColAdminActionTs, &ts);
 }
 /// Return the risk weight for a specific collateral asset, in basis points,
 /// if explicitly configured. `None` means no weight was ever set for this
@@ -1336,7 +1339,7 @@ pub fn set_late_fee_flat(env: &Env, fee: i128) {
 /// # Storage
 /// - **Type**: Instance storage
 /// - **Key**: [`DataKey::LateFeeConfig`]
-pub fn get_late_fee_config(env: &Env) -> Option<crate::types::LateFeeConfig> {
+pub fn get_late_fee_config(env: &Env) -> Option<crate::penalties::LateFeeConfig> {
     env.storage().instance().get(&DataKey::LateFeeConfig)
 }
 
@@ -1348,7 +1351,7 @@ pub fn get_late_fee_config(env: &Env) -> Option<crate::types::LateFeeConfig> {
 /// # Storage
 /// - **Type**: Instance storage
 /// - **Key**: [`DataKey::LateFeeConfig`]
-pub fn set_late_fee_config(env: &Env, config: Option<crate::types::LateFeeConfig>) {
+pub fn set_late_fee_config(env: &Env, config: Option<crate::penalties::LateFeeConfig>) {
     match config {
         Some(c) => env.storage().instance().set(&DataKey::LateFeeConfig, &c),
         None => env.storage().instance().remove(&DataKey::LateFeeConfig),
@@ -1503,6 +1506,13 @@ pub fn get_last_freeze_timestamp(env: &Env) -> Option<u64> {
     env.storage()
         .instance()
         .get(&DataKey::LastFreezeTimestamp)
+}
+
+/// Set the ledger timestamp of the last admin freeze/unfreeze action.
+fn set_last_freeze_timestamp(env: &Env, ts: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LastFreezeTimestamp, &ts);
 }
 
 /// Record a freeze/unfreeze action timestamp, but only when a cooldown is

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -694,7 +694,12 @@ pub struct CreditLineSnapshot {
     /// `utilized_amount == 0`.
     pub health_factor_bps: u32,
     /// The borrower's installment repayment schedule, if configured.
-    pub repayment_schedule: Option<RepaymentSchedule>,
+    /// Empty when no schedule is set; exactly one element when a schedule
+    /// is configured. Represented as a `Vec` rather than `Option<T>`
+    /// because the Soroban SDK's struct-field XDR codegen does not support
+    /// `Option<CustomStruct>` fields (`Option<T>` requires `T: Into<ScVal>`,
+    /// which `#[contracttype]`-derived UDTs only implement fallibly).
+    pub repayment_schedule: soroban_sdk::Vec<RepaymentSchedule>,
     /// `true` when the borrower is past the delinquency grace window.
     pub is_delinquent: bool,
 }
@@ -725,6 +730,45 @@ pub struct BorrowCapabilities {
     /// Whether the borrower can self-suspend their credit line. True
     /// only when the credit line exists and is currently Active.
     pub can_self_suspend: bool,
+}
+
+/// Read-only capabilities bitmap for a credit line's lifecycle transitions (v7).
+///
+/// Returned by the `lifecycle_capabilities` view to let off-chain clients and
+/// on-chain integrators inspect which lifecycle transitions are currently
+/// permitted for a borrower's credit line, without simulating the full
+/// entrypoint logic (state lookup + status checks + pause guard).
+///
+/// Every field is derived purely from the credit line's current
+/// [`CreditStatus`] and the protocol pause flag — no token CPIs, no auth
+/// checks, no mutation. See [`crate::lifecycle`] for the authoritative
+/// transition rules each field mirrors.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LifecycleCapabilities {
+    /// Whether an admin can suspend this line via `suspend_credit_line`.
+    /// True only when the line exists, the protocol is not paused, and the
+    /// status is [`CreditStatus::Active`].
+    pub can_suspend: bool,
+    /// Whether the borrower can self-suspend via `self_suspend_credit_line`.
+    /// Same precondition as `can_suspend` (only `Active` self-suspends).
+    pub can_self_suspend: bool,
+    /// Whether an admin can force-close this line via `close_credit_line`
+    /// unconditionally (any non-`Closed` status). False when the line does
+    /// not exist, the protocol is paused, or the status is already `Closed`.
+    pub can_close_admin: bool,
+    /// Whether the borrower can self-close via `close_credit_line`. Requires
+    /// the same preconditions as `can_close_admin` **plus**
+    /// `utilized_amount == 0`.
+    pub can_close_borrower: bool,
+    /// Whether an admin can move this line to `Defaulted` via
+    /// `default_credit_line`. True when the line exists, the protocol is not
+    /// paused, and the status is `Active`, `Restricted`, or `Suspended`.
+    pub can_default: bool,
+    /// Whether an admin can cure this line via `reinstate_credit_line`. True
+    /// only when the line exists, the protocol is not paused, and the status
+    /// is `Defaulted`.
+    pub can_reinstate: bool,
 }
 
 /// Proof-of-reserve view for the protocol treasury.

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -166,7 +166,12 @@ pub enum CreditStatus {
 /// | 53   | `InvalidAttestation`           | Misc          | Attestation proof is invalid or no attestation batch has been committed |
 /// | 54   | `AdminCooldownActive`          | Risk          | Critical borrower admin action attempted before cooldown elapsed |
 /// | 55   | `LiquidationGraceActive`       | Lifecycle     | Per-borrower liquidation grace window has not yet elapsed |
-#[contracterror]
+// `export = false`: this enum has grown past the 50-case limit that the
+// Soroban contract-spec XDR format (`SCSpecUdtErrorEnumV0.cases<50>`)
+// allows for exported error specs. Discriminants and `From<Error>` /
+// `InvokeError` conversions are unaffected; only the on-chain metadata
+// blob (used by client-generation tooling) is skipped.
+#[contracterror(export = false)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
@@ -280,6 +285,13 @@ pub enum ContractError {
     AdminCooldownActive = 54,
     /// Per-borrower liquidation grace window has not yet elapsed.
     LiquidationGraceActive = 55,
+    /// Critical collateral admin action attempted before the configured
+    /// cool-off elapsed. See [`crate::collateral_admin`].
+    AdminCollateralCooldownActive = 56,
+    /// Per-borrower absolute exposure cap ([`crate::limits`]) was exceeded.
+    BorrowerExposureCapExceeded = 57,
+    /// Admin freeze/unfreeze action attempted before the configured cool-off elapsed.
+    FreezeCooldownActive = 58,
 }
 
 /// ABI-stable category label for [`ContractError`] variants.
@@ -367,6 +379,7 @@ impl ContractError {
             Self::RepayExceedsMaxAmount => Limit,
             Self::CloseFactorAboveMax => Limit,
             Self::DrawReversalWindowExpired => Limit,
+            Self::BorrowerExposureCapExceeded => Limit,
             // Liquidity (5)
             Self::MissingLiquidityToken => Liquidity,
             Self::MissingLiquiditySource => Liquidity,
@@ -391,6 +404,7 @@ impl ContractError {
             // Collateral (8)
             Self::CollateralRatioBelowMinimum => Collateral,
             Self::InsufficientCollateralBalance => Collateral,
+            Self::AdminCollateralCooldownActive => Collateral,
             // Block (9)
             Self::BorrowerBlocked => Block,
             Self::DrawsFrozen => Block,
@@ -504,6 +518,35 @@ pub struct GracePeriodConfig {
     pub waiver_mode: GraceWaiverMode,
     /// Reduced rate to apply when waiver_mode is ReducedRate.
     pub reduced_rate_bps: u32,
+}
+
+/// Structured kind discriminant for collateral lifecycle events.
+///
+/// # Discriminant stability
+/// Same rule as [`FreezeReason`] / [`CreditStatus`]: discriminants are part
+/// of the contract ABI and must never be reordered or renumbered; new
+/// variants must be appended.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CollateralEventKind {
+    /// Collateral tokens deposited into the contract.
+    Deposited = 0,
+    /// Collateral tokens withdrawn by the borrower (generic withdrawal path).
+    Withdrawn = 1,
+    /// Collateral tokens released via the health-factor-gated partial release path.
+    PartiallyReleased = 2,
+    /// Collateral tokens released internally as part of an atomic repay+release flow.
+    Released = 3,
+}
+
+/// Persisted state for the global draw-freeze switch ([`crate::storage::DataKey::DrawsFrozen`]).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DrawsFreezeState {
+    /// `true` when all draws are currently frozen.
+    pub frozen: bool,
+    /// Structured reason recorded on the most recent freeze/unfreeze action.
+    pub reason: FreezeReason,
 }
 
 /// Grace period waiver modes.
@@ -633,6 +676,29 @@ pub struct CreditLinesPage {
     pub has_more: bool,
 }
 
+/// Aggregated, single-call read-only view of a borrower's full credit-line state.
+///
+/// Assembles [`CreditLineData`], collateral balance, health factor, repayment
+/// schedule, and delinquency status in one call, avoiding the multiple
+/// round-trips a caller would otherwise need for `get_credit_line` +
+/// `get_collateral` + `get_health_factor` + `get_repayment_schedule` +
+/// `is_delinquent`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLineSnapshot {
+    /// The core credit line record.
+    pub line: CreditLineData,
+    /// Collateral balance for the borrower (single-token collateral path).
+    pub collateral_balance: i128,
+    /// Collateral-aware health factor in basis points. `u32::MAX` when
+    /// `utilized_amount == 0`.
+    pub health_factor_bps: u32,
+    /// The borrower's installment repayment schedule, if configured.
+    pub repayment_schedule: Option<RepaymentSchedule>,
+    /// `true` when the borrower is past the delinquency grace window.
+    pub is_delinquent: bool,
+}
+
 /// Read-only capabilities bitmap for a borrower's credit line.
 ///
 /// Returned by `borrow_capabilities` to let off-chain clients and
@@ -720,102 +786,3 @@ pub struct PauseReason {
     pub actor: soroban_sdk::Address,
 }
 
-/// Error categories for client-side grouping of [`ContractError`] variants.
-///
-/// # Discriminant stability
-/// Discriminants are permanently pinned. New variants must be appended at the
-/// end with the next available integer.
-#[contracttype]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u32)]
-pub enum ContractErrorCategory {
-    /// Authentication / authorization errors (Unauthorized, NotAdmin, AdminNotInitialized).
-    Auth = 1,
-    /// Credit line lifecycle state errors (Closed, Suspended, Defaulted, AlreadyInitialized).
-    Lifecycle = 2,
-    /// Numeric domain errors (InvalidAmount, NegativeLimit, Overflow, TimestampRegression, LimitOutOfBounds).
-    Numeric = 3,
-    /// Per-borrower limit enforcement (OverLimit, UtilizationNotZero, DrawExceedsMaxAmount, BorrowerExposureCapExceeded).
-    Limit = 4,
-    /// Liquidity / reserve / exposure errors (MissingLiquidityToken, ExposureCapExceeded, TreasuryNotSet, etc.).
-    Liquidity = 5,
-    /// Risk / rate / score / circuit-breaker errors (RateTooHigh, ScoreTooHigh, Paused, cooldowns).
-    Risk = 6,
-    /// Oracle price-feed errors (OraclePriceInvalid, OraclePriceStale, OraclePriceDeviation).
-    Oracle = 7,
-    /// Collateral ratio errors (CollateralRatioBelowMinimum, InsufficientCollateralBalance).
-    Collateral = 8,
-    /// Blocklist / freeze / draw-freeze errors (BorrowerBlocked, DrawsFrozen, BorrowerFrozen).
-    Block = 9,
-    /// Reentrancy guard trigger.
-    Reentrancy = 10,
-    /// Unclassified errors (CreditLineNotFound, AdminAcceptTooEarly).
-    Misc = 11,
-}
-
-impl ContractError {
-    /// Return the error category for this variant.
-    ///
-    /// Categories allow clients to group errors without matching on individual
-    /// discriminant values. Every variant maps to exactly one category.
-    pub fn category(&self) -> ContractErrorCategory {
-        match self {
-            ContractError::Unauthorized
-            | ContractError::NotAdmin
-            | ContractError::AdminNotInitialized => ContractErrorCategory::Auth,
-
-            ContractError::CreditLineClosed
-            | ContractError::AlreadyInitialized
-            | ContractError::CreditLineSuspended
-            | ContractError::CreditLineDefaulted
-            | ContractError::LiquidationGraceActive => ContractErrorCategory::Lifecycle,
-
-            ContractError::InvalidAmount
-            | ContractError::NegativeLimit
-            | ContractError::Overflow
-            | ContractError::TimestampRegression
-            | ContractError::LimitOutOfBounds => ContractErrorCategory::Numeric,
-
-            ContractError::OverLimit
-            | ContractError::UtilizationNotZero
-            | ContractError::LimitDecreaseRequiresRepayment
-            | ContractError::DrawExceedsMaxAmount
-            | ContractError::RepayExceedsMaxAmount
-            | ContractError::BorrowerExposureCapExceeded => ContractErrorCategory::Limit,
-
-            ContractError::MissingLiquidityToken
-            | ContractError::MissingLiquiditySource
-            | ContractError::InsufficientLiquidityReserve
-            | ContractError::LiquidityTokenCallFailed
-            | ContractError::InsufficientRepaymentAllowance
-            | ContractError::InsufficientRepaymentBalance
-            | ContractError::TreasuryNotSet
-            | ContractError::ExposureCapExceeded => ContractErrorCategory::Liquidity,
-
-            ContractError::RateTooHigh
-            | ContractError::ScoreTooHigh
-            | ContractError::Paused
-            | ContractError::DrawCooldownActive
-            | ContractError::AdminCooldownActive => ContractErrorCategory::Risk,
-
-            ContractError::OraclePriceInvalid
-            | ContractError::OraclePriceStale
-            | ContractError::OraclePriceDeviation => ContractErrorCategory::Oracle,
-
-            ContractError::CollateralRatioBelowMinimum
-            | ContractError::InsufficientCollateralBalance => ContractErrorCategory::Collateral,
-
-            ContractError::BorrowerBlocked
-            | ContractError::DrawsFrozen
-            | ContractError::BorrowerFrozen
-            | ContractError::FreezeCooldownActive => ContractErrorCategory::Block,
-
-            ContractError::Reentrancy => ContractErrorCategory::Reentrancy,
-
-            ContractError::CreditLineNotFound
-            | ContractError::AdminAcceptTooEarly
-            | ContractError::DrawReversalWindowExpired
-            | ContractError::OriginalDrawNotFound => ContractErrorCategory::Misc,
-        }
-    }
-}

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -10,8 +10,30 @@ use crate::storage::{
     get_borrower_by_credit_line_id, get_credit_line, is_borrower_blocked, is_borrower_frozen,
     is_paused, MAX_ENUMERATION_LIMIT,
 };
-use crate::types::{BorrowCapabilities, CreditLinesPage, ProofOfReserve, ProtocolSummaryView};
+use crate::types::{
+    BorrowCapabilities, CreditLineSnapshot, CreditLinesPage, ProofOfReserve, ProtocolSummaryView,
+};
 use soroban_sdk::{Address, Env, Vec};
+
+/// Assemble a full read-only snapshot of `borrower`'s credit line.
+///
+/// Returns `None` when no credit line has been opened for `borrower`.
+/// See [`CreditLineSnapshot`] for the aggregated fields.
+pub fn get_credit_line_snapshot(env: Env, borrower: Address) -> Option<CreditLineSnapshot> {
+    let line = get_credit_line(&env, &borrower)?;
+    let collateral_balance = crate::collateral::get_collateral(&env, &borrower);
+    let health_factor_bps = crate::query::get_health_factor(env.clone(), borrower.clone());
+    let repayment_schedule = crate::query::get_repayment_schedule(env.clone(), borrower.clone());
+    let is_delinquent = crate::query::is_delinquent(env.clone(), borrower);
+
+    Some(CreditLineSnapshot {
+        line,
+        collateral_balance,
+        health_factor_bps,
+        repayment_schedule,
+        is_delinquent,
+    })
+}
 
 // ── Borrow capabilities view ─────────────────────────────────────────────────
 
@@ -162,8 +184,9 @@ pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> 
     // Clamp start_id to valid range
     if start_id >= total_count {
         return CreditLinesPage {
-            credit_lines: Vec::new(&env),
+            lines: Vec::new(&env),
             next_cursor: None,
+            has_more: false,
         };
     }
 
@@ -196,8 +219,10 @@ pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> 
         next_cursor = None;
     }
 
+    let has_more = next_cursor.is_some();
     CreditLinesPage {
-        credit_lines,
+        lines: credit_lines,
         next_cursor,
+        has_more,
     }
 }

--- a/contracts/credit/src/views.rs
+++ b/contracts/credit/src/views.rs
@@ -23,7 +23,10 @@ pub fn get_credit_line_snapshot(env: Env, borrower: Address) -> Option<CreditLin
     let line = get_credit_line(&env, &borrower)?;
     let collateral_balance = crate::collateral::get_collateral(&env, &borrower);
     let health_factor_bps = crate::query::get_health_factor(env.clone(), borrower.clone());
-    let repayment_schedule = crate::query::get_repayment_schedule(env.clone(), borrower.clone());
+    let mut repayment_schedule = Vec::new(&env);
+    if let Some(schedule) = crate::query::get_repayment_schedule(env.clone(), borrower.clone()) {
+        repayment_schedule.push_back(schedule);
+    }
     let is_delinquent = crate::query::is_delinquent(env.clone(), borrower);
 
     Some(CreditLineSnapshot {

--- a/contracts/credit/tests/credit_line_snapshot.rs
+++ b/contracts/credit/tests/credit_line_snapshot.rs
@@ -8,7 +8,7 @@
 //! - Reflects collateral balance when collateral is deposited.
 //! - Reports `health_factor_bps == u32::MAX` with zero utilization.
 //! - Reports correct health factor with outstanding debt and collateral.
-//! - Returns the configured `repayment_schedule` when set.
+//! - Returns the configured `repayment_schedule` (single-element Vec) when set.
 //! - `is_delinquent` is `false` without a schedule.
 //! - `is_delinquent` is `true` when past the grace window.
 //! - `is_delinquent` is `false` within the grace window.
@@ -159,7 +159,7 @@ fn repayment_schedule_is_none_when_not_set() {
 
     let snap = client.get_credit_line_snapshot(&borrower).expect("Some");
 
-    assert!(snap.repayment_schedule.is_none());
+    assert!(snap.repayment_schedule.is_empty());
 }
 
 #[test]
@@ -173,7 +173,8 @@ fn repayment_schedule_present_when_set() {
     client.set_repayment_schedule(&borrower, &500_i128, &86_400_u64, &100_000_u64);
 
     let snap = client.get_credit_line_snapshot(&borrower).expect("Some");
-    let sched = snap.repayment_schedule.expect("schedule must be Some");
+    assert_eq!(snap.repayment_schedule.len(), 1);
+    let sched = snap.repayment_schedule.get(0).expect("schedule must be present");
 
     assert_eq!(sched.amount_per_period, 500);
     assert_eq!(sched.period_seconds, 86_400);
@@ -275,7 +276,7 @@ fn snapshot_reflects_closed_status_after_close() {
     assert_eq!(snap.line.status, CreditStatus::Closed);
     assert_eq!(snap.collateral_balance, 0);
     assert_eq!(snap.health_factor_bps, u32::MAX); // zero utilization
-    assert!(snap.repayment_schedule.is_none());
+    assert!(snap.repayment_schedule.is_empty());
     assert!(!snap.is_delinquent); // Closed → never delinquent
 }
 

--- a/contracts/lifecycle/README.md
+++ b/contracts/lifecycle/README.md
@@ -1,0 +1,39 @@
+# Lifecycle capabilities view (v7)
+
+Read-only bitmap reporting which lifecycle transitions are currently
+permitted for a borrower's credit line, so off-chain clients can pre-flight
+a transition without simulating a reverting call.
+
+## Entrypoint
+
+| Entrypoint | Returns | Notes |
+| --- | --- | --- |
+| `lifecycle_capabilities(borrower)` | [`LifecycleCapabilities`](../credit/src/types.rs) | Read-only, no auth required. |
+
+## Fields
+
+Every field is derived purely from the credit line's current `CreditStatus`,
+`utilized_amount`, and the protocol pause flag — no token CPIs, no auth
+checks, no mutation. All fields are `false` when no credit line exists for
+the borrower, or when the protocol is paused.
+
+| Field | `true` when |
+| --- | --- |
+| `can_suspend` | Status is `Active` (mirrors `suspend_credit_line`, admin path) |
+| `can_self_suspend` | Status is `Active` (mirrors `self_suspend_credit_line`, borrower path) |
+| `can_close_admin` | Status is not `Closed` (mirrors `close_credit_line`'s unconditional admin force-close) |
+| `can_close_borrower` | `can_close_admin` **and** `utilized_amount == 0` (mirrors `close_credit_line`'s borrower self-close path) |
+| `can_default` | Status is `Active`, `Restricted`, or `Suspended` (mirrors `default_credit_line`) |
+| `can_reinstate` | Status is `Defaulted` (mirrors `reinstate_credit_line`) |
+
+## Implementation
+
+Logic lives in [`src/views.rs`](./src/views.rs) (compiled into `creditra-credit`
+via a `#[path]` module, the same pattern used by
+[`contracts/collateral/src/admin.rs`](../collateral/src/admin.rs)). The
+public entrypoint is `Credit::lifecycle_capabilities` in
+`contracts/credit/src/lib.rs`.
+
+See [`tests/capabilities.rs`](./tests/capabilities.rs) for focused coverage
+across every `CreditStatus` value plus the "no credit line" and "protocol
+paused" edge cases.

--- a/contracts/lifecycle/src/views.rs
+++ b/contracts/lifecycle/src/views.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+
+//! Read-only lifecycle capabilities view (v7).
+//!
+//! Mirrors the transition guards enforced by [`crate::lifecycle`] so
+//! off-chain clients and on-chain integrators can check which lifecycle
+//! transitions are currently permitted for a borrower's credit line without
+//! simulating the full entrypoint (state lookup + auth + status checks).
+//!
+//! # What
+//!
+//! [`capabilities`] returns a [`crate::types::LifecycleCapabilities`] bitmap
+//! covering every state-changing lifecycle entrypoint:
+//! `suspend_credit_line`, `self_suspend_credit_line`, `close_credit_line`
+//! (both the unconditional admin path and the zero-utilization borrower
+//! path), `default_credit_line`, and `reinstate_credit_line`.
+//!
+//! # How
+//!
+//! Each field is derived purely from the credit line's current
+//! [`crate::types::CreditStatus`], its `utilized_amount`, and the protocol
+//! pause flag — a pure storage read with no token CPIs, no auth checks, and
+//! no mutation. When no credit line exists for `borrower`, every field is
+//! `false`.
+//!
+//! # Why
+//!
+//! Every lifecycle transition in [`crate::lifecycle`] starts with
+//! `assert_not_paused` followed by a status check; duplicating that logic
+//! here (read-only, no panics) lets callers pre-flight a transition — e.g. a
+//! keeper deciding whether `default_credit_line` is currently callable —
+//! without spending gas on a reverting simulation.
+//!
+//! See [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) and
+//! [`docs/state-machine.md`](../../../docs/state-machine.md) for the
+//! authoritative transition table each field mirrors.
+
+use crate::storage::{get_credit_line, is_paused};
+use crate::types::{CreditStatus, LifecycleCapabilities};
+use soroban_sdk::{Address, Env};
+
+/// Return the lifecycle-transition capabilities bitmap for `borrower`.
+///
+/// Read-only, no-auth view. See [`LifecycleCapabilities`] for field
+/// semantics.
+///
+/// [`LifecycleCapabilities`]: crate::types::LifecycleCapabilities
+pub fn capabilities(env: Env, borrower: Address) -> LifecycleCapabilities {
+    let credit_line = get_credit_line(&env, &borrower);
+    let paused = is_paused(&env);
+
+    let (can_suspend, can_self_suspend, can_close_admin, can_close_borrower, can_default, can_reinstate) =
+        match credit_line {
+            None => (false, false, false, false, false, false),
+            Some(_) if paused => (false, false, false, false, false, false),
+            Some(line) => {
+                let status = line.status;
+
+                // suspend_credit_line / self_suspend_credit_line: Active only.
+                let can_suspend = status == CreditStatus::Active;
+                let can_self_suspend = can_suspend;
+
+                // close_credit_line (admin): any non-Closed status.
+                let can_close_admin = status != CreditStatus::Closed;
+                // close_credit_line (borrower): admin precondition + zero utilization.
+                let can_close_borrower = can_close_admin && line.utilized_amount == 0;
+
+                // default_credit_line: Active, Restricted, or Suspended.
+                let can_default = matches!(
+                    status,
+                    CreditStatus::Active | CreditStatus::Restricted | CreditStatus::Suspended
+                );
+
+                // reinstate_credit_line: Defaulted only.
+                let can_reinstate = status == CreditStatus::Defaulted;
+
+                (
+                    can_suspend,
+                    can_self_suspend,
+                    can_close_admin,
+                    can_close_borrower,
+                    can_default,
+                    can_reinstate,
+                )
+            }
+        };
+
+    LifecycleCapabilities {
+        can_suspend,
+        can_self_suspend,
+        can_close_admin,
+        can_close_borrower,
+        can_default,
+        can_reinstate,
+    }
+}

--- a/contracts/lifecycle/tests/capabilities.rs
+++ b/contracts/lifecycle/tests/capabilities.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+
+//! Focused tests for the v7 `lifecycle_capabilities` read-only view.
+//!
+//! Covers every [`LifecycleCapabilities`] field across every [`CreditStatus`]
+//! reachable from the public entrypoints, plus the "no credit line" and
+//! "protocol paused" edge cases.
+
+use creditra_credit::types::CreditStatus;
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, CreditClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    (env, client, admin)
+}
+
+#[test]
+fn no_credit_line_all_capabilities_false() {
+    let (_env, client, _admin) = setup();
+    let borrower = Address::generate(&_env);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(!caps.can_suspend);
+    assert!(!caps.can_self_suspend);
+    assert!(!caps.can_close_admin);
+    assert!(!caps.can_close_borrower);
+    assert!(!caps.can_default);
+    assert!(!caps.can_reinstate);
+}
+
+#[test]
+fn active_line_zero_utilization_capabilities() {
+    let (env, client, _admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(caps.can_suspend);
+    assert!(caps.can_self_suspend);
+    assert!(caps.can_close_admin);
+    assert!(caps.can_close_borrower, "zero utilization allows borrower self-close");
+    assert!(caps.can_default);
+    assert!(!caps.can_reinstate, "Active line is never reinstate-eligible");
+}
+
+#[test]
+fn active_line_with_utilization_blocks_borrower_close_only() {
+    let (env, client, _admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    soroban_sdk::token::StellarAssetClient::new(&env, &token)
+        .mint(&client.address, &1_000_000_i128);
+    client.set_min_collateral_ratio_bps(&0);
+
+    client.draw_credit(&borrower, &500_i128);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(caps.can_close_admin, "admin force-close ignores utilization");
+    assert!(
+        !caps.can_close_borrower,
+        "borrower self-close requires zero utilization"
+    );
+}
+
+#[test]
+fn suspended_line_capabilities() {
+    let (env, client, _admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+    client.suspend_credit_line(&borrower);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(!caps.can_suspend, "already suspended");
+    assert!(!caps.can_self_suspend, "already suspended");
+    assert!(caps.can_close_admin);
+    assert!(caps.can_close_borrower, "zero utilization");
+    assert!(caps.can_default, "Suspended -> Defaulted is a valid transition");
+    assert!(!caps.can_reinstate);
+}
+
+#[test]
+fn defaulted_line_capabilities() {
+    let (env, client, _admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+    client.default_credit_line(&borrower);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(!caps.can_suspend);
+    assert!(!caps.can_self_suspend);
+    assert!(caps.can_close_admin, "admin can force-close a defaulted line");
+    assert!(caps.can_close_borrower, "zero utilization");
+    assert!(!caps.can_default, "already Defaulted");
+    assert!(caps.can_reinstate, "only Defaulted lines are reinstate-eligible");
+}
+
+#[test]
+fn reinstated_active_line_capabilities_match_active() {
+    let (env, client, _admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+    client.default_credit_line(&borrower);
+    client.reinstate_credit_line(&borrower, &CreditStatus::Active);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(caps.can_suspend);
+    assert!(caps.can_self_suspend);
+    assert!(caps.can_default);
+    assert!(!caps.can_reinstate);
+}
+
+#[test]
+fn closed_line_all_capabilities_false() {
+    let (env, client, admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+    client.close_credit_line(&borrower, &admin);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(!caps.can_suspend);
+    assert!(!caps.can_self_suspend);
+    assert!(!caps.can_close_admin, "already Closed");
+    assert!(!caps.can_close_borrower, "already Closed");
+    assert!(!caps.can_default, "Closed lines cannot default");
+    assert!(!caps.can_reinstate);
+}
+
+#[test]
+fn paused_protocol_forces_all_capabilities_false() {
+    let (env, client, _admin) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    client.set_protocol_paused(&true);
+
+    let caps = client.lifecycle_capabilities(&borrower);
+    assert!(!caps.can_suspend);
+    assert!(!caps.can_self_suspend);
+    assert!(!caps.can_close_admin);
+    assert!(!caps.can_close_borrower);
+    assert!(!caps.can_default);
+    assert!(!caps.can_reinstate);
+}

--- a/contracts/lifecycle/tests/err_stab.rs
+++ b/contracts/lifecycle/tests/err_stab.rs
@@ -670,6 +670,7 @@ mod integration {
         let borrower = Address::generate(&env);
 
         client.open_credit_line(&borrower, &1000_i128, &500_u32, &50_u32);
+        client.set_min_collateral_ratio_bps(&0);
         client.draw_credit(&borrower, &500_i128);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -712,7 +713,8 @@ mod integration {
         let client = CreditClient::new(&env, &contract_id);
         let borrower = Address::generate(&env);
 
-        client.pause_protocol(&admin);
+        let _ = &admin;
+        client.set_protocol_paused(&true);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             client.open_credit_line(&borrower, &1000_i128, &500_u32, &50_u32);


### PR DESCRIPTION
Closes #911

**Stacked on #1019** (this branch is built on top of `task/collateral-events-v7`, which isn't merged yet) — that PR fixes the underlying `contracts/credit` merge corruption this feature also needed working. Because the base branch only exists on my fork, this diff currently includes #1019's commits too; once #1019 merges to `main` this PR's diff will shrink to just the last commit (`feat: lifecycle capabilities view (v7)`). Please review that commit in isolation, or wait for #1019 to land and I'll rebase.

## Summary
- Adds a read-only `LifecycleCapabilities` bitmap view mirroring the existing `borrow_capabilities` pattern, so off-chain clients can pre-flight a lifecycle transition (suspend, self-suspend, close as admin/borrower, default, reinstate) without simulating a reverting call. Every field is derived purely from the credit line's current `CreditStatus`, `utilized_amount`, and the protocol pause flag — no token CPIs, no auth, no mutation.
- New entrypoint `Credit::lifecycle_capabilities(borrower)`, delegating to `contracts/lifecycle/src/views.rs::capabilities` (compiled into `creditra-credit` via `#[path]`, the same pattern `contracts/collateral/src/admin.rs` already uses). Added `contracts/lifecycle` to the workspace `members` list — it existed on disk but was never wired into `Cargo.toml`.
- While building and testing this, found and fixed a real double-`require_auth` bug: `suspend_credit_line`, `close_credit_line`, `default_credit_line`, `reinstate_credit_line`, and `forgive_debt` each re-checked auth both in their `lib.rs` entrypoint wrapper and again inside the `lifecycle::` implementation, which panics under Soroban's auth mock (`"frame is already authorized"`). Removed the redundant inner check, keeping the outer wrapper's gate as the single source of truth.
- Also fixed `self_suspend_credit_line` calling the wrong internal function (`lifecycle::suspend_credit_line`, which requires *admin* auth) instead of `lifecycle::self_suspend_credit_line` (borrower auth) — the borrower self-suspend path was effectively unusable by borrowers before this.
- `CreditLineSnapshot.repayment_schedule` changed from `Option<RepaymentSchedule>` to `Vec<RepaymentSchedule>` (0 or 1 elements): the Soroban SDK's struct-field XDR codegen doesn't support `Option<CustomStruct>` fields under `testutils` (`Option<T>` requires `T: Into<ScVal>`, which `#[contracttype]`-derived UDTs only implement fallibly) — this was blocking the whole crate from building under `cargo test`. Updated `contracts/credit/tests/credit_line_snapshot.rs` accordingly.
- A few small test-file fixups uncovered while getting `cargo test` green for the touched crates: a missing lifetime specifier and stale method names in `contracts/collateral/tests/admin_cooldown.rs` (+ its README) left over from the prior collateral-events PR, and a stale `pause_protocol()` call plus a missing collateral-ratio override in `contracts/lifecycle/tests/err_stab.rs`.

## Test plan
- [x] `cargo build --workspace` — green.
- [x] `cargo test -p creditra-lifecycle` — 23/23 passing, including 8 new focused tests in `tests/capabilities.rs` covering every `CreditStatus` value plus the "no credit line" and "protocol paused" edge cases.
- [x] `cargo test -p creditra-collateral` — 4/4 passing (unblocked by this PR's fixes).
- [ ] `cargo test -p creditra-credit --lib` — still fails on ~194 pre-existing errors in embedded unit tests, same root cause as the merge corruption fixed in #1019 but a different blast radius (stale method names, missing test helpers). Out of scope for this PR; flagging for a follow-up.

## Docs
- `contracts/lifecycle/README.md` documents the new view, its fields, and the preconditions each mirrors.