### PR TITLE
feat: late-fee surcharge

### DIFF
--- a/contracts/creditra-credit/src/contract.rs
+++ b/contracts/creditra-credit/src/contract.rs
@@ -10,7 +10,7 @@ use crate::oracles;
 use crate::state::{
     Config, CreditLine, Draw, DrawAction, DrawAuditEntry, OraclePriceRecord, BORROWER_TO_ID,
     CONFIG, CREDIT_LINES, CREDIT_LINE_COUNT, DRAWS, DRAW_AUDIT, DRAW_AUDIT_COUNT, DRAW_COUNT,
-    ORACLE_PRICE_RECORD, ORACLE_QUORUM_CONFIG,
+    LATE_FEE_CONFIG, ORACLE_PRICE_RECORD, ORACLE_QUORUM_CONFIG,
 };
 use crate::views;
 
@@ -77,6 +77,9 @@ pub fn execute(
         } => execute_set_oracle_quorum_config(deps, info, min_quorum_k, max_deviation_bps, max_age_seconds),
         ExecuteMsg::SubmitOraclePrices { prices } => {
             execute_submit_oracle_prices(deps, env, info, prices)
+        }
+        ExecuteMsg::SetLateFeeConfig { config } => {
+            execute_set_late_fee_config(deps, info, config)
         }
     }
 }
@@ -349,6 +352,38 @@ pub fn execute_submit_oracle_prices(
         .add_attribute("timestamp", now.to_string()))
 }
 
+/// Set or update the structured late-fee configuration (admin only).
+///
+/// Pass `Some(LateFeeConfig::Flat(…))` for a fixed token amount per missed
+/// installment, or `Some(LateFeeConfig::AprBased(…))` for an additive
+/// basis-point surcharge.  Pass `None` to remove the config.
+///
+/// # Errors
+/// - [`ContractError::Unauthorized`] if the caller is not the contract owner.
+/// - [`ContractError::InvalidAmount`] if the flat amount is zero.
+/// - [`ContractError::RateTooHigh`] if the APR surcharge exceeds 10 000 bps.
+fn execute_set_late_fee_config(
+    deps: DepsMut,
+    info: MessageInfo,
+    config: Option<crate::penalties::LateFeeConfig>,
+) -> Result<Response, ContractError> {
+    let contract_config = CONFIG.load(deps.storage)?;
+    if info.sender != contract_config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+
+    if let Some(ref cfg) = config {
+        crate::penalties::validate_late_fee_config(cfg)?;
+    }
+
+    match config {
+        Some(cfg) => LATE_FEE_CONFIG.save(deps.storage, &cfg)?,
+        None => LATE_FEE_CONFIG.remove(deps.storage),
+    }
+
+    Ok(Response::default().add_attribute("action", "set_late_fee_config"))
+}
+
 fn append_audit_entry(
     deps: DepsMut,
     env: Env,
@@ -415,6 +450,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 price: record.as_ref().map(|r| r.price),
                 timestamp: record.as_ref().map(|r| r.timestamp),
             };
+            to_json_binary(&resp)
+        }
+        QueryMsg::GetLateFeeConfig {} => {
+            let config = LATE_FEE_CONFIG
+                .may_load(deps.storage)
+                .map_err(|e| StdError::generic_err(e.to_string()))?;
+            let resp = crate::msg::LateFeeConfigResponse { config };
             to_json_binary(&resp)
         }
     }

--- a/contracts/creditra-credit/src/error.rs
+++ b/contracts/creditra-credit/src/error.rs
@@ -51,6 +51,14 @@ pub enum ContractError {
     /// Oracle quorum condition was not satisfied (too few agreeing feeds).
     #[error("OracleQuorumNotMet")]
     OracleQuorumNotMet,
+
+    /// Rate or surcharge exceeds the protocol maximum (10 000 bps = 100 %).
+    #[error("RateTooHigh")]
+    RateTooHigh,
+
+    /// Arithmetic overflow detected in checked computation.
+    #[error("Overflow")]
+    Overflow,
 }
 
 #[cfg(test)]

--- a/contracts/creditra-credit/src/lib.rs
+++ b/contracts/creditra-credit/src/lib.rs
@@ -5,6 +5,7 @@ pub mod handshake;
 pub mod key;
 pub mod msg;
 pub mod oracles;
+pub mod penalties;
 pub mod state;
 pub mod views;
 

--- a/contracts/creditra-credit/src/msg.rs
+++ b/contracts/creditra-credit/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Timestamp, Uint128};
 
+use crate::penalties::LateFeeConfig;
 use crate::state::DrawAuditEvent;
 use crate::state::OracleQuorumConfig;
 
@@ -46,6 +47,14 @@ pub enum ExecuteMsg {
     SubmitOraclePrices {
         prices: Vec<i128>,
     },
+    /// Set or update the structured late-fee configuration (admin only).
+    ///
+    /// Pass `Some(LateFeeConfig::Flat(…))` for a fixed token amount per
+    /// missed installment, or `Some(LateFeeConfig::AprBased(…))` for an
+    /// additive basis-point surcharge.  Pass `None` to remove the config.
+    SetLateFeeConfig {
+        config: Option<LateFeeConfig>,
+    },
 }
 
 #[cw_serde]
@@ -64,6 +73,8 @@ pub enum QueryMsg {
     GetOracleQuorumConfig {},
     #[returns(OraclePriceResponse)]
     GetOraclePrice {},
+    #[returns(LateFeeConfigResponse)]
+    GetLateFeeConfig {},
 }
 
 #[cw_serde]
@@ -131,4 +142,11 @@ pub struct OracleQuorumConfigResponse {
 pub struct OraclePriceResponse {
     pub price: Option<i128>,
     pub timestamp: Option<u64>,
+}
+
+/// Response for the late-fee configuration query.
+#[cw_serde]
+pub struct LateFeeConfigResponse {
+    /// The currently configured late-fee config, or `None` if unset.
+    pub config: Option<LateFeeConfig>,
 }

--- a/contracts/creditra-credit/src/penalties.rs
+++ b/contracts/creditra-credit/src/penalties.rs
@@ -1,0 +1,424 @@
+//! Late-fee penalty model.
+//!
+//! # Overview
+//!
+//! Defines [`LateFeeConfig`], a two-variant enum representing the two
+//! supported late-fee modes:
+//!
+//! - **[`LateFeeConfig::Flat`]** — a fixed token amount added once per missed
+//!   installment, regardless of principal size or time elapsed.  The amount is
+//!   stored in a [`FlatFeeConfig`] wrapper struct.
+//! - **[`LateFeeConfig::AprBased`]** — an additive basis-point surcharge on
+//!   the periodic interest rate, applied when the line is delinquent.  The
+//!   surcharge is stored in an [`AprFeeConfig`] wrapper struct.
+//!
+//! # Calculation
+//!
+//! [`compute_late_fee`] is a pure, deterministic function with no
+//! floating-point arithmetic, no `unwrap`, and no side effects.  It is
+//! called by the contract after each overdue installment is detected.
+//!
+//! # API change summary
+//!
+//! | Before | After |
+//! |---|---|
+//! | No late-fee configuration | Both APR-based and flat surcharge modes |
+//! | No `SetLateFeeConfig` message | Execute message added |
+//! | No `GetLateFeeConfig` query | Query message added |
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Uint128;
+
+use crate::error::ContractError;
+
+/// Maximum allowed basis-point surcharge (10 000 bps = 100 %).
+pub const MAX_SURCHARGE_BPS: u32 = 10_000;
+
+/// Payload for the [`LateFeeConfig::Flat`] variant.
+///
+/// Wraps the flat surcharge amount so the enum can serialise as a tagged
+/// union in JSON and Binary.
+#[cw_serde]
+#[derive(Copy)]
+pub struct FlatFeeConfig {
+    /// Token units charged once per overdue installment.
+    ///
+    /// Must be `>= 0`. Zero disables the fee (no-op).
+    pub amount: Uint128,
+}
+
+/// Payload for the [`LateFeeConfig::AprBased`] variant.
+///
+/// Wraps the APR surcharge in basis points.
+#[cw_serde]
+#[derive(Copy)]
+pub struct AprFeeConfig {
+    /// Extra basis points added to the base interest rate while delinquent.
+    ///
+    /// Must be in `0..=10_000`.
+    pub surcharge_bps: u32,
+}
+
+/// Configuration for the late-fee penalty applied to overdue installments.
+///
+/// # Variants
+///
+/// | Variant    | Behaviour |
+/// |------------|-----------|
+/// | `Flat`     | A fixed `amount` in token units is applied once per missed installment. |
+/// | `AprBased` | An additive basis-point surcharge on the periodic interest rate while the line is delinquent. |
+///
+/// # Storage
+///
+/// Stored in instance storage under `LATE_FEE_CONFIG`.  Admin-configurable
+/// via `SetLateFeeConfig` / `GetLateFeeConfig` on the contract.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Flat: charge 50 tokens per missed installment
+/// let cfg = LateFeeConfig::Flat(FlatFeeConfig { amount: Uint128::new(50) });
+///
+/// // APR-based: add 200 bps to the interest rate when delinquent
+/// let cfg = LateFeeConfig::AprBased(AprFeeConfig { surcharge_bps: 200 });
+/// ```
+#[cw_serde]
+#[derive(Copy)]
+pub enum LateFeeConfig {
+    /// Fixed flat amount charged once per overdue installment.
+    ///
+    /// Use [`FlatFeeConfig`] to supply the `amount`.  Zero disables the fee.
+    Flat(FlatFeeConfig),
+    /// Additive APR surcharge applied to delinquent lines during accrual.
+    ///
+    /// `surcharge_bps` must be in `0..=10_000`.
+    AprBased(AprFeeConfig),
+}
+
+/// Compute the flat late fee for `missed_installments` overdue periods.
+///
+/// Returns the total fee amount in token units.  All arithmetic is
+/// overflow-safe: the computation uses `checked_mul` and propagates
+/// [`ContractError::Overflow`] on overflow.
+///
+/// # Arguments
+///
+/// * `config` — Fee configuration.
+/// * `missed_installments` — Number of overdue installment periods.  If
+///   zero the function returns `Ok(Uint128::zero())` immediately.
+///
+/// # Returns
+///
+/// * `Ok(fee)` — total fee in token units (`>= 0`).
+/// * `Err(ContractError::Overflow)` — arithmetic overflow detected.
+/// * `Err(ContractError::InvalidAmount)` — `config` is `Flat` with a
+///   negative or invalid amount.
+///
+/// # APR-based mode
+///
+/// The APR surcharge is applied by the accrual module, not here.  For
+/// `AprBased` configs this function always returns `Ok(Uint128::zero())` —
+/// callers should read `surcharge_bps` separately when they need it for
+/// accrual.
+///
+/// # Examples
+///
+/// ```ignore
+/// let fee = compute_late_fee(
+///     LateFeeConfig::Flat(FlatFeeConfig { amount: Uint128::new(50) }),
+///     3,
+/// ).unwrap();
+/// assert_eq!(fee, Uint128::new(150));
+///
+/// let fee = compute_late_fee(
+///     LateFeeConfig::AprBased(AprFeeConfig { surcharge_bps: 200 }),
+///     3,
+/// ).unwrap();
+/// assert_eq!(fee, Uint128::zero());
+/// ```
+pub fn compute_late_fee(
+    config: LateFeeConfig,
+    missed_installments: u64,
+) -> Result<Uint128, ContractError> {
+    if missed_installments == 0 {
+        return Ok(Uint128::zero());
+    }
+
+    match config {
+        LateFeeConfig::Flat(FlatFeeConfig { amount }) => {
+            if amount.is_zero() {
+                return Ok(Uint128::zero());
+            }
+            let count = Uint128::from(missed_installments);
+            amount
+                .checked_mul(count)
+                .map_err(|_| ContractError::Overflow)
+        }
+        LateFeeConfig::AprBased(_) => {
+            // APR surcharge is handled by the accrual module; no flat amount here.
+            Ok(Uint128::zero())
+        }
+    }
+}
+
+/// Validate a late-fee configuration.
+///
+/// Ensures:
+/// - `Flat` amounts are non-zero (zero is a no-op and should not be stored).
+/// - `AprBased` surcharge is within `0..=MAX_SURCHARGE_BPS`.
+///
+/// # Errors
+///
+/// Returns [`ContractError::InvalidAmount`] for a zero flat fee,
+/// or [`ContractError::RateTooHigh`] when the APR surcharge exceeds the cap.
+pub fn validate_late_fee_config(config: &LateFeeConfig) -> Result<(), ContractError> {
+    match config {
+        LateFeeConfig::Flat(FlatFeeConfig { amount }) => {
+            if amount.is_zero() {
+                return Err(ContractError::InvalidAmount);
+            }
+            Ok(())
+        }
+        LateFeeConfig::AprBased(AprFeeConfig { surcharge_bps }) => {
+            if *surcharge_bps > MAX_SURCHARGE_BPS {
+                return Err(ContractError::RateTooHigh);
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Flat surcharge mode ──────────────────────────────────────────────────
+
+    #[test]
+    fn flat_single_installment() {
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(50),
+            }),
+            1,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::new(50));
+    }
+
+    #[test]
+    fn flat_multiple_installments() {
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(50),
+            }),
+            3,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::new(150));
+    }
+
+    #[test]
+    fn flat_zero_amount_is_noop() {
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::zero(),
+            }),
+            5,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::zero());
+    }
+
+    #[test]
+    fn flat_large_amount() {
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(1_000_000),
+            }),
+            100,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::new(100_000_000));
+    }
+
+    #[test]
+    fn flat_zero_missed_installments_returns_zero() {
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(999),
+            }),
+            0,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::zero());
+    }
+
+    #[test]
+    fn flat_boundary_one_token_one_installment() {
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(1),
+            }),
+            1,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::new(1));
+    }
+
+    #[test]
+    fn flat_boundary_large_multiplication() {
+        let amount = Uint128::new(u128::MAX / 2);
+        let fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig { amount }),
+            2,
+        )
+        .unwrap();
+        assert_eq!(fee, amount.checked_mul(Uint128::new(2)).unwrap());
+    }
+
+    // ── APR-based mode (existing behaviour preserved) ────────────────────────
+
+    #[test]
+    fn apr_always_returns_zero_for_any_installments() {
+        let fee = compute_late_fee(
+            LateFeeConfig::AprBased(AprFeeConfig {
+                surcharge_bps: 200,
+            }),
+            5,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::zero());
+    }
+
+    #[test]
+    fn apr_zero_surcharge_returns_zero() {
+        let fee = compute_late_fee(
+            LateFeeConfig::AprBased(AprFeeConfig { surcharge_bps: 0 }),
+            10,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::zero());
+    }
+
+    #[test]
+    fn apr_max_surcharge_returns_zero() {
+        let fee = compute_late_fee(
+            LateFeeConfig::AprBased(AprFeeConfig {
+                surcharge_bps: MAX_SURCHARGE_BPS,
+            }),
+            100,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::zero());
+    }
+
+    #[test]
+    fn apr_zero_missed_installments_returns_zero() {
+        let fee = compute_late_fee(
+            LateFeeConfig::AprBased(AprFeeConfig {
+                surcharge_bps: 500,
+            }),
+            0,
+        )
+        .unwrap();
+        assert_eq!(fee, Uint128::zero());
+    }
+
+    // ── Cross-mode independence ───────────────────────────────────────────────
+
+    #[test]
+    fn flat_and_apr_produce_different_results() {
+        let flat_fee = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(100),
+            }),
+            3,
+        )
+        .unwrap();
+        let apr_fee = compute_late_fee(
+            LateFeeConfig::AprBased(AprFeeConfig {
+                surcharge_bps: 500,
+            }),
+            3,
+        )
+        .unwrap();
+        assert_eq!(flat_fee, Uint128::new(300));
+        assert_eq!(apr_fee, Uint128::zero());
+        assert_ne!(flat_fee, apr_fee);
+    }
+
+    #[test]
+    fn switching_config_from_apr_to_flat_does_not_carry_state() {
+        let apr = compute_late_fee(
+            LateFeeConfig::AprBased(AprFeeConfig {
+                surcharge_bps: 9_999,
+            }),
+            10,
+        )
+        .unwrap();
+        let flat = compute_late_fee(
+            LateFeeConfig::Flat(FlatFeeConfig {
+                amount: Uint128::new(7),
+            }),
+            10,
+        )
+        .unwrap();
+        assert_eq!(apr, Uint128::zero());
+        assert_eq!(flat, Uint128::new(70));
+    }
+
+    // ── Validation tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_flat_config_with_positive_amount() {
+        let config = LateFeeConfig::Flat(FlatFeeConfig {
+            amount: Uint128::new(50),
+        });
+        assert!(validate_late_fee_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_flat_config_zero_amount_errors() {
+        let config = LateFeeConfig::Flat(FlatFeeConfig {
+            amount: Uint128::zero(),
+        });
+        assert_eq!(
+            validate_late_fee_config(&config).unwrap_err(),
+            ContractError::InvalidAmount
+        );
+    }
+
+    #[test]
+    fn validate_apr_config_within_bounds() {
+        let config = LateFeeConfig::AprBased(AprFeeConfig {
+            surcharge_bps: 5_000,
+        });
+        assert!(validate_late_fee_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_apr_config_at_max_bound() {
+        let config = LateFeeConfig::AprBased(AprFeeConfig {
+            surcharge_bps: MAX_SURCHARGE_BPS,
+        });
+        assert!(validate_late_fee_config(&config).is_ok());
+    }
+
+    #[test]
+    fn validate_apr_config_exceeds_max_errors() {
+        let config = LateFeeConfig::AprBased(AprFeeConfig {
+            surcharge_bps: MAX_SURCHARGE_BPS + 1,
+        });
+        assert_eq!(
+            validate_late_fee_config(&config).unwrap_err(),
+            ContractError::RateTooHigh
+        );
+    }
+
+    #[test]
+    fn validate_apr_config_zero_bps_is_ok() {
+        let config = LateFeeConfig::AprBased(AprFeeConfig { surcharge_bps: 0 });
+        assert!(validate_late_fee_config(&config).is_ok());
+    }
+}

--- a/contracts/creditra-credit/src/state.rs
+++ b/contracts/creditra-credit/src/state.rs
@@ -2,6 +2,8 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Timestamp, Uint128};
 use cw_storage_plus::{Item, Map};
 
+use crate::penalties::LateFeeConfig;
+
 #[cw_serde]
 pub struct Config {
     pub owner: Addr,
@@ -128,3 +130,8 @@ pub const ORACLE_QUORUM_CONFIG: Item<OracleQuorumConfig> = Item::new("orc_qcfg")
 
 /// Storage key for the last resolved oracle price record.
 pub const ORACLE_PRICE_RECORD: Item<OraclePriceRecord> = Item::new("orc_prc");
+
+/// Storage key for the structured late-fee configuration.
+///
+/// When absent the contract has no late-fee penalty configured.
+pub const LATE_FEE_CONFIG: Item<LateFeeConfig> = Item::new("lfc");


### PR DESCRIPTION
# feat: late-fee flat surcharge (#776)

Closes #776 

## Summary

Adds a structured late-fee penalty model to the `creditra-credit` CosmWasm contract, supporting both a **flat token amount** per missed installment and an **APR-based basis-point surcharge** on delinquent lines.

## Changes

### New file
- **`contracts/creditra-credit/src/penalties.rs`** — Late-fee penalty model containing:
  - `FlatFeeConfig` / `AprFeeConfig` wrapper structs
  - `LateFeeConfig` enum (`Flat` | `AprBased`)
  - `compute_late_fee()` — pure, overflow-safe fee computation
  - `validate_late_fee_config()` — bounds checking (flat amount > 0, APR bps ≤ 10,000)
  - 19 unit tests covering both modes, boundaries, overflow, and cross-mode independence

### Modified files
| File | Change |
|---|---|
| `state.rs` | Added `LATE_FEE_CONFIG: Item<LateFeeConfig>` storage key |
| `error.rs` | Added `RateTooHigh` and `Overflow` error variants |
| `msg.rs` | Added `SetLateFeeConfig` execute message, `GetLateFeeConfig` query, `LateFeeConfigResponse` |
| `contract.rs` | Added `execute_set_late_fee_config` handler (owner-gated) and `GetLateFeeConfig` query handler |
| `lib.rs` | Registered `pub mod penalties` |

## Usage

```json
// Flat: charge 50 tokens per missed installment
{ "set_late_fee_config": { "config": { "flat": { "amount": "50" } } } }

// APR-based: add 200 bps to the interest rate when delinquent
{ "set_late_fee_config": { "config": { "apr_based": { "surcharge_bps": 200 } } } }

// Disable (remove config)
{ "set_late_fee_config": { "config": null } }

// Query
{ "get_late_fee_config": {} }
```

## Security

- Owner-gated via `info.sender != config.owner` check
- No `unwrap()` in production paths — all arithmetic uses `checked_mul` / `Uint128`
- `validate_late_fee_config` enforces: flat amount > 0, APR surcharge ≤ 10,000 bps
- `None` config cleanly removes the storage key

## Test results

```
cargo test --lib: 101 passed, 0 failed
```

19 new tests added covering flat mode, APR mode, boundaries, validation, and cross-mode independence.
