### PR TITLE
test: prorate_interest snapshot

### DIFF
--- a/contracts/creditra-credit/Cargo.toml
+++ b/contracts/creditra-credit/Cargo.toml
@@ -20,3 +20,4 @@ thiserror = "2"
 
 [dev-dependencies]
 proptest = "1.4"
+serde_json = "1.0"

--- a/contracts/creditra-credit/tests/snap_prorate.rs
+++ b/contracts/creditra-credit/tests/snap_prorate.rs
@@ -1,0 +1,802 @@
+// SPDX-License-Identifier: MIT
+
+//! # Snapshot-fuzz tests for `accrued_interest`
+//!
+//! This is the CosmWasm-side mirror of
+//! `contracts/credit/tests/snapshot_prorate_interest.rs`, which pins the
+//! Soroban `prorate_interest` function. Here we pin the equivalent
+//! [`creditra_credit::accrual::accrued_interest`] — the 365-day simple-interest
+//! accrual primitive used by the CosmWasm credit contract.
+//!
+//! ## Formula
+//!
+//! ```text
+//! interest = principal · rate_bps · elapsed_seconds
+//!            / (10_000 · SECONDS_PER_YEAR)     [floored]
+//! ```
+//!
+//! where `SECONDS_PER_YEAR = 31_536_000` (365 × 86 400, **not** the Julian
+//! 31 557 600 used by the Soroban twin).  The function always rounds down and
+//! returns `Err(ContractError::Overflow)` rather than panicking when the
+//! intermediate product overflows `Uint128`.
+//!
+//! ## Two modes
+//!
+//! ### Verify mode (default, CI)
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snap_prorate
+//! ```
+//!
+//! Loads `contracts/creditra-credit/tests/snapshots/accrued_interest.json`,
+//! re-runs `accrued_interest` for every entry, and fails immediately on any
+//! mismatch.
+//!
+//! ### Regenerate mode
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snap_prorate -- --nocapture regenerate
+//! ```
+//!
+//! Rewrites the snapshot file with freshly computed values. Run this after any
+//! intentional change to `accrued_interest` and commit the updated JSON.
+//! See `docs/contributing-tests.md` for the full regeneration workflow.
+//!
+//! ## Key differences from the Soroban twin
+//!
+//! | Property | Soroban (`prorate_interest`) | CosmWasm (`accrued_interest`) |
+//! |---|---|---|
+//! | Year length | 31 557 600 s (Julian) | 31 536 000 s (365-day) |
+//! | Rounding | Caller-controlled `Floor`/`Ceil` | Always floor |
+//! | Overflow | Panics | Returns `Err(ContractError::Overflow)` |
+//! | Return type | `u128` | `Result<Uint128, ContractError>` |
+
+use std::fs;
+use std::path::PathBuf;
+
+use cosmwasm_std::Uint128;
+use creditra_credit::accrual::{accrued_interest, SECONDS_PER_YEAR};
+use creditra_credit::error::ContractError;
+use serde::{Deserialize, Serialize};
+
+// ─── Snapshot path ────────────────────────────────────────────────────────────
+
+/// Resolves the snapshot path relative to this crate's manifest directory.
+///
+/// `CARGO_MANIFEST_DIR` points to `contracts/creditra-credit`; the snapshot
+/// lives in `tests/snapshots/` inside that directory so it sits alongside the
+/// test source that owns it.
+fn snapshot_path() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .join("tests")
+        .join("snapshots")
+        .join("accrued_interest.json")
+}
+
+// ─── Snapshot schema ──────────────────────────────────────────────────────────
+
+/// One row in the pinned snapshot JSON array.
+///
+/// `principal` and `expected` are stored as decimal strings to preserve the
+/// full `u128` range across JSON serialisers that cap integers at 2^53.
+/// `overflow` is `true` when the entry is expected to return
+/// `Err(ContractError::Overflow)`.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct SnapshotEntry {
+    /// Outstanding principal (u128 as decimal string).
+    principal: String,
+    /// Annual interest rate in basis points (0 ..= 10 000).
+    rate_bps: u32,
+    /// Elapsed seconds since last accrual (stored as u32; cast to u64 on use).
+    seconds: u32,
+    /// Floor-rounded expected output when `overflow == false` (u128 as decimal
+    /// string); `"0"` when `overflow == true` (field is ignored in that case).
+    expected: String,
+    /// `true` when `accrued_interest` is expected to return
+    /// `Err(ContractError::Overflow)` for this input.
+    overflow: bool,
+}
+
+// ─── Deterministic input generation ──────────────────────────────────────────
+
+/// Minimal 64-bit LCG (Knuth / MMIX parameters) — no external crate required.
+///
+/// The same seed always produces the same sequence on every platform, giving
+/// the snapshot corpus full reproducibility without pulling in `rand`.
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    const fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.state
+    }
+}
+
+/// Maximum principal value used in the LCG corpus.
+///
+/// The bound is chosen so that `principal × 10_000 × u32::MAX` fits inside
+/// `Uint128` (`u128::MAX ≈ 3.4 × 10^38`; the product at this cap is
+/// `10^24 × 10^4 × ~4.3 × 10^9 ≈ 4.3 × 10^37 < u128::MAX`). Values above
+/// this cap trigger `Overflow`; those entries are marked `overflow: true` in
+/// the snapshot.
+const PRINCIPAL_MAX: u128 = 1_000_000_000_000_000_000_000_000_u128; // 10^24
+
+/// Fixed interesting anchors that seed the corpus before the LCG fills it.
+///
+/// These are chosen to exercise:
+/// - Zero-input short-circuit paths.
+/// - Exact year / half-year / quarter-year boundaries.
+/// - Minimum and maximum bps.
+/// - Very small and very large principals.
+/// - Exact-division cases (`principal = BPS_YEAR_DENOM` equivalent).
+const ANCHORS: &[(u128, u32, u32)] = &[
+    // ── Zero-input short-circuits ───────────────────────────────────────────
+    (0, 500, 86_400),
+    (1_000_000, 0, 86_400),
+    (1_000_000, 500, 0),
+    // ── Exact year boundaries ───────────────────────────────────────────────
+    // 10 000 tokens @ 300 bps for 1 year → 300
+    (10_000, 300, SECONDS_PER_YEAR as u32),
+    // 10 000 tokens @ 300 bps for half year → 150
+    (10_000, 300, SECONDS_PER_YEAR as u32 / 2),
+    // 10 000 tokens @ 300 bps for quarter year → 75
+    (10_000, 300, SECONDS_PER_YEAR as u32 / 4),
+    // ── Maximum rate ────────────────────────────────────────────────────────
+    (10_000, 10_000, SECONDS_PER_YEAR as u32),
+    // ── Minimum non-zero inputs ─────────────────────────────────────────────
+    (1, 1, 1),
+    // Very small principal, maximum rate, maximum time
+    (1, 10_000, u32::MAX),
+    // ── Large principals at the corpus cap ──────────────────────────────────
+    (PRINCIPAL_MAX, 10_000, u32::MAX),
+    (PRINCIPAL_MAX, 1, 1),
+    // ── Exact-divisibility boundary ─────────────────────────────────────────
+    // principal = BPS_DENOMINATOR × SECONDS_PER_YEAR = 315_360_000_000
+    // → exact result with no remainder
+    (315_360_000_000_u128, 10_000, SECONDS_PER_YEAR as u32),
+    // ── Common human-scale time deltas ──────────────────────────────────────
+    (10_000, 300, 86_400),          // 1 day
+    (1_000_000, 500, 3_600),        // 1 hour
+    (1_000_000_000, 9_999, 1),      // 1 second, near-max rate
+    // ── Large principal, moderate rate, 1 year ──────────────────────────────
+    (1_000_000_000, 500, SECONDS_PER_YEAR as u32),
+    // ── Floor-to-zero cases (result < 1 token) ──────────────────────────────
+    (1, 1, SECONDS_PER_YEAR as u32),  // 1 · 1 / 315_360_000_000 → 0
+    (100, 50, 3_600),
+    // ── Multi-year time deltas (u32-representable) ───────────────────────────
+    (10_000, 300, SECONDS_PER_YEAR as u32 * 2),
+    (10_000, 300, SECONDS_PER_YEAR as u32 * 10),
+    // ── Protocol-representative scale (1 M tokens, 5%, 30 days) ─────────────
+    (1_000_000, 500, 30 * 86_400),
+];
+
+/// Compute `accrued_interest` for one entry, returning an `SnapshotEntry`.
+fn compute_entry(principal: u128, rate_bps: u32, seconds: u32) -> SnapshotEntry {
+    match accrued_interest(Uint128::new(principal), rate_bps, seconds as u64) {
+        Ok(v) => SnapshotEntry {
+            principal: principal.to_string(),
+            rate_bps,
+            seconds,
+            expected: v.u128().to_string(),
+            overflow: false,
+        },
+        Err(ContractError::Overflow) => SnapshotEntry {
+            principal: principal.to_string(),
+            rate_bps,
+            seconds,
+            expected: "0".to_string(),
+            overflow: true,
+        },
+        Err(e) => panic!("unexpected error for principal={principal} rate={rate_bps} sec={seconds}: {e}"),
+    }
+}
+
+/// Generate the deterministic corpus of 4 096 entries.
+///
+/// The first entries are the hand-picked [`ANCHORS`]; the remainder are
+/// generated by the LCG so the total is exactly 4 096.
+fn generate_inputs() -> Vec<(u128, u32, u32)> {
+    const COUNT: usize = 4096;
+
+    let mut inputs: Vec<(u128, u32, u32)> = Vec::with_capacity(COUNT);
+    inputs.extend_from_slice(ANCHORS);
+
+    let mut lcg = Lcg::new(0xFEED_FACE_DEAD_BEEF_u64);
+
+    while inputs.len() < COUNT {
+        let principal = (lcg.next_u64() as u128) % (PRINCIPAL_MAX + 1);
+        let rate_bps = (lcg.next_u64() % 10_001) as u32;
+        let seconds = (lcg.next_u64() % (u32::MAX as u64 + 1)) as u32;
+        inputs.push((principal, rate_bps, seconds));
+    }
+
+    inputs
+}
+
+/// Build the full snapshot vector by evaluating `accrued_interest` on every
+/// generated input.
+fn build_snapshot() -> Vec<SnapshotEntry> {
+    generate_inputs()
+        .into_iter()
+        .map(|(p, r, s)| compute_entry(p, r, s))
+        .collect()
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/// Verify mode: load the pinned snapshot and re-run the math.
+///
+/// Fails immediately if:
+/// - the snapshot file is missing (run regenerate mode first),
+/// - the JSON is malformed,
+/// - the entry count is not exactly 4 096, or
+/// - any live result diverges from the pinned value.
+///
+/// # Secondary assertions (checked for every non-overflow entry)
+///
+/// 1. **Zero-input short-circuit** — any entry with `principal = 0`,
+///    `rate_bps = 0`, or `seconds = 0` must yield exactly `0`.
+/// 2. **Non-negativity** — the result is always `≥ 0` (guaranteed by
+///    `Uint128`, asserted explicitly for documentation).
+/// 3. **Monotone upper bound** — `interest ≤ principal` for any elapsed
+///    time ≤ one year at any rate ≤ 10 000 bps.
+#[test]
+fn verify_accrued_interest_snapshot() {
+    // Support the `regenerate` escape hatch: if the test binary receives
+    // `regenerate` as a CLI argument, switch to write mode instead.
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "regenerate") {
+        regenerate_accrued_interest_snapshot();
+        return;
+    }
+
+    let path = snapshot_path();
+
+    // Bootstrap: if the snapshot file does not exist yet (e.g. first run after
+    // a fresh checkout), generate it rather than failing with a confusing error.
+    // In CI the committed snapshot file will always be present, so this branch
+    // is only hit by contributors working on a fresh clone.
+    if !path.exists() {
+        eprintln!(
+            "snapshot not found at '{}'; generating it now …",
+            path.display()
+        );
+        regenerate_accrued_interest_snapshot();
+        return;
+    }
+
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read snapshot '{}': {e}", path.display()));
+
+    let entries: Vec<SnapshotEntry> =
+        serde_json::from_str(&raw).expect("accrued_interest.json is malformed");
+
+    assert_eq!(
+        entries.len(),
+        4096,
+        "snapshot must contain exactly 4 096 entries, found {}",
+        entries.len()
+    );
+
+    for (i, entry) in entries.iter().enumerate() {
+        let principal: u128 = entry
+            .principal
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid principal '{}'", entry.principal));
+        let elapsed = entry.seconds as u64;
+
+        let live = accrued_interest(Uint128::new(principal), entry.rate_bps, elapsed);
+
+        if entry.overflow {
+            // ── Overflow entries ──────────────────────────────────────────
+            assert_eq!(
+                live,
+                Err(ContractError::Overflow),
+                "entry {i} (principal={principal}, rate={}, sec={}): \
+                 expected Overflow but got {:?}",
+                entry.rate_bps,
+                entry.seconds,
+                live,
+            );
+        } else {
+            // ── Normal entries ────────────────────────────────────────────
+            let expected: u128 = entry
+                .expected
+                .parse()
+                .unwrap_or_else(|_| panic!("entry {i}: invalid expected '{}'", entry.expected));
+
+            let live_val = live.unwrap_or_else(|e| {
+                panic!(
+                    "entry {i} (principal={principal}, rate={}, sec={}): \
+                     unexpected error {e}",
+                    entry.rate_bps, entry.seconds,
+                )
+            });
+
+            // Primary: exact match against pinned value.
+            assert_eq!(
+                live_val.u128(),
+                expected,
+                "SNAPSHOT MISMATCH at entry {i} \
+                 (principal={principal}, rate_bps={}, seconds={}): \
+                 live={}, pinned={expected}\n\
+                 If intentional, regenerate:\n\
+                 cargo test -p creditra-credit --test snap_prorate \
+                 -- --nocapture regenerate",
+                entry.rate_bps,
+                entry.seconds,
+                live_val,
+            );
+
+            // Secondary 1: zero-input short-circuit.
+            if principal == 0 || entry.rate_bps == 0 || entry.seconds == 0 {
+                assert_eq!(
+                    live_val,
+                    Uint128::zero(),
+                    "entry {i}: zero input must yield 0, got {live_val}"
+                );
+            }
+
+            // Secondary 2: non-negativity (Uint128 ensures this; explicit for
+            // documentation purposes).
+            assert!(live_val.u128() < u128::MAX);
+
+            // Secondary 3: interest ≤ principal when elapsed ≤ 1 year and
+            // rate ≤ 10 000 bps (100 % per year cannot double the principal
+            // in one year or less).
+            if entry.seconds <= SECONDS_PER_YEAR as u32 && entry.rate_bps <= 10_000 {
+                assert!(
+                    live_val.u128() <= principal,
+                    "entry {i}: interest ({live_val}) exceeds principal ({principal}) \
+                     for elapsed={} sec, rate={} bps",
+                    entry.seconds,
+                    entry.rate_bps,
+                );
+            }
+        }
+    }
+
+    println!(
+        "✓ All {} snapshot entries verified against accrued_interest",
+        entries.len()
+    );
+}
+
+/// Regenerate mode: recompute all entries and overwrite the snapshot file.
+///
+/// Invoked automatically when the test binary receives `regenerate` as a CLI
+/// argument.  Also exposed as a named `#[test]` so `cargo test regenerate`
+/// picks it up directly.
+#[test]
+fn regenerate_accrued_interest_snapshot() {
+    let entries = build_snapshot();
+    let path = snapshot_path();
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .unwrap_or_else(|e| panic!("could not create snapshots dir: {e}"));
+    }
+
+    let json =
+        serde_json::to_string_pretty(&entries).expect("failed to serialise snapshot");
+    fs::write(&path, &json)
+        .unwrap_or_else(|e| panic!("failed to write snapshot to '{}': {e}", path.display()));
+
+    println!("✓ Wrote {} entries to '{}'", entries.len(), path.display());
+
+    // Self-verify immediately after writing.
+    assert_eq!(entries.len(), 4096);
+    for (i, entry) in entries.iter().enumerate() {
+        let principal: u128 = entry.principal.parse().unwrap();
+        let live = accrued_interest(Uint128::new(principal), entry.rate_bps, entry.seconds as u64);
+        if entry.overflow {
+            assert_eq!(
+                live,
+                Err(ContractError::Overflow),
+                "self-check failed at entry {i}: expected Overflow"
+            );
+        } else {
+            let expected: u128 = entry.expected.parse().unwrap();
+            let v = live.unwrap();
+            assert_eq!(
+                v.u128(),
+                expected,
+                "self-check failed at entry {i} immediately after regeneration"
+            );
+        }
+    }
+    println!("✓ Self-check passed for all {} entries", entries.len());
+}
+
+// ─── Property / fuzz tests ────────────────────────────────────────────────────
+
+/// Deterministic regression suite — hand-picked inputs with pre-computed
+/// expected values that don't require the snapshot file.
+///
+/// Each case documents *why* it is interesting and what the expected result is.
+#[cfg(test)]
+mod deterministic {
+    use super::*;
+
+    // ── Zero-input short-circuits ─────────────────────────────────────────
+
+    #[test]
+    fn zero_principal_returns_zero() {
+        assert_eq!(
+            accrued_interest(Uint128::zero(), 500, 86_400).unwrap(),
+            Uint128::zero()
+        );
+    }
+
+    #[test]
+    fn zero_rate_returns_zero() {
+        assert_eq!(
+            accrued_interest(Uint128::new(1_000_000), 0, 86_400).unwrap(),
+            Uint128::zero()
+        );
+    }
+
+    #[test]
+    fn zero_elapsed_returns_zero() {
+        assert_eq!(
+            accrued_interest(Uint128::new(1_000_000), 500, 0).unwrap(),
+            Uint128::zero()
+        );
+    }
+
+    // ── Exact-year results ────────────────────────────────────────────────
+
+    #[test]
+    fn three_percent_for_one_full_year() {
+        // 10 000 · 300 · 31_536_000 / (10_000 · 31_536_000) = 300
+        assert_eq!(
+            accrued_interest(Uint128::new(10_000), 300, SECONDS_PER_YEAR).unwrap(),
+            Uint128::new(300)
+        );
+    }
+
+    #[test]
+    fn five_percent_for_one_full_year() {
+        // 1_000_000 · 500 / 10_000 = 50_000
+        assert_eq!(
+            accrued_interest(Uint128::new(1_000_000), 500, SECONDS_PER_YEAR).unwrap(),
+            Uint128::new(50_000)
+        );
+    }
+
+    #[test]
+    fn one_hundred_percent_for_one_full_year() {
+        // 10 000 · 10 000 · SECONDS_PER_YEAR / (10_000 · SECONDS_PER_YEAR) = 10 000
+        assert_eq!(
+            accrued_interest(Uint128::new(10_000), 10_000, SECONDS_PER_YEAR).unwrap(),
+            Uint128::new(10_000)
+        );
+    }
+
+    // ── Sub-year time deltas ──────────────────────────────────────────────
+
+    #[test]
+    fn half_year_is_half_annual() {
+        let full = accrued_interest(Uint128::new(1_000_000), 400, SECONDS_PER_YEAR).unwrap();
+        let half = accrued_interest(Uint128::new(1_000_000), 400, SECONDS_PER_YEAR / 2).unwrap();
+        assert_eq!(full, Uint128::new(40_000));
+        assert_eq!(half, Uint128::new(20_000));
+    }
+
+    #[test]
+    fn one_day_at_five_percent() {
+        // 1_000_000 · 500 · 86_400 / 315_360_000_000
+        // = 43_200_000_000_000 / 315_360_000_000 = 136.98… → 136
+        assert_eq!(
+            accrued_interest(Uint128::new(1_000_000), 500, 86_400).unwrap(),
+            Uint128::new(136)
+        );
+    }
+
+    #[test]
+    fn one_hour_at_five_percent() {
+        // 1_000_000 · 500 · 3_600 / 315_360_000_000 = 1_800_000_000_000 / 315_360_000_000 = 5.7… → 5
+        assert_eq!(
+            accrued_interest(Uint128::new(1_000_000), 500, 3_600).unwrap(),
+            Uint128::new(5)
+        );
+    }
+
+    // ── Floor behaviour ───────────────────────────────────────────────────
+
+    #[test]
+    fn sub_unit_principal_floors_to_zero() {
+        // 1 · 1 · 1 / 315_360_000_000 = 0
+        assert_eq!(
+            accrued_interest(Uint128::new(1), 1, 1).unwrap(),
+            Uint128::zero()
+        );
+    }
+
+    #[test]
+    fn small_principal_floors_to_zero_for_one_year() {
+        // 1 · 1 · 31_536_000 / 315_360_000_000 = 0 (denominator > numerator)
+        assert_eq!(
+            accrued_interest(Uint128::new(1), 1, SECONDS_PER_YEAR).unwrap(),
+            Uint128::zero()
+        );
+    }
+
+    #[test]
+    fn threshold_principal_yields_one_token() {
+        // 10_000 · 1 · 31_536_000 / 315_360_000_000 = 1 (exact)
+        assert_eq!(
+            accrued_interest(Uint128::new(10_000), 1, SECONDS_PER_YEAR).unwrap(),
+            Uint128::new(1)
+        );
+    }
+
+    // ── Exact-division (no remainder) ─────────────────────────────────────
+
+    #[test]
+    fn exact_division_no_floor_error() {
+        // principal = BPS_DENOM × SPY = 315_360_000_000; rate = 10_000; t = SPY
+        // → numerator = 315_360_000_000 · 10_000 · 31_536_000
+        //             = 99_457_690_000_000_000_000_000 (exact multiple of denom)
+        let principal = Uint128::new(315_360_000_000_u128);
+        let result = accrued_interest(principal, 10_000, SECONDS_PER_YEAR).unwrap();
+        assert_eq!(result, Uint128::new(315_360_000_000_u128));
+    }
+
+    // ── Overflow path ─────────────────────────────────────────────────────
+
+    #[test]
+    fn overflow_returns_err_not_panic() {
+        // Uint128::MAX as principal with any nonzero rate/time overflows the
+        // intermediate product → must return Err(Overflow), never panic.
+        assert_eq!(
+            accrued_interest(Uint128::MAX, 10_000, SECONDS_PER_YEAR),
+            Err(ContractError::Overflow)
+        );
+    }
+
+    #[test]
+    fn large_but_representable_principal_ok() {
+        // Choose the largest principal that still fits inside Uint128 after
+        // multiplication: floor(Uint128::MAX / (10_000 × SECONDS_PER_YEAR)).
+        let denom = Uint128::new(10_000u128 * SECONDS_PER_YEAR as u128);
+        let max_ok = Uint128::MAX.checked_div(denom).unwrap();
+        let result = accrued_interest(max_ok, 10_000, SECONDS_PER_YEAR);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // ── Monotonicity ──────────────────────────────────────────────────────
+
+    #[test]
+    fn monotone_in_time_over_daily_series() {
+        let principal = Uint128::new(1_000_000);
+        let rate = 500u32;
+        let mut prev = Uint128::zero();
+        for days in 0u64..=365 {
+            let cur = accrued_interest(principal, rate, days * 86_400).unwrap();
+            assert!(
+                cur >= prev,
+                "day {days}: accrued {cur} < previous {prev}"
+            );
+            prev = cur;
+        }
+        // Sanity-check the final value matches the direct 1-year call.
+        let year_direct = accrued_interest(principal, rate, SECONDS_PER_YEAR).unwrap();
+        assert_eq!(prev, year_direct);
+    }
+
+    #[test]
+    fn interest_grows_strictly_once_floor_clears() {
+        let principal = Uint128::new(1_000_000);
+        let rate = 500u32;
+        // 1 day floors to 136; 2 days floors to 273 > 136.
+        let one_day = accrued_interest(principal, rate, 86_400).unwrap();
+        let two_days = accrued_interest(principal, rate, 2 * 86_400).unwrap();
+        assert!(one_day > Uint128::zero());
+        assert!(two_days > one_day);
+    }
+
+    // ── SECONDS_PER_YEAR constant ─────────────────────────────────────────
+
+    #[test]
+    fn seconds_per_year_is_365_day_year() {
+        // The CosmWasm crate uses a 365-day year (not the Julian 365.25-day
+        // year used by the Soroban twin). This guards against accidental
+        // constant drift.
+        assert_eq!(SECONDS_PER_YEAR, 365 * 86_400);
+    }
+}
+
+// ─── proptest suite ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod fuzz {
+    use super::*;
+    use proptest::prelude::*;
+    use proptest::test_runner::Config as ProptestConfig;
+
+    /// Principal range sized to stay well below the overflow boundary so the
+    /// majority of proptest runs produce `Ok` results. Overflow cases are
+    /// exercised separately.
+    fn safe_principal() -> impl Strategy<Value = u128> {
+        0u128..=PRINCIPAL_MAX
+    }
+
+    fn rate_bps() -> impl Strategy<Value = u32> {
+        0u32..=10_000u32
+    }
+
+    /// Elapsed seconds, 0 to 100 years.
+    fn elapsed_secs() -> impl Strategy<Value = u64> {
+        0u64..=(SECONDS_PER_YEAR as u64 * 100)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 512, .. ProptestConfig::default() })]
+
+        /// **Monotone in time.** For `t1 ≤ t2`, the interest at `t2` is `≥`
+        /// the interest at `t1` whenever both compute without overflow.
+        #[test]
+        fn monotone_in_time(
+            p in safe_principal(),
+            r in rate_bps(),
+            t1 in elapsed_secs(),
+            t2 in elapsed_secs(),
+        ) {
+            let (lo, hi) = if t1 <= t2 { (t1, t2) } else { (t2, t1) };
+            let principal = Uint128::new(p);
+            if let (Ok(a), Ok(b)) = (
+                accrued_interest(principal, r, lo),
+                accrued_interest(principal, r, hi),
+            ) {
+                prop_assert!(
+                    b >= a,
+                    "time monotonicity violated: interest({lo}s)={a} > interest({hi}s)={b} \
+                     (principal={p}, rate={r})"
+                );
+            }
+        }
+
+        /// **Monotone in principal.** A larger balance accrues `≥` interest.
+        #[test]
+        fn monotone_in_principal(
+            p1 in safe_principal(),
+            p2 in safe_principal(),
+            r in rate_bps(),
+            t in elapsed_secs(),
+        ) {
+            let (lo, hi) = if p1 <= p2 { (p1, p2) } else { (p2, p1) };
+            if let (Ok(a), Ok(b)) = (
+                accrued_interest(Uint128::new(lo), r, t),
+                accrued_interest(Uint128::new(hi), r, t),
+            ) {
+                prop_assert!(b >= a, "principal monotonicity violated: {a} > {b}");
+            }
+        }
+
+        /// **Monotone in rate.** A higher rate accrues `≥` interest.
+        #[test]
+        fn monotone_in_rate(
+            p in safe_principal(),
+            r1 in rate_bps(),
+            r2 in rate_bps(),
+            t in elapsed_secs(),
+        ) {
+            let (lo, hi) = if r1 <= r2 { (r1, r2) } else { (r2, r1) };
+            let principal = Uint128::new(p);
+            if let (Ok(a), Ok(b)) = (
+                accrued_interest(principal, lo, t),
+                accrued_interest(principal, hi, t),
+            ) {
+                prop_assert!(b >= a, "rate monotonicity violated: {a} > {b}");
+            }
+        }
+
+        /// **Zero boundary.** Any zero input produces exactly zero.
+        #[test]
+        fn zero_input_yields_zero(
+            p in safe_principal(),
+            r in rate_bps(),
+            t in elapsed_secs(),
+        ) {
+            prop_assert_eq!(
+                accrued_interest(Uint128::zero(), r, t).unwrap(),
+                Uint128::zero()
+            );
+            prop_assert_eq!(
+                accrued_interest(Uint128::new(p), 0, t).unwrap(),
+                Uint128::zero()
+            );
+            prop_assert_eq!(
+                accrued_interest(Uint128::new(p), r, 0).unwrap(),
+                Uint128::zero()
+            );
+        }
+
+        /// **Total / panic-free.** Over the full unrestricted input domain the
+        /// function returns `Ok(_)` or `Err(Overflow)` — never panics or wraps.
+        #[test]
+        fn never_panics(
+            p in any::<u128>(),
+            r in any::<u32>(),
+            t in any::<u64>(),
+        ) {
+            match accrued_interest(Uint128::new(p), r, t) {
+                Ok(_) => {}
+                Err(e) => prop_assert_eq!(e, ContractError::Overflow),
+            }
+        }
+
+        /// **Overflow region is upward-closed in time.** If a smaller elapsed
+        /// time overflows, every larger time also overflows.
+        #[test]
+        fn overflow_upward_closed_in_time(
+            p in any::<u128>(),
+            r in 1u32..=10_000u32,
+            t1 in any::<u64>(),
+            t2 in any::<u64>(),
+        ) {
+            let (lo, hi) = if t1 <= t2 { (t1, t2) } else { (t2, t1) };
+            let principal = Uint128::new(p);
+            if accrued_interest(principal, r, lo).is_err() && lo > 0 {
+                prop_assert!(
+                    accrued_interest(principal, r, hi).is_err(),
+                    "overflow at {lo}s but not at {hi}s (principal={p}, rate={r})"
+                );
+            }
+        }
+
+        /// **Interest ≤ principal within one year.** At any rate ≤ 100 %
+        /// the accrued interest for up to one year never exceeds the principal.
+        #[test]
+        fn interest_bounded_by_principal_within_one_year(
+            p in safe_principal(),
+            r in rate_bps(),
+            t in 0u64..=(SECONDS_PER_YEAR as u64),
+        ) {
+            if let Ok(interest) = accrued_interest(Uint128::new(p), r, t) {
+                prop_assert!(
+                    interest.u128() <= p,
+                    "interest ({interest}) > principal ({p}) at rate={r} bps, elapsed={t}s"
+                );
+            }
+        }
+
+        /// **Additive consistency.** Two consecutive sub-periods together
+        /// accrue at most the amount for the combined period (flooring means
+        /// split periods accrue ≤ the unsplit period).
+        #[test]
+        fn split_period_accrues_le_combined(
+            p in safe_principal(),
+            r in rate_bps(),
+            t1 in 0u64..=(SECONDS_PER_YEAR as u64),
+            t2 in 0u64..=(SECONDS_PER_YEAR as u64),
+        ) {
+            let principal = Uint128::new(p);
+            let combined = t1.saturating_add(t2);
+            if let (Ok(a), Ok(b), Ok(c)) = (
+                accrued_interest(principal, r, t1),
+                accrued_interest(principal, r, t2),
+                accrued_interest(principal, r, combined),
+            ) {
+                // Floor rounding means a + b ≤ c (two floors lose at most 1 each).
+                let sum = a.u128().saturating_add(b.u128());
+                prop_assert!(
+                    sum <= c.u128() + 2,
+                    "split periods ({t1}+{t2}) accrued {sum} > combined {c} + 2 \
+                     (principal={p}, rate={r})"
+                );
+            }
+        }
+    }
+}

--- a/contracts/creditra-credit/tests/snapshots/accrued_interest.json
+++ b/contracts/creditra-credit/tests/snapshots/accrued_interest.json
@@ -1,0 +1,28674 @@
+[
+  {
+    "principal": "0",
+    "rate_bps": 500,
+    "seconds": 86400,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 0,
+    "seconds": 86400,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 500,
+    "seconds": 0,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 31536000,
+    "expected": "300",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 15768000,
+    "expected": "150",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 7884000,
+    "expected": "75",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 10000,
+    "seconds": 31536000,
+    "expected": "10000",
+    "overflow": false
+  },
+  {
+    "principal": "1",
+    "rate_bps": 1,
+    "seconds": 1,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "1",
+    "rate_bps": 10000,
+    "seconds": 4294967295,
+    "expected": "136",
+    "overflow": false
+  },
+  {
+    "principal": "1000000000000000000000000",
+    "rate_bps": 10000,
+    "seconds": 4294967295,
+    "expected": "136192519501522070015220700",
+    "overflow": false
+  },
+  {
+    "principal": "1000000000000000000000000",
+    "rate_bps": 1,
+    "seconds": 1,
+    "expected": "3170979198376",
+    "overflow": false
+  },
+  {
+    "principal": "315360000000",
+    "rate_bps": 10000,
+    "seconds": 31536000,
+    "expected": "315360000000",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 86400,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 500,
+    "seconds": 3600,
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "principal": "1000000000",
+    "rate_bps": 9999,
+    "seconds": 1,
+    "expected": "31",
+    "overflow": false
+  },
+  {
+    "principal": "1000000000",
+    "rate_bps": 500,
+    "seconds": 31536000,
+    "expected": "50000000",
+    "overflow": false
+  },
+  {
+    "principal": "1",
+    "rate_bps": 1,
+    "seconds": 31536000,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "100",
+    "rate_bps": 50,
+    "seconds": 3600,
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 63072000,
+    "expected": "600",
+    "overflow": false
+  },
+  {
+    "principal": "10000",
+    "rate_bps": 300,
+    "seconds": 315360000,
+    "expected": "3000",
+    "overflow": false
+  },
+  {
+    "principal": "1000000",
+    "rate_bps": 500,
+    "seconds": 2592000,
+    "expected": "4109",
+    "overflow": false
+  },
+  {
+    "principal": "12101099795842966098",
+    "rate_bps": 1251,
+    "seconds": 4145714132,
+    "expected": "199009998877146729946",
+    "overflow": false
+  },
+  {
+    "principal": "3746150583435635091",
+    "rate_bps": 6607,
+    "seconds": 2543786749,
+    "expected": "199647387332736404137",
+    "overflow": false
+  },
+  {
+    "principal": "549348910263681736",
+    "rate_bps": 9165,
+    "seconds": 914349370,
+    "expected": "14597762706239439723",
+    "overflow": false
+  },
+  {
+    "principal": "17419306416503728769",
+    "rate_bps": 2212,
+    "seconds": 516180379,
+    "expected": "63068262505801353294",
+    "overflow": false
+  },
+  {
+    "principal": "17449466761977222798",
+    "rate_bps": 2082,
+    "seconds": 1966353008,
+    "expected": "226525848078904992969",
+    "overflow": false
+  },
+  {
+    "principal": "1564515639699212031",
+    "rate_bps": 4829,
+    "seconds": 2184224329,
+    "expected": "52327230252949996406",
+    "overflow": false
+  },
+  {
+    "principal": "7603533237666089764",
+    "rate_bps": 8192,
+    "seconds": 1111647478,
+    "expected": "219566395552553518297",
+    "overflow": false
+  },
+  {
+    "principal": "11250815731280333453",
+    "rate_bps": 6260,
+    "seconds": 458330247,
+    "expected": "102359995237865288462",
+    "overflow": false
+  },
+  {
+    "principal": "12972331846145925642",
+    "rate_bps": 2718,
+    "seconds": 2476337740,
+    "expected": "276866730244787066860",
+    "overflow": false
+  },
+  {
+    "principal": "14745059706585048235",
+    "rate_bps": 4230,
+    "seconds": 844602325,
+    "expected": "167044649084172610966",
+    "overflow": false
+  },
+  {
+    "principal": "2142854812328628416",
+    "rate_bps": 8520,
+    "seconds": 3966561266,
+    "expected": "229635961835751525260",
+    "overflow": false
+  },
+  {
+    "principal": "15554232625478764761",
+    "rate_bps": 1269,
+    "seconds": 1434984371,
+    "expected": "89815393310071508540",
+    "overflow": false
+  },
+  {
+    "principal": "11557624799261745350",
+    "rate_bps": 529,
+    "seconds": 428593000,
+    "expected": "8309267308083156709",
+    "overflow": false
+  },
+  {
+    "principal": "18332005755020349079",
+    "rate_bps": 1818,
+    "seconds": 3283107745,
+    "expected": "346962383427219175232",
+    "overflow": false
+  },
+  {
+    "principal": "3947533757617573788",
+    "rate_bps": 8497,
+    "seconds": 1683328558,
+    "expected": "179041519621839966590",
+    "overflow": false
+  },
+  {
+    "principal": "17966792552766001509",
+    "rate_bps": 6833,
+    "seconds": 2603664159,
+    "expected": "1013585366833237930324",
+    "overflow": false
+  },
+  {
+    "principal": "15877310903722520258",
+    "rate_bps": 4775,
+    "seconds": 3558151620,
+    "expected": "855397877587905437588",
+    "overflow": false
+  },
+  {
+    "principal": "9314286090221031619",
+    "rate_bps": 2946,
+    "seconds": 3747280301,
+    "expected": "326055769117730556244",
+    "overflow": false
+  },
+  {
+    "principal": "13556588128473875384",
+    "rate_bps": 1088,
+    "seconds": 853780394,
+    "expected": "39931798196166517513",
+    "overflow": false
+  },
+  {
+    "principal": "13668541489906143281",
+    "rate_bps": 9059,
+    "seconds": 1679197899,
+    "expected": "659322217000206013275",
+    "overflow": false
+  },
+  {
+    "principal": "4508339641130346494",
+    "rate_bps": 5516,
+    "seconds": 3731372384,
+    "expected": "294240784801141710786",
+    "overflow": false
+  },
+  {
+    "principal": "2850039978615912239",
+    "rate_bps": 8236,
+    "seconds": 1544055289,
+    "expected": "114927386409873792614",
+    "overflow": false
+  },
+  {
+    "principal": "17264967556828080404",
+    "rate_bps": 2565,
+    "seconds": 1175180390,
+    "expected": "165025502923219539019",
+    "overflow": false
+  },
+  {
+    "principal": "10931610998917329213",
+    "rate_bps": 6690,
+    "seconds": 800241335,
+    "expected": "185577218076747147996",
+    "overflow": false
+  },
+  {
+    "principal": "8351623618642929786",
+    "rate_bps": 9922,
+    "seconds": 662369852,
+    "expected": "174046016088861875723",
+    "overflow": false
+  },
+  {
+    "principal": "7003167179572547035",
+    "rate_bps": 5066,
+    "seconds": 2084931717,
+    "expected": "234555115218425636651",
+    "overflow": false
+  },
+  {
+    "principal": "292098768365648816",
+    "rate_bps": 1652,
+    "seconds": 1871442018,
+    "expected": "2863581433549487186",
+    "overflow": false
+  },
+  {
+    "principal": "9162312355123257481",
+    "rate_bps": 5281,
+    "seconds": 790159075,
+    "expected": "121235326460837083255",
+    "overflow": false
+  },
+  {
+    "principal": "17084945603701001270",
+    "rate_bps": 3348,
+    "seconds": 4041361496,
+    "expected": "733027288029316010447",
+    "overflow": false
+  },
+  {
+    "principal": "14593086247053942983",
+    "rate_bps": 6717,
+    "seconds": 3070721361,
+    "expected": "954456853316633524136",
+    "overflow": false
+  },
+  {
+    "principal": "16872743562398709644",
+    "rate_bps": 3366,
+    "seconds": 854005662,
+    "expected": "153799159028972405200",
+    "overflow": false
+  },
+  {
+    "principal": "2266821621617789461",
+    "rate_bps": 7727,
+    "seconds": 3340946255,
+    "expected": "185562895694854040418",
+    "overflow": false
+  },
+  {
+    "principal": "17989650882225794866",
+    "rate_bps": 2093,
+    "seconds": 1122921396,
+    "expected": "134070958287321959297",
+    "overflow": false
+  },
+  {
+    "principal": "4407082899535477747",
+    "rate_bps": 1413,
+    "seconds": 913814621,
+    "expected": "18044501026257739918",
+    "overflow": false
+  },
+  {
+    "principal": "14301362270260517032",
+    "rate_bps": 7735,
+    "seconds": 4272006682,
+    "expected": "1498521720951538591425",
+    "overflow": false
+  },
+  {
+    "principal": "5414573548093741537",
+    "rate_bps": 800,
+    "seconds": 3067906043,
+    "expected": "42139530462873517990",
+    "overflow": false
+  },
+  {
+    "principal": "6029010134342561134",
+    "rate_bps": 4937,
+    "seconds": 2449923152,
+    "expected": "231235759238967974518",
+    "overflow": false
+  },
+  {
+    "principal": "1989826337920510815",
+    "rate_bps": 2305,
+    "seconds": 2030033321,
+    "expected": "29524507665853655069",
+    "overflow": false
+  },
+  {
+    "principal": "17457866229417548548",
+    "rate_bps": 310,
+    "seconds": 750598102,
+    "expected": "12881122493654615793",
+    "overflow": false
+  },
+  {
+    "principal": "16357183483080834029",
+    "rate_bps": 6320,
+    "seconds": 3996147943,
+    "expected": "1309967601523535506445",
+    "overflow": false
+  },
+  {
+    "principal": "17084799519464235754",
+    "rate_bps": 1868,
+    "seconds": 289822252,
+    "expected": "29329987550529339329",
+    "overflow": false
+  },
+  {
+    "principal": "17863461088467647243",
+    "rate_bps": 5866,
+    "seconds": 3231045941,
+    "expected": "1073604178562236661314",
+    "overflow": false
+  },
+  {
+    "principal": "9755092021694495392",
+    "rate_bps": 159,
+    "seconds": 1718921426,
+    "expected": "8454305027594113609",
+    "overflow": false
+  },
+  {
+    "principal": "11953869451094613049",
+    "rate_bps": 4779,
+    "seconds": 1624433171,
+    "expected": "294266471258100372451",
+    "overflow": false
+  },
+  {
+    "principal": "1251097734626126758",
+    "rate_bps": 9499,
+    "seconds": 1851184456,
+    "expected": "69760922249014973830",
+    "overflow": false
+  },
+  {
+    "principal": "11794877761164785399",
+    "rate_bps": 5609,
+    "seconds": 1011343105,
+    "expected": "212163560641441414516",
+    "overflow": false
+  },
+  {
+    "principal": "4465236452531254140",
+    "rate_bps": 5142,
+    "seconds": 1194857742,
+    "expected": "86993364722386223777",
+    "overflow": false
+  },
+  {
+    "principal": "9655480191259715269",
+    "rate_bps": 1893,
+    "seconds": 1634654079,
+    "expected": "94742261416167945517",
+    "overflow": false
+  },
+  {
+    "principal": "15641090412581905314",
+    "rate_bps": 1670,
+    "seconds": 4069365156,
+    "expected": "337057156601239231459",
+    "overflow": false
+  },
+  {
+    "principal": "15296422797849078563",
+    "rate_bps": 2894,
+    "seconds": 403199757,
+    "expected": "56598127175131446240",
+    "overflow": false
+  },
+  {
+    "principal": "12286514201741967768",
+    "rate_bps": 2407,
+    "seconds": 1525209226,
+    "expected": "143030149961363638217",
+    "overflow": false
+  },
+  {
+    "principal": "18082069015451404177",
+    "rate_bps": 7779,
+    "seconds": 1360088363,
+    "expected": "606641912103838365487",
+    "overflow": false
+  },
+  {
+    "principal": "10346881929600657118",
+    "rate_bps": 1193,
+    "seconds": 1162285888,
+    "expected": "45494227479488281709",
+    "overflow": false
+  },
+  {
+    "principal": "17299451049046877071",
+    "rate_bps": 6570,
+    "seconds": 3736726873,
+    "expected": "1346735908815031387248",
+    "overflow": false
+  },
+  {
+    "principal": "12645236519198679284",
+    "rate_bps": 3458,
+    "seconds": 3545599814,
+    "expected": "491626240011668470849",
+    "overflow": false
+  },
+  {
+    "principal": "770152562040203933",
+    "rate_bps": 5538,
+    "seconds": 2933231383,
+    "expected": "39670660549738751357",
+    "overflow": false
+  },
+  {
+    "principal": "16359330700548182362",
+    "rate_bps": 4270,
+    "seconds": 1266879004,
+    "expected": "280622144006066184838",
+    "overflow": false
+  },
+  {
+    "principal": "12831099633455344699",
+    "rate_bps": 8073,
+    "seconds": 3665530341,
+    "expected": "1204007082143196819706",
+    "overflow": false
+  },
+  {
+    "principal": "181895125885848976",
+    "rate_bps": 9671,
+    "seconds": 2432046402,
+    "expected": "13566183740415548460",
+    "overflow": false
+  },
+  {
+    "principal": "14789472100647107561",
+    "rate_bps": 8366,
+    "seconds": 3553700163,
+    "expected": "1394263017515945072639",
+    "overflow": false
+  },
+  {
+    "principal": "13295358627585130262",
+    "rate_bps": 6336,
+    "seconds": 3770709560,
+    "expected": "1007237067922011021589",
+    "overflow": false
+  },
+  {
+    "principal": "17374643375545389351",
+    "rate_bps": 2245,
+    "seconds": 1597269169,
+    "expected": "197562151217208964322",
+    "overflow": false
+  },
+  {
+    "principal": "11285017571622257516",
+    "rate_bps": 8951,
+    "seconds": 1525122686,
+    "expected": "488508327036715232871",
+    "overflow": false
+  },
+  {
+    "principal": "5596561376285337461",
+    "rate_bps": 6877,
+    "seconds": 3879724975,
+    "expected": "473494162194132863869",
+    "overflow": false
+  },
+  {
+    "principal": "9900909974487174162",
+    "rate_bps": 4245,
+    "seconds": 1696174996,
+    "expected": "226056425513380726520",
+    "overflow": false
+  },
+  {
+    "principal": "14582516845618716243",
+    "rate_bps": 5562,
+    "seconds": 727702973,
+    "expected": "187159128223470915916",
+    "overflow": false
+  },
+  {
+    "principal": "1413708771972300424",
+    "rate_bps": 9396,
+    "seconds": 1646804730,
+    "expected": "69364691592398421831",
+    "overflow": false
+  },
+  {
+    "principal": "18154577059638843713",
+    "rate_bps": 4690,
+    "seconds": 3606042203,
+    "expected": "973605854408986121074",
+    "overflow": false
+  },
+  {
+    "principal": "5291111351041545294",
+    "rate_bps": 6500,
+    "seconds": 1553980976,
+    "expected": "169472544010671691468",
+    "overflow": false
+  },
+  {
+    "principal": "11718583461822029759",
+    "rate_bps": 3733,
+    "seconds": 1259971849,
+    "expected": "174778232244332882222",
+    "overflow": false
+  },
+  {
+    "principal": "2013835156141767396",
+    "rate_bps": 6758,
+    "seconds": 1813240502,
+    "expected": "78251182644162329317",
+    "overflow": false
+  },
+  {
+    "principal": "12241723999093210445",
+    "rate_bps": 316,
+    "seconds": 1609384263,
+    "expected": "19741620985975051923",
+    "overflow": false
+  },
+  {
+    "principal": "17550057296905712586",
+    "rate_bps": 3136,
+    "seconds": 2616726028,
+    "expected": "456673951164590684383",
+    "overflow": false
+  },
+  {
+    "principal": "1964636700465602923",
+    "rate_bps": 9711,
+    "seconds": 694789781,
+    "expected": "42033254953969249494",
+    "overflow": false
+  },
+  {
+    "principal": "3224282525993448576",
+    "rate_bps": 7321,
+    "seconds": 1075787186,
+    "expected": "80523613662291169448",
+    "overflow": false
+  },
+  {
+    "principal": "3359380189575462809",
+    "rate_bps": 9022,
+    "seconds": 1936634995,
+    "expected": "186124330228882210436",
+    "overflow": false
+  },
+  {
+    "principal": "10886311636508952198",
+    "rate_bps": 887,
+    "seconds": 3191221032,
+    "expected": "97713520558349183106",
+    "overflow": false
+  },
+  {
+    "principal": "1289737199345856343",
+    "rate_bps": 7122,
+    "seconds": 3150974561,
+    "expected": "91778612029020751213",
+    "overflow": false
+  },
+  {
+    "principal": "4074373001226823516",
+    "rate_bps": 8546,
+    "seconds": 886336494,
+    "expected": "97862363019901393072",
+    "overflow": false
+  },
+  {
+    "principal": "6674057919191813157",
+    "rate_bps": 9706,
+    "seconds": 2214656991,
+    "expected": "454914859450221856069",
+    "overflow": false
+  },
+  {
+    "principal": "2129995513801631874",
+    "rate_bps": 7267,
+    "seconds": 3757663620,
+    "expected": "184435765306867342478",
+    "overflow": false
+  },
+  {
+    "principal": "13395937924607825283",
+    "rate_bps": 8640,
+    "seconds": 4094773357,
+    "expected": "1502830950841369798425",
+    "overflow": false
+  },
+  {
+    "principal": "7975244709269360504",
+    "rate_bps": 840,
+    "seconds": 4161722730,
+    "expected": "88407648511091999663",
+    "overflow": false
+  },
+  {
+    "principal": "2847793381240819441",
+    "rate_bps": 4462,
+    "seconds": 2264081291,
+    "expected": "91227012179035155477",
+    "overflow": false
+  },
+  {
+    "principal": "17044001193244603838",
+    "rate_bps": 2960,
+    "seconds": 3687333152,
+    "expected": "589887289136326810894",
+    "overflow": false
+  },
+  {
+    "principal": "8672827538181791727",
+    "rate_bps": 5827,
+    "seconds": 3829530809,
+    "expected": "613683842995069457090",
+    "overflow": false
+  },
+  {
+    "principal": "8284327315795241172",
+    "rate_bps": 1023,
+    "seconds": 4000782886,
+    "expected": "107515544872013586008",
+    "overflow": false
+  },
+  {
+    "principal": "5203537569013167101",
+    "rate_bps": 1588,
+    "seconds": 3053614967,
+    "expected": "80012319637593921669",
+    "overflow": false
+  },
+  {
+    "principal": "4715383412659948090",
+    "rate_bps": 7881,
+    "seconds": 2209115644,
+    "expected": "260321586981424826054",
+    "overflow": false
+  },
+  {
+    "principal": "17208821895612521115",
+    "rate_bps": 1566,
+    "seconds": 1091773253,
+    "expected": "93297228146719991361",
+    "overflow": false
+  },
+  {
+    "principal": "13142014220691107696",
+    "rate_bps": 2443,
+    "seconds": 3326020130,
+    "expected": "338613030180259443904",
+    "overflow": false
+  },
+  {
+    "principal": "375491888470107977",
+    "rate_bps": 6686,
+    "seconds": 1564902307,
+    "expected": "12457977889438228984",
+    "overflow": false
+  },
+  {
+    "principal": "1149101368929780214",
+    "rate_bps": 3973,
+    "seconds": 2484007960,
+    "expected": "35960298108503406331",
+    "overflow": false
+  },
+  {
+    "principal": "15763530173726085511",
+    "rate_bps": 4521,
+    "seconds": 777903121,
+    "expected": "175795152924463713242",
+    "overflow": false
+  },
+  {
+    "principal": "11678274591099756364",
+    "rate_bps": 461,
+    "seconds": 421381470,
+    "expected": "7193635607161475205",
+    "overflow": false
+  },
+  {
+    "principal": "12263428735675585749",
+    "rate_bps": 8520,
+    "seconds": 1096619023,
+    "expected": "363329511396885354764",
+    "overflow": false
+  },
+  {
+    "principal": "17227246322964396274",
+    "rate_bps": 8756,
+    "seconds": 1540623220,
+    "expected": "736904907296814379035",
+    "overflow": false
+  },
+  {
+    "principal": "145272833828720819",
+    "rate_bps": 7330,
+    "seconds": 2179962653,
+    "expected": "7360898503090097653",
+    "overflow": false
+  },
+  {
+    "principal": "5031069273550582888",
+    "rate_bps": 5430,
+    "seconds": 965453786,
+    "expected": "83634412374216140032",
+    "overflow": false
+  },
+  {
+    "principal": "3664217752393689249",
+    "rate_bps": 3038,
+    "seconds": 1775645883,
+    "expected": "62678529045171648603",
+    "overflow": false
+  },
+  {
+    "principal": "11635474723295365934",
+    "rate_bps": 4159,
+    "seconds": 1438068752,
+    "expected": "220671410016154546888",
+    "overflow": false
+  },
+  {
+    "principal": "12416811233548887071",
+    "rate_bps": 5026,
+    "seconds": 3902144617,
+    "expected": "772199145730236375440",
+    "overflow": false
+  },
+  {
+    "principal": "3436580740057705156",
+    "rate_bps": 5211,
+    "seconds": 2269007254,
+    "expected": "128847768769905045022",
+    "overflow": false
+  },
+  {
+    "principal": "1101958231571730093",
+    "rate_bps": 5504,
+    "seconds": 1541419431,
+    "expected": "29645431842795610241",
+    "overflow": false
+  },
+  {
+    "principal": "16732513322458748074",
+    "rate_bps": 4465,
+    "seconds": 786898412,
+    "expected": "186420944775098111458",
+    "overflow": false
+  },
+  {
+    "principal": "4540920291902871499",
+    "rate_bps": 6120,
+    "seconds": 2573927413,
+    "expected": "226821902663019371049",
+    "overflow": false
+  },
+  {
+    "principal": "15682616990441586272",
+    "rate_bps": 8155,
+    "seconds": 3873739410,
+    "expected": "1570964229715511634624",
+    "overflow": false
+  },
+  {
+    "principal": "17301984143407952633",
+    "rate_bps": 6331,
+    "seconds": 288593619,
+    "expected": "100241680916168630368",
+    "overflow": false
+  },
+  {
+    "principal": "7095824424487268710",
+    "rate_bps": 5658,
+    "seconds": 4141994248,
+    "expected": "527313255438254551699",
+    "overflow": false
+  },
+  {
+    "principal": "15544265521199593399",
+    "rate_bps": 7460,
+    "seconds": 2204159425,
+    "expected": "810485837060120095701",
+    "overflow": false
+  },
+  {
+    "principal": "4977837684712237884",
+    "rate_bps": 1321,
+    "seconds": 958567118,
+    "expected": "19987545669354888822",
+    "overflow": false
+  },
+  {
+    "principal": "16752902747463188869",
+    "rate_bps": 9579,
+    "seconds": 926887999,
+    "expected": "471662004990349691400",
+    "overflow": false
+  },
+  {
+    "principal": "1839831171217571170",
+    "rate_bps": 4032,
+    "seconds": 1955628388,
+    "expected": "46002159767895150559",
+    "overflow": false
+  },
+  {
+    "principal": "9453338194388946915",
+    "rate_bps": 1094,
+    "seconds": 554551757,
+    "expected": "18186033878436314910",
+    "overflow": false
+  },
+  {
+    "principal": "4473074113384131928",
+    "rate_bps": 7034,
+    "seconds": 3972901450,
+    "expected": "396378092423274031580",
+    "overflow": false
+  },
+  {
+    "principal": "14077237515934967377",
+    "rate_bps": 7481,
+    "seconds": 2190739947,
+    "expected": "731579139735291780163",
+    "overflow": false
+  },
+  {
+    "principal": "7822218365750989982",
+    "rate_bps": 9050,
+    "seconds": 3701716736,
+    "expected": "830950379141870972430",
+    "overflow": false
+  },
+  {
+    "principal": "7050400225327295567",
+    "rate_bps": 6277,
+    "seconds": 1589158937,
+    "expected": "223011175713956075233",
+    "overflow": false
+  },
+  {
+    "principal": "12987613613451755700",
+    "rate_bps": 9481,
+    "seconds": 141063430,
+    "expected": "55079671192336227832",
+    "overflow": false
+  },
+  {
+    "principal": "6145287221232536925",
+    "rate_bps": 8756,
+    "seconds": 579956695,
+    "expected": "98954807477177749314",
+    "overflow": false
+  },
+  {
+    "principal": "8525393045197607706",
+    "rate_bps": 7055,
+    "seconds": 1697587676,
+    "expected": "323770320539215769676",
+    "overflow": false
+  },
+  {
+    "principal": "9532210950951180539",
+    "rate_bps": 8564,
+    "seconds": 1050953893,
+    "expected": "272049141538539604131",
+    "overflow": false
+  },
+  {
+    "principal": "4457436192490332496",
+    "rate_bps": 3969,
+    "seconds": 1189007106,
+    "expected": "66702801899798853474",
+    "overflow": false
+  },
+  {
+    "principal": "7232493535259124393",
+    "rate_bps": 7345,
+    "seconds": 2706435587,
+    "expected": "455901417671476178752",
+    "overflow": false
+  },
+  {
+    "principal": "4796424454130619606",
+    "rate_bps": 4642,
+    "seconds": 1921368568,
+    "expected": "135652193101701010741",
+    "overflow": false
+  },
+  {
+    "principal": "4196532843104215527",
+    "rate_bps": 8844,
+    "seconds": 664527729,
+    "expected": "78207042169244398453",
+    "overflow": false
+  },
+  {
+    "principal": "17813620402797710124",
+    "rate_bps": 4802,
+    "seconds": 595711038,
+    "expected": "161585873236639608109",
+    "overflow": false
+  },
+  {
+    "principal": "10422532079414317621",
+    "rate_bps": 4550,
+    "seconds": 3151122543,
+    "expected": "473852659966873437788",
+    "overflow": false
+  },
+  {
+    "principal": "12614893757077239250",
+    "rate_bps": 4376,
+    "seconds": 1498796884,
+    "expected": "262359675543856805351",
+    "overflow": false
+  },
+  {
+    "principal": "15596875403492872979",
+    "rate_bps": 3312,
+    "seconds": 163504253,
+    "expected": "26782454623557097309",
+    "overflow": false
+  },
+  {
+    "principal": "16979233760217397832",
+    "rate_bps": 9800,
+    "seconds": 4047757498,
+    "expected": "2135758001901015095790",
+    "overflow": false
+  },
+  {
+    "principal": "10955990139592263681",
+    "rate_bps": 9070,
+    "seconds": 4268204827,
+    "expected": "1344923448393058663596",
+    "overflow": false
+  },
+  {
+    "principal": "16737521908160958990",
+    "rate_bps": 9587,
+    "seconds": 4060402160,
+    "expected": "2066028599487718449609",
+    "overflow": false
+  },
+  {
+    "principal": "4846671982824421503",
+    "rate_bps": 9771,
+    "seconds": 3314346953,
+    "expected": "497707292167419794436",
+    "overflow": false
+  },
+  {
+    "principal": "11143534282220415652",
+    "rate_bps": 5183,
+    "seconds": 1496617078,
+    "expected": "274099505518406887402",
+    "overflow": false
+  },
+  {
+    "principal": "11098629374050398221",
+    "rate_bps": 6701,
+    "seconds": 828453383,
+    "expected": "195375649869164134671",
+    "overflow": false
+  },
+  {
+    "principal": "8861479011874882954",
+    "rate_bps": 4578,
+    "seconds": 2034989516,
+    "expected": "261780667495719601948",
+    "overflow": false
+  },
+  {
+    "principal": "13547715810433441323",
+    "rate_bps": 1554,
+    "seconds": 2167533909,
+    "expected": "144702617062974964122",
+    "overflow": false
+  },
+  {
+    "principal": "6561285469884192832",
+    "rate_bps": 8888,
+    "seconds": 3694968690,
+    "expected": "683277524182205677803",
+    "overflow": false
+  },
+  {
+    "principal": "4121191296082163289",
+    "rate_bps": 6080,
+    "seconds": 3791227187,
+    "expected": "301230925627757297710",
+    "overflow": false
+  },
+  {
+    "principal": "5288720329731206214",
+    "rate_bps": 1725,
+    "seconds": 2047985384,
+    "expected": "59246124551256405161",
+    "overflow": false
+  },
+  {
+    "principal": "8707403720884523031",
+    "rate_bps": 4828,
+    "seconds": 3625065761,
+    "expected": "483242614061510140600",
+    "overflow": false
+  },
+  {
+    "principal": "10929656894595202844",
+    "rate_bps": 4396,
+    "seconds": 874154414,
+    "expected": "133182069912349141437",
+    "overflow": false
+  },
+  {
+    "principal": "13709975362289862373",
+    "rate_bps": 9891,
+    "seconds": 2474734751,
+    "expected": "1064140386940336145749",
+    "overflow": false
+  },
+  {
+    "principal": "17914999223205421634",
+    "rate_bps": 7386,
+    "seconds": 3163223364,
+    "expected": "1327239657496912695627",
+    "overflow": false
+  },
+  {
+    "principal": "9324315510685653571",
+    "rate_bps": 9260,
+    "seconds": 278256429,
+    "expected": "76184487009897304911",
+    "overflow": false
+  },
+  {
+    "principal": "60251807626779448",
+    "rate_bps": 1292,
+    "seconds": 2946321194,
+    "expected": "727287422950176748",
+    "overflow": false
+  },
+  {
+    "principal": "4960466981322591665",
+    "rate_bps": 7276,
+    "seconds": 1691091019,
+    "expected": "193542180542494530013",
+    "overflow": false
+  },
+  {
+    "principal": "18171095921609130878",
+    "rate_bps": 5388,
+    "seconds": 1989247200,
+    "expected": "617576634538187975988",
+    "overflow": false
+  },
+  {
+    "principal": "16354699414747105455",
+    "rate_bps": 8983,
+    "seconds": 3291862905,
+    "expected": "1533554092627288581691",
+    "overflow": false
+  },
+  {
+    "principal": "11154133866337298580",
+    "rate_bps": 7818,
+    "seconds": 3860963302,
+    "expected": "1067629548804249598772",
+    "overflow": false
+  },
+  {
+    "principal": "4419328153286194877",
+    "rate_bps": 580,
+    "seconds": 903510071,
+    "expected": "7343627429787503531",
+    "overflow": false
+  },
+  {
+    "principal": "15433801984644541434",
+    "rate_bps": 5895,
+    "seconds": 960701884,
+    "expected": "277165243486722952825",
+    "overflow": false
+  },
+  {
+    "principal": "6584602877264226139",
+    "rate_bps": 6032,
+    "seconds": 2781281797,
+    "expected": "350291264250346226764",
+    "overflow": false
+  },
+  {
+    "principal": "4609624250118021936",
+    "rate_bps": 3966,
+    "seconds": 1582130146,
+    "expected": "91717843368818993493",
+    "overflow": false
+  },
+  {
+    "principal": "379202130694188553",
+    "rate_bps": 7505,
+    "seconds": 2580047971,
+    "expected": "23283198432466441756",
+    "overflow": false
+  },
+  {
+    "principal": "15040216878721660854",
+    "rate_bps": 6390,
+    "seconds": 1474093016,
+    "expected": "449234641798936435036",
+    "overflow": false
+  },
+  {
+    "principal": "4970681673306800711",
+    "rate_bps": 8910,
+    "seconds": 1376156369,
+    "expected": "193265721762637094137",
+    "overflow": false
+  },
+  {
+    "principal": "11304680409861572364",
+    "rate_bps": 3909,
+    "seconds": 67875614,
+    "expected": "9511108232807677136",
+    "overflow": false
+  },
+  {
+    "principal": "706590279775805333",
+    "rate_bps": 9432,
+    "seconds": 553098447,
+    "expected": "11688728817264255789",
+    "overflow": false
+  },
+  {
+    "principal": "3545053101120799410",
+    "rate_bps": 7776,
+    "seconds": 3285642036,
+    "expected": "287205423013840863832",
+    "overflow": false
+  },
+  {
+    "principal": "3846191434644432243",
+    "rate_bps": 85,
+    "seconds": 1449507293,
+    "expected": "1502670013499667614",
+    "overflow": false
+  },
+  {
+    "principal": "4213078386129424424",
+    "rate_bps": 8210,
+    "seconds": 2311645594,
+    "expected": "253546337412357266462",
+    "overflow": false
+  },
+  {
+    "principal": "10675729369348831073",
+    "rate_bps": 4652,
+    "seconds": 3346801019,
+    "expected": "527060594454659983757",
+    "overflow": false
+  },
+  {
+    "principal": "1854691950501587182",
+    "rate_bps": 1444,
+    "seconds": 2587935696,
+    "expected": "21977882862342453688",
+    "overflow": false
+  },
+  {
+    "principal": "5240839087073402079",
+    "rate_bps": 5074,
+    "seconds": 3658901289,
+    "expected": "308528561674328450425",
+    "overflow": false
+  },
+  {
+    "principal": "7763173151372081796",
+    "rate_bps": 6431,
+    "seconds": 284074838,
+    "expected": "44972180305061619454",
+    "overflow": false
+  },
+  {
+    "principal": "5364416570459152749",
+    "rate_bps": 3406,
+    "seconds": 2479374951,
+    "expected": "143649044405177270867",
+    "overflow": false
+  },
+  {
+    "principal": "11423372464114058858",
+    "rate_bps": 556,
+    "seconds": 3730646444,
+    "expected": "75135748056584395600",
+    "overflow": false
+  },
+  {
+    "principal": "13151414836117337227",
+    "rate_bps": 2757,
+    "seconds": 2505469621,
+    "expected": "288065850904782788913",
+    "overflow": false
+  },
+  {
+    "principal": "5346978669679985184",
+    "rate_bps": 3704,
+    "seconds": 3047144530,
+    "expected": "191366483533063577750",
+    "overflow": false
+  },
+  {
+    "principal": "7953351264369265081",
+    "rate_bps": 1346,
+    "seconds": 2979564435,
+    "expected": "101144296595457153388",
+    "overflow": false
+  },
+  {
+    "principal": "17818639237650904870",
+    "rate_bps": 1536,
+    "seconds": 494800072,
+    "expected": "42942655599302004702",
+    "overflow": false
+  },
+  {
+    "principal": "11851894768626759799",
+    "rate_bps": 4269,
+    "seconds": 50068609,
+    "expected": "8032909251028872857",
+    "overflow": false
+  },
+  {
+    "principal": "2059552609727668988",
+    "rate_bps": 3843,
+    "seconds": 3652472974,
+    "expected": "91669250138548863139",
+    "overflow": false
+  },
+  {
+    "principal": "10548421827929447493",
+    "rate_bps": 5747,
+    "seconds": 2501888255,
+    "expected": "480938990336228653121",
+    "overflow": false
+  },
+  {
+    "principal": "14304427996979615522",
+    "rate_bps": 8761,
+    "seconds": 4162893092,
+    "expected": "1654294505228187156054",
+    "overflow": false
+  },
+  {
+    "principal": "15912161525582279843",
+    "rate_bps": 1320,
+    "seconds": 4165041293,
+    "expected": "277405977155364073655",
+    "overflow": false
+  },
+  {
+    "principal": "7868134055274174744",
+    "rate_bps": 4133,
+    "seconds": 1257618442,
+    "expected": "129681924351869792251",
+    "overflow": false
+  },
+  {
+    "principal": "2979006429646849297",
+    "rate_bps": 2433,
+    "seconds": 4067624619,
+    "expected": "93486265159246114092",
+    "overflow": false
+  },
+  {
+    "principal": "10821472224422494814",
+    "rate_bps": 7920,
+    "seconds": 3427375808,
+    "expected": "931465235612387352652",
+    "overflow": false
+  },
+  {
+    "principal": "10585818214394819855",
+    "rate_bps": 263,
+    "seconds": 248617689,
+    "expected": "2194853807545398807",
+    "overflow": false
+  },
+  {
+    "principal": "7067012182249988212",
+    "rate_bps": 9244,
+    "seconds": 2694486726,
+    "expected": "558168364612693044946",
+    "overflow": false
+  },
+  {
+    "principal": "11163403278754705437",
+    "rate_bps": 5133,
+    "seconds": 2503315607,
+    "expected": "454859090102788446335",
+    "overflow": false
+  },
+  {
+    "principal": "14883008689797584090",
+    "rate_bps": 2698,
+    "seconds": 4246763932,
+    "expected": "540734642663544623989",
+    "overflow": false
+  },
+  {
+    "principal": "15802937319259719099",
+    "rate_bps": 4674,
+    "seconds": 2366849893,
+    "expected": "554358402054295497682",
+    "overflow": false
+  },
+  {
+    "principal": "1895380979950974224",
+    "rate_bps": 1015,
+    "seconds": 1812121794,
+    "expected": "11054607748058634590",
+    "overflow": false
+  },
+  {
+    "principal": "15612034604769675625",
+    "rate_bps": 9108,
+    "seconds": 1686434499,
+    "expected": "760405760335336639672",
+    "overflow": false
+  },
+  {
+    "principal": "3955569792373746326",
+    "rate_bps": 841,
+    "seconds": 2479639992,
+    "expected": "26156948216751213212",
+    "overflow": false
+  },
+  {
+    "principal": "12694621948277650087",
+    "rate_bps": 7661,
+    "seconds": 3098911281,
+    "expected": "955669597856227041981",
+    "overflow": false
+  },
+  {
+    "principal": "3892867520638505708",
+    "rate_bps": 3233,
+    "seconds": 414409214,
+    "expected": "16538576445268588042",
+    "overflow": false
+  },
+  {
+    "principal": "10095557160569322741",
+    "rate_bps": 4904,
+    "seconds": 522516783,
+    "expected": "82030317217953095911",
+    "overflow": false
+  },
+  {
+    "principal": "8573899369263177618",
+    "rate_bps": 682,
+    "seconds": 898585364,
+    "expected": "16661553434800827620",
+    "overflow": false
+  },
+  {
+    "principal": "4058598378399074259",
+    "rate_bps": 901,
+    "seconds": 3212583741,
+    "expected": "37251924888020491654",
+    "overflow": false
+  },
+  {
+    "principal": "15005758005045491208",
+    "rate_bps": 5807,
+    "seconds": 2542977658,
+    "expected": "702660761576966776884",
+    "overflow": false
+  },
+  {
+    "principal": "1819883900062676673",
+    "rate_bps": 8925,
+    "seconds": 2615914459,
+    "expected": "134731405141066581740",
+    "overflow": false
+  },
+  {
+    "principal": "11229616611604959182",
+    "rate_bps": 9505,
+    "seconds": 2871199152,
+    "expected": "971792987086037265040",
+    "overflow": false
+  },
+  {
+    "principal": "13790283051215999295",
+    "rate_bps": 494,
+    "seconds": 2722787977,
+    "expected": "58817606368249721799",
+    "overflow": false
+  },
+  {
+    "principal": "2025637473489295972",
+    "rate_bps": 7011,
+    "seconds": 828671542,
+    "expected": "37317926719435236061",
+    "overflow": false
+  },
+  {
+    "principal": "12543000155967054541",
+    "rate_bps": 6363,
+    "seconds": 2590859975,
+    "expected": "655693209156771002096",
+    "overflow": false
+  },
+  {
+    "principal": "3848446144740169546",
+    "rate_bps": 1088,
+    "seconds": 1968447884,
+    "expected": "26135548735693486765",
+    "overflow": false
+  },
+  {
+    "principal": "404644379866815211",
+    "rate_bps": 2425,
+    "seconds": 3463478293,
+    "expected": "10776832154296406431",
+    "overflow": false
+  },
+  {
+    "principal": "16784006671909567488",
+    "rate_bps": 4479,
+    "seconds": 478513458,
+    "expected": "114068112595168229382",
+    "overflow": false
+  },
+  {
+    "principal": "3772265656868302105",
+    "rate_bps": 5840,
+    "seconds": 1877515763,
+    "expected": "131157189499884933651",
+    "overflow": false
+  },
+  {
+    "principal": "10405898094374146566",
+    "rate_bps": 1002,
+    "seconds": 719233704,
+    "expected": "23779937769923216370",
+    "overflow": false
+  },
+  {
+    "principal": "13714876007658516695",
+    "rate_bps": 3382,
+    "seconds": 1362521057,
+    "expected": "200402024585190185474",
+    "overflow": false
+  },
+  {
+    "principal": "11393716768526702300",
+    "rate_bps": 1362,
+    "seconds": 2984765294,
+    "expected": "146874400234830736034",
+    "overflow": false
+  },
+  {
+    "principal": "15157798167182885285",
+    "rate_bps": 7843,
+    "seconds": 477244767,
+    "expected": "179909005578007800741",
+    "overflow": false
+  },
+  {
+    "principal": "15635767015409884162",
+    "rate_bps": 5488,
+    "seconds": 2609497348,
+    "expected": "710041194738999643522",
+    "overflow": false
+  },
+  {
+    "principal": "14984109173777637123",
+    "rate_bps": 33,
+    "seconds": 3517492717,
+    "expected": "5515329564159560364",
+    "overflow": false
+  },
+  {
+    "principal": "11870560926678099704",
+    "rate_bps": 732,
+    "seconds": 1565457642,
+    "expected": "43133732091597595289",
+    "overflow": false
+  },
+  {
+    "principal": "9230850254494239857",
+    "rate_bps": 4651,
+    "seconds": 2489392395,
+    "expected": "338902518946629809699",
+    "overflow": false
+  },
+  {
+    "principal": "15998687088342536510",
+    "rate_bps": 8805,
+    "seconds": 4102292640,
+    "expected": "1832456760060129012991",
+    "overflow": false
+  },
+  {
+    "principal": "1032756130633724271",
+    "rate_bps": 5577,
+    "seconds": 3164859961,
+    "expected": "57802459401520212266",
+    "overflow": false
+  },
+  {
+    "principal": "11786175938701797460",
+    "rate_bps": 1694,
+    "seconds": 2764793254,
+    "expected": "175042045584319701442",
+    "overflow": false
+  },
+  {
+    "principal": "5023888633924663677",
+    "rate_bps": 3036,
+    "seconds": 1241168119,
+    "expected": "60029645078993145514",
+    "overflow": false
+  },
+  {
+    "principal": "1270195515052494266",
+    "rate_bps": 2443,
+    "seconds": 1644109180,
+    "expected": "16177748860508957614",
+    "overflow": false
+  },
+  {
+    "principal": "276627834360575003",
+    "rate_bps": 8998,
+    "seconds": 1327569093,
+    "expected": "10478337719810007228",
+    "overflow": false
+  },
+  {
+    "principal": "8237914232833414896",
+    "rate_bps": 6888,
+    "seconds": 3816226210,
+    "expected": "686653926071335934597",
+    "overflow": false
+  },
+  {
+    "principal": "2625814025605182665",
+    "rate_bps": 5604,
+    "seconds": 1130269987,
+    "expected": "52739702907202532426",
+    "overflow": false
+  },
+  {
+    "principal": "5946491464885841270",
+    "rate_bps": 2854,
+    "seconds": 3926657944,
+    "expected": "211315441108372393198",
+    "overflow": false
+  },
+  {
+    "principal": "10956067993989018375",
+    "rate_bps": 4238,
+    "seconds": 1791056273,
+    "expected": "263704958135178168874",
+    "overflow": false
+  },
+  {
+    "principal": "4047413381848116940",
+    "rate_bps": 6383,
+    "seconds": 2473648350,
+    "expected": "202644005770533648966",
+    "overflow": false
+  },
+  {
+    "principal": "1391972064252078677",
+    "rate_bps": 5121,
+    "seconds": 1219650959,
+    "expected": "27568570658809944264",
+    "overflow": false
+  },
+  {
+    "principal": "2718882011730168946",
+    "rate_bps": 1512,
+    "seconds": 2092370676,
+    "expected": "27275591061600448417",
+    "overflow": false
+  },
+  {
+    "principal": "2757927497990896179",
+    "rate_bps": 3708,
+    "seconds": 1620712605,
+    "expected": "52555959993836259599",
+    "overflow": false
+  },
+  {
+    "principal": "4249855590896069608",
+    "rate_bps": 5502,
+    "seconds": 1125739354,
+    "expected": "83469151891687089384",
+    "overflow": false
+  },
+  {
+    "principal": "5296391773093037601",
+    "rate_bps": 6826,
+    "seconds": 4136521275,
+    "expected": "474214731955279318891",
+    "overflow": false
+  },
+  {
+    "principal": "12173558241607911086",
+    "rate_bps": 2220,
+    "seconds": 1969461136,
+    "expected": "168776245094393707050",
+    "overflow": false
+  },
+  {
+    "principal": "9616725340934739359",
+    "rate_bps": 2202,
+    "seconds": 507579881,
+    "expected": "34083353569771909660",
+    "overflow": false
+  },
+  {
+    "principal": "6894119634062707268",
+    "rate_bps": 9532,
+    "seconds": 2442017046,
+    "expected": "508867756370197071128",
+    "overflow": false
+  },
+  {
+    "principal": "9899071443927790637",
+    "rate_bps": 1239,
+    "seconds": 3232273191,
+    "expected": "125709245051109226719",
+    "overflow": false
+  },
+  {
+    "principal": "18113919063661787178",
+    "rate_bps": 4502,
+    "seconds": 157838700,
+    "expected": "40815470005660194580",
+    "overflow": false
+  },
+  {
+    "principal": "7190340317334688075",
+    "rate_bps": 488,
+    "seconds": 1763187061,
+    "expected": "19618285533089307895",
+    "overflow": false
+  },
+  {
+    "principal": "473654795674977760",
+    "rate_bps": 615,
+    "seconds": 3462800914,
+    "expected": "3198585551499983143",
+    "overflow": false
+  },
+  {
+    "principal": "9344185873827700857",
+    "rate_bps": 3773,
+    "seconds": 818004051,
+    "expected": "91448612701313270389",
+    "overflow": false
+  },
+  {
+    "principal": "6549001077804399846",
+    "rate_bps": 2707,
+    "seconds": 1609271432,
+    "expected": "90466130034080656047",
+    "overflow": false
+  },
+  {
+    "principal": "14559604299999082807",
+    "rate_bps": 9303,
+    "seconds": 333015873,
+    "expected": "143031245457406953719",
+    "overflow": false
+  },
+  {
+    "principal": "17740471907891387068",
+    "rate_bps": 4347,
+    "seconds": 414010958,
+    "expected": "101241841863293694187",
+    "overflow": false
+  },
+  {
+    "principal": "984636680182757125",
+    "rate_bps": 6637,
+    "seconds": 3989873087,
+    "expected": "82679968506795232219",
+    "overflow": false
+  },
+  {
+    "principal": "13761692429448949986",
+    "rate_bps": 9706,
+    "seconds": 1325278436,
+    "expected": "561322768821553726622",
+    "overflow": false
+  },
+  {
+    "principal": "2023912160766531939",
+    "rate_bps": 7376,
+    "seconds": 1516465997,
+    "expected": "71785815394350537191",
+    "overflow": false
+  },
+  {
+    "principal": "12424514657634108632",
+    "rate_bps": 5044,
+    "seconds": 421596618,
+    "expected": "83780900138215496572",
+    "overflow": false
+  },
+  {
+    "principal": "944332744716985297",
+    "rate_bps": 7914,
+    "seconds": 1466844011,
+    "expected": "34761492923548307428",
+    "overflow": false
+  },
+  {
+    "principal": "740323581707317278",
+    "rate_bps": 3937,
+    "seconds": 4193828480,
+    "expected": "38760650392795828206",
+    "overflow": false
+  },
+  {
+    "principal": "7552233501523869135",
+    "rate_bps": 4577,
+    "seconds": 3485782425,
+    "expected": "382076204139040577841",
+    "overflow": false
+  },
+  {
+    "principal": "6153388338662883380",
+    "rate_bps": 6472,
+    "seconds": 3014393990,
+    "expected": "380667886666590501270",
+    "overflow": false
+  },
+  {
+    "principal": "9345689673045119709",
+    "rate_bps": 3704,
+    "seconds": 3246518615,
+    "expected": "356363835451943566080",
+    "overflow": false
+  },
+  {
+    "principal": "857052463580845722",
+    "rate_bps": 6350,
+    "seconds": 3440841052,
+    "expected": "59379855585941785246",
+    "overflow": false
+  },
+  {
+    "principal": "6002507741013095035",
+    "rate_bps": 2693,
+    "seconds": 2324200997,
+    "expected": "119134119242473883362",
+    "overflow": false
+  },
+  {
+    "principal": "210428406960163024",
+    "rate_bps": 5638,
+    "seconds": 1277297282,
+    "expected": "4805237083696774683",
+    "overflow": false
+  },
+  {
+    "principal": "8651890316762837033",
+    "rate_bps": 2108,
+    "seconds": 2620209027,
+    "expected": "151534298633054618611",
+    "overflow": false
+  },
+  {
+    "principal": "15620867949229981782",
+    "rate_bps": 6107,
+    "seconds": 2454985080,
+    "expected": "742634859435324281698",
+    "overflow": false
+  },
+  {
+    "principal": "3360403066278544231",
+    "rate_bps": 746,
+    "seconds": 2067898609,
+    "expected": "16438146018904760815",
+    "overflow": false
+  },
+  {
+    "principal": "9678049804991421100",
+    "rate_bps": 3499,
+    "seconds": 2050764734,
+    "expected": "220212024085705132204",
+    "overflow": false
+  },
+  {
+    "principal": "17337942287811946421",
+    "rate_bps": 135,
+    "seconds": 335012335,
+    "expected": "2486483103568117385",
+    "overflow": false
+  },
+  {
+    "principal": "443817936854632786",
+    "rate_bps": 8006,
+    "seconds": 2609255124,
+    "expected": "29398852144354511270",
+    "overflow": false
+  },
+  {
+    "principal": "13308408219324120211",
+    "rate_bps": 6321,
+    "seconds": 425174525,
+    "expected": "113415531522377099763",
+    "overflow": false
+  },
+  {
+    "principal": "18211283128719847880",
+    "rate_bps": 9207,
+    "seconds": 1221911610,
+    "expected": "649668595565166792606",
+    "overflow": false
+  },
+  {
+    "principal": "12917153220208256385",
+    "rate_bps": 3567,
+    "seconds": 4131126427,
+    "expected": "603575773517949570133",
+    "overflow": false
+  },
+  {
+    "principal": "11008223238256512398",
+    "rate_bps": 3051,
+    "seconds": 1035630960,
+    "expected": "110295515275229347148",
+    "overflow": false
+  },
+  {
+    "principal": "10045782353002719743",
+    "rate_bps": 6060,
+    "seconds": 3524409673,
+    "expected": "680355917480084492353",
+    "overflow": false
+  },
+  {
+    "principal": "15731458387378162212",
+    "rate_bps": 7270,
+    "seconds": 1550040054,
+    "expected": "562133814441038191820",
+    "overflow": false
+  },
+  {
+    "principal": "10665715900379600269",
+    "rate_bps": 5,
+    "seconds": 3855733639,
+    "expected": "652019272912081393",
+    "overflow": false
+  },
+  {
+    "principal": "3686083550614694154",
+    "rate_bps": 9534,
+    "seconds": 433195340,
+    "expected": "48274467480524297807",
+    "overflow": false
+  },
+  {
+    "principal": "817491047095195563",
+    "rate_bps": 3021,
+    "seconds": 3857008341,
+    "expected": "30204920812883999802",
+    "overflow": false
+  },
+  {
+    "principal": "2284135748780269504",
+    "rate_bps": 4153,
+    "seconds": 2629407474,
+    "expected": "79092468132112957901",
+    "overflow": false
+  },
+  {
+    "principal": "5589999359720055769",
+    "rate_bps": 5566,
+    "seconds": 737931955,
+    "expected": "72805580739827972758",
+    "overflow": false
+  },
+  {
+    "principal": "9358933346962831302",
+    "rate_bps": 5314,
+    "seconds": 3999055464,
+    "expected": "630664993223522375600",
+    "overflow": false
+  },
+  {
+    "principal": "8909388042825011607",
+    "rate_bps": 8866,
+    "seconds": 2684156577,
+    "expected": "672321254480946311521",
+    "overflow": false
+  },
+  {
+    "principal": "7697503043996774044",
+    "rate_bps": 4830,
+    "seconds": 1039959342,
+    "expected": "122604596871112921591",
+    "overflow": false
+  },
+  {
+    "principal": "1997657168352033893",
+    "rate_bps": 3544,
+    "seconds": 2979210783,
+    "expected": "66882006775098685725",
+    "overflow": false
+  },
+  {
+    "principal": "17370053005494818242",
+    "rate_bps": 3741,
+    "seconds": 4004893892,
+    "expected": "825226677361318328564",
+    "overflow": false
+  },
+  {
+    "principal": "16930681263830803395",
+    "rate_bps": 5664,
+    "seconds": 336183469,
+    "expected": "102227426005683007351",
+    "overflow": false
+  },
+  {
+    "principal": "5437418292377891512",
+    "rate_bps": 2757,
+    "seconds": 1155788458,
+    "expected": "54941594121507924627",
+    "overflow": false
+  },
+  {
+    "principal": "3311958956214111025",
+    "rate_bps": 7413,
+    "seconds": 3966925259,
+    "expected": "308834889506063985580",
+    "overflow": false
+  },
+  {
+    "principal": "14323816672649649918",
+    "rate_bps": 7419,
+    "seconds": 3680487520,
+    "expected": "1240231813989451300121",
+    "overflow": false
+  },
+  {
+    "principal": "12164316606797011503",
+    "rate_bps": 5853,
+    "seconds": 3461104889,
+    "expected": "781401774638325075696",
+    "overflow": false
+  },
+  {
+    "principal": "6752212773460256788",
+    "rate_bps": 3759,
+    "seconds": 3795086182,
+    "expected": "305445323737510415034",
+    "overflow": false
+  },
+  {
+    "principal": "11809801392003218493",
+    "rate_bps": 8321,
+    "seconds": 3441637815,
+    "expected": "1072449062736543042144",
+    "overflow": false
+  },
+  {
+    "principal": "2433844061623119738",
+    "rate_bps": 2105,
+    "seconds": 1470125372,
+    "expected": "23883205489434760398",
+    "overflow": false
+  },
+  {
+    "principal": "11697457162812604635",
+    "rate_bps": 4363,
+    "seconds": 568423301,
+    "expected": "91990280231401095418",
+    "overflow": false
+  },
+  {
+    "principal": "12258114171303938736",
+    "rate_bps": 9499,
+    "seconds": 1098635106,
+    "expected": "405647137062305922957",
+    "overflow": false
+  },
+  {
+    "principal": "7692904504572771209",
+    "rate_bps": 1568,
+    "seconds": 4173918691,
+    "expected": "159651784585084206111",
+    "overflow": false
+  },
+  {
+    "principal": "5204236656937837366",
+    "rate_bps": 4191,
+    "seconds": 945583960,
+    "expected": "65398560325929272234",
+    "overflow": false
+  },
+  {
+    "principal": "17398518428504236999",
+    "rate_bps": 5903,
+    "seconds": 21919825,
+    "expected": "7138640743242499986",
+    "overflow": false
+  },
+  {
+    "principal": "15366808307751179916",
+    "rate_bps": 3942,
+    "seconds": 2802667166,
+    "expected": "538350613629378190604",
+    "overflow": false
+  },
+  {
+    "principal": "2607668466952746261",
+    "rate_bps": 1215,
+    "seconds": 3679284815,
+    "expected": "36964552627192687399",
+    "overflow": false
+  },
+  {
+    "principal": "9845711413282608690",
+    "rate_bps": 8939,
+    "seconds": 3358878388,
+    "expected": "937397330482384769366",
+    "overflow": false
+  },
+  {
+    "principal": "1476596535185739507",
+    "rate_bps": 1913,
+    "seconds": 2370617181,
+    "expected": "21233991331701689177",
+    "overflow": false
+  },
+  {
+    "principal": "16557697291762616232",
+    "rate_bps": 901,
+    "seconds": 4181536026,
+    "expected": "197812606441940384149",
+    "overflow": false
+  },
+  {
+    "principal": "10868422568372229345",
+    "rate_bps": 6286,
+    "seconds": 1573698299,
+    "expected": "340922575567733572522",
+    "overflow": false
+  },
+  {
+    "principal": "11572724350536508526",
+    "rate_bps": 8392,
+    "seconds": 1021291344,
+    "expected": "314517002607313669491",
+    "overflow": false
+  },
+  {
+    "principal": "998189819173883487",
+    "rate_bps": 8858,
+    "seconds": 3319133353,
+    "expected": "93060826755962961569",
+    "overflow": false
+  },
+  {
+    "principal": "10795582097830468100",
+    "rate_bps": 2005,
+    "seconds": 282922710,
+    "expected": "19418766688886005570",
+    "overflow": false
+  },
+  {
+    "principal": "845020473571755757",
+    "rate_bps": 3391,
+    "seconds": 1296114663,
+    "expected": "11776923067891642871",
+    "overflow": false
+  },
+  {
+    "principal": "14245305795173247466",
+    "rate_bps": 3839,
+    "seconds": 3653825836,
+    "expected": "633623277971721500835",
+    "overflow": false
+  },
+  {
+    "principal": "9799572813512142347",
+    "rate_bps": 3503,
+    "seconds": 158336053,
+    "expected": "17235365164772941263",
+    "overflow": false
+  },
+  {
+    "principal": "439232601749162400",
+    "rate_bps": 1911,
+    "seconds": 1828179922,
+    "expected": "4865949338249554574",
+    "overflow": false
+  },
+  {
+    "principal": "11963312842537056057",
+    "rate_bps": 1884,
+    "seconds": 3178181907,
+    "expected": "227145690812683630569",
+    "overflow": false
+  },
+  {
+    "principal": "7553044562211979942",
+    "rate_bps": 1255,
+    "seconds": 2078950472,
+    "expected": "62488961741653267617",
+    "overflow": false
+  },
+  {
+    "principal": "4707988668849928695",
+    "rate_bps": 4576,
+    "seconds": 1320753665,
+    "expected": "90227025910722282721",
+    "overflow": false
+  },
+  {
+    "principal": "14727891647982244476",
+    "rate_bps": 8209,
+    "seconds": 634227726,
+    "expected": "243147300894806801884",
+    "overflow": false
+  },
+  {
+    "principal": "874925869111054789",
+    "rate_bps": 6433,
+    "seconds": 4094802559,
+    "expected": "73082125216997801997",
+    "overflow": false
+  },
+  {
+    "principal": "6696518819197045410",
+    "rate_bps": 2427,
+    "seconds": 2330514596,
+    "expected": "120105830423103748634",
+    "overflow": false
+  },
+  {
+    "principal": "1062256906821058083",
+    "rate_bps": 8480,
+    "seconds": 1144234509,
+    "expected": "32683898295807896378",
+    "overflow": false
+  },
+  {
+    "principal": "17326703265679700120",
+    "rate_bps": 7455,
+    "seconds": 990879626,
+    "expected": "405861519886782291936",
+    "overflow": false
+  },
+  {
+    "principal": "1661347260197110417",
+    "rate_bps": 1821,
+    "seconds": 2823143467,
+    "expected": "27082996100405247274",
+    "overflow": false
+  },
+  {
+    "principal": "5747228959050210782",
+    "rate_bps": 443,
+    "seconds": 2339447360,
+    "expected": "18887257260576942949",
+    "overflow": false
+  },
+  {
+    "principal": "3928742751306794639",
+    "rate_bps": 2156,
+    "seconds": 3260172377,
+    "expected": "87566160099524639473",
+    "overflow": false
+  },
+  {
+    "principal": "9970423759708839924",
+    "rate_bps": 4091,
+    "seconds": 2572985926,
+    "expected": "332792783488255350609",
+    "overflow": false
+  },
+  {
+    "principal": "1814992514787800477",
+    "rate_bps": 1322,
+    "seconds": 2721485335,
+    "expected": "20706451760006200715",
+    "overflow": false
+  },
+  {
+    "principal": "14535255782055450714",
+    "rate_bps": 2313,
+    "seconds": 3469928732,
+    "expected": "369923787897736814542",
+    "overflow": false
+  },
+  {
+    "principal": "17692604243567664955",
+    "rate_bps": 681,
+    "seconds": 1002698981,
+    "expected": "38309178728133344504",
+    "overflow": false
+  },
+  {
+    "principal": "14279015027265297552",
+    "rate_bps": 345,
+    "seconds": 1929149506,
+    "expected": "30135376716055687879",
+    "overflow": false
+  },
+  {
+    "principal": "4293565669290022633",
+    "rate_bps": 6644,
+    "seconds": 118078531,
+    "expected": "10681003763530770618",
+    "overflow": false
+  },
+  {
+    "principal": "10356110139362235926",
+    "rate_bps": 9264,
+    "seconds": 4225574200,
+    "expected": "1285506663733449229309",
+    "overflow": false
+  },
+  {
+    "principal": "7482312426303902759",
+    "rate_bps": 6022,
+    "seconds": 402644913,
+    "expected": "57529711904991558892",
+    "overflow": false
+  },
+  {
+    "principal": "11518608202843267692",
+    "rate_bps": 7979,
+    "seconds": 3353099646,
+    "expected": "977210948871438867114",
+    "overflow": false
+  },
+  {
+    "principal": "16294014958762840693",
+    "rate_bps": 2057,
+    "seconds": 3708488367,
+    "expected": "394142000422979546140",
+    "overflow": false
+  },
+  {
+    "principal": "3041053717668311826",
+    "rate_bps": 9861,
+    "seconds": 1828328084,
+    "expected": "173857157106790966685",
+    "overflow": false
+  },
+  {
+    "principal": "11364011061473194323",
+    "rate_bps": 6434,
+    "seconds": 605120701,
+    "expected": "140296910570675165151",
+    "overflow": false
+  },
+  {
+    "principal": "11669930003082882440",
+    "rate_bps": 7598,
+    "seconds": 952780282,
+    "expected": "267888267871508795741",
+    "overflow": false
+  },
+  {
+    "principal": "14273628698907169857",
+    "rate_bps": 151,
+    "seconds": 2484635995,
+    "expected": "16981166027175404236",
+    "overflow": false
+  },
+  {
+    "principal": "12411552262975048526",
+    "rate_bps": 7608,
+    "seconds": 2676698416,
+    "expected": "801474001790172703527",
+    "overflow": false
+  },
+  {
+    "principal": "3764925607943160511",
+    "rate_bps": 921,
+    "seconds": 2242134025,
+    "expected": "24653069033476915215",
+    "overflow": false
+  },
+  {
+    "principal": "17550815359849216484",
+    "rate_bps": 8934,
+    "seconds": 2180133302,
+    "expected": "1083976051701193332133",
+    "overflow": false
+  },
+  {
+    "principal": "9990744548995860557",
+    "rate_bps": 9089,
+    "seconds": 2655945799,
+    "expected": "764762455889511844950",
+    "overflow": false
+  },
+  {
+    "principal": "9637544674527214282",
+    "rate_bps": 3946,
+    "seconds": 814035212,
+    "expected": "98165768170184433630",
+    "overflow": false
+  },
+  {
+    "principal": "10140318854205805675",
+    "rate_bps": 416,
+    "seconds": 3696251285,
+    "expected": "49442431835330611816",
+    "overflow": false
+  },
+  {
+    "principal": "6488889450061874048",
+    "rate_bps": 4183,
+    "seconds": 949542066,
+    "expected": "81727053612744542556",
+    "overflow": false
+  },
+  {
+    "principal": "7747049747136682649",
+    "rate_bps": 8132,
+    "seconds": 1693681523,
+    "expected": "338344294577023356515",
+    "overflow": false
+  },
+  {
+    "principal": "5005693053161659782",
+    "rate_bps": 2196,
+    "seconds": 575412776,
+    "expected": "20057160258783520564",
+    "overflow": false
+  },
+  {
+    "principal": "10225893625872118359",
+    "rate_bps": 3043,
+    "seconds": 2099628385,
+    "expected": "207175812870771474104",
+    "overflow": false
+  },
+  {
+    "principal": "4879439870489527900",
+    "rate_bps": 5279,
+    "seconds": 2820170478,
+    "expected": "230351151520554978584",
+    "overflow": false
+  },
+  {
+    "principal": "8004670216947300133",
+    "rate_bps": 7696,
+    "seconds": 631529183,
+    "expected": "123365953685591605306",
+    "overflow": false
+  },
+  {
+    "principal": "11737152247923462018",
+    "rate_bps": 6357,
+    "seconds": 1741628548,
+    "expected": "412063244161427411379",
+    "overflow": false
+  },
+  {
+    "principal": "12724158564030113923",
+    "rate_bps": 4299,
+    "seconds": 4101575533,
+    "expected": "711443841681825776828",
+    "overflow": false
+  },
+  {
+    "principal": "3423891001461440120",
+    "rate_bps": 3630,
+    "seconds": 3927711850,
+    "expected": "154795940677831463752",
+    "overflow": false
+  },
+  {
+    "principal": "14653776246389852657",
+    "rate_bps": 6640,
+    "seconds": 2210403979,
+    "expected": "681997341897222886848",
+    "overflow": false
+  },
+  {
+    "principal": "9215562161978436798",
+    "rate_bps": 8604,
+    "seconds": 4041526304,
+    "expected": "1016157524568964346915",
+    "overflow": false
+  },
+  {
+    "principal": "3443496073115681519",
+    "rate_bps": 2609,
+    "seconds": 971955129,
+    "expected": "27689383101584170579",
+    "overflow": false
+  },
+  {
+    "principal": "10074685203123660756",
+    "rate_bps": 8903,
+    "seconds": 2518462758,
+    "expected": "716303023699737776731",
+    "overflow": false
+  },
+  {
+    "principal": "1430787029346713341",
+    "rate_bps": 916,
+    "seconds": 3658742391,
+    "expected": "15205324516728892445",
+    "overflow": false
+  },
+  {
+    "principal": "838863429886185786",
+    "rate_bps": 4720,
+    "seconds": 3018247420,
+    "expected": "37894963367882683255",
+    "overflow": false
+  },
+  {
+    "principal": "8898402446923435419",
+    "rate_bps": 465,
+    "seconds": 1120407109,
+    "expected": "14700572401472430502",
+    "overflow": false
+  },
+  {
+    "principal": "15885793273156943472",
+    "rate_bps": 5820,
+    "seconds": 2753294626,
+    "expected": "807194086211340632430",
+    "overflow": false
+  },
+  {
+    "principal": "10381229430046114377",
+    "rate_bps": 8988,
+    "seconds": 2563217059,
+    "expected": "758386565144474832508",
+    "overflow": false
+  },
+  {
+    "principal": "6217122953345554678",
+    "rate_bps": 520,
+    "seconds": 1888363288,
+    "expected": "19358501730979004187",
+    "overflow": false
+  },
+  {
+    "principal": "1005984621009343623",
+    "rate_bps": 8622,
+    "seconds": 3731740433,
+    "expected": "102637054760801524436",
+    "overflow": false
+  },
+  {
+    "principal": "13304639463109738060",
+    "rate_bps": 3512,
+    "seconds": 1587608670,
+    "expected": "235230955420961328490",
+    "overflow": false
+  },
+  {
+    "principal": "1457903993775488981",
+    "rate_bps": 7872,
+    "seconds": 998815503,
+    "expected": "36349017683781753254",
+    "overflow": false
+  },
+  {
+    "principal": "14116473375987277810",
+    "rate_bps": 1196,
+    "seconds": 672074356,
+    "expected": "35980575928388900100",
+    "overflow": false
+  },
+  {
+    "principal": "3089479686619653043",
+    "rate_bps": 5772,
+    "seconds": 155034141,
+    "expected": "8766624540271120116",
+    "overflow": false
+  },
+  {
+    "principal": "4134913360297354088",
+    "rate_bps": 7234,
+    "seconds": 2146709210,
+    "expected": "203615826339746971878",
+    "overflow": false
+  },
+  {
+    "principal": "3076057156155597729",
+    "rate_bps": 8241,
+    "seconds": 2750900155,
+    "expected": "221127387916044367030",
+    "overflow": false
+  },
+  {
+    "principal": "15759177747537166894",
+    "rate_bps": 8606,
+    "seconds": 2255814416,
+    "expected": "970133845979228979087",
+    "overflow": false
+  },
+  {
+    "principal": "12673825603616589599",
+    "rate_bps": 4702,
+    "seconds": 563420009,
+    "expected": "106467243694335134758",
+    "overflow": false
+  },
+  {
+    "principal": "10702149218255202756",
+    "rate_bps": 5604,
+    "seconds": 3600491670,
+    "expected": "684737845701499773077",
+    "overflow": false
+  },
+  {
+    "principal": "10800558792507480493",
+    "rate_bps": 4063,
+    "seconds": 3830576295,
+    "expected": "533028655808542272910",
+    "overflow": false
+  },
+  {
+    "principal": "3414510501091171242",
+    "rate_bps": 5259,
+    "seconds": 3107896556,
+    "expected": "176966707887392509606",
+    "overflow": false
+  },
+  {
+    "principal": "263069060466723531",
+    "rate_bps": 1817,
+    "seconds": 2870882037,
+    "expected": "4351444433076562267",
+    "overflow": false
+  },
+  {
+    "principal": "17932942290412260704",
+    "rate_bps": 9986,
+    "seconds": 219462034,
+    "expected": "124622341155237555233",
+    "overflow": false
+  },
+  {
+    "principal": "14207957736940211705",
+    "rate_bps": 8953,
+    "seconds": 3328240083,
+    "expected": "1342481410769659073339",
+    "overflow": false
+  },
+  {
+    "principal": "15648736512818759782",
+    "rate_bps": 1260,
+    "seconds": 1866088456,
+    "expected": "116674364099827331932",
+    "overflow": false
+  },
+  {
+    "principal": "8968948271960603319",
+    "rate_bps": 9586,
+    "seconds": 2354776257,
+    "expected": "641980719508293493880",
+    "overflow": false
+  },
+  {
+    "principal": "17658533377178126908",
+    "rate_bps": 3168,
+    "seconds": 1893009870,
+    "expected": "335804162283058353273",
+    "overflow": false
+  },
+  {
+    "principal": "7180610061085797509",
+    "rate_bps": 4622,
+    "seconds": 2594378559,
+    "expected": "273034812465504667903",
+    "overflow": false
+  },
+  {
+    "principal": "8733799378990998626",
+    "rate_bps": 2503,
+    "seconds": 4255171684,
+    "expected": "294967754234785205657",
+    "overflow": false
+  },
+  {
+    "principal": "18136849488659849955",
+    "rate_bps": 3247,
+    "seconds": 4067562701,
+    "expected": "759576966917557538411",
+    "overflow": false
+  },
+  {
+    "principal": "4546666630869408856",
+    "rate_bps": 7722,
+    "seconds": 3565252938,
+    "expected": "396923350792014068972",
+    "overflow": false
+  },
+  {
+    "principal": "6753334615956398417",
+    "rate_bps": 1759,
+    "seconds": 465140971,
+    "expected": "17521129375653410497",
+    "overflow": false
+  },
+  {
+    "principal": "16510307801432722334",
+    "rate_bps": 1854,
+    "seconds": 3866281472,
+    "expected": "375276838265909138680",
+    "overflow": false
+  },
+  {
+    "principal": "18303536415038656335",
+    "rate_bps": 6499,
+    "seconds": 1194983193,
+    "expected": "450751037247707062753",
+    "overflow": false
+  },
+  {
+    "principal": "4687504917855977396",
+    "rate_bps": 6014,
+    "seconds": 3916205062,
+    "expected": "350077321637396124464",
+    "overflow": false
+  },
+  {
+    "principal": "15919016208350910557",
+    "rate_bps": 3800,
+    "seconds": 1913877207,
+    "expected": "367119357750825117124",
+    "overflow": false
+  },
+  {
+    "principal": "4922301005358324250",
+    "rate_bps": 1046,
+    "seconds": 1007943900,
+    "expected": "16456201873545378593",
+    "overflow": false
+  },
+  {
+    "principal": "9505605643359538171",
+    "rate_bps": 8021,
+    "seconds": 3850744741,
+    "expected": "930993037827429684805",
+    "overflow": false
+  },
+  {
+    "principal": "5765896533703651408",
+    "rate_bps": 7330,
+    "seconds": 2891068930,
+    "expected": "387456239477481062750",
+    "overflow": false
+  },
+  {
+    "principal": "1301773595232435625",
+    "rate_bps": 8650,
+    "seconds": 2749006083,
+    "expected": "98156860577279132172",
+    "overflow": false
+  },
+  {
+    "principal": "6957914824798874582",
+    "rate_bps": 4731,
+    "seconds": 2653384952,
+    "expected": "276965523022468057765",
+    "overflow": false
+  },
+  {
+    "principal": "1349906312921179367",
+    "rate_bps": 95,
+    "seconds": 2008047217,
+    "expected": "816572118889047469",
+    "overflow": false
+  },
+  {
+    "principal": "12526854567956523564",
+    "rate_bps": 7914,
+    "seconds": 3243477822,
+    "expected": "1019629535506153538752",
+    "overflow": false
+  },
+  {
+    "principal": "4250819163288812853",
+    "rate_bps": 269,
+    "seconds": 4246631279,
+    "expected": "15397948299823766601",
+    "overflow": false
+  },
+  {
+    "principal": "15794769124860681426",
+    "rate_bps": 312,
+    "seconds": 3417002580,
+    "expected": "53395735848705690825",
+    "overflow": false
+  },
+  {
+    "principal": "14514135865371960851",
+    "rate_bps": 767,
+    "seconds": 745106301,
+    "expected": "26302569522516014433",
+    "overflow": false
+  },
+  {
+    "principal": "597818807515572552",
+    "rate_bps": 5128,
+    "seconds": 3677546426,
+    "expected": "35749432129950253010",
+    "overflow": false
+  },
+  {
+    "principal": "15827649488099574529",
+    "rate_bps": 2471,
+    "seconds": 1010914843,
+    "expected": "125371013207701402341",
+    "overflow": false
+  },
+  {
+    "principal": "17491752396463933710",
+    "rate_bps": 2923,
+    "seconds": 106242288,
+    "expected": "17224750681501264588",
+    "overflow": false
+  },
+  {
+    "principal": "10438773065220709247",
+    "rate_bps": 5323,
+    "seconds": 767592137,
+    "expected": "135247682725334388697",
+    "overflow": false
+  },
+  {
+    "principal": "5843581125273446820",
+    "rate_bps": 2150,
+    "seconds": 2312103798,
+    "expected": "92112433867267814210",
+    "overflow": false
+  },
+  {
+    "principal": "13940146976121469709",
+    "rate_bps": 3960,
+    "seconds": 2393076999,
+    "expected": "418902164387662791435",
+    "overflow": false
+  },
+  {
+    "principal": "9265860586326232202",
+    "rate_bps": 9842,
+    "seconds": 3274545356,
+    "expected": "946920514853237327056",
+    "overflow": false
+  },
+  {
+    "principal": "6029090056020726059",
+    "rate_bps": 1554,
+    "seconds": 108108885,
+    "expected": "3211867098781125415",
+    "overflow": false
+  },
+  {
+    "principal": "4611033405384501056",
+    "rate_bps": 1523,
+    "seconds": 199452274,
+    "expected": "4441509108794119829",
+    "overflow": false
+  },
+  {
+    "principal": "10677389046923989337",
+    "rate_bps": 7296,
+    "seconds": 2844744755,
+    "expected": "702726920277988290352",
+    "overflow": false
+  },
+  {
+    "principal": "2498515236509123398",
+    "rate_bps": 9311,
+    "seconds": 1684846056,
+    "expected": "124288786435769268002",
+    "overflow": false
+  },
+  {
+    "principal": "1806960444284965655",
+    "rate_bps": 4643,
+    "seconds": 3782268961,
+    "expected": "100622043053313458297",
+    "overflow": false
+  },
+  {
+    "principal": "13014438385831042588",
+    "rate_bps": 1754,
+    "seconds": 4294672558,
+    "expected": "310869755022963699188",
+    "overflow": false
+  },
+  {
+    "principal": "1904688598221418981",
+    "rate_bps": 7138,
+    "seconds": 2338707359,
+    "expected": "100825364548900292636",
+    "overflow": false
+  },
+  {
+    "principal": "2813200257558595906",
+    "rate_bps": 3106,
+    "seconds": 4170560580,
+    "expected": "115555315308942391084",
+    "overflow": false
+  },
+  {
+    "principal": "3561869580495875395",
+    "rate_bps": 8832,
+    "seconds": 3484853805,
+    "expected": "347628224647318744124",
+    "overflow": false
+  },
+  {
+    "principal": "10148054831137557048",
+    "rate_bps": 7066,
+    "seconds": 280465962,
+    "expected": "63771993486519166815",
+    "overflow": false
+  },
+  {
+    "principal": "10845280990023190705",
+    "rate_bps": 377,
+    "seconds": 2970219339,
+    "expected": "38509162470550773887",
+    "overflow": false
+  },
+  {
+    "principal": "2943370301855005310",
+    "rate_bps": 5278,
+    "seconds": 986910688,
+    "expected": "48616706531243871519",
+    "overflow": false
+  },
+  {
+    "principal": "6111696434891942831",
+    "rate_bps": 4823,
+    "seconds": 2152444537,
+    "expected": "201189077592851193364",
+    "overflow": false
+  },
+  {
+    "principal": "3612445044477061012",
+    "rate_bps": 4285,
+    "seconds": 4165220070,
+    "expected": "204448260893596332521",
+    "overflow": false
+  },
+  {
+    "principal": "16036051642893681085",
+    "rate_bps": 1904,
+    "seconds": 3415014199,
+    "expected": "330636120888337118415",
+    "overflow": false
+  },
+  {
+    "principal": "4629018347052397306",
+    "rate_bps": 4203,
+    "seconds": 1351779516,
+    "expected": "83396446586832069343",
+    "overflow": false
+  },
+  {
+    "principal": "3662743376478739035",
+    "rate_bps": 9428,
+    "seconds": 378857733,
+    "expected": "41485431800772969290",
+    "overflow": false
+  },
+  {
+    "principal": "10980275649278046768",
+    "rate_bps": 1290,
+    "seconds": 1998015202,
+    "expected": "89741874028209872906",
+    "overflow": false
+  },
+  {
+    "principal": "10516900596528695561",
+    "rate_bps": 5713,
+    "seconds": 1109031779,
+    "expected": "211295076344754298524",
+    "overflow": false
+  },
+  {
+    "principal": "157702531561311926",
+    "rate_bps": 1529,
+    "seconds": 6360792,
+    "expected": "4863520353676191",
+    "overflow": false
+  },
+  {
+    "principal": "17373734790515934535",
+    "rate_bps": 7679,
+    "seconds": 182416849,
+    "expected": "77171367830269082666",
+    "overflow": false
+  },
+  {
+    "principal": "4308718124947400204",
+    "rate_bps": 4704,
+    "seconds": 434891294,
+    "expected": "27950494989693089581",
+    "overflow": false
+  },
+  {
+    "principal": "18438597846727559829",
+    "rate_bps": 9188,
+    "seconds": 203702223,
+    "expected": "109430413518088728274",
+    "overflow": false
+  },
+  {
+    "principal": "17826273000583424434",
+    "rate_bps": 1944,
+    "seconds": 1577511476,
+    "expected": "173349556229153260726",
+    "overflow": false
+  },
+  {
+    "principal": "5950227310867282035",
+    "rate_bps": 7828,
+    "seconds": 1093453021,
+    "expected": "161501996628294981083",
+    "overflow": false
+  },
+  {
+    "principal": "6086163043594583848",
+    "rate_bps": 2900,
+    "seconds": 3942543514,
+    "expected": "220653829384652285663",
+    "overflow": false
+  },
+  {
+    "principal": "16675602862346056289",
+    "rate_bps": 2250,
+    "seconds": 2949534843,
+    "expected": "350922315000857775028",
+    "overflow": false
+  },
+  {
+    "principal": "14752355961447145454",
+    "rate_bps": 3567,
+    "seconds": 669225680,
+    "expected": "111668448724628110006",
+    "overflow": false
+  },
+  {
+    "principal": "9313793670128697311",
+    "rate_bps": 3809,
+    "seconds": 3258876457,
+    "expected": "366605414797745365501",
+    "overflow": false
+  },
+  {
+    "principal": "15698172958211291524",
+    "rate_bps": 5628,
+    "seconds": 1787329110,
+    "expected": "500727127262181352159",
+    "overflow": false
+  },
+  {
+    "principal": "1081236138777357421",
+    "rate_bps": 6688,
+    "seconds": 1889207655,
+    "expected": "43320145546456887864",
+    "overflow": false
+  },
+  {
+    "principal": "7870852954013076842",
+    "rate_bps": 9956,
+    "seconds": 1367983276,
+    "expected": "339923248034808721012",
+    "overflow": false
+  },
+  {
+    "principal": "18300875603434039179",
+    "rate_bps": 8406,
+    "seconds": 3269630389,
+    "expected": "1594972901914642366944",
+    "overflow": false
+  },
+  {
+    "principal": "11478229583079559456",
+    "rate_bps": 2846,
+    "seconds": 1786569554,
+    "expected": "185064502704165230406",
+    "overflow": false
+  },
+  {
+    "principal": "13945297166808065209",
+    "rate_bps": 1959,
+    "seconds": 4199997075,
+    "expected": "363835096782929781294",
+    "overflow": false
+  },
+  {
+    "principal": "14071364013076680230",
+    "rate_bps": 947,
+    "seconds": 2006678472,
+    "expected": "84792484668856310773",
+    "overflow": false
+  },
+  {
+    "principal": "3164129776836049783",
+    "rate_bps": 4561,
+    "seconds": 3850319745,
+    "expected": "176199450445235410119",
+    "overflow": false
+  },
+  {
+    "principal": "10813044114473468",
+    "rate_bps": 29,
+    "seconds": 2843985806,
+    "expected": "2827917857227349",
+    "overflow": false
+  },
+  {
+    "principal": "1928946101742143301",
+    "rate_bps": 6831,
+    "seconds": 340044799,
+    "expected": "14208031389600290167",
+    "overflow": false
+  },
+  {
+    "principal": "7297300388573101602",
+    "rate_bps": 7405,
+    "seconds": 954594340,
+    "expected": "163568448772854883504",
+    "overflow": false
+  },
+  {
+    "principal": "15054841866273245091",
+    "rate_bps": 916,
+    "seconds": 3789473677,
+    "expected": "165708184610268439203",
+    "overflow": false
+  },
+  {
+    "principal": "1633212562686380056",
+    "rate_bps": 6002,
+    "seconds": 1228309258,
+    "expected": "38180342612885511833",
+    "overflow": false
+  },
+  {
+    "principal": "355599760483188753",
+    "rate_bps": 4712,
+    "seconds": 680098219,
+    "expected": "3613530894654238317",
+    "overflow": false
+  },
+  {
+    "principal": "3566883739356412254",
+    "rate_bps": 923,
+    "seconds": 2965219776,
+    "expected": "30955721870337910537",
+    "overflow": false
+  },
+  {
+    "principal": "16911915846345201679",
+    "rate_bps": 785,
+    "seconds": 4282119641,
+    "expected": "180266346096114066615",
+    "overflow": false
+  },
+  {
+    "principal": "9629743125324193652",
+    "rate_bps": 6817,
+    "seconds": 2073801158,
+    "expected": "431686534609424690972",
+    "overflow": false
+  },
+  {
+    "principal": "17652523279085533981",
+    "rate_bps": 975,
+    "seconds": 2883097495,
+    "expected": "157349051893714078160",
+    "overflow": false
+  },
+  {
+    "principal": "15501179637296552922",
+    "rate_bps": 3761,
+    "seconds": 2392479900,
+    "expected": "442292702069852180823",
+    "overflow": false
+  },
+  {
+    "principal": "647756176431937723",
+    "rate_bps": 8689,
+    "seconds": 210611813,
+    "expected": "3758871503560115204",
+    "overflow": false
+  },
+  {
+    "principal": "17672502478087406608",
+    "rate_bps": 4025,
+    "seconds": 65220546,
+    "expected": "14710985222441131155",
+    "overflow": false
+  },
+  {
+    "principal": "10838093054010860649",
+    "rate_bps": 2602,
+    "seconds": 2975827395,
+    "expected": "266110063291538803935",
+    "overflow": false
+  },
+  {
+    "principal": "15724703169743995286",
+    "rate_bps": 9554,
+    "seconds": 2264071352,
+    "expected": "1078577100991490915451",
+    "overflow": false
+  },
+  {
+    "principal": "12646815924818884007",
+    "rate_bps": 2420,
+    "seconds": 3272809777,
+    "expected": "317622105505241717682",
+    "overflow": false
+  },
+  {
+    "principal": "17373008723412513260",
+    "rate_bps": 5770,
+    "seconds": 1717704958,
+    "expected": "546000214285240599801",
+    "overflow": false
+  },
+  {
+    "principal": "1996375559879387125",
+    "rate_bps": 1390,
+    "seconds": 921836591,
+    "expected": "8111559919647873959",
+    "overflow": false
+  },
+  {
+    "principal": "14801828822903473810",
+    "rate_bps": 959,
+    "seconds": 425316884,
+    "expected": "19144322476686602257",
+    "overflow": false
+  },
+  {
+    "principal": "9117846593885526739",
+    "rate_bps": 4482,
+    "seconds": 3206524477,
+    "expected": "415520146799396688706",
+    "overflow": false
+  },
+  {
+    "principal": "3056656815579882760",
+    "rate_bps": 6774,
+    "seconds": 3821980026,
+    "expected": "250942187644604157452",
+    "overflow": false
+  },
+  {
+    "principal": "10647679459952849345",
+    "rate_bps": 4844,
+    "seconds": 4118176475,
+    "expected": "673530783004829253611",
+    "overflow": false
+  },
+  {
+    "principal": "4059166811402831566",
+    "rate_bps": 279,
+    "seconds": 3889714352,
+    "expected": "13968578239376307279",
+    "overflow": false
+  },
+  {
+    "principal": "17337354088075080767",
+    "rate_bps": 2004,
+    "seconds": 2066156937,
+    "expected": "227634055093469307317",
+    "overflow": false
+  },
+  {
+    "principal": "17959563096661481828",
+    "rate_bps": 2885,
+    "seconds": 2612845878,
+    "expected": "429288022027151272216",
+    "overflow": false
+  },
+  {
+    "principal": "6118725247941619149",
+    "rate_bps": 7786,
+    "seconds": 3247482311,
+    "expected": "490586438795802404694",
+    "overflow": false
+  },
+  {
+    "principal": "17724601352092737098",
+    "rate_bps": 1326,
+    "seconds": 462110860,
+    "expected": "34439716534398306627",
+    "overflow": false
+  },
+  {
+    "principal": "4307377763005976043",
+    "rate_bps": 2313,
+    "seconds": 4178126613,
+    "expected": "131996855125911431892",
+    "overflow": false
+  },
+  {
+    "principal": "8098361120657492736",
+    "rate_bps": 7722,
+    "seconds": 1918447666,
+    "expected": "380426082982897794425",
+    "overflow": false
+  },
+  {
+    "principal": "3871674123563812889",
+    "rate_bps": 6352,
+    "seconds": 3364843763,
+    "expected": "262402266627891846343",
+    "overflow": false
+  },
+  {
+    "principal": "10611567727893408006",
+    "rate_bps": 4069,
+    "seconds": 2457768360,
+    "expected": "336512795376253686665",
+    "overflow": false
+  },
+  {
+    "principal": "6249570440230040535",
+    "rate_bps": 7592,
+    "seconds": 94250721,
+    "expected": "14180268072436284151",
+    "overflow": false
+  },
+  {
+    "principal": "5253942275984258524",
+    "rate_bps": 6328,
+    "seconds": 2506481262,
+    "expected": "264246730652204050951",
+    "overflow": false
+  },
+  {
+    "principal": "11047222811896458405",
+    "rate_bps": 5895,
+    "seconds": 899125343,
+    "expected": "185673769690730796425",
+    "overflow": false
+  },
+  {
+    "principal": "3550655016173175554",
+    "rate_bps": 7244,
+    "seconds": 3536421892,
+    "expected": "288432625439795237432",
+    "overflow": false
+  },
+  {
+    "principal": "1970889354652267011",
+    "rate_bps": 8995,
+    "seconds": 1115846893,
+    "expected": "62727995978264166731",
+    "overflow": false
+  },
+  {
+    "principal": "12102948614939432440",
+    "rate_bps": 9990,
+    "seconds": 3161867242,
+    "expected": "1212254212342373065159",
+    "overflow": false
+  },
+  {
+    "principal": "14948822488058201969",
+    "rate_bps": 5807,
+    "seconds": 185602059,
+    "expected": "51089893072700005963",
+    "overflow": false
+  },
+  {
+    "principal": "6696846166867757118",
+    "rate_bps": 3232,
+    "seconds": 4276786080,
+    "expected": "293530068503551442430",
+    "overflow": false
+  },
+  {
+    "principal": "14347413330765796463",
+    "rate_bps": 1844,
+    "seconds": 1646446905,
+    "expected": "138126068238748541925",
+    "overflow": false
+  },
+  {
+    "principal": "935295144557881172",
+    "rate_bps": 832,
+    "seconds": 2154495142,
+    "expected": "5316317602987286737",
+    "overflow": false
+  },
+  {
+    "principal": "7768387831435248765",
+    "rate_bps": 2844,
+    "seconds": 1011760119,
+    "expected": "70881261957182107222",
+    "overflow": false
+  },
+  {
+    "principal": "2732942883386201274",
+    "rate_bps": 4904,
+    "seconds": 1197702268,
+    "expected": "50900644556427375385",
+    "overflow": false
+  },
+  {
+    "principal": "1228369164160329499",
+    "rate_bps": 823,
+    "seconds": 1107821509,
+    "expected": "3551337334485866148",
+    "overflow": false
+  },
+  {
+    "principal": "450403115252311536",
+    "rate_bps": 3252,
+    "seconds": 1714283682,
+    "expected": "7962106949259125087",
+    "overflow": false
+  },
+  {
+    "principal": "16671159736303816649",
+    "rate_bps": 4338,
+    "seconds": 1401004067,
+    "expected": "321283298214187158456",
+    "overflow": false
+  },
+  {
+    "principal": "5430109468006351990",
+    "rate_bps": 5420,
+    "seconds": 2509585048,
+    "expected": "234208785807086841233",
+    "overflow": false
+  },
+  {
+    "principal": "12853750093004420615",
+    "rate_bps": 3555,
+    "seconds": 3479393425,
+    "expected": "504157681400574321791",
+    "overflow": false
+  },
+  {
+    "principal": "17237966794148695500",
+    "rate_bps": 7318,
+    "seconds": 2024675294,
+    "expected": "809892209516655890113",
+    "overflow": false
+  },
+  {
+    "principal": "16402141721607984469",
+    "rate_bps": 5780,
+    "seconds": 803211407,
+    "expected": "241463593250732989963",
+    "overflow": false
+  },
+  {
+    "principal": "13863459866376598386",
+    "rate_bps": 5657,
+    "seconds": 1809582580,
+    "expected": "450017712928719284117",
+    "overflow": false
+  },
+  {
+    "principal": "17437207137356434739",
+    "rate_bps": 9295,
+    "seconds": 3789170589,
+    "expected": "1947439037677900424259",
+    "overflow": false
+  },
+  {
+    "principal": "10354265249301420776",
+    "rate_bps": 1312,
+    "seconds": 2384196186,
+    "expected": "102704270762545738175",
+    "overflow": false
+  },
+  {
+    "principal": "15069947707578499361",
+    "rate_bps": 1262,
+    "seconds": 2819719483,
+    "expected": "170047557554759814583",
+    "overflow": false
+  },
+  {
+    "principal": "5630226014726421934",
+    "rate_bps": 1079,
+    "seconds": 921396880,
+    "expected": "17749552339146360357",
+    "overflow": false
+  },
+  {
+    "principal": "8393585484180879519",
+    "rate_bps": 8268,
+    "seconds": 2022844649,
+    "expected": "445147470453233004911",
+    "overflow": false
+  },
+  {
+    "principal": "12515335086150863172",
+    "rate_bps": 2870,
+    "seconds": 2489651222,
+    "expected": "283567387636663397346",
+    "overflow": false
+  },
+  {
+    "principal": "267143062037479213",
+    "rate_bps": 1083,
+    "seconds": 484202023,
+    "expected": "444214109549992952",
+    "overflow": false
+  },
+  {
+    "principal": "10301768708050321194",
+    "rate_bps": 7756,
+    "seconds": 2355760236,
+    "expected": "596862199945859247673",
+    "overflow": false
+  },
+  {
+    "principal": "3085427666553226315",
+    "rate_bps": 6827,
+    "seconds": 92095605,
+    "expected": "6151451023477472803",
+    "overflow": false
+  },
+  {
+    "principal": "7206069554781066464",
+    "rate_bps": 4458,
+    "seconds": 2163232018,
+    "expected": "220361139382309629198",
+    "overflow": false
+  },
+  {
+    "principal": "11379803416182848377",
+    "rate_bps": 2447,
+    "seconds": 1209078611,
+    "expected": "106761990086283257840",
+    "overflow": false
+  },
+  {
+    "principal": "9426351272112231398",
+    "rate_bps": 6576,
+    "seconds": 315488136,
+    "expected": "62012872590628399287",
+    "overflow": false
+  },
+  {
+    "principal": "12019909381246188599",
+    "rate_bps": 5291,
+    "seconds": 3001394753,
+    "expected": "605278805777605280779",
+    "overflow": false
+  },
+  {
+    "principal": "5754081543468677564",
+    "rate_bps": 4530,
+    "seconds": 3214525774,
+    "expected": "265695696109574065265",
+    "overflow": false
+  },
+  {
+    "principal": "10295944482670436869",
+    "rate_bps": 6827,
+    "seconds": 3551954111,
+    "expected": "791693053524648984910",
+    "overflow": false
+  },
+  {
+    "principal": "4231990476984719330",
+    "rate_bps": 9627,
+    "seconds": 242770916,
+    "expected": "31363585355442835333",
+    "overflow": false
+  },
+  {
+    "principal": "4304684891700931683",
+    "rate_bps": 1598,
+    "seconds": 3476666957,
+    "expected": "75835861383154036111",
+    "overflow": false
+  },
+  {
+    "principal": "7888386427577856984",
+    "rate_bps": 4810,
+    "seconds": 1022285002,
+    "expected": "122998166028780769462",
+    "overflow": false
+  },
+  {
+    "principal": "4828692724184325841",
+    "rate_bps": 4432,
+    "seconds": 2239084139,
+    "expected": "151947349241945901559",
+    "overflow": false
+  },
+  {
+    "principal": "865329969455081246",
+    "rate_bps": 6080,
+    "seconds": 3490827648,
+    "expected": "58238090165722038604",
+    "overflow": false
+  },
+  {
+    "principal": "16977276560110985423",
+    "rate_bps": 5314,
+    "seconds": 3407359129,
+    "expected": "974767130710527995210",
+    "overflow": false
+  },
+  {
+    "principal": "3640905379700031284",
+    "rate_bps": 2826,
+    "seconds": 1739200390,
+    "expected": "56744603701107341396",
+    "overflow": false
+  },
+  {
+    "principal": "5010030749118045661",
+    "rate_bps": 1602,
+    "seconds": 172356695,
+    "expected": "4386563836598520880",
+    "overflow": false
+  },
+  {
+    "principal": "6567125733633531290",
+    "rate_bps": 7547,
+    "seconds": 2149970012,
+    "expected": "337890107312380084224",
+    "overflow": false
+  },
+  {
+    "principal": "10890689205380081019",
+    "rate_bps": 1628,
+    "seconds": 1973152037,
+    "expected": "110933753616201859668",
+    "overflow": false
+  },
+  {
+    "principal": "17976750804719228880",
+    "rate_bps": 9980,
+    "seconds": 3312413058,
+    "expected": "1884428312333588717728",
+    "overflow": false
+  },
+  {
+    "principal": "11948070637475367721",
+    "rate_bps": 8170,
+    "seconds": 2925054595,
+    "expected": "905414004225569672808",
+    "overflow": false
+  },
+  {
+    "principal": "3580306480877344598",
+    "rate_bps": 1671,
+    "seconds": 67094648,
+    "expected": "1272852050114986501",
+    "overflow": false
+  },
+  {
+    "principal": "10455943606310618727",
+    "rate_bps": 7533,
+    "seconds": 1659378673,
+    "expected": "414448046366978694451",
+    "overflow": false
+  },
+  {
+    "principal": "6436572621161494956",
+    "rate_bps": 8114,
+    "seconds": 4140295870,
+    "expected": "685668893446854384646",
+    "overflow": false
+  },
+  {
+    "principal": "16152188544441995957",
+    "rate_bps": 5445,
+    "seconds": 2370176239,
+    "expected": "661002790097319368443",
+    "overflow": false
+  },
+  {
+    "principal": "14032053195786940498",
+    "rate_bps": 6233,
+    "seconds": 4156920276,
+    "expected": "1152878228444299221376",
+    "overflow": false
+  },
+  {
+    "principal": "17307443651351039891",
+    "rate_bps": 1988,
+    "seconds": 2834575613,
+    "expected": "309264980665311924049",
+    "overflow": false
+  },
+  {
+    "principal": "6524172315081744584",
+    "rate_bps": 5542,
+    "seconds": 1180560186,
+    "expected": "135354740389632130142",
+    "overflow": false
+  },
+  {
+    "principal": "18106824522305740929",
+    "rate_bps": 1615,
+    "seconds": 108507035,
+    "expected": "10061578244297976941",
+    "overflow": false
+  },
+  {
+    "principal": "7362731725514228878",
+    "rate_bps": 8184,
+    "seconds": 4191471728,
+    "expected": "800874620784206042002",
+    "overflow": false
+  },
+  {
+    "principal": "13602153340525759743",
+    "rate_bps": 2689,
+    "seconds": 1587008585,
+    "expected": "184064967226494405565",
+    "overflow": false
+  },
+  {
+    "principal": "8276772270616414500",
+    "rate_bps": 5755,
+    "seconds": 528028406,
+    "expected": "79754833683397584819",
+    "overflow": false
+  },
+  {
+    "principal": "9788549131093270669",
+    "rate_bps": 9611,
+    "seconds": 2178291335,
+    "expected": "649824766211088629747",
+    "overflow": false
+  },
+  {
+    "principal": "5206334918649016330",
+    "rate_bps": 6022,
+    "seconds": 3277727820,
+    "expected": "325866063204680234750",
+    "overflow": false
+  },
+  {
+    "principal": "6739001496591813291",
+    "rate_bps": 1677,
+    "seconds": 2295787989,
+    "expected": "82272328289518994944",
+    "overflow": false
+  },
+  {
+    "principal": "1280528602087141056",
+    "rate_bps": 821,
+    "seconds": 129645042,
+    "expected": "432196998326441255",
+    "overflow": false
+  },
+  {
+    "principal": "15454554253732658905",
+    "rate_bps": 6643,
+    "seconds": 3501442483,
+    "expected": "1139885228381055157990",
+    "overflow": false
+  },
+  {
+    "principal": "7344317664585846470",
+    "rate_bps": 8361,
+    "seconds": 3393301864,
+    "expected": "660732341802309439555",
+    "overflow": false
+  },
+  {
+    "principal": "8049279392494490775",
+    "rate_bps": 4118,
+    "seconds": 1651357089,
+    "expected": "173571226616291777795",
+    "overflow": false
+  },
+  {
+    "principal": "17135238289922477468",
+    "rate_bps": 697,
+    "seconds": 4162288686,
+    "expected": "157633499812413261352",
+    "overflow": false
+  },
+  {
+    "principal": "18363292829769869157",
+    "rate_bps": 4841,
+    "seconds": 3069806879,
+    "expected": "865346597502084897557",
+    "overflow": false
+  },
+  {
+    "principal": "10577435213365116098",
+    "rate_bps": 2047,
+    "seconds": 1747620804,
+    "expected": "119988276629168401513",
+    "overflow": false
+  },
+  {
+    "principal": "13253676016024794819",
+    "rate_bps": 1375,
+    "seconds": 698125229,
+    "expected": "40342775574569655742",
+    "overflow": false
+  },
+  {
+    "principal": "9676692780812329400",
+    "rate_bps": 6440,
+    "seconds": 823670186,
+    "expected": "162764451821979239303",
+    "overflow": false
+  },
+  {
+    "principal": "3247090230242199089",
+    "rate_bps": 1778,
+    "seconds": 1754426571,
+    "expected": "32118459191858155899",
+    "overflow": false
+  },
+  {
+    "principal": "8155861933699126782",
+    "rate_bps": 638,
+    "seconds": 3270203232,
+    "expected": "53958352433091328409",
+    "overflow": false
+  },
+  {
+    "principal": "7496862337119190319",
+    "rate_bps": 839,
+    "seconds": 3761512441,
+    "expected": "75023512356235809984",
+    "overflow": false
+  },
+  {
+    "principal": "11811192893729318676",
+    "rate_bps": 6808,
+    "seconds": 3864068710,
+    "expected": "985261568139451471213",
+    "overflow": false
+  },
+  {
+    "principal": "264531392219809597",
+    "rate_bps": 4307,
+    "seconds": 118996151,
+    "expected": "429910840758539951",
+    "overflow": false
+  },
+  {
+    "principal": "13674986368583169658",
+    "rate_bps": 6029,
+    "seconds": 4061770812,
+    "expected": "1061893575826229752171",
+    "overflow": false
+  },
+  {
+    "principal": "14328648409995670491",
+    "rate_bps": 7875,
+    "seconds": 2850119301,
+    "expected": "1019793456528258249678",
+    "overflow": false
+  },
+  {
+    "principal": "3380660435317561776",
+    "rate_bps": 5064,
+    "seconds": 1562361442,
+    "expected": "84814509221157133777",
+    "overflow": false
+  },
+  {
+    "principal": "16622828495633421961",
+    "rate_bps": 3777,
+    "seconds": 1807549667,
+    "expected": "359861628927485742484",
+    "overflow": false
+  },
+  {
+    "principal": "5271501352439970358",
+    "rate_bps": 5716,
+    "seconds": 501917272,
+    "expected": "47957007600101992461",
+    "overflow": false
+  },
+  {
+    "principal": "4522529195689273031",
+    "rate_bps": 1487,
+    "seconds": 3032052561,
+    "expected": "64658029693019297263",
+    "overflow": false
+  },
+  {
+    "principal": "9973485665194276236",
+    "rate_bps": 8955,
+    "seconds": 1520928158,
+    "expected": "430739452217332151581",
+    "overflow": false
+  },
+  {
+    "principal": "4701820402607415317",
+    "rate_bps": 5914,
+    "seconds": 3380351311,
+    "expected": "298059238212543315673",
+    "overflow": false
+  },
+  {
+    "principal": "1211121027863002418",
+    "rate_bps": 6141,
+    "seconds": 2471389620,
+    "expected": "58285597552125709653",
+    "overflow": false
+  },
+  {
+    "principal": "16870786594395939315",
+    "rate_bps": 2602,
+    "seconds": 3624258141,
+    "expected": "504492994948103155756",
+    "overflow": false
+  },
+  {
+    "principal": "2519462206508185256",
+    "rate_bps": 9387,
+    "seconds": 4245468186,
+    "expected": "318385770526054130908",
+    "overflow": false
+  },
+  {
+    "principal": "13637897599999414241",
+    "rate_bps": 2117,
+    "seconds": 4085313019,
+    "expected": "374013272660862819523",
+    "overflow": false
+  },
+  {
+    "principal": "1578337412943698798",
+    "rate_bps": 3483,
+    "seconds": 156006992,
+    "expected": "2719510762664269915",
+    "overflow": false
+  },
+  {
+    "principal": "17635678087911223647",
+    "rate_bps": 89,
+    "seconds": 1431310249,
+    "expected": "7123761050168040047",
+    "overflow": false
+  },
+  {
+    "principal": "1146413465076504836",
+    "rate_bps": 2073,
+    "seconds": 1542514134,
+    "expected": "11624201394047764970",
+    "overflow": false
+  },
+  {
+    "principal": "14866437504182194669",
+    "rate_bps": 2006,
+    "seconds": 1406527207,
+    "expected": "133008491674656426852",
+    "overflow": false
+  },
+  {
+    "principal": "1110689515481116906",
+    "rate_bps": 3600,
+    "seconds": 2476708908,
+    "expected": "31402449965916508526",
+    "overflow": false
+  },
+  {
+    "principal": "5320348923772166411",
+    "rate_bps": 1220,
+    "seconds": 1739468597,
+    "expected": "35802217945018407250",
+    "overflow": false
+  },
+  {
+    "principal": "5907135178727889056",
+    "rate_bps": 7751,
+    "seconds": 2351888082,
+    "expected": "341463816968946109363",
+    "overflow": false
+  },
+  {
+    "principal": "16651127901664907833",
+    "rate_bps": 8322,
+    "seconds": 3729754131,
+    "expected": "1638871733977551366096",
+    "overflow": false
+  },
+  {
+    "principal": "12318320777411877286",
+    "rate_bps": 2343,
+    "seconds": 4270961480,
+    "expected": "390879456180120240950",
+    "overflow": false
+  },
+  {
+    "principal": "6158006318316436727",
+    "rate_bps": 755,
+    "seconds": 2370721025,
+    "expected": "34951106238715412416",
+    "overflow": false
+  },
+  {
+    "principal": "1746009782292902268",
+    "rate_bps": 7647,
+    "seconds": 3805741838,
+    "expected": "161127801146279142373",
+    "overflow": false
+  },
+  {
+    "principal": "18182015352473189573",
+    "rate_bps": 3009,
+    "seconds": 2344131967,
+    "expected": "406667680198381161692",
+    "overflow": false
+  },
+  {
+    "principal": "2327069040317051298",
+    "rate_bps": 5401,
+    "seconds": 2417496996,
+    "expected": "96348017251554581548",
+    "overflow": false
+  },
+  {
+    "principal": "10246860722102685987",
+    "rate_bps": 1484,
+    "seconds": 3074616589,
+    "expected": "148254912654244561608",
+    "overflow": false
+  },
+  {
+    "principal": "5417932169133006744",
+    "rate_bps": 8228,
+    "seconds": 2473223818,
+    "expected": "349610654825745539189",
+    "overflow": false
+  },
+  {
+    "principal": "8695012183719542161",
+    "rate_bps": 256,
+    "seconds": 691942187,
+    "expected": "4883974223354273605",
+    "overflow": false
+  },
+  {
+    "principal": "3259625222478746846",
+    "rate_bps": 4050,
+    "seconds": 1781477696,
+    "expected": "74575551770097500087",
+    "overflow": false
+  },
+  {
+    "principal": "10659152003195857295",
+    "rate_bps": 3285,
+    "seconds": 3415122777,
+    "expected": "379190758225201552502",
+    "overflow": false
+  },
+  {
+    "principal": "9367669786832559860",
+    "rate_bps": 707,
+    "seconds": 89636166,
+    "expected": "1882468216832558093",
+    "overflow": false
+  },
+  {
+    "principal": "2163120637700702365",
+    "rate_bps": 5596,
+    "seconds": 2283509015,
+    "expected": "87650534778465521416",
+    "overflow": false
+  },
+  {
+    "principal": "3257159655949475674",
+    "rate_bps": 4631,
+    "seconds": 175556636,
+    "expected": "8397006150041823217",
+    "overflow": false
+  },
+  {
+    "principal": "7045952958640067131",
+    "rate_bps": 2211,
+    "seconds": 628122597,
+    "expected": "31028893773984528089",
+    "overflow": false
+  },
+  {
+    "principal": "4163362941481036688",
+    "rate_bps": 7423,
+    "seconds": 2092360514,
+    "expected": "205047104744671981789",
+    "overflow": false
+  },
+  {
+    "principal": "10006872475716366825",
+    "rate_bps": 219,
+    "seconds": 1501974339,
+    "expected": "10437545605674571953",
+    "overflow": false
+  },
+  {
+    "principal": "9873169374449544470",
+    "rate_bps": 4228,
+    "seconds": 2735592504,
+    "expected": "362106536212076812888",
+    "overflow": false
+  },
+  {
+    "principal": "1909020649757972263",
+    "rate_bps": 4722,
+    "seconds": 4293876401,
+    "expected": "122738140987304566293",
+    "overflow": false
+  },
+  {
+    "principal": "10609004417396851052",
+    "rate_bps": 3489,
+    "seconds": 4064605310,
+    "expected": "477075784303970156020",
+    "overflow": false
+  },
+  {
+    "principal": "15215343903510560117",
+    "rate_bps": 4649,
+    "seconds": 1121594799,
+    "expected": "251576863837427085926",
+    "overflow": false
+  },
+  {
+    "principal": "10045404547239008786",
+    "rate_bps": 9378,
+    "seconds": 1219400084,
+    "expected": "364264856420187012316",
+    "overflow": false
+  },
+  {
+    "principal": "1268914247613776979",
+    "rate_bps": 4279,
+    "seconds": 4138136509,
+    "expected": "71248014535590880319",
+    "overflow": false
+  },
+  {
+    "principal": "14125939453267287176",
+    "rate_bps": 9157,
+    "seconds": 916475130,
+    "expected": "375910651655713534395",
+    "overflow": false
+  },
+  {
+    "principal": "807448998826151745",
+    "rate_bps": 912,
+    "seconds": 4127538267,
+    "expected": "9638166847003015030",
+    "overflow": false
+  },
+  {
+    "principal": "11611299112212447822",
+    "rate_bps": 8902,
+    "seconds": 839547952,
+    "expected": "275173940110553353952",
+    "overflow": false
+  },
+  {
+    "principal": "4926223518070941119",
+    "rate_bps": 16,
+    "seconds": 148036361,
+    "expected": "36999502947125310",
+    "overflow": false
+  },
+  {
+    "principal": "2294938535123122404",
+    "rate_bps": 5979,
+    "seconds": 3166996662,
+    "expected": "137797269042033734171",
+    "overflow": false
+  },
+  {
+    "principal": "1920632152327967565",
+    "rate_bps": 4450,
+    "seconds": 1513342791,
+    "expected": "41014262929360505265",
+    "overflow": false
+  },
+  {
+    "principal": "7408156548917150154",
+    "rate_bps": 2878,
+    "seconds": 2221297676,
+    "expected": "150176194900253578940",
+    "overflow": false
+  },
+  {
+    "principal": "1738294933163706219",
+    "rate_bps": 3152,
+    "seconds": 3399154837,
+    "expected": "59057357947671878757",
+    "overflow": false
+  },
+  {
+    "principal": "299103806185853568",
+    "rate_bps": 915,
+    "seconds": 2814804914,
+    "expected": "2442782090483766050",
+    "overflow": false
+  },
+  {
+    "principal": "17360319668417197465",
+    "rate_bps": 2008,
+    "seconds": 280779379,
+    "expected": "31037020895754853396",
+    "overflow": false
+  },
+  {
+    "principal": "4386683003172123782",
+    "rate_bps": 725,
+    "seconds": 1769343272,
+    "expected": "17843487893496417132",
+    "overflow": false
+  },
+  {
+    "principal": "16076196863631029591",
+    "rate_bps": 6717,
+    "seconds": 2963244129,
+    "expected": "1014657546452678920731",
+    "overflow": false
+  },
+  {
+    "principal": "5380884098129782108",
+    "rate_bps": 6255,
+    "seconds": 4157626862,
+    "expected": "443731085789002657186",
+    "overflow": false
+  },
+  {
+    "principal": "9091117280223978021",
+    "rate_bps": 7138,
+    "seconds": 3796615647,
+    "expected": "781238846979695937541",
+    "overflow": false
+  },
+  {
+    "principal": "1862874489213236866",
+    "rate_bps": 6422,
+    "seconds": 1786307460,
+    "expected": "67764697129435063307",
+    "overflow": false
+  },
+  {
+    "principal": "9331701532780526467",
+    "rate_bps": 6069,
+    "seconds": 2714033773,
+    "expected": "487401226795980230319",
+    "overflow": false
+  },
+  {
+    "principal": "17941111592234757496",
+    "rate_bps": 940,
+    "seconds": 4066207594,
+    "expected": "217450365135329839609",
+    "overflow": false
+  },
+  {
+    "principal": "5984840670875108593",
+    "rate_bps": 6258,
+    "seconds": 3763407243,
+    "expected": "446953931056281857474",
+    "overflow": false
+  },
+  {
+    "principal": "13708744271497601982",
+    "rate_bps": 31,
+    "seconds": 1284856608,
+    "expected": "1731439911856579905",
+    "overflow": false
+  },
+  {
+    "principal": "3563034654896121327",
+    "rate_bps": 8829,
+    "seconds": 994031289,
+    "expected": "99157372718997102527",
+    "overflow": false
+  },
+  {
+    "principal": "12636305290790004436",
+    "rate_bps": 4629,
+    "seconds": 565594150,
+    "expected": "104907271691219203984",
+    "overflow": false
+  },
+  {
+    "principal": "12656573187058502141",
+    "rate_bps": 7861,
+    "seconds": 1185512823,
+    "expected": "374018927018600123272",
+    "overflow": false
+  },
+  {
+    "principal": "14756731300072364090",
+    "rate_bps": 4771,
+    "seconds": 3933547516,
+    "expected": "878167539287541154242",
+    "overflow": false
+  },
+  {
+    "principal": "17810624051211550875",
+    "rate_bps": 3466,
+    "seconds": 1927346501,
+    "expected": "377277484512610378401",
+    "overflow": false
+  },
+  {
+    "principal": "1463364366425754992",
+    "rate_bps": 5240,
+    "seconds": 2276251682,
+    "expected": "55347426897471978165",
+    "overflow": false
+  },
+  {
+    "principal": "3680663807837625673",
+    "rate_bps": 5445,
+    "seconds": 1770826147,
+    "expected": "112536486988797029071",
+    "overflow": false
+  },
+  {
+    "principal": "7629397378925604854",
+    "rate_bps": 7280,
+    "seconds": 3340849688,
+    "expected": "588399025018786872756",
+    "overflow": false
+  },
+  {
+    "principal": "2120852069370091399",
+    "rate_bps": 3613,
+    "seconds": 2208420369,
+    "expected": "53660346913061213479",
+    "overflow": false
+  },
+  {
+    "principal": "14373974018945768780",
+    "rate_bps": 6338,
+    "seconds": 3751293790,
+    "expected": "1083686246422721109334",
+    "overflow": false
+  },
+  {
+    "principal": "5175436307133508309",
+    "rate_bps": 6775,
+    "seconds": 1001937423,
+    "expected": "111401300003437786853",
+    "overflow": false
+  },
+  {
+    "principal": "11925786555475019506",
+    "rate_bps": 209,
+    "seconds": 1444809076,
+    "expected": "11419239258757987397",
+    "overflow": false
+  },
+  {
+    "principal": "7291209753594934963",
+    "rate_bps": 2687,
+    "seconds": 1349496093,
+    "expected": "83836334780756141976",
+    "overflow": false
+  },
+  {
+    "principal": "14395247087221166696",
+    "rate_bps": 4685,
+    "seconds": 194033114,
+    "expected": "41495209889135853756",
+    "overflow": false
+  },
+  {
+    "principal": "11556453992161648289",
+    "rate_bps": 1496,
+    "seconds": 953981627,
+    "expected": "52298543231742610555",
+    "overflow": false
+  },
+  {
+    "principal": "3677006611073235246",
+    "rate_bps": 9376,
+    "seconds": 885444112,
+    "expected": "96798038467076809108",
+    "overflow": false
+  },
+  {
+    "principal": "6857634809135737375",
+    "rate_bps": 7882,
+    "seconds": 2839033449,
+    "expected": "486602893169753516574",
+    "overflow": false
+  },
+  {
+    "principal": "5232486872519026884",
+    "rate_bps": 3368,
+    "seconds": 149683094,
+    "expected": "8364623061122939346",
+    "overflow": false
+  },
+  {
+    "principal": "7297060128786752685",
+    "rate_bps": 3827,
+    "seconds": 3225925543,
+    "expected": "285663083343357530493",
+    "overflow": false
+  },
+  {
+    "principal": "15300404697199911594",
+    "rate_bps": 9016,
+    "seconds": 3505019884,
+    "expected": "1533206671218750400711",
+    "overflow": false
+  },
+  {
+    "principal": "13381099771168538059",
+    "rate_bps": 3098,
+    "seconds": 506812917,
+    "expected": "66621482164624194018",
+    "overflow": false
+  },
+  {
+    "principal": "13871382972411796576",
+    "rate_bps": 8037,
+    "seconds": 133750930,
+    "expected": "47282881365325177698",
+    "overflow": false
+  },
+  {
+    "principal": "4858721799380756729",
+    "rate_bps": 5521,
+    "seconds": 735198419,
+    "expected": "62537099934205981456",
+    "overflow": false
+  },
+  {
+    "principal": "17537464677885796198",
+    "rate_bps": 4169,
+    "seconds": 950447880,
+    "expected": "220353728721417505439",
+    "overflow": false
+  },
+  {
+    "principal": "13589239282298600887",
+    "rate_bps": 8327,
+    "seconds": 1299792833,
+    "expected": "466392160182720920062",
+    "overflow": false
+  },
+  {
+    "principal": "12965389388189673788",
+    "rate_bps": 6134,
+    "seconds": 2197520590,
+    "expected": "554186168144236375943",
+    "overflow": false
+  },
+  {
+    "principal": "17388736088807921541",
+    "rate_bps": 8351,
+    "seconds": 789247551,
+    "expected": "363423608201946287926",
+    "overflow": false
+  },
+  {
+    "principal": "7202813682003807074",
+    "rate_bps": 2403,
+    "seconds": 260375396,
+    "expected": "14290561332548834015",
+    "overflow": false
+  },
+  {
+    "principal": "10696012824002147811",
+    "rate_bps": 3037,
+    "seconds": 3602538445,
+    "expected": "371081004959695131711",
+    "overflow": false
+  },
+  {
+    "principal": "4453372436364266328",
+    "rate_bps": 6651,
+    "seconds": 1885943882,
+    "expected": "177132447487572829825",
+    "overflow": false
+  },
+  {
+    "principal": "5219352090364943441",
+    "rate_bps": 6238,
+    "seconds": 1252192235,
+    "expected": "129278517914846749985",
+    "overflow": false
+  },
+  {
+    "principal": "2197779090815599262",
+    "rate_bps": 9186,
+    "seconds": 3839218944,
+    "expected": "245780119653829801067",
+    "overflow": false
+  },
+  {
+    "principal": "12160140803689738831",
+    "rate_bps": 1091,
+    "seconds": 1633638937,
+    "expected": "68724695365532227956",
+    "overflow": false
+  },
+  {
+    "principal": "9602750922990665396",
+    "rate_bps": 9836,
+    "seconds": 3966018310,
+    "expected": "1187851887898414279088",
+    "overflow": false
+  },
+  {
+    "principal": "11009561507384402781",
+    "rate_bps": 3266,
+    "seconds": 1612281303,
+    "expected": "183831704159248317088",
+    "overflow": false
+  },
+  {
+    "principal": "16431366313583698202",
+    "rate_bps": 2441,
+    "seconds": 1733091292,
+    "expected": "220422686040667214599",
+    "overflow": false
+  },
+  {
+    "principal": "11188639055346990843",
+    "rate_bps": 422,
+    "seconds": 1623924389,
+    "expected": "24313580102725994100",
+    "overflow": false
+  },
+  {
+    "principal": "2718202525388422992",
+    "rate_bps": 4027,
+    "seconds": 4118387970,
+    "expected": "142949977365578869965",
+    "overflow": false
+  },
+  {
+    "principal": "12845397772774807721",
+    "rate_bps": 5579,
+    "seconds": 2980582403,
+    "expected": "677327088547051892528",
+    "overflow": false
+  },
+  {
+    "principal": "11328220292328686294",
+    "rate_bps": 3287,
+    "seconds": 836575224,
+    "expected": "98777898289986119700",
+    "overflow": false
+  },
+  {
+    "principal": "6807825863413475303",
+    "rate_bps": 7593,
+    "seconds": 2196298097,
+    "expected": "360003328918856437024",
+    "overflow": false
+  },
+  {
+    "principal": "5272715753097382188",
+    "rate_bps": 3971,
+    "seconds": 412697150,
+    "expected": "27400539218974298579",
+    "overflow": false
+  },
+  {
+    "principal": "4103970835999156277",
+    "rate_bps": 8431,
+    "seconds": 3664680559,
+    "expected": "402080371512960992437",
+    "overflow": false
+  },
+  {
+    "principal": "16576040959076467666",
+    "rate_bps": 5053,
+    "seconds": 768921940,
+    "expected": "204223519096165129220",
+    "overflow": false
+  },
+  {
+    "principal": "6361852169146923283",
+    "rate_bps": 4174,
+    "seconds": 4109891197,
+    "expected": "346066639478044898946",
+    "overflow": false
+  },
+  {
+    "principal": "15786919637939574856",
+    "rate_bps": 1335,
+    "seconds": 676720314,
+    "expected": "45225280635875758725",
+    "overflow": false
+  },
+  {
+    "principal": "5509841293740785153",
+    "rate_bps": 7422,
+    "seconds": 2329872667,
+    "expected": "302124273498019167298",
+    "overflow": false
+  },
+  {
+    "principal": "18235137981454712846",
+    "rate_bps": 7739,
+    "seconds": 3325652976,
+    "expected": "1488210016465504070121",
+    "overflow": false
+  },
+  {
+    "principal": "12155391877511134847",
+    "rate_bps": 1734,
+    "seconds": 3935838665,
+    "expected": "263056319010340422301",
+    "overflow": false
+  },
+  {
+    "principal": "12995612491238418596",
+    "rate_bps": 6944,
+    "seconds": 1532968566,
+    "expected": "438665124460866748642",
+    "overflow": false
+  },
+  {
+    "principal": "16225036740779312653",
+    "rate_bps": 511,
+    "seconds": 359249927,
+    "expected": "9444884919648380082",
+    "overflow": false
+  },
+  {
+    "principal": "1062228989635679114",
+    "rate_bps": 8644,
+    "seconds": 1751365580,
+    "expected": "50992125048540248705",
+    "overflow": false
+  },
+  {
+    "principal": "17639703468024857643",
+    "rate_bps": 2721,
+    "seconds": 320161621,
+    "expected": "48728437433865289219",
+    "overflow": false
+  },
+  {
+    "principal": "12509542068521088576",
+    "rate_bps": 9142,
+    "seconds": 1849560434,
+    "expected": "670725083690722375358",
+    "overflow": false
+  },
+  {
+    "principal": "43813686369152089",
+    "rate_bps": 2927,
+    "seconds": 392769331,
+    "expected": "159721536576755422",
+    "overflow": false
+  },
+  {
+    "principal": "17601730002376596038",
+    "rate_bps": 6361,
+    "seconds": 232498408,
+    "expected": "82545637712739057879",
+    "overflow": false
+  },
+  {
+    "principal": "2126611469399922199",
+    "rate_bps": 2610,
+    "seconds": 3908277025,
+    "expected": "68787162003926651697",
+    "overflow": false
+  },
+  {
+    "principal": "11357995587181657372",
+    "rate_bps": 2507,
+    "seconds": 2756736942,
+    "expected": "248911377783477416131",
+    "overflow": false
+  },
+  {
+    "principal": "13408663890153299173",
+    "rate_bps": 3183,
+    "seconds": 3394124447,
+    "expected": "459349553079881438871",
+    "overflow": false
+  },
+  {
+    "principal": "3349337464438763586",
+    "rate_bps": 8491,
+    "seconds": 3413406532,
+    "expected": "307821646270876633171",
+    "overflow": false
+  },
+  {
+    "principal": "10477385504300105795",
+    "rate_bps": 5846,
+    "seconds": 129724717,
+    "expected": "25195783018698741387",
+    "overflow": false
+  },
+  {
+    "principal": "15882372799016253752",
+    "rate_bps": 7735,
+    "seconds": 3288717610,
+    "expected": "1281137314614440236111",
+    "overflow": false
+  },
+  {
+    "principal": "6195745729820787633",
+    "rate_bps": 6389,
+    "seconds": 3373000267,
+    "expected": "423385756069467161392",
+    "overflow": false
+  },
+  {
+    "principal": "3026824177666830718",
+    "rate_bps": 3231,
+    "seconds": 2712182496,
+    "expected": "84107835033572730854",
+    "overflow": false
+  },
+  {
+    "principal": "6088990485773061807",
+    "rate_bps": 1792,
+    "seconds": 4094004601,
+    "expected": "141652753282111399742",
+    "overflow": false
+  },
+  {
+    "principal": "14303045589778917012",
+    "rate_bps": 4239,
+    "seconds": 1784335846,
+    "expected": "343053561780129542449",
+    "overflow": false
+  },
+  {
+    "principal": "7841650919214206141",
+    "rate_bps": 2515,
+    "seconds": 1438875191,
+    "expected": "89983319903637941001",
+    "overflow": false
+  },
+  {
+    "principal": "3504517601330264570",
+    "rate_bps": 5409,
+    "seconds": 171303868,
+    "expected": "10296883269684809247",
+    "overflow": false
+  },
+  {
+    "principal": "1402477159930842459",
+    "rate_bps": 8436,
+    "seconds": 29807621,
+    "expected": "1118286486833926239",
+    "overflow": false
+  },
+  {
+    "principal": "7295232762950336816",
+    "rate_bps": 4243,
+    "seconds": 1368732130,
+    "expected": "134345783381486385968",
+    "overflow": false
+  },
+  {
+    "principal": "5020581518413292553",
+    "rate_bps": 2175,
+    "seconds": 1806732899,
+    "expected": "62560560369442405845",
+    "overflow": false
+  },
+  {
+    "principal": "3341896245004379574",
+    "rate_bps": 8501,
+    "seconds": 4277747160,
+    "expected": "385364303467051458288",
+    "overflow": false
+  },
+  {
+    "principal": "9681431856127248455",
+    "rate_bps": 5486,
+    "seconds": 1155297489,
+    "expected": "194573019559899761711",
+    "overflow": false
+  },
+  {
+    "principal": "9822071915668571404",
+    "rate_bps": 7529,
+    "seconds": 1732256030,
+    "expected": "406205576891065172231",
+    "overflow": false
+  },
+  {
+    "principal": "3961242921626318229",
+    "rate_bps": 7495,
+    "seconds": 693428943,
+    "expected": "65282754592723315672",
+    "overflow": false
+  },
+  {
+    "principal": "16989360192151031986",
+    "rate_bps": 8008,
+    "seconds": 1980426548,
+    "expected": "854384224708989225155",
+    "overflow": false
+  },
+  {
+    "principal": "5262510170780945267",
+    "rate_bps": 38,
+    "seconds": 3084373981,
+    "expected": "1955856414666334770",
+    "overflow": false
+  },
+  {
+    "principal": "761552191563935272",
+    "rate_bps": 910,
+    "seconds": 3446142874,
+    "expected": "7572996159642300837",
+    "overflow": false
+  },
+  {
+    "principal": "10888848936268033377",
+    "rate_bps": 1878,
+    "seconds": 1592035195,
+    "expected": "103234205127237587539",
+    "overflow": false
+  },
+  {
+    "principal": "260453192228165358",
+    "rate_bps": 9588,
+    "seconds": 2400870864,
+    "expected": "19011654111280759707",
+    "overflow": false
+  },
+  {
+    "principal": "8099682225217397471",
+    "rate_bps": 3413,
+    "seconds": 84581673,
+    "expected": "7414364504808964867",
+    "overflow": false
+  },
+  {
+    "principal": "16132735351391877252",
+    "rate_bps": 1261,
+    "seconds": 588665174,
+    "expected": "37973867651235942294",
+    "overflow": false
+  },
+  {
+    "principal": "1192599834452522861",
+    "rate_bps": 1186,
+    "seconds": 1290913895,
+    "expected": "5789887193045349169",
+    "overflow": false
+  },
+  {
+    "principal": "10793475726473811050",
+    "rate_bps": 4909,
+    "seconds": 3993658284,
+    "expected": "670994014617708105549",
+    "overflow": false
+  },
+  {
+    "principal": "4187569173616482955",
+    "rate_bps": 9065,
+    "seconds": 2647835829,
+    "expected": "318723620525714905469",
+    "overflow": false
+  },
+  {
+    "principal": "5679726017764319264",
+    "rate_bps": 9682,
+    "seconds": 2953710162,
+    "expected": "515055151139776483668",
+    "overflow": false
+  },
+  {
+    "principal": "5628751158621765561",
+    "rate_bps": 2571,
+    "seconds": 3747164563,
+    "expected": "171953209116547752653",
+    "overflow": false
+  },
+  {
+    "principal": "5402490210178835750",
+    "rate_bps": 4330,
+    "seconds": 4274842312,
+    "expected": "317099368648413452732",
+    "overflow": false
+  },
+  {
+    "principal": "592653004231802487",
+    "rate_bps": 2050,
+    "seconds": 203846273,
+    "expected": "785326983430230968",
+    "overflow": false
+  },
+  {
+    "principal": "8921405848988459260",
+    "rate_bps": 6349,
+    "seconds": 1338457742,
+    "expected": "240401227482001377672",
+    "overflow": false
+  },
+  {
+    "principal": "8394861697434382917",
+    "rate_bps": 6341,
+    "seconds": 4033711871,
+    "expected": "680878412848893592672",
+    "overflow": false
+  },
+  {
+    "principal": "9955587138940904738",
+    "rate_bps": 3035,
+    "seconds": 511652644,
+    "expected": "49022357095103788150",
+    "overflow": false
+  },
+  {
+    "principal": "13584113569625430691",
+    "rate_bps": 3877,
+    "seconds": 2858422925,
+    "expected": "477361054511566103774",
+    "overflow": false
+  },
+  {
+    "principal": "3167972130546497304",
+    "rate_bps": 1542,
+    "seconds": 933972490,
+    "expected": "14467490420232098686",
+    "overflow": false
+  },
+  {
+    "principal": "15730760179636009745",
+    "rate_bps": 7070,
+    "seconds": 1617161387,
+    "expected": "570316426024855049555",
+    "overflow": false
+  },
+  {
+    "principal": "8841625589697212510",
+    "rate_bps": 3496,
+    "seconds": 3854940352,
+    "expected": "377845800556337302015",
+    "overflow": false
+  },
+  {
+    "principal": "199648346306001679",
+    "rate_bps": 1366,
+    "seconds": 759845081,
+    "expected": "657105142525895036",
+    "overflow": false
+  },
+  {
+    "principal": "1625425022814281332",
+    "rate_bps": 3296,
+    "seconds": 4103129286,
+    "expected": "69704808561194223729",
+    "overflow": false
+  },
+  {
+    "principal": "18146612143124055581",
+    "rate_bps": 6849,
+    "seconds": 218076823,
+    "expected": "85945991839541363318",
+    "overflow": false
+  },
+  {
+    "principal": "18277201371523244762",
+    "rate_bps": 7338,
+    "seconds": 275265436,
+    "expected": "117066458271910046712",
+    "overflow": false
+  },
+  {
+    "principal": "13999066523547446203",
+    "rate_bps": 1515,
+    "seconds": 2892765541,
+    "expected": "194544222878327457330",
+    "overflow": false
+  },
+  {
+    "principal": "8100216479540712208",
+    "rate_bps": 5498,
+    "seconds": 997693122,
+    "expected": "140893751317167126282",
+    "overflow": false
+  },
+  {
+    "principal": "2144868352590430057",
+    "rate_bps": 2420,
+    "seconds": 4118681795,
+    "expected": "67790313204895185781",
+    "overflow": false
+  },
+  {
+    "principal": "6237138471930665110",
+    "rate_bps": 9510,
+    "seconds": 3190664120,
+    "expected": "600123156110528319374",
+    "overflow": false
+  },
+  {
+    "principal": "10431163812931893415",
+    "rate_bps": 1153,
+    "seconds": 345282609,
+    "expected": "13168313904869182675",
+    "overflow": false
+  },
+  {
+    "principal": "10675888201052950764",
+    "rate_bps": 3632,
+    "seconds": 1770311678,
+    "expected": "217667196806882003748",
+    "overflow": false
+  },
+  {
+    "principal": "9910367040416584437",
+    "rate_bps": 8682,
+    "seconds": 381894447,
+    "expected": "104194850861027979112",
+    "overflow": false
+  },
+  {
+    "principal": "12568233204331113874",
+    "rate_bps": 5191,
+    "seconds": 150491412,
+    "expected": "31133673700301237684",
+    "overflow": false
+  },
+  {
+    "principal": "7168505698675502547",
+    "rate_bps": 322,
+    "seconds": 816265533,
+    "expected": "5974607205199177659",
+    "overflow": false
+  },
+  {
+    "principal": "873892249353769992",
+    "rate_bps": 448,
+    "seconds": 3477000314,
+    "expected": "4316522654051054675",
+    "overflow": false
+  },
+  {
+    "principal": "15933593615073324225",
+    "rate_bps": 3090,
+    "seconds": 3418691035,
+    "expected": "533734728468416541357",
+    "overflow": false
+  },
+  {
+    "principal": "16762512112006921678",
+    "rate_bps": 4602,
+    "seconds": 740402096,
+    "expected": "181111801963465068102",
+    "overflow": false
+  },
+  {
+    "principal": "2415481618345334591",
+    "rate_bps": 3088,
+    "seconds": 3030886537,
+    "expected": "71687609764630768032",
+    "overflow": false
+  },
+  {
+    "principal": "3501875087684474980",
+    "rate_bps": 6052,
+    "seconds": 587805750,
+    "expected": "39502701148455451800",
+    "overflow": false
+  },
+  {
+    "principal": "17855866980684953805",
+    "rate_bps": 4675,
+    "seconds": 3191335111,
+    "expected": "844750311432538963935",
+    "overflow": false
+  },
+  {
+    "principal": "16634675109428798794",
+    "rate_bps": 8334,
+    "seconds": 3105251212,
+    "expected": "1365079523729060768739",
+    "overflow": false
+  },
+  {
+    "principal": "11399166364543926507",
+    "rate_bps": 5752,
+    "seconds": 4144353813,
+    "expected": "861672410063768120354",
+    "overflow": false
+  },
+  {
+    "principal": "11196878009151707648",
+    "rate_bps": 3021,
+    "seconds": 3068188466,
+    "expected": "329096374492280536841",
+    "overflow": false
+  },
+  {
+    "principal": "319639144492507929",
+    "rate_bps": 9153,
+    "seconds": 3011134451,
+    "expected": "27934889821556507263",
+    "overflow": false
+  },
+  {
+    "principal": "13547883682136195078",
+    "rate_bps": 1046,
+    "seconds": 2503114920,
+    "expected": "112480522669399768996",
+    "overflow": false
+  },
+  {
+    "principal": "10608094657313470167",
+    "rate_bps": 3958,
+    "seconds": 1143595489,
+    "expected": "152257608072302183483",
+    "overflow": false
+  },
+  {
+    "principal": "16833945057584731356",
+    "rate_bps": 1916,
+    "seconds": 1297601902,
+    "expected": "132713858711569369371",
+    "overflow": false
+  },
+  {
+    "principal": "14170513606960977829",
+    "rate_bps": 5489,
+    "seconds": 3250647903,
+    "expected": "801755866378753713051",
+    "overflow": false
+  },
+  {
+    "principal": "17005612330330450434",
+    "rate_bps": 5871,
+    "seconds": 3168617220,
+    "expected": "1003153807669311483533",
+    "overflow": false
+  },
+  {
+    "principal": "7654701310597350659",
+    "rate_bps": 7803,
+    "seconds": 4164961261,
+    "expected": "788849610299175123483",
+    "overflow": false
+  },
+  {
+    "principal": "12526285159937803512",
+    "rate_bps": 2968,
+    "seconds": 2849082090,
+    "expected": "335880310881930409347",
+    "overflow": false
+  },
+  {
+    "principal": "11079664835382280817",
+    "rate_bps": 9928,
+    "seconds": 3112370955,
+    "expected": "1085608258187476558000",
+    "overflow": false
+  },
+  {
+    "principal": "7250200579767041854",
+    "rate_bps": 9258,
+    "seconds": 132457120,
+    "expected": "28192649960441299004",
+    "overflow": false
+  },
+  {
+    "principal": "6330789502394300271",
+    "rate_bps": 6906,
+    "seconds": 3410338873,
+    "expected": "472797722695048434451",
+    "overflow": false
+  },
+  {
+    "principal": "10018258323499558484",
+    "rate_bps": 6489,
+    "seconds": 939430822,
+    "expected": "193654769691392599180",
+    "overflow": false
+  },
+  {
+    "principal": "2271623064817291133",
+    "rate_bps": 8673,
+    "seconds": 3475357431,
+    "expected": "217119328077133100674",
+    "overflow": false
+  },
+  {
+    "principal": "5168135837690993594",
+    "rate_bps": 7271,
+    "seconds": 1796987772,
+    "expected": "214124607342855618999",
+    "overflow": false
+  },
+  {
+    "principal": "6112728263935367707",
+    "rate_bps": 8182,
+    "seconds": 4216516293,
+    "expected": "668716041002922066371",
+    "overflow": false
+  },
+  {
+    "principal": "15433222325685204208",
+    "rate_bps": 4071,
+    "seconds": 1721289634,
+    "expected": "342929669811881744964",
+    "overflow": false
+  },
+  {
+    "principal": "7464164914648754889",
+    "rate_bps": 2608,
+    "seconds": 3504911139,
+    "expected": "216351154981619536332",
+    "overflow": false
+  },
+  {
+    "principal": "9087812830724119414",
+    "rate_bps": 3228,
+    "seconds": 1932683672,
+    "expected": "179782357306075756736",
+    "overflow": false
+  },
+  {
+    "principal": "6450211919019014407",
+    "rate_bps": 2897,
+    "seconds": 1093226385,
+    "expected": "64777767518682659192",
+    "overflow": false
+  },
+  {
+    "principal": "16344053564224072908",
+    "rate_bps": 1364,
+    "seconds": 2438942430,
+    "expected": "172412635072917023236",
+    "overflow": false
+  },
+  {
+    "principal": "17750978087555596373",
+    "rate_bps": 6773,
+    "seconds": 1964092303,
+    "expected": "748787611099226622509",
+    "overflow": false
+  },
+  {
+    "principal": "7317087411179723378",
+    "rate_bps": 9677,
+    "seconds": 4107602164,
+    "expected": "922275668709247849386",
+    "overflow": false
+  },
+  {
+    "principal": "6947027659046985779",
+    "rate_bps": 9131,
+    "seconds": 3137221277,
+    "expected": "631038585761397385069",
+    "overflow": false
+  },
+  {
+    "principal": "4377078824405518824",
+    "rate_bps": 4574,
+    "seconds": 2521987418,
+    "expected": "160109402409422248867",
+    "overflow": false
+  },
+  {
+    "principal": "494470868814822433",
+    "rate_bps": 232,
+    "seconds": 2354623547,
+    "expected": "856531957876482435",
+    "overflow": false
+  },
+  {
+    "principal": "7953161791754695854",
+    "rate_bps": 8999,
+    "seconds": 772224400,
+    "expected": "175255228022176287044",
+    "overflow": false
+  },
+  {
+    "principal": "18241366337812061087",
+    "rate_bps": 3827,
+    "seconds": 965166057,
+    "expected": "213654114508916003118",
+    "overflow": false
+  },
+  {
+    "principal": "218375773407152196",
+    "rate_bps": 8918,
+    "seconds": 1915741974,
+    "expected": "11830479080730101908",
+    "overflow": false
+  },
+  {
+    "principal": "9715075431375637037",
+    "rate_bps": 656,
+    "seconds": 613685543,
+    "expected": "12401930745661004522",
+    "overflow": false
+  },
+  {
+    "principal": "16482028588940215850",
+    "rate_bps": 5092,
+    "seconds": 3569331052,
+    "expected": "949903048341534240854",
+    "overflow": false
+  },
+  {
+    "principal": "3986907860226225995",
+    "rate_bps": 150,
+    "seconds": 2605084533,
+    "expected": "4940178843783993160",
+    "overflow": false
+  },
+  {
+    "principal": "659032120520156128",
+    "rate_bps": 503,
+    "seconds": 2150528018,
+    "expected": "2260544524004616593",
+    "overflow": false
+  },
+  {
+    "principal": "2441715774702802553",
+    "rate_bps": 5196,
+    "seconds": 3886310995,
+    "expected": "156349031628593167178",
+    "overflow": false
+  },
+  {
+    "principal": "8917833073234520806",
+    "rate_bps": 5586,
+    "seconds": 3468977800,
+    "expected": "547967982748297951210",
+    "overflow": false
+  },
+  {
+    "principal": "3811131910608060215",
+    "rate_bps": 7015,
+    "seconds": 571859265,
+    "expected": "48480178586145588180",
+    "overflow": false
+  },
+  {
+    "principal": "10316306872324610236",
+    "rate_bps": 3397,
+    "seconds": 955923534,
+    "expected": "106227349623864259373",
+    "overflow": false
+  },
+  {
+    "principal": "16702314207226678533",
+    "rate_bps": 1658,
+    "seconds": 1117808575,
+    "expected": "98157164800850669235",
+    "overflow": false
+  },
+  {
+    "principal": "12800750543693446882",
+    "rate_bps": 2989,
+    "seconds": 2395382500,
+    "expected": "290622754583507063765",
+    "overflow": false
+  },
+  {
+    "principal": "3730881749364064099",
+    "rate_bps": 2605,
+    "seconds": 4008969549,
+    "expected": "123550743275410952383",
+    "overflow": false
+  },
+  {
+    "principal": "5074952731429348056",
+    "rate_bps": 6827,
+    "seconds": 2364578762,
+    "expected": "259782015556601393849",
+    "overflow": false
+  },
+  {
+    "principal": "13288251345247017425",
+    "rate_bps": 905,
+    "seconds": 557918571,
+    "expected": "21275541579383195273",
+    "overflow": false
+  },
+  {
+    "principal": "10700890213207432734",
+    "rate_bps": 6016,
+    "seconds": 1388240000,
+    "expected": "283390757986973135129",
+    "overflow": false
+  },
+  {
+    "principal": "12289405456389489615",
+    "rate_bps": 6227,
+    "seconds": 269453209,
+    "expected": "65386259201673660715",
+    "overflow": false
+  },
+  {
+    "principal": "2027580907861589556",
+    "rate_bps": 6523,
+    "seconds": 899427974,
+    "expected": "37721187440510888438",
+    "overflow": false
+  },
+  {
+    "principal": "12358611880177969373",
+    "rate_bps": 4204,
+    "seconds": 1234040663,
+    "expected": "203308372753571756406",
+    "overflow": false
+  },
+  {
+    "principal": "865387888596165786",
+    "rate_bps": 4945,
+    "seconds": 3213414236,
+    "expected": "43605092806748720171",
+    "overflow": false
+  },
+  {
+    "principal": "5285946691522828411",
+    "rate_bps": 5002,
+    "seconds": 3440596005,
+    "expected": "288465274485099717172",
+    "overflow": false
+  },
+  {
+    "principal": "2549963545371780816",
+    "rate_bps": 9252,
+    "seconds": 2591084674,
+    "expected": "193840532608399760323",
+    "overflow": false
+  },
+  {
+    "principal": "746338687663908393",
+    "rate_bps": 7383,
+    "seconds": 2747817347,
+    "expected": "48012030902158979995",
+    "overflow": false
+  },
+  {
+    "principal": "17821181397591846486",
+    "rate_bps": 5913,
+    "seconds": 2512353144,
+    "expected": "839495645888141054022",
+    "overflow": false
+  },
+  {
+    "principal": "17800131736935074151",
+    "rate_bps": 7110,
+    "seconds": 498243313,
+    "expected": "199952891571721201215",
+    "overflow": false
+  },
+  {
+    "principal": "15771039763314940076",
+    "rate_bps": 7314,
+    "seconds": 617061822,
+    "expected": "225703011063835703343",
+    "overflow": false
+  },
+  {
+    "principal": "17538700467399654837",
+    "rate_bps": 5343,
+    "seconds": 4204275695,
+    "expected": "1249301223979355203231",
+    "overflow": false
+  },
+  {
+    "principal": "795707604412208978",
+    "rate_bps": 7286,
+    "seconds": 2077823188,
+    "expected": "38198354695096396137",
+    "overflow": false
+  },
+  {
+    "principal": "13531198792015848083",
+    "rate_bps": 7898,
+    "seconds": 1987361789,
+    "expected": "673478494387948002647",
+    "overflow": false
+  },
+  {
+    "principal": "4384424920209166280",
+    "rate_bps": 8946,
+    "seconds": 521859642,
+    "expected": "64906566573082667680",
+    "overflow": false
+  },
+  {
+    "principal": "6036226529070996353",
+    "rate_bps": 4261,
+    "seconds": 4286014107,
+    "expected": "349561869334628149362",
+    "overflow": false
+  },
+  {
+    "principal": "13073031830083845006",
+    "rate_bps": 3015,
+    "seconds": 428021616,
+    "expected": "53496174952260125368",
+    "overflow": false
+  },
+  {
+    "principal": "1130060365967863807",
+    "rate_bps": 5436,
+    "seconds": 1472294729,
+    "expected": "28679345885868815848",
+    "overflow": false
+  },
+  {
+    "principal": "214921648679831588",
+    "rate_bps": 5145,
+    "seconds": 2072144374,
+    "expected": "7265724838794336018",
+    "overflow": false
+  },
+  {
+    "principal": "4096264985189231501",
+    "rate_bps": 9603,
+    "seconds": 2673760647,
+    "expected": "333511560186288994661",
+    "overflow": false
+  },
+  {
+    "principal": "5677158930753140490",
+    "rate_bps": 2198,
+    "seconds": 4081484,
+    "expected": "161499146639506151",
+    "overflow": false
+  },
+  {
+    "principal": "7400722778253737387",
+    "rate_bps": 8849,
+    "seconds": 1261214933,
+    "expected": "261909245090752775400",
+    "overflow": false
+  },
+  {
+    "principal": "8165122283707678144",
+    "rate_bps": 4191,
+    "seconds": 493805810,
+    "expected": "53583359948708920979",
+    "overflow": false
+  },
+  {
+    "principal": "18108328438859766233",
+    "rate_bps": 4364,
+    "seconds": 4088371379,
+    "expected": "1024487908887162955997",
+    "overflow": false
+  },
+  {
+    "principal": "17354768725965088198",
+    "rate_bps": 2667,
+    "seconds": 490380392,
+    "expected": "71972789579692745149",
+    "overflow": false
+  },
+  {
+    "principal": "1157839251133732759",
+    "rate_bps": 9205,
+    "seconds": 990015649,
+    "expected": "33458580635646687200",
+    "overflow": false
+  },
+  {
+    "principal": "9528096306764590236",
+    "rate_bps": 821,
+    "seconds": 2191946542,
+    "expected": "54371666774305744961",
+    "overflow": false
+  },
+  {
+    "principal": "17833290537022755429",
+    "rate_bps": 7965,
+    "seconds": 1533275167,
+    "expected": "690606656700544527302",
+    "overflow": false
+  },
+  {
+    "principal": "13198250410728907714",
+    "rate_bps": 2330,
+    "seconds": 2960347844,
+    "expected": "288674499951731693485",
+    "overflow": false
+  },
+  {
+    "principal": "16202832163116173763",
+    "rate_bps": 4109,
+    "seconds": 1343444653,
+    "expected": "283622216607609805339",
+    "overflow": false
+  },
+  {
+    "principal": "15640954769927737528",
+    "rate_bps": 8972,
+    "seconds": 3883957418,
+    "expected": "1728304966593348879111",
+    "overflow": false
+  },
+  {
+    "principal": "10924541690526548273",
+    "rate_bps": 1510,
+    "seconds": 2289459147,
+    "expected": "119758532373287234515",
+    "overflow": false
+  },
+  {
+    "principal": "10142420978783948030",
+    "rate_bps": 7966,
+    "seconds": 84600416,
+    "expected": "21674437053717075556",
+    "overflow": false
+  },
+  {
+    "principal": "4312959025009106991",
+    "rate_bps": 5629,
+    "seconds": 3250584313,
+    "expected": "250242695293143077796",
+    "overflow": false
+  },
+  {
+    "principal": "14470519212534474260",
+    "rate_bps": 9571,
+    "seconds": 1113692518,
+    "expected": "489102773446030973192",
+    "overflow": false
+  },
+  {
+    "principal": "17957511378239951421",
+    "rate_bps": 2337,
+    "seconds": 2375040951,
+    "expected": "316059870606601340466",
+    "overflow": false
+  },
+  {
+    "principal": "10688234678950919546",
+    "rate_bps": 8083,
+    "seconds": 1726419772,
+    "expected": "472953402249395686743",
+    "overflow": false
+  },
+  {
+    "principal": "15908586810435741403",
+    "rate_bps": 8798,
+    "seconds": 1145391493,
+    "expected": "508350091531152479282",
+    "overflow": false
+  },
+  {
+    "principal": "7544579218818427056",
+    "rate_bps": 8988,
+    "seconds": 2994185570,
+    "expected": "643828493200239613741",
+    "overflow": false
+  },
+  {
+    "principal": "12777954157391065481",
+    "rate_bps": 7465,
+    "seconds": 938809315,
+    "expected": "283963107998404214206",
+    "overflow": false
+  },
+  {
+    "principal": "17250577173408207158",
+    "rate_bps": 690,
+    "seconds": 294442328,
+    "expected": "11113384926986811342",
+    "overflow": false
+  },
+  {
+    "principal": "14232936009669519815",
+    "rate_bps": 9510,
+    "seconds": 21524049,
+    "expected": "9238306757159362271",
+    "overflow": false
+  },
+  {
+    "principal": "17453274223731676300",
+    "rate_bps": 8577,
+    "seconds": 1035320478,
+    "expected": "491451335559815839676",
+    "overflow": false
+  },
+  {
+    "principal": "1868104493609126677",
+    "rate_bps": 1481,
+    "seconds": 1101968463,
+    "expected": "9667602434694929478",
+    "overflow": false
+  },
+  {
+    "principal": "15860481041619444786",
+    "rate_bps": 7626,
+    "seconds": 339503284,
+    "expected": "130211855835242924557",
+    "overflow": false
+  },
+  {
+    "principal": "10200271195404449011",
+    "rate_bps": 2526,
+    "seconds": 1185076573,
+    "expected": "96824412554005669455",
+    "overflow": false
+  },
+  {
+    "principal": "4113079734387156392",
+    "rate_bps": 3318,
+    "seconds": 4195367706,
+    "expected": "181554465089185051300",
+    "overflow": false
+  },
+  {
+    "principal": "8289429358627900129",
+    "rate_bps": 5259,
+    "seconds": 670638331,
+    "expected": "92706368909171563766",
+    "overflow": false
+  },
+  {
+    "principal": "7079733154653000302",
+    "rate_bps": 5952,
+    "seconds": 1733118288,
+    "expected": "231580191865546703586",
+    "overflow": false
+  },
+  {
+    "principal": "10117875439061701727",
+    "rate_bps": 9345,
+    "seconds": 1466837673,
+    "expected": "439788716644369562199",
+    "overflow": false
+  },
+  {
+    "principal": "11310237946617780228",
+    "rate_bps": 5065,
+    "seconds": 4260936918,
+    "expected": "774015556087386158323",
+    "overflow": false
+  },
+  {
+    "principal": "3677919542754729197",
+    "rate_bps": 7510,
+    "seconds": 2985208295,
+    "expected": "261462972522130028753",
+    "overflow": false
+  },
+  {
+    "principal": "5233498593600993258",
+    "rate_bps": 5081,
+    "seconds": 2932486956,
+    "expected": "247269635575388790177",
+    "overflow": false
+  },
+  {
+    "principal": "4176818882540033035",
+    "rate_bps": 4135,
+    "seconds": 189815349,
+    "expected": "10395511861595914411",
+    "overflow": false
+  },
+  {
+    "principal": "15048257197037365152",
+    "rate_bps": 8497,
+    "seconds": 3021610450,
+    "expected": "1225134276045382518477",
+    "overflow": false
+  },
+  {
+    "principal": "4080397839270931769",
+    "rate_bps": 761,
+    "seconds": 1936972563,
+    "expected": "19072342087972235338",
+    "overflow": false
+  },
+  {
+    "principal": "866613495192514726",
+    "rate_bps": 3046,
+    "seconds": 1716331080,
+    "expected": "14366461280890926651",
+    "overflow": false
+  },
+  {
+    "principal": "3882123836268756983",
+    "rate_bps": 4549,
+    "seconds": 671584257,
+    "expected": "37607911986578536422",
+    "overflow": false
+  },
+  {
+    "principal": "4206359233890963580",
+    "rate_bps": 6902,
+    "seconds": 1851030030,
+    "expected": "170407290971992562553",
+    "overflow": false
+  },
+  {
+    "principal": "17313876585152243653",
+    "rate_bps": 6370,
+    "seconds": 3630399615,
+    "expected": "1269642862006139592443",
+    "overflow": false
+  },
+  {
+    "principal": "16990963301801203874",
+    "rate_bps": 9359,
+    "seconds": 1914393252,
+    "expected": "965321539828837076685",
+    "overflow": false
+  },
+  {
+    "principal": "15868182406686598179",
+    "rate_bps": 4030,
+    "seconds": 2704685069,
+    "expected": "548456675516745697819",
+    "overflow": false
+  },
+  {
+    "principal": "1900337823841439384",
+    "rate_bps": 6647,
+    "seconds": 1408839050,
+    "expected": "56430157862407032851",
+    "overflow": false
+  },
+  {
+    "principal": "17392742279392655505",
+    "rate_bps": 6828,
+    "seconds": 2214241835,
+    "expected": "833834805298711832724",
+    "overflow": false
+  },
+  {
+    "principal": "15390306575447821278",
+    "rate_bps": 7757,
+    "seconds": 1367425088,
+    "expected": "517652122636583578452",
+    "overflow": false
+  },
+  {
+    "principal": "6221370413608307855",
+    "rate_bps": 6170,
+    "seconds": 711917145,
+    "expected": "86655088222172654501",
+    "overflow": false
+  },
+  {
+    "principal": "3592549326077124084",
+    "rate_bps": 6701,
+    "seconds": 122082374,
+    "expected": "9319416396802793244",
+    "overflow": false
+  },
+  {
+    "principal": "9214136262509169565",
+    "rate_bps": 731,
+    "seconds": 277125143,
+    "expected": "5918904471933621644",
+    "overflow": false
+  },
+  {
+    "principal": "2923699279078663770",
+    "rate_bps": 5172,
+    "seconds": 1852745500,
+    "expected": "88838328167014793385",
+    "overflow": false
+  },
+  {
+    "principal": "14091026655087543611",
+    "rate_bps": 4998,
+    "seconds": 3347107557,
+    "expected": "747484083752072186343",
+    "overflow": false
+  },
+  {
+    "principal": "18237960655438641808",
+    "rate_bps": 1059,
+    "seconds": 2653243970,
+    "expected": "162496051886904089621",
+    "overflow": false
+  },
+  {
+    "principal": "9091863574564195561",
+    "rate_bps": 3610,
+    "seconds": 2068243011,
+    "expected": "215255903396622679388",
+    "overflow": false
+  },
+  {
+    "principal": "16460327958722872342",
+    "rate_bps": 7013,
+    "seconds": 1179812664,
+    "expected": "431865756592441739826",
+    "overflow": false
+  },
+  {
+    "principal": "5244496828671023655",
+    "rate_bps": 1762,
+    "seconds": 1191368113,
+    "expected": "34909939509447591460",
+    "overflow": false
+  },
+  {
+    "principal": "11279744974984241260",
+    "rate_bps": 2232,
+    "seconds": 3391204222,
+    "expected": "270732758504508023670",
+    "overflow": false
+  },
+  {
+    "principal": "9196351798107711605",
+    "rate_bps": 4533,
+    "seconds": 3366801583,
+    "expected": "445053490270638728049",
+    "overflow": false
+  },
+  {
+    "principal": "9872782263802954002",
+    "rate_bps": 2996,
+    "seconds": 1748439188,
+    "expected": "163992993329067790166",
+    "overflow": false
+  },
+  {
+    "principal": "2124876658953606995",
+    "rate_bps": 7572,
+    "seconds": 3542122173,
+    "expected": "180717937280346264420",
+    "overflow": false
+  },
+  {
+    "principal": "17329022996097960840",
+    "rate_bps": 588,
+    "seconds": 1269453818,
+    "expected": "41016793220156446690",
+    "overflow": false
+  },
+  {
+    "principal": "4455744409673353793",
+    "rate_bps": 8388,
+    "seconds": 2897604443,
+    "expected": "343408613928500896818",
+    "overflow": false
+  },
+  {
+    "principal": "16146746415817144654",
+    "rate_bps": 2382,
+    "seconds": 2216545072,
+    "expected": "270331554511697535575",
+    "overflow": false
+  },
+  {
+    "principal": "10715615519196645567",
+    "rate_bps": 7794,
+    "seconds": 77952521,
+    "expected": "20644343753438832558",
+    "overflow": false
+  },
+  {
+    "principal": "4047871051030902756",
+    "rate_bps": 1880,
+    "seconds": 210427830,
+    "expected": "5077864270072025634",
+    "overflow": false
+  },
+  {
+    "principal": "15176961824478862925",
+    "rate_bps": 5858,
+    "seconds": 1134365255,
+    "expected": "319801515857242677451",
+    "overflow": false
+  },
+  {
+    "principal": "17944845125409474762",
+    "rate_bps": 8775,
+    "seconds": 127627020,
+    "expected": "63726910103441755281",
+    "overflow": false
+  },
+  {
+    "principal": "1763007352326126187",
+    "rate_bps": 6872,
+    "seconds": 608806805,
+    "expected": "23388919843157079539",
+    "overflow": false
+  },
+  {
+    "principal": "16224132388143620480",
+    "rate_bps": 2173,
+    "seconds": 2108172978,
+    "expected": "235678976377806131184",
+    "overflow": false
+  },
+  {
+    "principal": "2287505466705531033",
+    "rate_bps": 389,
+    "seconds": 650718579,
+    "expected": "1836108502427381663",
+    "overflow": false
+  },
+  {
+    "principal": "29418027082550150",
+    "rate_bps": 2116,
+    "seconds": 62126120,
+    "expected": "12263002903183654",
+    "overflow": false
+  },
+  {
+    "principal": "5176599090626951255",
+    "rate_bps": 2078,
+    "seconds": 2252160865,
+    "expected": "76821516408213391933",
+    "overflow": false
+  },
+  {
+    "principal": "5807637501716841564",
+    "rate_bps": 6734,
+    "seconds": 335302894,
+    "expected": "41581802173411036552",
+    "overflow": false
+  },
+  {
+    "principal": "969785496738581797",
+    "rate_bps": 8277,
+    "seconds": 1777804511,
+    "expected": "45250776598067550716",
+    "overflow": false
+  },
+  {
+    "principal": "10421268389697592706",
+    "rate_bps": 7739,
+    "seconds": 1475781252,
+    "expected": "377416436222368653266",
+    "overflow": false
+  },
+  {
+    "principal": "2806618408575405699",
+    "rate_bps": 6097,
+    "seconds": 737454445,
+    "expected": "40015491461683035040",
+    "overflow": false
+  },
+  {
+    "principal": "6905836395955707000",
+    "rate_bps": 7966,
+    "seconds": 13807210,
+    "expected": "2408551355349797868",
+    "overflow": false
+  },
+  {
+    "principal": "6347414805110374385",
+    "rate_bps": 7800,
+    "seconds": 1285946507,
+    "expected": "201886732615017184109",
+    "overflow": false
+  },
+  {
+    "principal": "3372766933572442814",
+    "rate_bps": 2683,
+    "seconds": 1591339552,
+    "expected": "45662875256009203151",
+    "overflow": false
+  },
+  {
+    "principal": "16971086535275022575",
+    "rate_bps": 5495,
+    "seconds": 406098361,
+    "expected": "120088653262532130450",
+    "overflow": false
+  },
+  {
+    "principal": "4528832865338451412",
+    "rate_bps": 5193,
+    "seconds": 2168708902,
+    "expected": "161733234217209410821",
+    "overflow": false
+  },
+  {
+    "principal": "4717042178317587709",
+    "rate_bps": 2396,
+    "seconds": 2881683575,
+    "expected": "103275250605481585072",
+    "overflow": false
+  },
+  {
+    "principal": "182370579879075642",
+    "rate_bps": 9339,
+    "seconds": 2539096828,
+    "expected": "13712852683173346439",
+    "overflow": false
+  },
+  {
+    "principal": "5207659106536125339",
+    "rate_bps": 7025,
+    "seconds": 22930501,
+    "expected": "2660086828574810513",
+    "overflow": false
+  },
+  {
+    "principal": "3130292059895749744",
+    "rate_bps": 7822,
+    "seconds": 1626455842,
+    "expected": "126281095579807705080",
+    "overflow": false
+  },
+  {
+    "principal": "16462840862020335689",
+    "rate_bps": 6669,
+    "seconds": 2140519587,
+    "expected": "745209009480836280381",
+    "overflow": false
+  },
+  {
+    "principal": "11492818599247972086",
+    "rate_bps": 4211,
+    "seconds": 130580760,
+    "expected": "20039384504165654839",
+    "overflow": false
+  },
+  {
+    "principal": "12422168107582823047",
+    "rate_bps": 2486,
+    "seconds": 1308216593,
+    "expected": "128106620016130428603",
+    "overflow": false
+  },
+  {
+    "principal": "10008989239681809484",
+    "rate_bps": 1155,
+    "seconds": 2349034078,
+    "expected": "86110263241856296960",
+    "overflow": false
+  },
+  {
+    "principal": "14700581475762034133",
+    "rate_bps": 9300,
+    "seconds": 4058774799,
+    "expected": "1759567007570913600894",
+    "overflow": false
+  },
+  {
+    "principal": "17376507309406580210",
+    "rate_bps": 3835,
+    "seconds": 1442908276,
+    "expected": "304901789367994175361",
+    "overflow": false
+  },
+  {
+    "principal": "11026859517559933363",
+    "rate_bps": 2530,
+    "seconds": 2273687581,
+    "expected": "201139119934501553570",
+    "overflow": false
+  },
+  {
+    "principal": "7807467648448479592",
+    "rate_bps": 9959,
+    "seconds": 3428924634,
+    "expected": "845429228643850173588",
+    "overflow": false
+  },
+  {
+    "principal": "16403543817649740193",
+    "rate_bps": 652,
+    "seconds": 3632647611,
+    "expected": "123197513502821171747",
+    "overflow": false
+  },
+  {
+    "principal": "16137799280618598446",
+    "rate_bps": 5596,
+    "seconds": 3500973328,
+    "expected": "1002545773602670692538",
+    "overflow": false
+  },
+  {
+    "principal": "12270165767751339295",
+    "rate_bps": 4971,
+    "seconds": 2944356713,
+    "expected": "569479389066521219088",
+    "overflow": false
+  },
+  {
+    "principal": "12069314848048605124",
+    "rate_bps": 8982,
+    "seconds": 238080662,
+    "expected": "81841424885046279493",
+    "overflow": false
+  },
+  {
+    "principal": "11766928295113977773",
+    "rate_bps": 4842,
+    "seconds": 2680257191,
+    "expected": "484236759939520767431",
+    "overflow": false
+  },
+  {
+    "principal": "3155000529440336298",
+    "rate_bps": 5852,
+    "seconds": 3857316588,
+    "expected": "225830414619180677957",
+    "overflow": false
+  },
+  {
+    "principal": "6186321263214964939",
+    "rate_bps": 9790,
+    "seconds": 581993717,
+    "expected": "111770411729369163678",
+    "overflow": false
+  },
+  {
+    "principal": "7023347395735677792",
+    "rate_bps": 3604,
+    "seconds": 3348170642,
+    "expected": "268738513047074917427",
+    "overflow": false
+  },
+  {
+    "principal": "9533409824887358457",
+    "rate_bps": 6969,
+    "seconds": 4052193235,
+    "expected": "853694076006697096300",
+    "overflow": false
+  },
+  {
+    "principal": "5208538334961628774",
+    "rate_bps": 1609,
+    "seconds": 3274120712,
+    "expected": "87008160946111982347",
+    "overflow": false
+  },
+  {
+    "principal": "13211218687791841463",
+    "rate_bps": 4049,
+    "seconds": 4139482817,
+    "expected": "702150380592693742993",
+    "overflow": false
+  },
+  {
+    "principal": "16834180423651395644",
+    "rate_bps": 7685,
+    "seconds": 1603663822,
+    "expected": "657873774797493157431",
+    "overflow": false
+  },
+  {
+    "principal": "17004140114128487045",
+    "rate_bps": 3617,
+    "seconds": 2759252287,
+    "expected": "538130971291956192852",
+    "overflow": false
+  },
+  {
+    "principal": "7579500323878531682",
+    "rate_bps": 6783,
+    "seconds": 440222308,
+    "expected": "71767502378538415540",
+    "overflow": false
+  },
+  {
+    "principal": "4381017061544937699",
+    "rate_bps": 7830,
+    "seconds": 4259752653,
+    "expected": "463355669924550570735",
+    "overflow": false
+  },
+  {
+    "principal": "455192927518341720",
+    "rate_bps": 360,
+    "seconds": 2961506122,
+    "expected": "1538877444676565377",
+    "overflow": false
+  },
+  {
+    "principal": "7869961293640243025",
+    "rate_bps": 9832,
+    "seconds": 3209716459,
+    "expected": "787543458641522949171",
+    "overflow": false
+  },
+  {
+    "principal": "7688851418867988894",
+    "rate_bps": 3166,
+    "seconds": 1204610048,
+    "expected": "92984862584292183638",
+    "overflow": false
+  },
+  {
+    "principal": "12680766146593920335",
+    "rate_bps": 4850,
+    "seconds": 3710432537,
+    "expected": "723611007820869608150",
+    "overflow": false
+  },
+  {
+    "principal": "1086113833190407604",
+    "rate_bps": 4167,
+    "seconds": 22067718,
+    "expected": "316701167330562622",
+    "overflow": false
+  },
+  {
+    "principal": "10192706436985728605",
+    "rate_bps": 6139,
+    "seconds": 2627958999,
+    "expected": "521433738145547475043",
+    "overflow": false
+  },
+  {
+    "principal": "13153354582962300954",
+    "rate_bps": 9123,
+    "seconds": 1457110748,
+    "expected": "554447152520994536520",
+    "overflow": false
+  },
+  {
+    "principal": "46662821024969211",
+    "rate_bps": 1525,
+    "seconds": 3765733797,
+    "expected": "849735658772705246",
+    "overflow": false
+  },
+  {
+    "principal": "4953578739607113296",
+    "rate_bps": 9149,
+    "seconds": 307561474,
+    "expected": "44199568034589671428",
+    "overflow": false
+  },
+  {
+    "principal": "12900860334159442857",
+    "rate_bps": 6500,
+    "seconds": 2058987267,
+    "expected": "547493647098451854824",
+    "overflow": false
+  },
+  {
+    "principal": "4901851516733970902",
+    "rate_bps": 8233,
+    "seconds": 2644954872,
+    "expected": "338477595217951768099",
+    "overflow": false
+  },
+  {
+    "principal": "12446549363264514791",
+    "rate_bps": 452,
+    "seconds": 2034586737,
+    "expected": "36295852624533952058",
+    "overflow": false
+  },
+  {
+    "principal": "16529228567066732588",
+    "rate_bps": 8032,
+    "seconds": 424868158,
+    "expected": "178864380163075206146",
+    "overflow": false
+  },
+  {
+    "principal": "8065230695514575669",
+    "rate_bps": 2621,
+    "seconds": 63093103,
+    "expected": "4229208490699680668",
+    "overflow": false
+  },
+  {
+    "principal": "6204558650182937298",
+    "rate_bps": 1017,
+    "seconds": 4023537748,
+    "expected": "80506940099089047135",
+    "overflow": false
+  },
+  {
+    "principal": "39719935502273555",
+    "rate_bps": 7470,
+    "seconds": 2473230717,
+    "expected": "2326950587500852655",
+    "overflow": false
+  },
+  {
+    "principal": "2393153428808157000",
+    "rate_bps": 9614,
+    "seconds": 3366778298,
+    "expected": "245630658632002193703",
+    "overflow": false
+  },
+  {
+    "principal": "3862237939014039809",
+    "rate_bps": 8600,
+    "seconds": 2587933723,
+    "expected": "272573744146912349482",
+    "overflow": false
+  },
+  {
+    "principal": "18166838253398849294",
+    "rate_bps": 4902,
+    "seconds": 2712780528,
+    "expected": "766056336025346714706",
+    "overflow": false
+  },
+  {
+    "principal": "11988784822925336959",
+    "rate_bps": 5104,
+    "seconds": 739491017,
+    "expected": "143486858413721558974",
+    "overflow": false
+  },
+  {
+    "principal": "16071623478478137252",
+    "rate_bps": 7104,
+    "seconds": 3185743222,
+    "expected": "1153365251649691433274",
+    "overflow": false
+  },
+  {
+    "principal": "2248036991865147661",
+    "rate_bps": 4630,
+    "seconds": 1974729479,
+    "expected": "65175661368077983863",
+    "overflow": false
+  },
+  {
+    "principal": "12074260123194104458",
+    "rate_bps": 7298,
+    "seconds": 3639465676,
+    "expected": "1016940182154041552739",
+    "overflow": false
+  },
+  {
+    "principal": "702214489914832683",
+    "rate_bps": 4825,
+    "seconds": 3608998485,
+    "expected": "38774588473316371279",
+    "overflow": false
+  },
+  {
+    "principal": "11804061996686460224",
+    "rate_bps": 9492,
+    "seconds": 4081890418,
+    "expected": "1450253579078468649288",
+    "overflow": false
+  },
+  {
+    "principal": "16670777483334895449",
+    "rate_bps": 3747,
+    "seconds": 3683058227,
+    "expected": "729527261762206950698",
+    "overflow": false
+  },
+  {
+    "principal": "16431499487843266886",
+    "rate_bps": 48,
+    "seconds": 3864957928,
+    "expected": "9666218297483679447",
+    "overflow": false
+  },
+  {
+    "principal": "1280661396894226711",
+    "rate_bps": 1345,
+    "seconds": 513429025,
+    "expected": "2804338359422937091",
+    "overflow": false
+  },
+  {
+    "principal": "3848187648778607644",
+    "rate_bps": 1431,
+    "seconds": 286879406,
+    "expected": "5009433793106302232",
+    "overflow": false
+  },
+  {
+    "principal": "2785909202005936101",
+    "rate_bps": 3011,
+    "seconds": 3841439,
+    "expected": "102179799847738878",
+    "overflow": false
+  },
+  {
+    "principal": "11781897885001586498",
+    "rate_bps": 2290,
+    "seconds": 2770809412,
+    "expected": "237055908269141022841",
+    "overflow": false
+  },
+  {
+    "principal": "4158289740955587395",
+    "rate_bps": 3525,
+    "seconds": 3903077421,
+    "expected": "181415515482611665212",
+    "overflow": false
+  },
+  {
+    "principal": "13601157970545174584",
+    "rate_bps": 6093,
+    "seconds": 3112706090,
+    "expected": "817972251869872709926",
+    "overflow": false
+  },
+  {
+    "principal": "12539555749543280305",
+    "rate_bps": 655,
+    "seconds": 1557256523,
+    "expected": "40558044032713311863",
+    "overflow": false
+  },
+  {
+    "principal": "15187684140842346622",
+    "rate_bps": 9831,
+    "seconds": 454176224,
+    "expected": "215033954125799992844",
+    "overflow": false
+  },
+  {
+    "principal": "9304321028999852463",
+    "rate_bps": 2029,
+    "seconds": 1331914873,
+    "expected": "79732722814155857074",
+    "overflow": false
+  },
+  {
+    "principal": "541810888745805204",
+    "rate_bps": 8312,
+    "seconds": 744842470,
+    "expected": "10636802316375628096",
+    "overflow": false
+  },
+  {
+    "principal": "12879255230409496509",
+    "rate_bps": 9451,
+    "seconds": 2222850359,
+    "expected": "857970060790473526540",
+    "overflow": false
+  },
+  {
+    "principal": "8697128857367150842",
+    "rate_bps": 8458,
+    "seconds": 3593290428,
+    "expected": "838164570384610429609",
+    "overflow": false
+  },
+  {
+    "principal": "4607053319479984219",
+    "rate_bps": 2473,
+    "seconds": 2539437829,
+    "expected": "91744139749228291421",
+    "overflow": false
+  },
+  {
+    "principal": "4338870216539869232",
+    "rate_bps": 6425,
+    "seconds": 3720812770,
+    "expected": "328912971939376596406",
+    "overflow": false
+  },
+  {
+    "principal": "3762483273465921289",
+    "rate_bps": 974,
+    "seconds": 3330974051,
+    "expected": "38707772270752064655",
+    "overflow": false
+  },
+  {
+    "principal": "8536059080424619190",
+    "rate_bps": 2183,
+    "seconds": 3282398424,
+    "expected": "193952703016323526155",
+    "overflow": false
+  },
+  {
+    "principal": "1527202641022733127",
+    "rate_bps": 6417,
+    "seconds": 805137361,
+    "expected": "25020274989356739200",
+    "overflow": false
+  },
+  {
+    "principal": "3378503918460150796",
+    "rate_bps": 9667,
+    "seconds": 3691534366,
+    "expected": "382310701169561355057",
+    "overflow": false
+  },
+  {
+    "principal": "6164766043899945109",
+    "rate_bps": 4056,
+    "seconds": 680101327,
+    "expected": "53923933092850144911",
+    "overflow": false
+  },
+  {
+    "principal": "15980902634885265330",
+    "rate_bps": 7683,
+    "seconds": 2078468148,
+    "expected": "809224280636629948747",
+    "overflow": false
+  },
+  {
+    "principal": "8030421428018880115",
+    "rate_bps": 6401,
+    "seconds": 3932609245,
+    "expected": "641003429805990718507",
+    "overflow": false
+  },
+  {
+    "principal": "15265861694194228520",
+    "rate_bps": 6465,
+    "seconds": 554008218,
+    "expected": "173380181279037641050",
+    "overflow": false
+  },
+  {
+    "principal": "18006573108710811745",
+    "rate_bps": 1445,
+    "seconds": 2227092091,
+    "expected": "183751327130997671876",
+    "overflow": false
+  },
+  {
+    "principal": "1232941418138848750",
+    "rate_bps": 633,
+    "seconds": 1071984848,
+    "expected": "2652944667515000993",
+    "overflow": false
+  },
+  {
+    "principal": "713783187858802143",
+    "rate_bps": 1303,
+    "seconds": 3531257897,
+    "expected": "10414383346304271796",
+    "overflow": false
+  },
+  {
+    "principal": "8885486561122269060",
+    "rate_bps": 2169,
+    "seconds": 714614870,
+    "expected": "43672314455676829434",
+    "overflow": false
+  },
+  {
+    "principal": "7036768611015803501",
+    "rate_bps": 429,
+    "seconds": 3637283687,
+    "expected": "34817784303271732990",
+    "overflow": false
+  },
+  {
+    "principal": "10246735321533717354",
+    "rate_bps": 9855,
+    "seconds": 601817772,
+    "expected": "192708356921222668776",
+    "overflow": false
+  },
+  {
+    "principal": "12874086638611484043",
+    "rate_bps": 6167,
+    "seconds": 1445392309,
+    "expected": "363889486770160901811",
+    "overflow": false
+  },
+  {
+    "principal": "10127205773579874080",
+    "rate_bps": 1390,
+    "seconds": 1985163602,
+    "expected": "88612324979161202359",
+    "overflow": false
+  },
+  {
+    "principal": "16576410774452886201",
+    "rate_bps": 3328,
+    "seconds": 278889619,
+    "expected": "48786488489960900869",
+    "overflow": false
+  },
+  {
+    "principal": "11660155262308039718",
+    "rate_bps": 4026,
+    "seconds": 588405192,
+    "expected": "87588682384466204902",
+    "overflow": false
+  },
+  {
+    "principal": "6557785581417628023",
+    "rate_bps": 2370,
+    "seconds": 2800856449,
+    "expected": "138035185208613913891",
+    "overflow": false
+  },
+  {
+    "principal": "15387686690479603708",
+    "rate_bps": 907,
+    "seconds": 3162420622,
+    "expected": "139956685398803907476",
+    "overflow": false
+  },
+  {
+    "principal": "13701362057518308677",
+    "rate_bps": 868,
+    "seconds": 3650777599,
+    "expected": "137677267523549934227",
+    "overflow": false
+  },
+  {
+    "principal": "11103391518051142690",
+    "rate_bps": 4176,
+    "seconds": 418148900,
+    "expected": "61480939514488606542",
+    "overflow": false
+  },
+  {
+    "principal": "14942881723678682531",
+    "rate_bps": 5305,
+    "seconds": 2177195405,
+    "expected": "547281224715453155892",
+    "overflow": false
+  },
+  {
+    "principal": "10623012088027735576",
+    "rate_bps": 4263,
+    "seconds": 106172682,
+    "expected": "15246465995019458784",
+    "overflow": false
+  },
+  {
+    "principal": "11637048054111303185",
+    "rate_bps": 8785,
+    "seconds": 1241669547,
+    "expected": "402516804642157892431",
+    "overflow": false
+  },
+  {
+    "principal": "1179990190678026078",
+    "rate_bps": 4042,
+    "seconds": 3680618432,
+    "expected": "55665856527972083997",
+    "overflow": false
+  },
+  {
+    "principal": "704046055648386575",
+    "rate_bps": 4932,
+    "seconds": 3372002265,
+    "expected": "37128327684995725308",
+    "overflow": false
+  },
+  {
+    "principal": "4516607554677071220",
+    "rate_bps": 8701,
+    "seconds": 4219068358,
+    "expected": "525764768027533551465",
+    "overflow": false
+  },
+  {
+    "principal": "12840167444200100125",
+    "rate_bps": 2351,
+    "seconds": 1756010903,
+    "expected": "168090789702805548778",
+    "overflow": false
+  },
+  {
+    "principal": "13512575449036319194",
+    "rate_bps": 6729,
+    "seconds": 4069136028,
+    "expected": "1173232976845835482816",
+    "overflow": false
+  },
+  {
+    "principal": "14118528330247495355",
+    "rate_bps": 3537,
+    "seconds": 2628682853,
+    "expected": "416251752260482612110",
+    "overflow": false
+  },
+  {
+    "principal": "9016668524303344144",
+    "rate_bps": 9423,
+    "seconds": 46136770,
+    "expected": "12430135847032188086",
+    "overflow": false
+  },
+  {
+    "principal": "10542471400943540841",
+    "rate_bps": 3136,
+    "seconds": 3772820419,
+    "expected": "395528709699028515637",
+    "overflow": false
+  },
+  {
+    "principal": "17111033110991630230",
+    "rate_bps": 3611,
+    "seconds": 2843499192,
+    "expected": "557121889486564872449",
+    "overflow": false
+  },
+  {
+    "principal": "14007928736068713383",
+    "rate_bps": 4170,
+    "seconds": 3711570737,
+    "expected": "687481654795052377177",
+    "overflow": false
+  },
+  {
+    "principal": "7664982733263155180",
+    "rate_bps": 9566,
+    "seconds": 303793918,
+    "expected": "70634036499256439942",
+    "overflow": false
+  },
+  {
+    "principal": "12644340820351925749",
+    "rate_bps": 8659,
+    "seconds": 1855480367,
+    "expected": "644189570955899740237",
+    "overflow": false
+  },
+  {
+    "principal": "629765759358276754",
+    "rate_bps": 2809,
+    "seconds": 1953157140,
+    "expected": "10956235584016855114",
+    "overflow": false
+  },
+  {
+    "principal": "5824415073477329107",
+    "rate_bps": 3935,
+    "seconds": 1142080573,
+    "expected": "83001738911828884077",
+    "overflow": false
+  },
+  {
+    "principal": "2323107341371654920",
+    "rate_bps": 3106,
+    "seconds": 1239603066,
+    "expected": "28362647238817370414",
+    "overflow": false
+  },
+  {
+    "principal": "14743937676112488385",
+    "rate_bps": 8524,
+    "seconds": 3470248155,
+    "expected": "1382963928028691408956",
+    "overflow": false
+  },
+  {
+    "principal": "7445465859175314638",
+    "rate_bps": 6194,
+    "seconds": 3892245168,
+    "expected": "569189210156640138380",
+    "overflow": false
+  },
+  {
+    "principal": "15337307292056779327",
+    "rate_bps": 8651,
+    "seconds": 2127315849,
+    "expected": "895036610026898850285",
+    "overflow": false
+  },
+  {
+    "principal": "437186209560483684",
+    "rate_bps": 8873,
+    "seconds": 3075050294,
+    "expected": "37825314888478885645",
+    "overflow": false
+  },
+  {
+    "principal": "2197316400011461581",
+    "rate_bps": 7709,
+    "seconds": 1080241095,
+    "expected": "58023608045224032656",
+    "overflow": false
+  },
+  {
+    "principal": "11732069529908472906",
+    "rate_bps": 8788,
+    "seconds": 3186982540,
+    "expected": "1041928106893655900000",
+    "overflow": false
+  },
+  {
+    "principal": "12717474215999189995",
+    "rate_bps": 4593,
+    "seconds": 4167466261,
+    "expected": "771903120879003154805",
+    "overflow": false
+  },
+  {
+    "principal": "12539179330924833024",
+    "rate_bps": 3024,
+    "seconds": 3659300402,
+    "expected": "439989544883319626870",
+    "overflow": false
+  },
+  {
+    "principal": "772506105348521497",
+    "rate_bps": 7346,
+    "seconds": 3769177843,
+    "expected": "67825478605407485121",
+    "overflow": false
+  },
+  {
+    "principal": "18303485498992236294",
+    "rate_bps": 5004,
+    "seconds": 2734321576,
+    "expected": "794134535263671931023",
+    "overflow": false
+  },
+  {
+    "principal": "7643869860888934871",
+    "rate_bps": 3622,
+    "seconds": 1020894433,
+    "expected": "89626401342386697440",
+    "overflow": false
+  },
+  {
+    "principal": "11212235149790983132",
+    "rate_bps": 8896,
+    "seconds": 3384659054,
+    "expected": "1070521249503617761516",
+    "overflow": false
+  },
+  {
+    "principal": "11476998634251551397",
+    "rate_bps": 2055,
+    "seconds": 1894667871,
+    "expected": "141698952520564086531",
+    "overflow": false
+  },
+  {
+    "principal": "14973610834971906306",
+    "rate_bps": 8644,
+    "seconds": 3385131524,
+    "expected": "1389345440178839581606",
+    "overflow": false
+  },
+  {
+    "principal": "4010154973057570819",
+    "rate_bps": 536,
+    "seconds": 585240301,
+    "expected": "3988903813641643725",
+    "overflow": false
+  },
+  {
+    "principal": "2548500936041214968",
+    "rate_bps": 4859,
+    "seconds": 358666730,
+    "expected": "14083681105922180703",
+    "overflow": false
+  },
+  {
+    "principal": "9152667324879306097",
+    "rate_bps": 9180,
+    "seconds": 1337587211,
+    "expected": "356373874871634269206",
+    "overflow": false
+  },
+  {
+    "principal": "10131559178319050302",
+    "rate_bps": 6079,
+    "seconds": 2138288544,
+    "expected": "417607347476315408494",
+    "overflow": false
+  },
+  {
+    "principal": "2666902981084715631",
+    "rate_bps": 6420,
+    "seconds": 671907641,
+    "expected": "36479192639883063619",
+    "overflow": false
+  },
+  {
+    "principal": "15409264982787106132",
+    "rate_bps": 3839,
+    "seconds": 3146132134,
+    "expected": "590160838137872345961",
+    "overflow": false
+  },
+  {
+    "principal": "15828119519660038781",
+    "rate_bps": 9275,
+    "seconds": 2994815479,
+    "expected": "1394141006586814564610",
+    "overflow": false
+  },
+  {
+    "principal": "11117990624284680890",
+    "rate_bps": 7633,
+    "seconds": 1026046588,
+    "expected": "276109938625447957569",
+    "overflow": false
+  },
+  {
+    "principal": "14992117990771215643",
+    "rate_bps": 2664,
+    "seconds": 2869025221,
+    "expected": "363349838213248202753",
+    "overflow": false
+  },
+  {
+    "principal": "1593705615181251568",
+    "rate_bps": 7948,
+    "seconds": 3568808610,
+    "expected": "143345020907559107660",
+    "overflow": false
+  },
+  {
+    "principal": "5891111277397951945",
+    "rate_bps": 8337,
+    "seconds": 1804846627,
+    "expected": "281086975766145674277",
+    "overflow": false
+  },
+  {
+    "principal": "17464649610055889526",
+    "rate_bps": 6424,
+    "seconds": 4075002008,
+    "expected": "1449728341722103397995",
+    "overflow": false
+  },
+  {
+    "principal": "4132157753857981447",
+    "rate_bps": 1412,
+    "seconds": 4027796113,
+    "expected": "74519933987443834531",
+    "overflow": false
+  },
+  {
+    "principal": "16163227847185304524",
+    "rate_bps": 846,
+    "seconds": 3448014302,
+    "expected": "149506787490196416713",
+    "overflow": false
+  },
+  {
+    "principal": "4441276674022189909",
+    "rate_bps": 8573,
+    "seconds": 3360116367,
+    "expected": "405684452161841057924",
+    "overflow": false
+  },
+  {
+    "principal": "8025879039793447282",
+    "rate_bps": 9511,
+    "seconds": 2275543028,
+    "expected": "550804191855228262664",
+    "overflow": false
+  },
+  {
+    "principal": "16208535693727167283",
+    "rate_bps": 7270,
+    "seconds": 470171037,
+    "expected": "175682077426270753892",
+    "overflow": false
+  },
+  {
+    "principal": "16403447658446993640",
+    "rate_bps": 4707,
+    "seconds": 1270677594,
+    "expected": "311105794813379226585",
+    "overflow": false
+  },
+  {
+    "principal": "1126099012788631329",
+    "rate_bps": 3163,
+    "seconds": 1399056187,
+    "expected": "15801718439197343411",
+    "overflow": false
+  },
+  {
+    "principal": "3515766414759979950",
+    "rate_bps": 2099,
+    "seconds": 3400991888,
+    "expected": "79585040353933671189",
+    "overflow": false
+  },
+  {
+    "principal": "14805746793897705119",
+    "rate_bps": 1704,
+    "seconds": 2434817769,
+    "expected": "194786908049762620748",
+    "overflow": false
+  },
+  {
+    "principal": "2616659093440087876",
+    "rate_bps": 3419,
+    "seconds": 451853846,
+    "expected": "12818512230998972055",
+    "overflow": false
+  },
+  {
+    "principal": "13235572031866131757",
+    "rate_bps": 4798,
+    "seconds": 2278546471,
+    "expected": "458832574846238095309",
+    "overflow": false
+  },
+  {
+    "principal": "13162805159905692970",
+    "rate_bps": 1693,
+    "seconds": 1382632044,
+    "expected": "97702442705805950708",
+    "overflow": false
+  },
+  {
+    "principal": "9877063701648976459",
+    "rate_bps": 6647,
+    "seconds": 1517525621,
+    "expected": "315924246801122368739",
+    "overflow": false
+  },
+  {
+    "principal": "9626662786628236000",
+    "rate_bps": 3595,
+    "seconds": 3156253458,
+    "expected": "346369719732738943738",
+    "overflow": false
+  },
+  {
+    "principal": "7503817299959918969",
+    "rate_bps": 2080,
+    "seconds": 3212556627,
+    "expected": "158997307931093505193",
+    "overflow": false
+  },
+  {
+    "principal": "14816314027107828198",
+    "rate_bps": 9136,
+    "seconds": 63886728,
+    "expected": "27422074359477078493",
+    "overflow": false
+  },
+  {
+    "principal": "10243088725241856567",
+    "rate_bps": 5373,
+    "seconds": 2439650369,
+    "expected": "425763825552994089263",
+    "overflow": false
+  },
+  {
+    "principal": "15528859905076737980",
+    "rate_bps": 5716,
+    "seconds": 1959703374,
+    "expected": "551588909511076842959",
+    "overflow": false
+  },
+  {
+    "principal": "18078178295191877637",
+    "rate_bps": 4931,
+    "seconds": 3935193791,
+    "expected": "1112369788766939171910",
+    "overflow": false
+  },
+  {
+    "principal": "11724969287346709986",
+    "rate_bps": 8206,
+    "seconds": 1072226788,
+    "expected": "327132183712543125236",
+    "overflow": false
+  },
+  {
+    "principal": "5690079471946388067",
+    "rate_bps": 4047,
+    "seconds": 3918680141,
+    "expected": "286144067024357654057",
+    "overflow": false
+  },
+  {
+    "principal": "8423410073640292824",
+    "rate_bps": 7648,
+    "seconds": 4180042442,
+    "expected": "853905690085300649163",
+    "overflow": false
+  },
+  {
+    "principal": "1254225108386125009",
+    "rate_bps": 1005,
+    "seconds": 3671104619,
+    "expected": "14673432098571123642",
+    "overflow": false
+  },
+  {
+    "principal": "1428629932496590110",
+    "rate_bps": 2106,
+    "seconds": 4060081024,
+    "expected": "38735235940182269103",
+    "overflow": false
+  },
+  {
+    "principal": "7564656425347606223",
+    "rate_bps": 2987,
+    "seconds": 3467305625,
+    "expected": "248433379754338029530",
+    "overflow": false
+  },
+  {
+    "principal": "18372918406470450484",
+    "rate_bps": 181,
+    "seconds": 226641286,
+    "expected": "2389951787779082905",
+    "overflow": false
+  },
+  {
+    "principal": "8596095848059319261",
+    "rate_bps": 8455,
+    "seconds": 794425943,
+    "expected": "183088755413020513631",
+    "overflow": false
+  },
+  {
+    "principal": "6228426558047824794",
+    "rate_bps": 556,
+    "seconds": 4215254620,
+    "expected": "46288205626023706728",
+    "overflow": false
+  },
+  {
+    "principal": "12931981249923963",
+    "rate_bps": 3536,
+    "seconds": 3236871973,
+    "expected": "469349368522380766",
+    "overflow": false
+  },
+  {
+    "principal": "11560906259225605584",
+    "rate_bps": 5517,
+    "seconds": 3139843970,
+    "expected": "635033043006101792432",
+    "overflow": false
+  },
+  {
+    "principal": "13176419184257712425",
+    "rate_bps": 453,
+    "seconds": 746320003,
+    "expected": "14125833390161677101",
+    "overflow": false
+  },
+  {
+    "principal": "7399339937008502102",
+    "rate_bps": 6956,
+    "seconds": 3079874168,
+    "expected": "502665315654122043056",
+    "overflow": false
+  },
+  {
+    "principal": "7406600665565416551",
+    "rate_bps": 7048,
+    "seconds": 3684766193,
+    "expected": "609941459177094453241",
+    "overflow": false
+  },
+  {
+    "principal": "9943381464469157804",
+    "rate_bps": 6302,
+    "seconds": 4097529022,
+    "expected": "814194062631196552525",
+    "overflow": false
+  },
+  {
+    "principal": "8014459801238350005",
+    "rate_bps": 2844,
+    "seconds": 200166127,
+    "expected": "14467311289323579409",
+    "overflow": false
+  },
+  {
+    "principal": "11932241616683810386",
+    "rate_bps": 9920,
+    "seconds": 2545979348,
+    "expected": "955612848984390175697",
+    "overflow": false
+  },
+  {
+    "principal": "9901420876744553875",
+    "rate_bps": 48,
+    "seconds": 2983806717,
+    "expected": "4496792407895651285",
+    "overflow": false
+  },
+  {
+    "principal": "1049958195404046024",
+    "rate_bps": 8488,
+    "seconds": 3272341818,
+    "expected": "92476084695098838117",
+    "overflow": false
+  },
+  {
+    "principal": "14362486518053344897",
+    "rate_bps": 3345,
+    "seconds": 2436568475,
+    "expected": "371191284130888012527",
+    "overflow": false
+  },
+  {
+    "principal": "2913756719265428110",
+    "rate_bps": 7772,
+    "seconds": 214263408,
+    "expected": "15386062115100397050",
+    "overflow": false
+  },
+  {
+    "principal": "4190837115335742207",
+    "rate_bps": 7193,
+    "seconds": 3985574473,
+    "expected": "380973847105424192381",
+    "overflow": false
+  },
+  {
+    "principal": "17878942535299335972",
+    "rate_bps": 1910,
+    "seconds": 1618985206,
+    "expected": "175311929272659428100",
+    "overflow": false
+  },
+  {
+    "principal": "3709368642778199693",
+    "rate_bps": 3569,
+    "seconds": 3999964295,
+    "expected": "167917535690031083508",
+    "overflow": false
+  },
+  {
+    "principal": "14038643335994736138",
+    "rate_bps": 7839,
+    "seconds": 1081239116,
+    "expected": "377312285970381238278",
+    "overflow": false
+  },
+  {
+    "principal": "3443709296884265131",
+    "rate_bps": 5492,
+    "seconds": 1558595541,
+    "expected": "93472494770406335799",
+    "overflow": false
+  },
+  {
+    "principal": "1892905528514694336",
+    "rate_bps": 4142,
+    "seconds": 3453454322,
+    "expected": "85859062750210496787",
+    "overflow": false
+  },
+  {
+    "principal": "1921074533068272857",
+    "rate_bps": 1811,
+    "seconds": 1156541363,
+    "expected": "12759017344516606447",
+    "overflow": false
+  },
+  {
+    "principal": "7285228482233777350",
+    "rate_bps": 4594,
+    "seconds": 1464306536,
+    "expected": "155403058392723739745",
+    "overflow": false
+  },
+  {
+    "principal": "8369686933100272279",
+    "rate_bps": 2078,
+    "seconds": 1505438625,
+    "expected": "83025443542545481870",
+    "overflow": false
+  },
+  {
+    "principal": "262247772997553052",
+    "rate_bps": 248,
+    "seconds": 3450432046,
+    "expected": "711590860432004222",
+    "overflow": false
+  },
+  {
+    "principal": "16294705014258138469",
+    "rate_bps": 2193,
+    "seconds": 1322405663,
+    "expected": "149845335304979773957",
+    "overflow": false
+  },
+  {
+    "principal": "3484685931698113218",
+    "rate_bps": 5212,
+    "seconds": 932188612,
+    "expected": "53686517733752473689",
+    "overflow": false
+  },
+  {
+    "principal": "6926579501839080643",
+    "rate_bps": 7885,
+    "seconds": 3077448109,
+    "expected": "532972317936196249653",
+    "overflow": false
+  },
+  {
+    "principal": "9174535878451216312",
+    "rate_bps": 7626,
+    "seconds": 1478280106,
+    "expected": "327967666474713374569",
+    "overflow": false
+  },
+  {
+    "principal": "11988944673561984049",
+    "rate_bps": 5507,
+    "seconds": 4229845707,
+    "expected": "885551761723773456293",
+    "overflow": false
+  },
+  {
+    "principal": "4810588766168531966",
+    "rate_bps": 2744,
+    "seconds": 297694560,
+    "expected": "12460820253356697494",
+    "overflow": false
+  },
+  {
+    "principal": "10196974281942680367",
+    "rate_bps": 5117,
+    "seconds": 2733626873,
+    "expected": "452292482190923801620",
+    "overflow": false
+  },
+  {
+    "principal": "9038205233748223252",
+    "rate_bps": 4417,
+    "seconds": 3865456742,
+    "expected": "489332215312956760665",
+    "overflow": false
+  },
+  {
+    "principal": "3863890094079253821",
+    "rate_bps": 631,
+    "seconds": 277660343,
+    "expected": "2146650652637416018",
+    "overflow": false
+  },
+  {
+    "principal": "16482860490947658874",
+    "rate_bps": 3867,
+    "seconds": 638087740,
+    "expected": "128967579300150892682",
+    "overflow": false
+  },
+  {
+    "principal": "10607106158302550491",
+    "rate_bps": 7593,
+    "seconds": 554513541,
+    "expected": "141617154612555512021",
+    "overflow": false
+  },
+  {
+    "principal": "8454777474678568880",
+    "rate_bps": 5283,
+    "seconds": 830704738,
+    "expected": "117658382305374777650",
+    "overflow": false
+  },
+  {
+    "principal": "5838359476221365385",
+    "rate_bps": 7911,
+    "seconds": 225520355,
+    "expected": "33029451044233862962",
+    "overflow": false
+  },
+  {
+    "principal": "15398954216495097910",
+    "rate_bps": 5575,
+    "seconds": 2202207320,
+    "expected": "599497939036974597889",
+    "overflow": false
+  },
+  {
+    "principal": "18180159185714343111",
+    "rate_bps": 955,
+    "seconds": 385575249,
+    "expected": "21227731899008530120",
+    "overflow": false
+  },
+  {
+    "principal": "12680428841932239756",
+    "rate_bps": 6429,
+    "seconds": 1077408670,
+    "expected": "278516690596069031092",
+    "overflow": false
+  },
+  {
+    "principal": "4095813526714496533",
+    "rate_bps": 7900,
+    "seconds": 4091893583,
+    "expected": "419841138344458443518",
+    "overflow": false
+  },
+  {
+    "principal": "10516252025325554482",
+    "rate_bps": 2665,
+    "seconds": 3137234868,
+    "expected": "278803759210154483591",
+    "overflow": false
+  },
+  {
+    "principal": "3821756079341438963",
+    "rate_bps": 3544,
+    "seconds": 153346141,
+    "expected": "6586018141764654298",
+    "overflow": false
+  },
+  {
+    "principal": "9665773311663346856",
+    "rate_bps": 2931,
+    "seconds": 3762799130,
+    "expected": "338031250471102235667",
+    "overflow": false
+  },
+  {
+    "principal": "18326044010876077537",
+    "rate_bps": 611,
+    "seconds": 2872398843,
+    "expected": "101987764307186065100",
+    "overflow": false
+  },
+  {
+    "principal": "5276011484718549358",
+    "rate_bps": 6376,
+    "seconds": 3336706128,
+    "expected": "355930654043877050037",
+    "overflow": false
+  },
+  {
+    "principal": "10010086754113386335",
+    "rate_bps": 5183,
+    "seconds": 4231021993,
+    "expected": "696077708750674114985",
+    "overflow": false
+  },
+  {
+    "principal": "12008217287563012",
+    "rate_bps": 1127,
+    "seconds": 3874788310,
+    "expected": "166281459493760397",
+    "overflow": false
+  },
+  {
+    "principal": "2124858552593590253",
+    "rate_bps": 9150,
+    "seconds": 395013351,
+    "expected": "24353214104319460352",
+    "overflow": false
+  },
+  {
+    "principal": "6474613618630672106",
+    "rate_bps": 5528,
+    "seconds": 2605240876,
+    "expected": "295680829183002672843",
+    "overflow": false
+  },
+  {
+    "principal": "3400535343426193163",
+    "rate_bps": 7561,
+    "seconds": 609649973,
+    "expected": "49705046345093092680",
+    "overflow": false
+  },
+  {
+    "principal": "6373791410151962272",
+    "rate_bps": 8144,
+    "seconds": 3568911570,
+    "expected": "587441726808985204863",
+    "overflow": false
+  },
+  {
+    "principal": "16116218276867393593",
+    "rate_bps": 2826,
+    "seconds": 752627219,
+    "expected": "108694761025968123290",
+    "overflow": false
+  },
+  {
+    "principal": "5721285856682444710",
+    "rate_bps": 8087,
+    "seconds": 589074760,
+    "expected": "86426096544953668156",
+    "overflow": false
+  },
+  {
+    "principal": "6320201680288203511",
+    "rate_bps": 7811,
+    "seconds": 1323617025,
+    "expected": "207201699158460374745",
+    "overflow": false
+  },
+  {
+    "principal": "1383970583647727484",
+    "rate_bps": 7679,
+    "seconds": 3091591438,
+    "expected": "104185436545518870285",
+    "overflow": false
+  },
+  {
+    "principal": "13466152381447066309",
+    "rate_bps": 3530,
+    "seconds": 2316460927,
+    "expected": "349169742120544630730",
+    "overflow": false
+  },
+  {
+    "principal": "14044185785241567138",
+    "rate_bps": 9368,
+    "seconds": 2700251556,
+    "expected": "1126525601779826258721",
+    "overflow": false
+  },
+  {
+    "principal": "16803577775037314851",
+    "rate_bps": 9418,
+    "seconds": 839746317,
+    "expected": "421407195987386493344",
+    "overflow": false
+  },
+  {
+    "principal": "3405429483679514008",
+    "rate_bps": 1946,
+    "seconds": 1824257162,
+    "expected": "38334886408584037431",
+    "overflow": false
+  },
+  {
+    "principal": "5091116122083947409",
+    "rate_bps": 8182,
+    "seconds": 1752897835,
+    "expected": "231538105641162050939",
+    "overflow": false
+  },
+  {
+    "principal": "15856811499877974750",
+    "rate_bps": 6931,
+    "seconds": 2976337728,
+    "expected": "1037259365723330418382",
+    "overflow": false
+  },
+  {
+    "principal": "923249058433281935",
+    "rate_bps": 5396,
+    "seconds": 250829145,
+    "expected": "3962435494153127520",
+    "overflow": false
+  },
+  {
+    "principal": "6854399518458141940",
+    "rate_bps": 3752,
+    "seconds": 2401889094,
+    "expected": "195874809582022426766",
+    "overflow": false
+  },
+  {
+    "principal": "1782003533273077405",
+    "rate_bps": 1217,
+    "seconds": 3950091031,
+    "expected": "27164369938320080989",
+    "overflow": false
+  },
+  {
+    "principal": "2036955747596840282",
+    "rate_bps": 7377,
+    "seconds": 1790608924,
+    "expected": "85320917160225881502",
+    "overflow": false
+  },
+  {
+    "principal": "14092461894778812475",
+    "rate_bps": 6774,
+    "seconds": 1375025637,
+    "expected": "416232751684975977960",
+    "overflow": false
+  },
+  {
+    "principal": "14881388262878103952",
+    "rate_bps": 9611,
+    "seconds": 3343364418,
+    "expected": "1516313963172783743492",
+    "overflow": false
+  },
+  {
+    "principal": "12240019250053081065",
+    "rate_bps": 323,
+    "seconds": 474707267,
+    "expected": "5951191101753831597",
+    "overflow": false
+  },
+  {
+    "principal": "16905449870105926422",
+    "rate_bps": 1711,
+    "seconds": 1437282872,
+    "expected": "131829433250722096917",
+    "overflow": false
+  },
+  {
+    "principal": "2506342810597268775",
+    "rate_bps": 7088,
+    "seconds": 490361009,
+    "expected": "27623169241523950576",
+    "overflow": false
+  },
+  {
+    "principal": "12677397000773468012",
+    "rate_bps": 8830,
+    "seconds": 1064460926,
+    "expected": "377845201733876633198",
+    "overflow": false
+  },
+  {
+    "principal": "5079813408731517813",
+    "rate_bps": 6199,
+    "seconds": 511996847,
+    "expected": "51124618001611838398",
+    "overflow": false
+  },
+  {
+    "principal": "15177324727827867666",
+    "rate_bps": 8729,
+    "seconds": 999526292,
+    "expected": "419901412211404286983",
+    "overflow": false
+  },
+  {
+    "principal": "11942375657737431635",
+    "rate_bps": 6990,
+    "seconds": 3917351357,
+    "expected": "1036940466785908335241",
+    "overflow": false
+  },
+  {
+    "principal": "13834297752930286216",
+    "rate_bps": 3625,
+    "seconds": 1743280890,
+    "expected": "277220850804773106297",
+    "overflow": false
+  },
+  {
+    "principal": "7392486739117573441",
+    "rate_bps": 2306,
+    "seconds": 1747624539,
+    "expected": "94469449439558592224",
+    "overflow": false
+  },
+  {
+    "principal": "11294916518156447822",
+    "rate_bps": 6184,
+    "seconds": 96803376,
+    "expected": "21440573747094961979",
+    "overflow": false
+  },
+  {
+    "principal": "5321074734026910655",
+    "rate_bps": 4983,
+    "seconds": 2837188873,
+    "expected": "238545861683284573227",
+    "overflow": false
+  },
+  {
+    "principal": "11398517899338905316",
+    "rate_bps": 385,
+    "seconds": 1631925942,
+    "expected": "22709258524254071951",
+    "overflow": false
+  },
+  {
+    "principal": "375389699157813581",
+    "rate_bps": 5442,
+    "seconds": 176835911,
+    "expected": "1145525459352040009",
+    "overflow": false
+  },
+  {
+    "principal": "2465914174679568330",
+    "rate_bps": 693,
+    "seconds": 707038732,
+    "expected": "3831314383819711026",
+    "overflow": false
+  },
+  {
+    "principal": "11096170041036008811",
+    "rate_bps": 5854,
+    "seconds": 425480853,
+    "expected": "87639367744865206351",
+    "overflow": false
+  },
+  {
+    "principal": "9356676283399073920",
+    "rate_bps": 6292,
+    "seconds": 2856178098,
+    "expected": "533198594351132783207",
+    "overflow": false
+  },
+  {
+    "principal": "7454267081067244441",
+    "rate_bps": 6045,
+    "seconds": 1461321843,
+    "expected": "208804821802469780704",
+    "overflow": false
+  },
+  {
+    "principal": "16862471180620243590",
+    "rate_bps": 7083,
+    "seconds": 1627776808,
+    "expected": "616490958819396207376",
+    "overflow": false
+  },
+  {
+    "principal": "18174500538063125335",
+    "rate_bps": 4078,
+    "seconds": 771684961,
+    "expected": "181360680102973889732",
+    "overflow": false
+  },
+  {
+    "principal": "18371860859642487644",
+    "rate_bps": 5504,
+    "seconds": 3969665006,
+    "expected": "1272854683078163781820",
+    "overflow": false
+  },
+  {
+    "principal": "11511567474744440869",
+    "rate_bps": 1551,
+    "seconds": 1822853087,
+    "expected": "103202762471476818520",
+    "overflow": false
+  },
+  {
+    "principal": "15869708089014879362",
+    "rate_bps": 9504,
+    "seconds": 2689098116,
+    "expected": "1286101981808324921291",
+    "overflow": false
+  },
+  {
+    "principal": "13785503671780712835",
+    "rate_bps": 6182,
+    "seconds": 3272111213,
+    "expected": "884245967958625593409",
+    "overflow": false
+  },
+  {
+    "principal": "15291139296335432568",
+    "rate_bps": 9988,
+    "seconds": 92009834,
+    "expected": "44560085809890535227",
+    "overflow": false
+  },
+  {
+    "principal": "4547630604444973809",
+    "rate_bps": 3942,
+    "seconds": 2025779083,
+    "expected": "115156186946190934584",
+    "overflow": false
+  },
+  {
+    "principal": "11435410471821545918",
+    "rate_bps": 1742,
+    "seconds": 2545056032,
+    "expected": "160764683587921080460",
+    "overflow": false
+  },
+  {
+    "principal": "7394927734381456367",
+    "rate_bps": 217,
+    "seconds": 13462713,
+    "expected": "68504586423093474",
+    "overflow": false
+  },
+  {
+    "principal": "8853663911541499092",
+    "rate_bps": 8401,
+    "seconds": 2764404262,
+    "expected": "652002053582734126018",
+    "overflow": false
+  },
+  {
+    "principal": "16241934341592588285",
+    "rate_bps": 8771,
+    "seconds": 3110110071,
+    "expected": "1404934295717999322708",
+    "overflow": false
+  },
+  {
+    "principal": "10240348941444556346",
+    "rate_bps": 6365,
+    "seconds": 713943548,
+    "expected": "147560605883823437217",
+    "overflow": false
+  },
+  {
+    "principal": "18027326167116785307",
+    "rate_bps": 6115,
+    "seconds": 507432773,
+    "expected": "177377971501807701845",
+    "overflow": false
+  },
+  {
+    "principal": "6513425027586468720",
+    "rate_bps": 609,
+    "seconds": 535471650,
+    "expected": "6735294450862095228",
+    "overflow": false
+  },
+  {
+    "principal": "4229286640794440521",
+    "rate_bps": 8685,
+    "seconds": 2330120099,
+    "expected": "271399249512904195603",
+    "overflow": false
+  },
+  {
+    "principal": "6100984109518478838",
+    "rate_bps": 2919,
+    "seconds": 2726539288,
+    "expected": "153971074986435026411",
+    "overflow": false
+  },
+  {
+    "principal": "15880184646040903047",
+    "rate_bps": 631,
+    "seconds": 1836435473,
+    "expected": "58351761819897391498",
+    "overflow": false
+  },
+  {
+    "principal": "2705328831484468044",
+    "rate_bps": 6267,
+    "seconds": 1407361374,
+    "expected": "75662167091173635875",
+    "overflow": false
+  },
+  {
+    "principal": "7007747341000212693",
+    "rate_bps": 7029,
+    "seconds": 237215759,
+    "expected": "37051765682572530545",
+    "overflow": false
+  },
+  {
+    "principal": "17848317474547504370",
+    "rate_bps": 4444,
+    "seconds": 2545420148,
+    "expected": "640212579076088469432",
+    "overflow": false
+  },
+  {
+    "principal": "2718846397418265779",
+    "rate_bps": 6148,
+    "seconds": 3732914973,
+    "expected": "197860919191836506359",
+    "overflow": false
+  },
+  {
+    "principal": "12031541972608561256",
+    "rate_bps": 46,
+    "seconds": 2993013722,
+    "expected": "5252683378229557048",
+    "overflow": false
+  },
+  {
+    "principal": "7664399863850079393",
+    "rate_bps": 7745,
+    "seconds": 854786235,
+    "expected": "160897942135765064206",
+    "overflow": false
+  },
+  {
+    "principal": "744181232745735982",
+    "rate_bps": 4805,
+    "seconds": 3391515664,
+    "expected": "38455576447729984351",
+    "overflow": false
+  },
+  {
+    "principal": "16438726922463375391",
+    "rate_bps": 2990,
+    "seconds": 1684696169,
+    "expected": "262575590454840542892",
+    "overflow": false
+  },
+  {
+    "principal": "3223311166889633476",
+    "rate_bps": 5795,
+    "seconds": 3597248918,
+    "expected": "213068651256642386907",
+    "overflow": false
+  },
+  {
+    "principal": "6123947359050775213",
+    "rate_bps": 1370,
+    "seconds": 851393959,
+    "expected": "22650405085679453853",
+    "overflow": false
+  },
+  {
+    "principal": "17230689595936354474",
+    "rate_bps": 3888,
+    "seconds": 1748867564,
+    "expected": "371517461996120834153",
+    "overflow": false
+  },
+  {
+    "principal": "1084998673436484555",
+    "rate_bps": 2889,
+    "seconds": 3901730805,
+    "expected": "38781753765911435694",
+    "overflow": false
+  },
+  {
+    "principal": "16384318921295854176",
+    "rate_bps": 4873,
+    "seconds": 1004351122,
+    "expected": "254275060579613205327",
+    "overflow": false
+  },
+  {
+    "principal": "15745506764631383801",
+    "rate_bps": 2311,
+    "seconds": 3347112659,
+    "expected": "386207151724926985206",
+    "overflow": false
+  },
+  {
+    "principal": "6664095070496820582",
+    "rate_bps": 8868,
+    "seconds": 2126220552,
+    "expected": "398445176165756357023",
+    "overflow": false
+  },
+  {
+    "principal": "13633000454462784439",
+    "rate_bps": 2378,
+    "seconds": 3089217985,
+    "expected": "317574225139521137514",
+    "overflow": false
+  },
+  {
+    "principal": "7168343381625595708",
+    "rate_bps": 3826,
+    "seconds": 4137971406,
+    "expected": "359869172299573467668",
+    "overflow": false
+  },
+  {
+    "principal": "11521989599151598981",
+    "rate_bps": 8444,
+    "seconds": 2867248191,
+    "expected": "884574435507979058445",
+    "overflow": false
+  },
+  {
+    "principal": "10450169563416156514",
+    "rate_bps": 8577,
+    "seconds": 2378793316,
+    "expected": "676096752671818055181",
+    "overflow": false
+  },
+  {
+    "principal": "8472881219128253411",
+    "rate_bps": 6906,
+    "seconds": 2549544397,
+    "expected": "473057207977832721316",
+    "overflow": false
+  },
+  {
+    "principal": "12194064765539215704",
+    "rate_bps": 2316,
+    "seconds": 2228536906,
+    "expected": "199572306289290988699",
+    "overflow": false
+  },
+  {
+    "principal": "3445488444568965713",
+    "rate_bps": 4001,
+    "seconds": 700569067,
+    "expected": "30624125768990414346",
+    "overflow": false
+  },
+  {
+    "principal": "10284186188564705438",
+    "rate_bps": 2153,
+    "seconds": 2136470272,
+    "expected": "150004472383596288050",
+    "overflow": false
+  },
+  {
+    "principal": "15601840055967692879",
+    "rate_bps": 2451,
+    "seconds": 3935703065,
+    "expected": "477237817234626686365",
+    "overflow": false
+  },
+  {
+    "principal": "17292320212901805236",
+    "rate_bps": 5727,
+    "seconds": 405852422,
+    "expected": "127450630204857144747",
+    "overflow": false
+  },
+  {
+    "principal": "14063814223455861085",
+    "rate_bps": 2809,
+    "seconds": 3618733015,
+    "expected": "453319912074818905812",
+    "overflow": false
+  },
+  {
+    "principal": "7103568339979267866",
+    "rate_bps": 2180,
+    "seconds": 2059050460,
+    "expected": "101109843780457668696",
+    "overflow": false
+  },
+  {
+    "principal": "4495130618917643515",
+    "rate_bps": 2174,
+    "seconds": 2491544741,
+    "expected": "77208290914141441562",
+    "overflow": false
+  },
+  {
+    "principal": "10919997363819273552",
+    "rate_bps": 5956,
+    "seconds": 4075055874,
+    "expected": "840435102851698502541",
+    "overflow": false
+  },
+  {
+    "principal": "5704424258815282857",
+    "rate_bps": 384,
+    "seconds": 2937010691,
+    "expected": "20400554075056604864",
+    "overflow": false
+  },
+  {
+    "principal": "12992008845900067030",
+    "rate_bps": 8967,
+    "seconds": 1367637496,
+    "expected": "505228533058824865149",
+    "overflow": false
+  },
+  {
+    "principal": "8221151691752844775",
+    "rate_bps": 8107,
+    "seconds": 2328219505,
+    "expected": "492051036500216127237",
+    "overflow": false
+  },
+  {
+    "principal": "15656252049003841324",
+    "rate_bps": 2151,
+    "seconds": 3011555390,
+    "expected": "321597351274111841618",
+    "overflow": false
+  },
+  {
+    "principal": "8113076980339654197",
+    "rate_bps": 2325,
+    "seconds": 689626223,
+    "expected": "41249217484935385847",
+    "overflow": false
+  },
+  {
+    "principal": "7441114110157541842",
+    "rate_bps": 3104,
+    "seconds": 2174996308,
+    "expected": "159298466215011446378",
+    "overflow": false
+  },
+  {
+    "principal": "11190451801104162579",
+    "rate_bps": 5941,
+    "seconds": 935398525,
+    "expected": "197195612184795830450",
+    "overflow": false
+  },
+  {
+    "principal": "1882402505259333192",
+    "rate_bps": 3218,
+    "seconds": 2889350330,
+    "expected": "55499890679351120497",
+    "overflow": false
+  },
+  {
+    "principal": "13543693690146468865",
+    "rate_bps": 7853,
+    "seconds": 442920731,
+    "expected": "149379885271166815561",
+    "overflow": false
+  },
+  {
+    "principal": "15605292168963321358",
+    "rate_bps": 4228,
+    "seconds": 146673136,
+    "expected": "30686747052680409293",
+    "overflow": false
+  },
+  {
+    "principal": "8603521244944008319",
+    "rate_bps": 461,
+    "seconds": 573790153,
+    "expected": "7216450629915191392",
+    "overflow": false
+  },
+  {
+    "principal": "3165924457566414500",
+    "rate_bps": 7545,
+    "seconds": 2707025014,
+    "expected": "205043239137677549740",
+    "overflow": false
+  },
+  {
+    "principal": "11852933399527463949",
+    "rate_bps": 8474,
+    "seconds": 1602371079,
+    "expected": "510353144172967558538",
+    "overflow": false
+  },
+  {
+    "principal": "15192350285325721994",
+    "rate_bps": 3848,
+    "seconds": 2227959244,
+    "expected": "413010091838393399702",
+    "overflow": false
+  },
+  {
+    "principal": "16299974790942157355",
+    "rate_bps": 9860,
+    "seconds": 2189991253,
+    "expected": "1116091038345251605818",
+    "overflow": false
+  },
+  {
+    "principal": "13730873468032996416",
+    "rate_bps": 9813,
+    "seconds": 2333039474,
+    "expected": "996817018261964071304",
+    "overflow": false
+  },
+  {
+    "principal": "4528333094609101401",
+    "rate_bps": 2222,
+    "seconds": 2783499571,
+    "expected": "88811043215985379733",
+    "overflow": false
+  },
+  {
+    "principal": "7106316758399076422",
+    "rate_bps": 3242,
+    "seconds": 1576370920,
+    "expected": "115162048140598554596",
+    "overflow": false
+  },
+  {
+    "principal": "3979256097076190231",
+    "rate_bps": 5371,
+    "seconds": 2992965921,
+    "expected": "202839348821663473180",
+    "overflow": false
+  },
+  {
+    "principal": "1980705878405708572",
+    "rate_bps": 2036,
+    "seconds": 911631790,
+    "expected": "11657639430565828157",
+    "overflow": false
+  },
+  {
+    "principal": "1336479573018063589",
+    "rate_bps": 2161,
+    "seconds": 3710582943,
+    "expected": "33982289009684830935",
+    "overflow": false
+  },
+  {
+    "principal": "7141453404274982466",
+    "rate_bps": 7976,
+    "seconds": 4121817412,
+    "expected": "744481473560657434562",
+    "overflow": false
+  },
+  {
+    "principal": "14519810880570369603",
+    "rate_bps": 2032,
+    "seconds": 2725316397,
+    "expected": "254973464820801344389",
+    "overflow": false
+  },
+  {
+    "principal": "16134007054129305400",
+    "rate_bps": 1942,
+    "seconds": 3778963242,
+    "expected": "375454685662197947034",
+    "overflow": false
+  },
+  {
+    "principal": "7047960561715214769",
+    "rate_bps": 4578,
+    "seconds": 475778123,
+    "expected": "48678491934637927788",
+    "overflow": false
+  },
+  {
+    "principal": "15785660160464822142",
+    "rate_bps": 7551,
+    "seconds": 386907360,
+    "expected": "146240479870926334870",
+    "overflow": false
+  },
+  {
+    "principal": "2901289128689587375",
+    "rate_bps": 9100,
+    "seconds": 3261416313,
+    "expected": "273043621279311792428",
+    "overflow": false
+  },
+  {
+    "principal": "8244128884599710868",
+    "rate_bps": 9914,
+    "seconds": 778304486,
+    "expected": "201714265873837346329",
+    "overflow": false
+  },
+  {
+    "principal": "4221370968151417533",
+    "rate_bps": 2584,
+    "seconds": 129795127,
+    "expected": "4489498275973626601",
+    "overflow": false
+  },
+  {
+    "principal": "14794887816615888890",
+    "rate_bps": 4022,
+    "seconds": 611885500,
+    "expected": "115456210101776357807",
+    "overflow": false
+  },
+  {
+    "principal": "4329609235920073563",
+    "rate_bps": 6583,
+    "seconds": 123120133,
+    "expected": "11127433960113378596",
+    "overflow": false
+  },
+  {
+    "principal": "17771992637027704624",
+    "rate_bps": 87,
+    "seconds": 195887074,
+    "expected": "960405303155347530",
+    "overflow": false
+  },
+  {
+    "principal": "6927103655934663177",
+    "rate_bps": 9873,
+    "seconds": 44610659,
+    "expected": "9674596375018618151",
+    "overflow": false
+  },
+  {
+    "principal": "11326441584849540022",
+    "rate_bps": 5568,
+    "seconds": 3194330072,
+    "expected": "638801458711628939629",
+    "overflow": false
+  },
+  {
+    "principal": "12357848286286843463",
+    "rate_bps": 9556,
+    "seconds": 4232210129,
+    "expected": "1584818804389850031846",
+    "overflow": false
+  },
+  {
+    "principal": "16081035938317878028",
+    "rate_bps": 8962,
+    "seconds": 1749323550,
+    "expected": "799433784729835939718",
+    "overflow": false
+  },
+  {
+    "principal": "8058188617562622869",
+    "rate_bps": 9710,
+    "seconds": 3116509391,
+    "expected": "773247441227543387635",
+    "overflow": false
+  },
+  {
+    "principal": "12521907182800887474",
+    "rate_bps": 7471,
+    "seconds": 3750684468,
+    "expected": "1112636082227895552872",
+    "overflow": false
+  },
+  {
+    "principal": "1475993897405313395",
+    "rate_bps": 8665,
+    "seconds": 148497885,
+    "expected": "6022361072126362167",
+    "overflow": false
+  },
+  {
+    "principal": "18065409432402955304",
+    "rate_bps": 7428,
+    "seconds": 3587638682,
+    "expected": "1526587826618918478781",
+    "overflow": false
+  },
+  {
+    "principal": "12637865398765413217",
+    "rate_bps": 3720,
+    "seconds": 3512528251,
+    "expected": "523636467507787567670",
+    "overflow": false
+  },
+  {
+    "principal": "4393143842898199790",
+    "rate_bps": 2374,
+    "seconds": 2856583120,
+    "expected": "94470539747186080644",
+    "overflow": false
+  },
+  {
+    "principal": "14511212125039601887",
+    "rate_bps": 3048,
+    "seconds": 1519309609,
+    "expected": "213087675077311037660",
+    "overflow": false
+  },
+  {
+    "principal": "10100499487125468804",
+    "rate_bps": 4347,
+    "seconds": 1896742742,
+    "expected": "264079272597394933131",
+    "overflow": false
+  },
+  {
+    "principal": "8222725913064181101",
+    "rate_bps": 4996,
+    "seconds": 3291172455,
+    "expected": "428728423117508311782",
+    "overflow": false
+  },
+  {
+    "principal": "3091251408530072170",
+    "rate_bps": 1169,
+    "seconds": 1661444524,
+    "expected": "19038296060173114920",
+    "overflow": false
+  },
+  {
+    "principal": "11664384853730607243",
+    "rate_bps": 4622,
+    "seconds": 467606197,
+    "expected": "79940237196814581818",
+    "overflow": false
+  },
+  {
+    "principal": "17211990427611692576",
+    "rate_bps": 3792,
+    "seconds": 2907461714,
+    "expected": "601737146424843726826",
+    "overflow": false
+  },
+  {
+    "principal": "18347471282185811385",
+    "rate_bps": 1872,
+    "seconds": 1042929555,
+    "expected": "113587470674049890427",
+    "overflow": false
+  },
+  {
+    "principal": "4776630061703058214",
+    "rate_bps": 5644,
+    "seconds": 1416349896,
+    "expected": "121080041374624552497",
+    "overflow": false
+  },
+  {
+    "principal": "11326927100857615479",
+    "rate_bps": 4849,
+    "seconds": 3856722049,
+    "expected": "671701044052431465818",
+    "overflow": false
+  },
+  {
+    "principal": "13254162584197488380",
+    "rate_bps": 6311,
+    "seconds": 3752471694,
+    "expected": "995316701851490093233",
+    "overflow": false
+  },
+  {
+    "principal": "15196793202415880261",
+    "rate_bps": 7221,
+    "seconds": 2144031999,
+    "expected": "746060341095452365339",
+    "overflow": false
+  },
+  {
+    "principal": "2873802812099851042",
+    "rate_bps": 2846,
+    "seconds": 2553131300,
+    "expected": "66215308088286473887",
+    "overflow": false
+  },
+  {
+    "principal": "1546905559855562915",
+    "rate_bps": 525,
+    "seconds": 2551097485,
+    "expected": "6569669944577698014",
+    "overflow": false
+  },
+  {
+    "principal": "2879708187918472472",
+    "rate_bps": 8665,
+    "seconds": 2771441674,
+    "expected": "219288665428355365948",
+    "overflow": false
+  },
+  {
+    "principal": "1220622884880019729",
+    "rate_bps": 9467,
+    "seconds": 2506412715,
+    "expected": "91841689287379020687",
+    "overflow": false
+  },
+  {
+    "principal": "11858913042092416606",
+    "rate_bps": 1960,
+    "seconds": 26334912,
+    "expected": "1941003061590391713",
+    "overflow": false
+  },
+  {
+    "principal": "5148452264579662095",
+    "rate_bps": 907,
+    "seconds": 38995673,
+    "expected": "577422616678880621",
+    "overflow": false
+  },
+  {
+    "principal": "11384880402221128820",
+    "rate_bps": 7118,
+    "seconds": 2153182918,
+    "expected": "553300133750005442318",
+    "overflow": false
+  },
+  {
+    "principal": "6420287143567629341",
+    "rate_bps": 4528,
+    "seconds": 1859755159,
+    "expected": "171439162096179100459",
+    "overflow": false
+  },
+  {
+    "principal": "13793768045199093978",
+    "rate_bps": 2993,
+    "seconds": 2768237980,
+    "expected": "362398550044270840988",
+    "overflow": false
+  },
+  {
+    "principal": "10311083247203389883",
+    "rate_bps": 3727,
+    "seconds": 223670117,
+    "expected": "27256183468433971994",
+    "overflow": false
+  },
+  {
+    "principal": "5529328470521393424",
+    "rate_bps": 2308,
+    "seconds": 1237083330,
+    "expected": "50061117762752281164",
+    "overflow": false
+  },
+  {
+    "principal": "13114160450313614697",
+    "rate_bps": 7055,
+    "seconds": 596065987,
+    "expected": "174874000260131071263",
+    "overflow": false
+  },
+  {
+    "principal": "771058718510892694",
+    "rate_bps": 4088,
+    "seconds": 3101624760,
+    "expected": "31001377202279232899",
+    "overflow": false
+  },
+  {
+    "principal": "5868205382895566503",
+    "rate_bps": 6490,
+    "seconds": 1292078641,
+    "expected": "156038706897518447160",
+    "overflow": false
+  },
+  {
+    "principal": "3962693368430382828",
+    "rate_bps": 7486,
+    "seconds": 1344683518,
+    "expected": "126489293148116287962",
+    "overflow": false
+  },
+  {
+    "principal": "9163899051403509",
+    "rate_bps": 5751,
+    "seconds": 4000417071,
+    "expected": "668532198378345867",
+    "overflow": false
+  },
+  {
+    "principal": "14517593301387393938",
+    "rate_bps": 5540,
+    "seconds": 3417394964,
+    "expected": "871551307445745291041",
+    "overflow": false
+  },
+  {
+    "principal": "5668382760900842451",
+    "rate_bps": 5854,
+    "seconds": 694308669,
+    "expected": "73056332687298731738",
+    "overflow": false
+  },
+  {
+    "principal": "4706164429408940552",
+    "rate_bps": 8230,
+    "seconds": 1136320122,
+    "expected": "139560019839222374753",
+    "overflow": false
+  },
+  {
+    "principal": "4990099069652247233",
+    "rate_bps": 4874,
+    "seconds": 2930670555,
+    "expected": "226024275945453991183",
+    "overflow": false
+  },
+  {
+    "principal": "16006191705916959694",
+    "rate_bps": 9263,
+    "seconds": 2339389872,
+    "expected": "1099855615748669581810",
+    "overflow": false
+  },
+  {
+    "principal": "16887170507049884991",
+    "rate_bps": 6100,
+    "seconds": 160751241,
+    "expected": "52509085037797743510",
+    "overflow": false
+  },
+  {
+    "principal": "8993569449608320612",
+    "rate_bps": 5882,
+    "seconds": 1216209462,
+    "expected": "204013489306564032439",
+    "overflow": false
+  },
+  {
+    "principal": "6260083582550609613",
+    "rate_bps": 3638,
+    "seconds": 4161957575,
+    "expected": "300561859203433718936",
+    "overflow": false
+  },
+  {
+    "principal": "3148621971603632970",
+    "rate_bps": 51,
+    "seconds": 2586353036,
+    "expected": "1316957914032031513",
+    "overflow": false
+  },
+  {
+    "principal": "13259897524756391659",
+    "rate_bps": 1588,
+    "seconds": 757803029,
+    "expected": "50598820799981334934",
+    "overflow": false
+  },
+  {
+    "principal": "5690546120075835392",
+    "rate_bps": 6888,
+    "seconds": 3423348018,
+    "expected": "425492129169731409085",
+    "overflow": false
+  },
+  {
+    "principal": "14240277810170550553",
+    "rate_bps": 8105,
+    "seconds": 1829363,
+    "expected": "669521865821344396",
+    "overflow": false
+  },
+  {
+    "principal": "480042748608392710",
+    "rate_bps": 9584,
+    "seconds": 735469224,
+    "expected": "10729626789228775145",
+    "overflow": false
+  },
+  {
+    "principal": "13807479267062414551",
+    "rate_bps": 1590,
+    "seconds": 531453921,
+    "expected": "36997342728990287037",
+    "overflow": false
+  },
+  {
+    "principal": "10295004101941760732",
+    "rate_bps": 7325,
+    "seconds": 4204249966,
+    "expected": "1005347206299835336663",
+    "overflow": false
+  },
+  {
+    "principal": "4105709582319250853",
+    "rate_bps": 1029,
+    "seconds": 4078942559,
+    "expected": "54644264342885506436",
+    "overflow": false
+  },
+  {
+    "principal": "14162293260839303170",
+    "rate_bps": 6085,
+    "seconds": 1770045700,
+    "expected": "483695490123817119148",
+    "overflow": false
+  },
+  {
+    "principal": "7520075847565208323",
+    "rate_bps": 2005,
+    "seconds": 4066892269,
+    "expected": "194443154950364406536",
+    "overflow": false
+  },
+  {
+    "principal": "2390547213034349304",
+    "rate_bps": 6415,
+    "seconds": 4012120298,
+    "expected": "195101822121076775537",
+    "overflow": false
+  },
+  {
+    "principal": "11757756474486290545",
+    "rate_bps": 9719,
+    "seconds": 2109008139,
+    "expected": "764218755258479913025",
+    "overflow": false
+  },
+  {
+    "principal": "16383866774798986558",
+    "rate_bps": 4251,
+    "seconds": 3583393952,
+    "expected": "791398936363717766479",
+    "overflow": false
+  },
+  {
+    "principal": "2434649826449702255",
+    "rate_bps": 1861,
+    "seconds": 2826394169,
+    "expected": "40607756899787015130",
+    "overflow": false
+  },
+  {
+    "principal": "15749563806022476884",
+    "rate_bps": 2346,
+    "seconds": 4211196326,
+    "expected": "493395767642419190429",
+    "overflow": false
+  },
+  {
+    "principal": "12863361321129076093",
+    "rate_bps": 1496,
+    "seconds": 2522924279,
+    "expected": "153951410240970917062",
+    "overflow": false
+  },
+  {
+    "principal": "8336865216333851066",
+    "rate_bps": 3426,
+    "seconds": 763926908,
+    "expected": "69188726901242932573",
+    "overflow": false
+  },
+  {
+    "principal": "13345884665856851995",
+    "rate_bps": 327,
+    "seconds": 2165621957,
+    "expected": "29968924606246609132",
+    "overflow": false
+  },
+  {
+    "principal": "10063003671686599408",
+    "rate_bps": 4432,
+    "seconds": 2693437858,
+    "expected": "380914702694078742122",
+    "overflow": false
+  },
+  {
+    "principal": "14272467349264523465",
+    "rate_bps": 310,
+    "seconds": 3548567843,
+    "expected": "49786002630387292862",
+    "overflow": false
+  },
+  {
+    "principal": "15369515995282475382",
+    "rate_bps": 4591,
+    "seconds": 2225653656,
+    "expected": "497987520826108492256",
+    "overflow": false
+  },
+  {
+    "principal": "11422162008297897735",
+    "rate_bps": 2893,
+    "seconds": 203507089,
+    "expected": "21324049627609783879",
+    "overflow": false
+  },
+  {
+    "principal": "456886363718462156",
+    "rate_bps": 332,
+    "seconds": 488488158,
+    "expected": "234959880681588249",
+    "overflow": false
+  },
+  {
+    "principal": "17288839903111140949",
+    "rate_bps": 2187,
+    "seconds": 3649106319,
+    "expected": "437516610447636916772",
+    "overflow": false
+  },
+  {
+    "principal": "12513786048484141170",
+    "rate_bps": 5164,
+    "seconds": 2487420660,
+    "expected": "509703468896481555394",
+    "overflow": false
+  },
+  {
+    "principal": "10082706429546251827",
+    "rate_bps": 3477,
+    "seconds": 888293533,
+    "expected": "98748772642955717905",
+    "overflow": false
+  },
+  {
+    "principal": "17674427965156698088",
+    "rate_bps": 6072,
+    "seconds": 2656798554,
+    "expected": "904126396433271377434",
+    "overflow": false
+  },
+  {
+    "principal": "14586740179080704545",
+    "rate_bps": 1804,
+    "seconds": 2905807419,
+    "expected": "242468319152213889394",
+    "overflow": false
+  },
+  {
+    "principal": "10844960465339900590",
+    "rate_bps": 590,
+    "seconds": 2096812944,
+    "expected": "42543485393603660834",
+    "overflow": false
+  },
+  {
+    "principal": "13599622320170934687",
+    "rate_bps": 1940,
+    "seconds": 2942138857,
+    "expected": "246141666353617578449",
+    "overflow": false
+  },
+  {
+    "principal": "7239020125711337028",
+    "rate_bps": 2944,
+    "seconds": 2124518678,
+    "expected": "143572590462631274156",
+    "overflow": false
+  },
+  {
+    "principal": "5821818165416599597",
+    "rate_bps": 1142,
+    "seconds": 4136607527,
+    "expected": "87209229945838665129",
+    "overflow": false
+  },
+  {
+    "principal": "15436347455663100970",
+    "rate_bps": 747,
+    "seconds": 1969678700,
+    "expected": "72020134631996597077",
+    "overflow": false
+  },
+  {
+    "principal": "14614613184840408395",
+    "rate_bps": 980,
+    "seconds": 1929692533,
+    "expected": "87638494852741270861",
+    "overflow": false
+  },
+  {
+    "principal": "4383377832899527136",
+    "rate_bps": 1362,
+    "seconds": 617005586,
+    "expected": "11680690146834119103",
+    "overflow": false
+  },
+  {
+    "principal": "4540023489793920121",
+    "rate_bps": 1706,
+    "seconds": 2140605523,
+    "expected": "52573532796503154553",
+    "overflow": false
+  },
+  {
+    "principal": "13559668287631055078",
+    "rate_bps": 5550,
+    "seconds": 569197704,
+    "expected": "135830900915089755294",
+    "overflow": false
+  },
+  {
+    "principal": "2175200016422143287",
+    "rate_bps": 8914,
+    "seconds": 820139841,
+    "expected": "50425838710306581734",
+    "overflow": false
+  },
+  {
+    "principal": "15077775939776485052",
+    "rate_bps": 5273,
+    "seconds": 1662462542,
+    "expected": "419121865421593327205",
+    "overflow": false
+  },
+  {
+    "principal": "319331237885682437",
+    "rate_bps": 9216,
+    "seconds": 2071997887,
+    "expected": "19335997082074253355",
+    "overflow": false
+  },
+  {
+    "principal": "12053857527298542818",
+    "rate_bps": 735,
+    "seconds": 2447319268,
+    "expected": "68753912254278131255",
+    "overflow": false
+  },
+  {
+    "principal": "16090392464407749987",
+    "rate_bps": 3537,
+    "seconds": 4011105101,
+    "expected": "723867589309178354974",
+    "overflow": false
+  },
+  {
+    "principal": "8679117352218067160",
+    "rate_bps": 2208,
+    "seconds": 1905273290,
+    "expected": "115777802391172581173",
+    "overflow": false
+  },
+  {
+    "principal": "8296412943865352145",
+    "rate_bps": 3032,
+    "seconds": 1646530411,
+    "expected": "131335673901960430651",
+    "overflow": false
+  },
+  {
+    "principal": "9313976922514607134",
+    "rate_bps": 7982,
+    "seconds": 500497024,
+    "expected": "117989068783048254142",
+    "overflow": false
+  },
+  {
+    "principal": "15115341573759240655",
+    "rate_bps": 9881,
+    "seconds": 921320857,
+    "expected": "436338124907973349930",
+    "overflow": false
+  },
+  {
+    "principal": "9943909490454707252",
+    "rate_bps": 6779,
+    "seconds": 3747372166,
+    "expected": "801019366655761759529",
+    "overflow": false
+  },
+  {
+    "principal": "5748885669326372573",
+    "rate_bps": 4923,
+    "seconds": 1806302551,
+    "expected": "162105367776872955733",
+    "overflow": false
+  },
+  {
+    "principal": "5076082829798552218",
+    "rate_bps": 4438,
+    "seconds": 2739572060,
+    "expected": "195700583001500146622",
+    "overflow": false
+  },
+  {
+    "principal": "4522393580667338363",
+    "rate_bps": 201,
+    "seconds": 2167286309,
+    "expected": "6247037227134867177",
+    "overflow": false
+  },
+  {
+    "principal": "66485415522485456",
+    "rate_bps": 7952,
+    "seconds": 395288194,
+    "expected": "662689356424340569",
+    "overflow": false
+  },
+  {
+    "principal": "14035704484264598569",
+    "rate_bps": 794,
+    "seconds": 4168319875,
+    "expected": "147302171909376840034",
+    "overflow": false
+  },
+  {
+    "principal": "14458579255504837718",
+    "rate_bps": 3660,
+    "seconds": 3648705912,
+    "expected": "612264330313840307363",
+    "overflow": false
+  },
+  {
+    "principal": "14035166899512119143",
+    "rate_bps": 2996,
+    "seconds": 3434319089,
+    "expected": "457924022813562484198",
+    "overflow": false
+  },
+  {
+    "principal": "3211395746144704172",
+    "rate_bps": 5499,
+    "seconds": 1428360126,
+    "expected": "79985020134647786801",
+    "overflow": false
+  },
+  {
+    "principal": "2371458798951453621",
+    "rate_bps": 9418,
+    "seconds": 1900572143,
+    "expected": "134602157883771404312",
+    "overflow": false
+  },
+  {
+    "principal": "14374252350238319954",
+    "rate_bps": 9524,
+    "seconds": 3145469652,
+    "expected": "1365474342651635248875",
+    "overflow": false
+  },
+  {
+    "principal": "3929085388755650707",
+    "rate_bps": 4042,
+    "seconds": 2334249469,
+    "expected": "117551571155800366108",
+    "overflow": false
+  },
+  {
+    "principal": "2667090412950711752",
+    "rate_bps": 6763,
+    "seconds": 573636666,
+    "expected": "32810090007671033510",
+    "overflow": false
+  },
+  {
+    "principal": "5509273433711792513",
+    "rate_bps": 8516,
+    "seconds": 1807927451,
+    "expected": "268970327916447484027",
+    "overflow": false
+  },
+  {
+    "principal": "1066997528397916558",
+    "rate_bps": 5806,
+    "seconds": 1134278000,
+    "expected": "22281957767404434227",
+    "overflow": false
+  },
+  {
+    "principal": "13168049359116891647",
+    "rate_bps": 6387,
+    "seconds": 1342219593,
+    "expected": "357960683881524777164",
+    "overflow": false
+  },
+  {
+    "principal": "14368066920761050660",
+    "rate_bps": 7570,
+    "seconds": 3195082742,
+    "expected": "1101969879800846932187",
+    "overflow": false
+  },
+  {
+    "principal": "12088487289967722893",
+    "rate_bps": 4697,
+    "seconds": 519757703,
+    "expected": "93580819900299221336",
+    "overflow": false
+  },
+  {
+    "principal": "9809221532033467658",
+    "rate_bps": 3184,
+    "seconds": 4093281612,
+    "expected": "405389615367646137213",
+    "overflow": false
+  },
+  {
+    "principal": "14414311130238133163",
+    "rate_bps": 7268,
+    "seconds": 3993236181,
+    "expected": "1326560926451357613732",
+    "overflow": false
+  },
+  {
+    "principal": "15494748056863759296",
+    "rate_bps": 9184,
+    "seconds": 150220530,
+    "expected": "67785854809378198376",
+    "overflow": false
+  },
+  {
+    "principal": "17395305400034119641",
+    "rate_bps": 8101,
+    "seconds": 1953709747,
+    "expected": "873019865695167672382",
+    "overflow": false
+  },
+  {
+    "principal": "16838077809337521094",
+    "rate_bps": 5132,
+    "seconds": 3899161192,
+    "expected": "1068424263729630133001",
+    "overflow": false
+  },
+  {
+    "principal": "1002469357584293271",
+    "rate_bps": 2954,
+    "seconds": 4002932385,
+    "expected": "37588348505633245535",
+    "overflow": false
+  },
+  {
+    "principal": "12627745859194972828",
+    "rate_bps": 4125,
+    "seconds": 3374342446,
+    "expected": "557355554782398328382",
+    "overflow": false
+  },
+  {
+    "principal": "3345589297772521573",
+    "rate_bps": 9710,
+    "seconds": 1095021087,
+    "expected": "112799644705950744777",
+    "overflow": false
+  },
+  {
+    "principal": "16274548740359139778",
+    "rate_bps": 4221,
+    "seconds": 1837158596,
+    "expected": "400188265315078714220",
+    "overflow": false
+  },
+  {
+    "principal": "4391677262788915139",
+    "rate_bps": 9109,
+    "seconds": 2410474669,
+    "expected": "305771556596234155183",
+    "overflow": false
+  },
+  {
+    "principal": "11834634646361468600",
+    "rate_bps": 8809,
+    "seconds": 1928137386,
+    "expected": "637401136837409769566",
+    "overflow": false
+  },
+  {
+    "principal": "16130704732414981937",
+    "rate_bps": 9525,
+    "seconds": 1938441675,
+    "expected": "944418438012505088563",
+    "overflow": false
+  },
+  {
+    "principal": "8703828456413887230",
+    "rate_bps": 3342,
+    "seconds": 1493566560,
+    "expected": "137763682447626391055",
+    "overflow": false
+  },
+  {
+    "principal": "13949991202511250991",
+    "rate_bps": 3816,
+    "seconds": 3015946489,
+    "expected": "509095577718291976413",
+    "overflow": false
+  },
+  {
+    "principal": "5222379737007399956",
+    "rate_bps": 6922,
+    "seconds": 3260991334,
+    "expected": "373803256346967664527",
+    "overflow": false
+  },
+  {
+    "principal": "11785702076952750141",
+    "rate_bps": 5819,
+    "seconds": 1074611639,
+    "expected": "233694638599794939170",
+    "overflow": false
+  },
+  {
+    "principal": "18416718437152033658",
+    "rate_bps": 5363,
+    "seconds": 2675822908,
+    "expected": "838051689507845176917",
+    "overflow": false
+  },
+  {
+    "principal": "15818903689877130459",
+    "rate_bps": 2634,
+    "seconds": 1882791813,
+    "expected": "248764180653233843561",
+    "overflow": false
+  },
+  {
+    "principal": "9756992173412058800",
+    "rate_bps": 9643,
+    "seconds": 3393418082,
+    "expected": "1012415734439063739785",
+    "overflow": false
+  },
+  {
+    "principal": "4231163242829473673",
+    "rate_bps": 1253,
+    "seconds": 2620472803,
+    "expected": "44053853368272971905",
+    "overflow": false
+  },
+  {
+    "principal": "16985668631060938550",
+    "rate_bps": 1835,
+    "seconds": 3809293144,
+    "expected": "376492651572142339072",
+    "overflow": false
+  },
+  {
+    "principal": "9366877839660036039",
+    "rate_bps": 7021,
+    "seconds": 634545233,
+    "expected": "132327408771098241255",
+    "overflow": false
+  },
+  {
+    "principal": "8622104955425936012",
+    "rate_bps": 6646,
+    "seconds": 1378757278,
+    "expected": "250527181847212865813",
+    "overflow": false
+  },
+  {
+    "principal": "11940435195286479125",
+    "rate_bps": 4280,
+    "seconds": 2418014799,
+    "expected": "391846771173419366802",
+    "overflow": false
+  },
+  {
+    "principal": "13485031459059053106",
+    "rate_bps": 2082,
+    "seconds": 4153697972,
+    "expected": "369794967558521253812",
+    "overflow": false
+  },
+  {
+    "principal": "6989254110985116403",
+    "rate_bps": 2198,
+    "seconds": 1334373213,
+    "expected": "65002375301490274850",
+    "overflow": false
+  },
+  {
+    "principal": "2366026433741783976",
+    "rate_bps": 4066,
+    "seconds": 2679327002,
+    "expected": "81734626164481643539",
+    "overflow": false
+  },
+  {
+    "principal": "16044400430386594017",
+    "rate_bps": 1017,
+    "seconds": 758482683,
+    "expected": "39244925430050102082",
+    "overflow": false
+  },
+  {
+    "principal": "17333628220974415982",
+    "rate_bps": 749,
+    "seconds": 2550851408,
+    "expected": "105014640268146315260",
+    "overflow": false
+  },
+  {
+    "principal": "12479962606651759199",
+    "rate_bps": 4338,
+    "seconds": 1939234985,
+    "expected": "332909863224481924730",
+    "overflow": false
+  },
+  {
+    "principal": "16145254174125676036",
+    "rate_bps": 660,
+    "seconds": 115632854,
+    "expected": "3907180366401296351",
+    "overflow": false
+  },
+  {
+    "principal": "4134836115638874861",
+    "rate_bps": 8008,
+    "seconds": 883699687,
+    "expected": "92785574189943071771",
+    "overflow": false
+  },
+  {
+    "principal": "8887171832850056682",
+    "rate_bps": 1770,
+    "seconds": 3374018860,
+    "expected": "168297530174059614633",
+    "overflow": false
+  },
+  {
+    "principal": "3177112489380493835",
+    "rate_bps": 2865,
+    "seconds": 3804278837,
+    "expected": "109805211423547021879",
+    "overflow": false
+  },
+  {
+    "principal": "12174664697157109152",
+    "rate_bps": 402,
+    "seconds": 3725355986,
+    "expected": "57815493159731861150",
+    "overflow": false
+  },
+  {
+    "principal": "10053200148081517369",
+    "rate_bps": 4771,
+    "seconds": 3129508115,
+    "expected": "475973989614296107252",
+    "overflow": false
+  },
+  {
+    "principal": "16458290013306461862",
+    "rate_bps": 6640,
+    "seconds": 2768240712,
+    "expected": "959290259404680736961",
+    "overflow": false
+  },
+  {
+    "principal": "1186999091581896183",
+    "rate_bps": 9367,
+    "seconds": 837158401,
+    "expected": "29515621992148116401",
+    "overflow": false
+  },
+  {
+    "principal": "705342694865899132",
+    "rate_bps": 2147,
+    "seconds": 2964023310,
+    "expected": "14233353152087245777",
+    "overflow": false
+  },
+  {
+    "principal": "13269224279461707205",
+    "rate_bps": 4242,
+    "seconds": 1355105919,
+    "expected": "241870462018215528617",
+    "overflow": false
+  },
+  {
+    "principal": "12040914957625779874",
+    "rate_bps": 1896,
+    "seconds": 2359152804,
+    "expected": "170784041439548217809",
+    "overflow": false
+  },
+  {
+    "principal": "8652365128934263331",
+    "rate_bps": 5446,
+    "seconds": 2580073997,
+    "expected": "385512114618874158570",
+    "overflow": false
+  },
+  {
+    "principal": "5165635410054687896",
+    "rate_bps": 5841,
+    "seconds": 3451042698,
+    "expected": "330182979657455871069",
+    "overflow": false
+  },
+  {
+    "principal": "13829119167412694673",
+    "rate_bps": 8269,
+    "seconds": 2260700203,
+    "expected": "819754628226761055432",
+    "overflow": false
+  },
+  {
+    "principal": "7071888245405219294",
+    "rate_bps": 3355,
+    "seconds": 4192296512,
+    "expected": "315408431266120523935",
+    "overflow": false
+  },
+  {
+    "principal": "16760252178626957967",
+    "rate_bps": 6135,
+    "seconds": 2837165145,
+    "expected": "925066864096641177342",
+    "overflow": false
+  },
+  {
+    "principal": "17764924311145765876",
+    "rate_bps": 3799,
+    "seconds": 2365653574,
+    "expected": "506264173514767507081",
+    "overflow": false
+  },
+  {
+    "principal": "8429255949980770717",
+    "rate_bps": 2336,
+    "seconds": 3370294807,
+    "expected": "210437611519215135536",
+    "overflow": false
+  },
+  {
+    "principal": "5397424234291901530",
+    "rate_bps": 9108,
+    "seconds": 1868195100,
+    "expected": "291222682797114354935",
+    "overflow": false
+  },
+  {
+    "principal": "10975708985046346555",
+    "rate_bps": 8726,
+    "seconds": 4107117797,
+    "expected": "1247321316035082151471",
+    "overflow": false
+  },
+  {
+    "principal": "2500443901364803728",
+    "rate_bps": 9764,
+    "seconds": 3894286402,
+    "expected": "301485318033524641283",
+    "overflow": false
+  },
+  {
+    "principal": "7406951496360952553",
+    "rate_bps": 8307,
+    "seconds": 3969124419,
+    "expected": "774411541848005800290",
+    "overflow": false
+  },
+  {
+    "principal": "6698643568619500054",
+    "rate_bps": 996,
+    "seconds": 1092084024,
+    "expected": "23104451094827070423",
+    "overflow": false
+  },
+  {
+    "principal": "3911161828501938215",
+    "rate_bps": 8930,
+    "seconds": 2996161457,
+    "expected": "331830155508748926221",
+    "overflow": false
+  },
+  {
+    "principal": "2908809927869734508",
+    "rate_bps": 9454,
+    "seconds": 1110907262,
+    "expected": "96872864214916076694",
+    "overflow": false
+  },
+  {
+    "principal": "13911422157982957173",
+    "rate_bps": 2581,
+    "seconds": 4099905199,
+    "expected": "466795587747355916508",
+    "overflow": false
+  },
+  {
+    "principal": "15992944844214423314",
+    "rate_bps": 7950,
+    "seconds": 851709588,
+    "expected": "343384349601002333149",
+    "overflow": false
+  },
+  {
+    "principal": "2277254287727623507",
+    "rate_bps": 3672,
+    "seconds": 1774163133,
+    "expected": "47043664540954046247",
+    "overflow": false
+  },
+  {
+    "principal": "4433796613179140488",
+    "rate_bps": 2883,
+    "seconds": 2069520890,
+    "expected": "83884866430546487924",
+    "overflow": false
+  },
+  {
+    "principal": "14444701418820976705",
+    "rate_bps": 4243,
+    "seconds": 3630388571,
+    "expected": "705550502132745611123",
+    "overflow": false
+  },
+  {
+    "principal": "8812956609902585678",
+    "rate_bps": 9703,
+    "seconds": 654338352,
+    "expected": "177428520925017161299",
+    "overflow": false
+  },
+  {
+    "principal": "5809083848555286207",
+    "rate_bps": 8199,
+    "seconds": 641117193,
+    "expected": "96827640315023498935",
+    "overflow": false
+  },
+  {
+    "principal": "10148340950860641764",
+    "rate_bps": 6109,
+    "seconds": 2868088246,
+    "expected": "563833761928328523651",
+    "overflow": false
+  },
+  {
+    "principal": "11555079563980747853",
+    "rate_bps": 3680,
+    "seconds": 1593544775,
+    "expected": "214871305565443112968",
+    "overflow": false
+  },
+  {
+    "principal": "10358617867754542794",
+    "rate_bps": 9115,
+    "seconds": 1543613708,
+    "expected": "462158031618168917808",
+    "overflow": false
+  },
+  {
+    "principal": "2030042037571018859",
+    "rate_bps": 1900,
+    "seconds": 3654483349,
+    "expected": "44696962727483858345",
+    "overflow": false
+  },
+  {
+    "principal": "8543725767950073728",
+    "rate_bps": 2823,
+    "seconds": 495417522,
+    "expected": "37889854196514988259",
+    "overflow": false
+  },
+  {
+    "principal": "7457674712428185241",
+    "rate_bps": 5713,
+    "seconds": 1370411891,
+    "expected": "185145078382038453648",
+    "overflow": false
+  },
+  {
+    "principal": "15989688847830595974",
+    "rate_bps": 5037,
+    "seconds": 4050376232,
+    "expected": "1034429083559413712497",
+    "overflow": false
+  },
+  {
+    "principal": "16979750123865243223",
+    "rate_bps": 6159,
+    "seconds": 3622090081,
+    "expected": "1201141407739742305145",
+    "overflow": false
+  },
+  {
+    "principal": "9744184395740971612",
+    "rate_bps": 7379,
+    "seconds": 1907375854,
+    "expected": "434883247032479622055",
+    "overflow": false
+  },
+  {
+    "principal": "828856922095526693",
+    "rate_bps": 9534,
+    "seconds": 2589584095,
+    "expected": "64890052934843730247",
+    "overflow": false
+  },
+  {
+    "principal": "12272301028636191618",
+    "rate_bps": 4455,
+    "seconds": 3010338948,
+    "expected": "521894233881323502291",
+    "overflow": false
+  },
+  {
+    "principal": "1817689126359053443",
+    "rate_bps": 1427,
+    "seconds": 2533375853,
+    "expected": "20837067669890262554",
+    "overflow": false
+  },
+  {
+    "principal": "3969126243027827320",
+    "rate_bps": 9385,
+    "seconds": 4032380010,
+    "expected": "476303788127834103064",
+    "overflow": false
+  },
+  {
+    "principal": "2485414003220788721",
+    "rate_bps": 4433,
+    "seconds": 345760395,
+    "expected": "12079949283272153039",
+    "overflow": false
+  },
+  {
+    "principal": "5764484850364467390",
+    "rate_bps": 4159,
+    "seconds": 1730086944,
+    "expected": "131525737095976505329",
+    "overflow": false
+  },
+  {
+    "principal": "6881755354758369007",
+    "rate_bps": 6346,
+    "seconds": 621430713,
+    "expected": "86056841806591965822",
+    "overflow": false
+  },
+  {
+    "principal": "1418754808473969620",
+    "rate_bps": 4972,
+    "seconds": 2084244774,
+    "expected": "46620892223116538872",
+    "overflow": false
+  },
+  {
+    "principal": "964139490017585917",
+    "rate_bps": 4898,
+    "seconds": 528615031,
+    "expected": "7915740588935333817",
+    "overflow": false
+  },
+  {
+    "principal": "10357334778859662650",
+    "rate_bps": 2495,
+    "seconds": 337135868,
+    "expected": "27625930624807882553",
+    "overflow": false
+  },
+  {
+    "principal": "13801995254608255387",
+    "rate_bps": 48,
+    "seconds": 4186159685,
+    "expected": "8794118128980576738",
+    "overflow": false
+  },
+  {
+    "principal": "7409812200835021424",
+    "rate_bps": 6865,
+    "seconds": 3029830946,
+    "expected": "488719348043821448943",
+    "overflow": false
+  },
+  {
+    "principal": "17014150727604973129",
+    "rate_bps": 7560,
+    "seconds": 997450403,
+    "expected": "406833563355021457898",
+    "overflow": false
+  },
+  {
+    "principal": "15447936043823936758",
+    "rate_bps": 2226,
+    "seconds": 122871576,
+    "expected": "13398014533463416234",
+    "overflow": false
+  },
+  {
+    "principal": "2529028666921164935",
+    "rate_bps": 4983,
+    "seconds": 303416081,
+    "expected": "12124857048556745120",
+    "overflow": false
+  },
+  {
+    "principal": "13495711226887748172",
+    "rate_bps": 8222,
+    "seconds": 657840222,
+    "expected": "231465925187051423032",
+    "overflow": false
+  },
+  {
+    "principal": "11539161685280107477",
+    "rate_bps": 5315,
+    "seconds": 1079984911,
+    "expected": "210033518796778812108",
+    "overflow": false
+  },
+  {
+    "principal": "2201370678620699634",
+    "rate_bps": 2034,
+    "seconds": 2336425588,
+    "expected": "33173360866944233468",
+    "overflow": false
+  },
+  {
+    "principal": "451036303650664371",
+    "rate_bps": 5272,
+    "seconds": 2237517341,
+    "expected": "16871228361309923054",
+    "overflow": false
+  },
+  {
+    "principal": "5097565959934582632",
+    "rate_bps": 6953,
+    "seconds": 2912832218,
+    "expected": "327373820000486432697",
+    "overflow": false
+  },
+  {
+    "principal": "3556445557608075169",
+    "rate_bps": 4422,
+    "seconds": 4163122107,
+    "expected": "207609606541347569943",
+    "overflow": false
+  },
+  {
+    "principal": "2925174377740066350",
+    "rate_bps": 7968,
+    "seconds": 2436119312,
+    "expected": "180049961882542818802",
+    "overflow": false
+  },
+  {
+    "principal": "4638349989418029855",
+    "rate_bps": 3867,
+    "seconds": 4160325481,
+    "expected": "236623780858494976663",
+    "overflow": false
+  },
+  {
+    "principal": "17690255722753713604",
+    "rate_bps": 1475,
+    "seconds": 1368817814,
+    "expected": "113257031082233239046",
+    "overflow": false
+  },
+  {
+    "principal": "12993734208977667501",
+    "rate_bps": 4689,
+    "seconds": 692125863,
+    "expected": "133718865326862224121",
+    "overflow": false
+  },
+  {
+    "principal": "11457412600675596202",
+    "rate_bps": 8777,
+    "seconds": 3353688300,
+    "expected": "1069421079348961715338",
+    "overflow": false
+  },
+  {
+    "principal": "5839444046867306187",
+    "rate_bps": 2987,
+    "seconds": 2681395957,
+    "expected": "148306801032578544211",
+    "overflow": false
+  },
+  {
+    "principal": "12963855686993742176",
+    "rate_bps": 2337,
+    "seconds": 1423791506,
+    "expected": "136783178366305238277",
+    "overflow": false
+  },
+  {
+    "principal": "16139232516236966393",
+    "rate_bps": 688,
+    "seconds": 1572746707,
+    "expected": "55376243841553402122",
+    "overflow": false
+  },
+  {
+    "principal": "12388443413242553446",
+    "rate_bps": 8398,
+    "seconds": 3680762888,
+    "expected": "1214293991949262115172",
+    "overflow": false
+  },
+  {
+    "principal": "16277000985453971127",
+    "rate_bps": 7994,
+    "seconds": 3249272001,
+    "expected": "1340657972085572879495",
+    "overflow": false
+  },
+  {
+    "principal": "1762471402509846076",
+    "rate_bps": 8778,
+    "seconds": 942073294,
+    "expected": "46216360383264375373",
+    "overflow": false
+  },
+  {
+    "principal": "7212304513232083077",
+    "rate_bps": 9818,
+    "seconds": 4066025279,
+    "expected": "912978499609387886251",
+    "overflow": false
+  },
+  {
+    "principal": "8976139807528894562",
+    "rate_bps": 1130,
+    "seconds": 3660169316,
+    "expected": "117723352342075876442",
+    "overflow": false
+  },
+  {
+    "principal": "13664810974893567715",
+    "rate_bps": 787,
+    "seconds": 3572187341,
+    "expected": "121816461768063141814",
+    "overflow": false
+  },
+  {
+    "principal": "16975052637625423960",
+    "rate_bps": 4642,
+    "seconds": 3713568074,
+    "expected": "927899729845876277467",
+    "overflow": false
+  },
+  {
+    "principal": "8432902156673224017",
+    "rate_bps": 2455,
+    "seconds": 972507371,
+    "expected": "63843230238246369746",
+    "overflow": false
+  },
+  {
+    "principal": "4036600940018722718",
+    "rate_bps": 5350,
+    "seconds": 4218880512,
+    "expected": "288908432163328911456",
+    "overflow": false
+  },
+  {
+    "principal": "17317173027989936975",
+    "rate_bps": 1373,
+    "seconds": 3114756889,
+    "expected": "234836220237392234206",
+    "overflow": false
+  },
+  {
+    "principal": "11500645896048327604",
+    "rate_bps": 2359,
+    "seconds": 553969670,
+    "expected": "47657313098950851827",
+    "overflow": false
+  },
+  {
+    "principal": "12539417605059724381",
+    "rate_bps": 3013,
+    "seconds": 3242426071,
+    "expected": "388454336068802390756",
+    "overflow": false
+  },
+  {
+    "principal": "12568629829610796570",
+    "rate_bps": 6477,
+    "seconds": 1122991324,
+    "expected": "289888926985379650133",
+    "overflow": false
+  },
+  {
+    "principal": "5017802116555446267",
+    "rate_bps": 4799,
+    "seconds": 2901630885,
+    "expected": "221564327283862624692",
+    "overflow": false
+  },
+  {
+    "principal": "15701152878274751568",
+    "rate_bps": 5757,
+    "seconds": 2267533826,
+    "expected": "649942503818654997797",
+    "overflow": false
+  },
+  {
+    "principal": "6509485699643763113",
+    "rate_bps": 9993,
+    "seconds": 4272475395,
+    "expected": "881283274784127838939",
+    "overflow": false
+  },
+  {
+    "principal": "9097509698227603414",
+    "rate_bps": 6618,
+    "seconds": 3178638584,
+    "expected": "606853462055665975228",
+    "overflow": false
+  },
+  {
+    "principal": "491516047452827879",
+    "rate_bps": 3213,
+    "seconds": 3882502769,
+    "expected": "19442566559416200069",
+    "overflow": false
+  },
+  {
+    "principal": "1415055931121182252",
+    "rate_bps": 421,
+    "seconds": 3609356094,
+    "expected": "6818342703743144714",
+    "overflow": false
+  },
+  {
+    "principal": "4189060430536206645",
+    "rate_bps": 473,
+    "seconds": 4202102639,
+    "expected": "26402060102774590850",
+    "overflow": false
+  },
+  {
+    "principal": "1888824910456125650",
+    "rate_bps": 9583,
+    "seconds": 1397313108,
+    "expected": "80201098369578083599",
+    "overflow": false
+  },
+  {
+    "principal": "14129199420977836563",
+    "rate_bps": 4846,
+    "seconds": 301700989,
+    "expected": "65504493295968950191",
+    "overflow": false
+  },
+  {
+    "principal": "10143882644296377672",
+    "rate_bps": 4076,
+    "seconds": 3270968250,
+    "expected": "428852664946507678326",
+    "overflow": false
+  },
+  {
+    "principal": "13511339529020010241",
+    "rate_bps": 387,
+    "seconds": 3142591003,
+    "expected": "52106347141044271928",
+    "overflow": false
+  },
+  {
+    "principal": "17267603608436729102",
+    "rate_bps": 3269,
+    "seconds": 1801346288,
+    "expected": "322431596091477975826",
+    "overflow": false
+  },
+  {
+    "principal": "3565806136882423679",
+    "rate_bps": 5800,
+    "seconds": 4244042441,
+    "expected": "278329239509075712898",
+    "overflow": false
+  },
+  {
+    "principal": "16863218270184859044",
+    "rate_bps": 9695,
+    "seconds": 4123345782,
+    "expected": "2137624527130582718636",
+    "overflow": false
+  },
+  {
+    "principal": "5134011599874025229",
+    "rate_bps": 9905,
+    "seconds": 2194964743,
+    "expected": "353942135799837702538",
+    "overflow": false
+  },
+  {
+    "principal": "6850810003055945866",
+    "rate_bps": 1292,
+    "seconds": 3690861772,
+    "expected": "103591855117290070890",
+    "overflow": false
+  },
+  {
+    "principal": "10827274579456449835",
+    "rate_bps": 5053,
+    "seconds": 1163413589,
+    "expected": "201834765353503571281",
+    "overflow": false
+  },
+  {
+    "principal": "17268478097167442752",
+    "rate_bps": 3991,
+    "seconds": 629539442,
+    "expected": "137578994068146672499",
+    "overflow": false
+  },
+  {
+    "principal": "5006544615508442457",
+    "rate_bps": 3052,
+    "seconds": 646883379,
+    "expected": "31343104134572481436",
+    "overflow": false
+  },
+  {
+    "principal": "5471379868910051142",
+    "rate_bps": 8471,
+    "seconds": 3835720168,
+    "expected": "563730923875997328503",
+    "overflow": false
+  },
+  {
+    "principal": "11496512902750641943",
+    "rate_bps": 8114,
+    "seconds": 3562259489,
+    "expected": "1053707520022177797637",
+    "overflow": false
+  },
+  {
+    "principal": "1364718306872941084",
+    "rate_bps": 7273,
+    "seconds": 67591342,
+    "expected": "2127360383084911165",
+    "overflow": false
+  },
+  {
+    "principal": "17763676361579503077",
+    "rate_bps": 3744,
+    "seconds": 287269791,
+    "expected": "60583176936231594177",
+    "overflow": false
+  },
+  {
+    "principal": "9325366200343127362",
+    "rate_bps": 5571,
+    "seconds": 755544132,
+    "expected": "124466444502546207133",
+    "overflow": false
+  },
+  {
+    "principal": "17571115548923935043",
+    "rate_bps": 7861,
+    "seconds": 1696715309,
+    "expected": "743155168253919630333",
+    "overflow": false
+  },
+  {
+    "principal": "16664996322298742328",
+    "rate_bps": 2907,
+    "seconds": 724086314,
+    "expected": "111233085914021213057",
+    "overflow": false
+  },
+  {
+    "principal": "12718939805768414385",
+    "rate_bps": 3024,
+    "seconds": 3081355083,
+    "expected": "375809573624833910551",
+    "overflow": false
+  },
+  {
+    "principal": "6604545715862197886",
+    "rate_bps": 5316,
+    "seconds": 94456800,
+    "expected": "10516096058672193181",
+    "overflow": false
+  },
+  {
+    "principal": "1202119541669623727",
+    "rate_bps": 9595,
+    "seconds": 2097880697,
+    "expected": "76730285863330972286",
+    "overflow": false
+  },
+  {
+    "principal": "5133806402638635924",
+    "rate_bps": 4742,
+    "seconds": 1616286438,
+    "expected": "124770742295234511263",
+    "overflow": false
+  },
+  {
+    "principal": "7711587364331417021",
+    "rate_bps": 521,
+    "seconds": 2407466807,
+    "expected": "30671513531333490802",
+    "overflow": false
+  },
+  {
+    "principal": "6867535315122458362",
+    "rate_bps": 4461,
+    "seconds": 1696071868,
+    "expected": "164767202633727079417",
+    "overflow": false
+  },
+  {
+    "principal": "3472475285883512411",
+    "rate_bps": 3436,
+    "seconds": 2176095493,
+    "expected": "82331051327533399028",
+    "overflow": false
+  },
+  {
+    "principal": "2928437772924235312",
+    "rate_bps": 6944,
+    "seconds": 3410421474,
+    "expected": "219911104346384565258",
+    "overflow": false
+  },
+  {
+    "principal": "10623772410407695625",
+    "rate_bps": 5905,
+    "seconds": 3490367331,
+    "expected": "694325616581166246223",
+    "overflow": false
+  },
+  {
+    "principal": "1911640325082163894",
+    "rate_bps": 5549,
+    "seconds": 1597623000,
+    "expected": "53738879305986615144",
+    "overflow": false
+  },
+  {
+    "principal": "4279202857177665863",
+    "rate_bps": 2042,
+    "seconds": 3651887569,
+    "expected": "101188091333478467768",
+    "overflow": false
+  },
+  {
+    "principal": "3164112849013531148",
+    "rate_bps": 8585,
+    "seconds": 4227122718,
+    "expected": "364108244657785324907",
+    "overflow": false
+  },
+  {
+    "principal": "12642543231031916181",
+    "rate_bps": 1113,
+    "seconds": 2365508559,
+    "expected": "105547397315619606160",
+    "overflow": false
+  },
+  {
+    "principal": "796209177281693106",
+    "rate_bps": 7027,
+    "seconds": 286189108,
+    "expected": "5077426281829585764",
+    "overflow": false
+  },
+  {
+    "principal": "16441827036608971891",
+    "rate_bps": 7761,
+    "seconds": 1127280861,
+    "expected": "456134882032259547134",
+    "overflow": false
+  },
+  {
+    "principal": "2058267762075138856",
+    "rate_bps": 3189,
+    "seconds": 3688664218,
+    "expected": "76774837706110737817",
+    "overflow": false
+  },
+  {
+    "principal": "13402099966786051681",
+    "rate_bps": 3167,
+    "seconds": 4106166395,
+    "expected": "552650864683702554107",
+    "overflow": false
+  },
+  {
+    "principal": "3115898229031713774",
+    "rate_bps": 5955,
+    "seconds": 1043779280,
+    "expected": "61413958998793898790",
+    "overflow": false
+  },
+  {
+    "principal": "11624563093324106719",
+    "rate_bps": 3000,
+    "seconds": 3443977769,
+    "expected": "380847953460293910312",
+    "overflow": false
+  },
+  {
+    "principal": "8908873009476056452",
+    "rate_bps": 9179,
+    "seconds": 3866613334,
+    "expected": "1002633648679254218457",
+    "overflow": false
+  },
+  {
+    "principal": "14829507637075957869",
+    "rate_bps": 2706,
+    "seconds": 3205370215,
+    "expected": "407874086747188652505",
+    "overflow": false
+  },
+  {
+    "principal": "9104114978041211242",
+    "rate_bps": 6966,
+    "seconds": 461652140,
+    "expected": "92838785436990134412",
+    "overflow": false
+  },
+  {
+    "principal": "14413590425431978891",
+    "rate_bps": 8784,
+    "seconds": 519783861,
+    "expected": "208679932700650073712",
+    "overflow": false
+  },
+  {
+    "principal": "1385170879192796448",
+    "rate_bps": 7631,
+    "seconds": 1157201746,
+    "expected": "38787097292856377938",
+    "overflow": false
+  },
+  {
+    "principal": "15525681244462813369",
+    "rate_bps": 2226,
+    "seconds": 402139795,
+    "expected": "44070326773969240151",
+    "overflow": false
+  },
+  {
+    "principal": "346484107279395366",
+    "rate_bps": 8782,
+    "seconds": 47790024,
+    "expected": "461113028772078645",
+    "overflow": false
+  },
+  {
+    "principal": "153605451188701047",
+    "rate_bps": 5588,
+    "seconds": 4176749441,
+    "expected": "11368282101656303365",
+    "overflow": false
+  },
+  {
+    "principal": "18110297620760215036",
+    "rate_bps": 7314,
+    "seconds": 2840175502,
+    "expected": "1192941408158034402048",
+    "overflow": false
+  },
+  {
+    "principal": "3212774460727931717",
+    "rate_bps": 5032,
+    "seconds": 2466265087,
+    "expected": "126431129934073777955",
+    "overflow": false
+  },
+  {
+    "principal": "8178320775680612898",
+    "rate_bps": 8054,
+    "seconds": 205713444,
+    "expected": "42966683637724477244",
+    "overflow": false
+  },
+  {
+    "principal": "16471932919137538979",
+    "rate_bps": 1899,
+    "seconds": 490468237,
+    "expected": "48648987975270509019",
+    "overflow": false
+  },
+  {
+    "principal": "2167980350604919832",
+    "rate_bps": 1532,
+    "seconds": 71409418,
+    "expected": "752078188389485586",
+    "overflow": false
+  },
+  {
+    "principal": "2127479347348007953",
+    "rate_bps": 3555,
+    "seconds": 4069213611,
+    "expected": "97590791305742429590",
+    "overflow": false
+  },
+  {
+    "principal": "4564564540686701918",
+    "rate_bps": 7552,
+    "seconds": 3361072576,
+    "expected": "367394471535651949850",
+    "overflow": false
+  },
+  {
+    "principal": "16130341494480118799",
+    "rate_bps": 5848,
+    "seconds": 156066265,
+    "expected": "46682419376189247041",
+    "overflow": false
+  },
+  {
+    "principal": "1328599781833530228",
+    "rate_bps": 8478,
+    "seconds": 1932004806,
+    "expected": "69006370326919573135",
+    "overflow": false
+  },
+  {
+    "principal": "75876476565923613",
+    "rate_bps": 6082,
+    "seconds": 3482099607,
+    "expected": "5095515823888271229",
+    "overflow": false
+  },
+  {
+    "principal": "297761921878095834",
+    "rate_bps": 173,
+    "seconds": 2546586780,
+    "expected": "415974908912646596",
+    "overflow": false
+  },
+  {
+    "principal": "15926233319808124091",
+    "rate_bps": 4550,
+    "seconds": 778000997,
+    "expected": "178771390080407466962",
+    "overflow": false
+  },
+  {
+    "principal": "10530464923095105552",
+    "rate_bps": 6802,
+    "seconds": 7130050,
+    "expected": "1619459687887705411",
+    "overflow": false
+  },
+  {
+    "principal": "10258179764137660521",
+    "rate_bps": 6104,
+    "seconds": 1836175811,
+    "expected": "364579701698904959154",
+    "overflow": false
+  },
+  {
+    "principal": "1035709328737705366",
+    "rate_bps": 2230,
+    "seconds": 1549121720,
+    "expected": "11345448983263143806",
+    "overflow": false
+  },
+  {
+    "principal": "8701750598912197031",
+    "rate_bps": 4397,
+    "seconds": 2482047281,
+    "expected": "301138678818577836291",
+    "overflow": false
+  },
+  {
+    "principal": "6325035490749345260",
+    "rate_bps": 8841,
+    "seconds": 329577726,
+    "expected": "58440726109152732003",
+    "overflow": false
+  },
+  {
+    "principal": "15206233375003546613",
+    "rate_bps": 187,
+    "seconds": 1179559983,
+    "expected": "10635959662942578020",
+    "overflow": false
+  },
+  {
+    "principal": "614217355341685394",
+    "rate_bps": 3131,
+    "seconds": 2127285780,
+    "expected": "12972520970791334929",
+    "overflow": false
+  },
+  {
+    "principal": "2982211264574039763",
+    "rate_bps": 1128,
+    "seconds": 278256189,
+    "expected": "2968149226776440000",
+    "overflow": false
+  },
+  {
+    "principal": "3734846494889746696",
+    "rate_bps": 5556,
+    "seconds": 2898716026,
+    "expected": "190736609485772640749",
+    "overflow": false
+  },
+  {
+    "principal": "5481663103965289921",
+    "rate_bps": 9109,
+    "seconds": 457780955,
+    "expected": "72482665659253219447",
+    "overflow": false
+  },
+  {
+    "principal": "17554013265673741006",
+    "rate_bps": 1460,
+    "seconds": 2255851696,
+    "expected": "183329863874891700143",
+    "overflow": false
+  },
+  {
+    "principal": "16596775723957043263",
+    "rate_bps": 8456,
+    "seconds": 2231466377,
+    "expected": "993053028242346880604",
+    "overflow": false
+  },
+  {
+    "principal": "12706650087199200612",
+    "rate_bps": 1464,
+    "seconds": 3332782390,
+    "expected": "196595013579686230862",
+    "overflow": false
+  },
+  {
+    "principal": "14432681518817040845",
+    "rate_bps": 226,
+    "seconds": 2504372679,
+    "expected": "25902865935369097086",
+    "overflow": false
+  },
+  {
+    "principal": "2915393866023336522",
+    "rate_bps": 5919,
+    "seconds": 3182410892,
+    "expected": "174138669094133733504",
+    "overflow": false
+  },
+  {
+    "principal": "13826495401438550507",
+    "rate_bps": 9701,
+    "seconds": 3310605077,
+    "expected": "1408086672485836562071",
+    "overflow": false
+  },
+  {
+    "principal": "15451923779744433920",
+    "rate_bps": 2073,
+    "seconds": 2091895858,
+    "expected": "212478656857958030446",
+    "overflow": false
+  },
+  {
+    "principal": "1757280387869258777",
+    "rate_bps": 9312,
+    "seconds": 3251813619,
+    "expected": "168734181088116052968",
+    "overflow": false
+  },
+  {
+    "principal": "14615088079885452550",
+    "rate_bps": 1851,
+    "seconds": 2680573352,
+    "expected": "229947633679542705890",
+    "overflow": false
+  },
+  {
+    "principal": "15111231194862288855",
+    "rate_bps": 760,
+    "seconds": 480580321,
+    "expected": "17501401119775559899",
+    "overflow": false
+  },
+  {
+    "principal": "17565197327541367260",
+    "rate_bps": 7997,
+    "seconds": 3487939182,
+    "expected": "1553611494692893521905",
+    "overflow": false
+  },
+  {
+    "principal": "5546505723540396197",
+    "rate_bps": 1427,
+    "seconds": 4166327391,
+    "expected": "104565935102432906980",
+    "overflow": false
+  },
+  {
+    "principal": "11459454334215626498",
+    "rate_bps": 8519,
+    "seconds": 202407940,
+    "expected": "62657562282846653072",
+    "overflow": false
+  },
+  {
+    "principal": "15630558696472575491",
+    "rate_bps": 9880,
+    "seconds": 2530321645,
+    "expected": "1239083488749683295243",
+    "overflow": false
+  },
+  {
+    "principal": "16933225699849015800",
+    "rate_bps": 83,
+    "seconds": 656105450,
+    "expected": "2924050223310924929",
+    "overflow": false
+  },
+  {
+    "principal": "9990546928061805425",
+    "rate_bps": 8643,
+    "seconds": 4084456459,
+    "expected": "1118359525021037435932",
+    "overflow": false
+  },
+  {
+    "principal": "13212262721519985726",
+    "rate_bps": 4293,
+    "seconds": 2051854240,
+    "expected": "369043863727569417046",
+    "overflow": false
+  },
+  {
+    "principal": "5468015983354994799",
+    "rate_bps": 7070,
+    "seconds": 2089170233,
+    "expected": "256104029419628024302",
+    "overflow": false
+  },
+  {
+    "principal": "1561384492303852372",
+    "rate_bps": 5171,
+    "seconds": 3866187942,
+    "expected": "98983032385961317042",
+    "overflow": false
+  },
+  {
+    "principal": "1406486549376036989",
+    "rate_bps": 5669,
+    "seconds": 717506551,
+    "expected": "18141003366938578529",
+    "overflow": false
+  },
+  {
+    "principal": "12834131277470675130",
+    "rate_bps": 294,
+    "seconds": 2889676924,
+    "expected": "34574546358687003414",
+    "overflow": false
+  },
+  {
+    "principal": "13882571439922524955",
+    "rate_bps": 383,
+    "seconds": 2911612869,
+    "expected": "49090303182103560313",
+    "overflow": false
+  },
+  {
+    "principal": "6490374217254642160",
+    "rate_bps": 4838,
+    "seconds": 3121709218,
+    "expected": "310828935901060605483",
+    "overflow": false
+  },
+  {
+    "principal": "9941842791792737225",
+    "rate_bps": 3764,
+    "seconds": 3098930211,
+    "expected": "367723762539949892934",
+    "overflow": false
+  },
+  {
+    "principal": "13427336794905927798",
+    "rate_bps": 8792,
+    "seconds": 2558654104,
+    "expected": "957816984406083410483",
+    "overflow": false
+  },
+  {
+    "principal": "7942798022101778951",
+    "rate_bps": 4735,
+    "seconds": 3310567569,
+    "expected": "394811097690193071377",
+    "overflow": false
+  },
+  {
+    "principal": "16845334673431644620",
+    "rate_bps": 6497,
+    "seconds": 1881863134,
+    "expected": "653091359458852262468",
+    "overflow": false
+  },
+  {
+    "principal": "4083296888745722197",
+    "rate_bps": 319,
+    "seconds": 1488884879,
+    "expected": "6149731478705857073",
+    "overflow": false
+  },
+  {
+    "principal": "13884048492501241714",
+    "rate_bps": 1657,
+    "seconds": 2327315956,
+    "expected": "169780328822357126516",
+    "overflow": false
+  },
+  {
+    "principal": "14486978761095420211",
+    "rate_bps": 1955,
+    "seconds": 901927837,
+    "expected": "81000886014332116496",
+    "overflow": false
+  },
+  {
+    "principal": "7398085771974678248",
+    "rate_bps": 7555,
+    "seconds": 2116947546,
+    "expected": "375195240912605252005",
+    "overflow": false
+  },
+  {
+    "principal": "11753306859103104289",
+    "rate_bps": 1978,
+    "seconds": 1237732667,
+    "expected": "91244481700243662075",
+    "overflow": false
+  },
+  {
+    "principal": "17212873601530354094",
+    "rate_bps": 2624,
+    "seconds": 3033703056,
+    "expected": "434493888817387888617",
+    "overflow": false
+  },
+  {
+    "principal": "3129998518134211743",
+    "rate_bps": 6753,
+    "seconds": 3292435689,
+    "expected": "220674207391338995149",
+    "overflow": false
+  },
+  {
+    "principal": "8091142290323817796",
+    "rate_bps": 9400,
+    "seconds": 2370333718,
+    "expected": "571663652480240773488",
+    "overflow": false
+  },
+  {
+    "principal": "5339370143297268525",
+    "rate_bps": 1202,
+    "seconds": 550724135,
+    "expected": "11207841972164768949",
+    "overflow": false
+  },
+  {
+    "principal": "9863872170205387562",
+    "rate_bps": 1521,
+    "seconds": 2914551916,
+    "expected": "138657012358785707279",
+    "overflow": false
+  },
+  {
+    "principal": "9718577606464442443",
+    "rate_bps": 8325,
+    "seconds": 351924341,
+    "expected": "90287920038282806169",
+    "overflow": false
+  },
+  {
+    "principal": "2275004913538420960",
+    "rate_bps": 394,
+    "seconds": 2854283538,
+    "expected": "8112768185537925992",
+    "overflow": false
+  },
+  {
+    "principal": "2917022328066566009",
+    "rate_bps": 485,
+    "seconds": 3623247699,
+    "expected": "16254473625310508876",
+    "overflow": false
+  },
+  {
+    "principal": "3099615256604798950",
+    "rate_bps": 8428,
+    "seconds": 2568991624,
+    "expected": "212808219511511855071",
+    "overflow": false
+  },
+  {
+    "principal": "15449296686327957559",
+    "rate_bps": 675,
+    "seconds": 813601345,
+    "expected": "26904042301584908778",
+    "overflow": false
+  },
+  {
+    "principal": "8643763183918151100",
+    "rate_bps": 5986,
+    "seconds": 4090732878,
+    "expected": "671172396338008150090",
+    "overflow": false
+  },
+  {
+    "principal": "5003603003337772549",
+    "rate_bps": 9300,
+    "seconds": 2775978175,
+    "expected": "409614416611999021331",
+    "overflow": false
+  },
+  {
+    "principal": "5565900573634606050",
+    "rate_bps": 4531,
+    "seconds": 4104740836,
+    "expected": "328252952632855128574",
+    "overflow": false
+  },
+  {
+    "principal": "12439200416434190435",
+    "rate_bps": 1462,
+    "seconds": 796583501,
+    "expected": "45937201854978067687",
+    "overflow": false
+  },
+  {
+    "principal": "7825241920872067032",
+    "rate_bps": 2188,
+    "seconds": 3861770442,
+    "expected": "209664516863053133894",
+    "overflow": false
+  },
+  {
+    "principal": "8994680762242501329",
+    "rate_bps": 5201,
+    "seconds": 1731953259,
+    "expected": "256922517116243191890",
+    "overflow": false
+  },
+  {
+    "principal": "7697815670571369246",
+    "rate_bps": 741,
+    "seconds": 1178470784,
+    "expected": "21315618003151394873",
+    "overflow": false
+  },
+  {
+    "principal": "7746224828121984207",
+    "rate_bps": 4646,
+    "seconds": 2026739865,
+    "expected": "231292050512258062265",
+    "overflow": false
+  },
+  {
+    "principal": "15794413917017226036",
+    "rate_bps": 4590,
+    "seconds": 2603250566,
+    "expected": "598446822324424059990",
+    "overflow": false
+  },
+  {
+    "principal": "8735204689570384349",
+    "rate_bps": 1266,
+    "seconds": 2927493207,
+    "expected": "102658775768446709841",
+    "overflow": false
+  },
+  {
+    "principal": "1152980896158824858",
+    "rate_bps": 5049,
+    "seconds": 665414748,
+    "expected": "12283250179041551389",
+    "overflow": false
+  },
+  {
+    "principal": "5328786129258623355",
+    "rate_bps": 55,
+    "seconds": 1037145381,
+    "expected": "963882311061516232",
+    "overflow": false
+  },
+  {
+    "principal": "6647136649665123280",
+    "rate_bps": 8220,
+    "seconds": 2678916482,
+    "expected": "464150680794996141427",
+    "overflow": false
+  },
+  {
+    "principal": "14561079299805738793",
+    "rate_bps": 4656,
+    "seconds": 3081705091,
+    "expected": "662507817997048382540",
+    "overflow": false
+  },
+  {
+    "principal": "16795780979420066646",
+    "rate_bps": 5843,
+    "seconds": 1802929272,
+    "expected": "561058533203582367473",
+    "overflow": false
+  },
+  {
+    "principal": "16840571236005991015",
+    "rate_bps": 4877,
+    "seconds": 552208369,
+    "expected": "143815584849564118566",
+    "overflow": false
+  },
+  {
+    "principal": "13165064142412871084",
+    "rate_bps": 2271,
+    "seconds": 931054270,
+    "expected": "88269060243106597568",
+    "overflow": false
+  },
+  {
+    "principal": "3701342554548207285",
+    "rate_bps": 7406,
+    "seconds": 3668349167,
+    "expected": "318865143928443545467",
+    "overflow": false
+  },
+  {
+    "principal": "6763637915650133074",
+    "rate_bps": 4175,
+    "seconds": 1460374996,
+    "expected": "130765931387951302323",
+    "overflow": false
+  },
+  {
+    "principal": "17798281581206412179",
+    "rate_bps": 5447,
+    "seconds": 843996413,
+    "expected": "259459419769535055046",
+    "overflow": false
+  },
+  {
+    "principal": "3393178580439555272",
+    "rate_bps": 872,
+    "seconds": 747243322,
+    "expected": "7010978532977468992",
+    "overflow": false
+  },
+  {
+    "principal": "1507666955631496321",
+    "rate_bps": 1257,
+    "seconds": 1057913755,
+    "expected": "6357470459710074452",
+    "overflow": false
+  },
+  {
+    "principal": "41465994517684366",
+    "rate_bps": 8737,
+    "seconds": 772146288,
+    "expected": "887048575249158613",
+    "overflow": false
+  },
+  {
+    "principal": "18228577988144388351",
+    "rate_bps": 2663,
+    "seconds": 2937471049,
+    "expected": "452158755830111309019",
+    "overflow": false
+  },
+  {
+    "principal": "16981782298157516068",
+    "rate_bps": 7398,
+    "seconds": 2237034230,
+    "expected": "891176280029441922002",
+    "overflow": false
+  },
+  {
+    "principal": "16548381928736361613",
+    "rate_bps": 6352,
+    "seconds": 3775865479,
+    "expected": "1258565815882047547687",
+    "overflow": false
+  },
+  {
+    "principal": "2683776758951742474",
+    "rate_bps": 8689,
+    "seconds": 2329322572,
+    "expected": "172242060854439034515",
+    "overflow": false
+  },
+  {
+    "principal": "7644173138516776619",
+    "rate_bps": 4158,
+    "seconds": 780508629,
+    "expected": "78665825069527644478",
+    "overflow": false
+  },
+  {
+    "principal": "4923290751332903616",
+    "rate_bps": 5881,
+    "seconds": 3200570866,
+    "expected": "293851224280492180960",
+    "overflow": false
+  },
+  {
+    "principal": "9734563427505810137",
+    "rate_bps": 7621,
+    "seconds": 842731955,
+    "expected": "198249132611521408104",
+    "overflow": false
+  },
+  {
+    "principal": "9545830276731529926",
+    "rate_bps": 9087,
+    "seconds": 1084057960,
+    "expected": "298181113532079034569",
+    "overflow": false
+  },
+  {
+    "principal": "7378785917863305367",
+    "rate_bps": 2871,
+    "seconds": 697868705,
+    "expected": "46879742682017948328",
+    "overflow": false
+  },
+  {
+    "principal": "12151258586363709852",
+    "rate_bps": 1862,
+    "seconds": 1695242286,
+    "expected": "121625911937134476069",
+    "overflow": false
+  },
+  {
+    "principal": "1056555299058144101",
+    "rate_bps": 4254,
+    "seconds": 3803911455,
+    "expected": "54214257014728150024",
+    "overflow": false
+  },
+  {
+    "principal": "7574498560206411970",
+    "rate_bps": 1037,
+    "seconds": 3259338692,
+    "expected": "81181211663752140067",
+    "overflow": false
+  },
+  {
+    "principal": "11133697424047473347",
+    "rate_bps": 5450,
+    "seconds": 147830701,
+    "expected": "28444214571624923008",
+    "overflow": false
+  },
+  {
+    "principal": "6275396433637711288",
+    "rate_bps": 6514,
+    "seconds": 670126506,
+    "expected": "86863857149771661542",
+    "overflow": false
+  },
+  {
+    "principal": "17133161967436444209",
+    "rate_bps": 7187,
+    "seconds": 2663004363,
+    "expected": "1039801492285672536320",
+    "overflow": false
+  },
+  {
+    "principal": "16628976584920347134",
+    "rate_bps": 2812,
+    "seconds": 1256297312,
+    "expected": "186280185505039312563",
+    "overflow": false
+  },
+  {
+    "principal": "7257470596631169327",
+    "rate_bps": 6882,
+    "seconds": 607882233,
+    "expected": "96274837989862273946",
+    "overflow": false
+  },
+  {
+    "principal": "5023035614698447636",
+    "rate_bps": 4199,
+    "seconds": 3326828134,
+    "expected": "222503010109914419111",
+    "overflow": false
+  },
+  {
+    "principal": "15407646812032054077",
+    "rate_bps": 2338,
+    "seconds": 3423717559,
+    "expected": "391085887626455220831",
+    "overflow": false
+  },
+  {
+    "principal": "6411259447575679610",
+    "rate_bps": 1690,
+    "seconds": 1128738876,
+    "expected": "38780815108433572622",
+    "overflow": false
+  },
+  {
+    "principal": "1061553591556554715",
+    "rate_bps": 4578,
+    "seconds": 1640565381,
+    "expected": "25281605388677965091",
+    "overflow": false
+  },
+  {
+    "principal": "530928483285554608",
+    "rate_bps": 6255,
+    "seconds": 1823955554,
+    "expected": "19207506259318237134",
+    "overflow": false
+  },
+  {
+    "principal": "6675861176792056457",
+    "rate_bps": 9557,
+    "seconds": 2486522083,
+    "expected": "503053988512877310171",
+    "overflow": false
+  },
+  {
+    "principal": "16405610395580388918",
+    "rate_bps": 1736,
+    "seconds": 2699780696,
+    "expected": "243817006714926791592",
+    "overflow": false
+  },
+  {
+    "principal": "2783881860299190983",
+    "rate_bps": 9459,
+    "seconds": 1573740369,
+    "expected": "131408211662377787861",
+    "overflow": false
+  },
+  {
+    "principal": "8631446249191469452",
+    "rate_bps": 9338,
+    "seconds": 1670930846,
+    "expected": "427060406763897258891",
+    "overflow": false
+  },
+  {
+    "principal": "11460198743246375957",
+    "rate_bps": 5959,
+    "seconds": 3328089423,
+    "expected": "720698992015851777703",
+    "overflow": false
+  },
+  {
+    "principal": "13398095262850636082",
+    "rate_bps": 5283,
+    "seconds": 972973492,
+    "expected": "218382620732993351068",
+    "overflow": false
+  },
+  {
+    "principal": "14080511450507881971",
+    "rate_bps": 3587,
+    "seconds": 1238496861,
+    "expected": "198352697037662911732",
+    "overflow": false
+  },
+  {
+    "principal": "14000251933976752808",
+    "rate_bps": 8948,
+    "seconds": 676515866,
+    "expected": "268740552507619330114",
+    "overflow": false
+  },
+  {
+    "principal": "6394911484208806881",
+    "rate_bps": 9447,
+    "seconds": 1576647163,
+    "expected": "302034365353640413539",
+    "overflow": false
+  },
+  {
+    "principal": "7021345002016454510",
+    "rate_bps": 5274,
+    "seconds": 1254602320,
+    "expected": "147319392044048105729",
+    "overflow": false
+  },
+  {
+    "principal": "9800621315298966879",
+    "rate_bps": 3022,
+    "seconds": 3986717609,
+    "expected": "374418187281899879439",
+    "overflow": false
+  },
+  {
+    "principal": "13191971616345756932",
+    "rate_bps": 8615,
+    "seconds": 1304969686,
+    "expected": "470282487138000426768",
+    "overflow": false
+  },
+  {
+    "principal": "10049048141246905837",
+    "rate_bps": 9955,
+    "seconds": 3109090023,
+    "expected": "986263319307228602032",
+    "overflow": false
+  },
+  {
+    "principal": "1055335538306174186",
+    "rate_bps": 4049,
+    "seconds": 2822901804,
+    "expected": "38249653414478125179",
+    "overflow": false
+  },
+  {
+    "principal": "3784622711010372875",
+    "rate_bps": 2065,
+    "seconds": 1989073717,
+    "expected": "49293189396480592491",
+    "overflow": false
+  },
+  {
+    "principal": "4264934041383097504",
+    "rate_bps": 4258,
+    "seconds": 3222508242,
+    "expected": "185568990853497591791",
+    "overflow": false
+  },
+  {
+    "principal": "12596637183196560953",
+    "rate_bps": 594,
+    "seconds": 3430470675,
+    "expected": "81393208744225078118",
+    "overflow": false
+  },
+  {
+    "principal": "13205911480004326822",
+    "rate_bps": 263,
+    "seconds": 1542942536,
+    "expected": "16992891141635874526",
+    "overflow": false
+  },
+  {
+    "principal": "11178042310858557687",
+    "rate_bps": 3632,
+    "seconds": 17514753,
+    "expected": "2254805051867060693",
+    "overflow": false
+  },
+  {
+    "principal": "16072336231768681852",
+    "rate_bps": 5025,
+    "seconds": 1199890190,
+    "expected": "307291092208193996416",
+    "overflow": false
+  },
+  {
+    "principal": "4698742000911952069",
+    "rate_bps": 5747,
+    "seconds": 3699124607,
+    "expected": "316748925701594691759",
+    "overflow": false
+  },
+  {
+    "principal": "14925196072303971746",
+    "rate_bps": 3706,
+    "seconds": 2770145188,
+    "expected": "485871455020232374063",
+    "overflow": false
+  },
+  {
+    "principal": "10226842690595167523",
+    "rate_bps": 3741,
+    "seconds": 141039885,
+    "expected": "17110575704835496215",
+    "overflow": false
+  },
+  {
+    "principal": "6706571325926955928",
+    "rate_bps": 3951,
+    "seconds": 1725792906,
+    "expected": "145007227815181055595",
+    "overflow": false
+  },
+  {
+    "principal": "10991853107141142929",
+    "rate_bps": 5429,
+    "seconds": 2395471659,
+    "expected": "453289007910961931157",
+    "overflow": false
+  },
+  {
+    "principal": "17587420565871571166",
+    "rate_bps": 742,
+    "seconds": 2599382336,
+    "expected": "107564660461724465397",
+    "overflow": false
+  },
+  {
+    "principal": "16308967088589927823",
+    "rate_bps": 700,
+    "seconds": 686296921,
+    "expected": "24844481634680115384",
+    "overflow": false
+  },
+  {
+    "principal": "11398066839433796340",
+    "rate_bps": 4621,
+    "seconds": 4039907654,
+    "expected": "674733074035268001639",
+    "overflow": false
+  },
+  {
+    "principal": "13151205597272583325",
+    "rate_bps": 3395,
+    "seconds": 1490526487,
+    "expected": "211027200172012018564",
+    "overflow": false
+  },
+  {
+    "principal": "7647336502621125466",
+    "rate_bps": 6655,
+    "seconds": 3964552220,
+    "expected": "639802298853451081351",
+    "overflow": false
+  },
+  {
+    "principal": "4307483935736028731",
+    "rate_bps": 2761,
+    "seconds": 3758755813,
+    "expected": "141751472478926120156",
+    "overflow": false
+  },
+  {
+    "principal": "1168200651370915728",
+    "rate_bps": 3165,
+    "seconds": 4037574466,
+    "expected": "47337475863798182900",
+    "overflow": false
+  },
+  {
+    "principal": "2987006270341488105",
+    "rate_bps": 6801,
+    "seconds": 2619382595,
+    "expected": "168733470684032620400",
+    "overflow": false
+  },
+  {
+    "principal": "11084056979548145942",
+    "rate_bps": 5820,
+    "seconds": 2023264312,
+    "expected": "413873622742150860789",
+    "overflow": false
+  },
+  {
+    "principal": "2311882847412855591",
+    "rate_bps": 6168,
+    "seconds": 924141233,
+    "expected": "41787070787369442698",
+    "overflow": false
+  },
+  {
+    "principal": "8359753541673008492",
+    "rate_bps": 9896,
+    "seconds": 3262107774,
+    "expected": "855745962710508377931",
+    "overflow": false
+  },
+  {
+    "principal": "2389578766949263733",
+    "rate_bps": 5200,
+    "seconds": 4198414767,
+    "expected": "165425870328390062345",
+    "overflow": false
+  },
+  {
+    "principal": "5563444750103016978",
+    "rate_bps": 2785,
+    "seconds": 3184037268,
+    "expected": "156437373010088989785",
+    "overflow": false
+  },
+  {
+    "principal": "4115210593089671251",
+    "rate_bps": 6448,
+    "seconds": 2212831165,
+    "expected": "186191034963143792393",
+    "overflow": false
+  },
+  {
+    "principal": "768274543217072264",
+    "rate_bps": 6794,
+    "seconds": 1979738362,
+    "expected": "32767490130703170410",
+    "overflow": false
+  },
+  {
+    "principal": "7573178695721941825",
+    "rate_bps": 1814,
+    "seconds": 2908751963,
+    "expected": "126711365083581919285",
+    "overflow": false
+  },
+  {
+    "principal": "12910910268458212942",
+    "rate_bps": 8392,
+    "seconds": 1473230896,
+    "expected": "506158517154290511848",
+    "overflow": false
+  },
+  {
+    "principal": "9771133868810351039",
+    "rate_bps": 7727,
+    "seconds": 2884978441,
+    "expected": "690703792692325596773",
+    "overflow": false
+  },
+  {
+    "principal": "13507712981999252708",
+    "rate_bps": 2282,
+    "seconds": 3650479286,
+    "expected": "356813062977845023109",
+    "overflow": false
+  },
+  {
+    "principal": "10567949270376578893",
+    "rate_bps": 9122,
+    "seconds": 4042314567,
+    "expected": "1235675077672106641356",
+    "overflow": false
+  },
+  {
+    "principal": "17200163303215586762",
+    "rate_bps": 2216,
+    "seconds": 221432844,
+    "expected": "26763182609493731530",
+    "overflow": false
+  },
+  {
+    "principal": "15546023865276388203",
+    "rate_bps": 8268,
+    "seconds": 2511186069,
+    "expected": "1023509986568853106362",
+    "overflow": false
+  },
+  {
+    "principal": "14415776068428959360",
+    "rate_bps": 6095,
+    "seconds": 3347390386,
+    "expected": "932634538875747456554",
+    "overflow": false
+  },
+  {
+    "principal": "8413707021674701209",
+    "rate_bps": 4429,
+    "seconds": 3330778739,
+    "expected": "393579293946344415051",
+    "overflow": false
+  },
+  {
+    "principal": "12821579291842171014",
+    "rate_bps": 3644,
+    "seconds": 619037992,
+    "expected": "91712934054689014810",
+    "overflow": false
+  },
+  {
+    "principal": "14869979512717836631",
+    "rate_bps": 7328,
+    "seconds": 3018748001,
+    "expected": "1043076315852307910722",
+    "overflow": false
+  },
+  {
+    "principal": "10990796808053481820",
+    "rate_bps": 3585,
+    "seconds": 2469934574,
+    "expected": "308600895103349153196",
+    "overflow": false
+  },
+  {
+    "principal": "17531033942609628709",
+    "rate_bps": 7662,
+    "seconds": 2735820255,
+    "expected": "1165280910357488172169",
+    "overflow": false
+  },
+  {
+    "principal": "488313805938283138",
+    "rate_bps": 1834,
+    "seconds": 23584644,
+    "expected": "66976284688307431",
+    "overflow": false
+  },
+  {
+    "principal": "4878597581483034499",
+    "rate_bps": 7346,
+    "seconds": 3621522029,
+    "expected": "411557428029899422698",
+    "overflow": false
+  },
+  {
+    "principal": "4886682537330633080",
+    "rate_bps": 2907,
+    "seconds": 2976547690,
+    "expected": "134080430613479212195",
+    "overflow": false
+  },
+  {
+    "principal": "11590730234638643441",
+    "rate_bps": 1122,
+    "seconds": 3493647755,
+    "expected": "144070864916123611494",
+    "overflow": false
+  },
+  {
+    "principal": "6683966250670882750",
+    "rate_bps": 5357,
+    "seconds": 1025480480,
+    "expected": "116433160373245815164",
+    "overflow": false
+  },
+  {
+    "principal": "2646591368609001967",
+    "rate_bps": 4939,
+    "seconds": 3035308729,
+    "expected": "125812033489654581165",
+    "overflow": false
+  },
+  {
+    "principal": "5588652606586315476",
+    "rate_bps": 3781,
+    "seconds": 4154762278,
+    "expected": "278389829382824135035",
+    "overflow": false
+  },
+  {
+    "principal": "13888090932750136829",
+    "rate_bps": 9270,
+    "seconds": 2384955767,
+    "expected": "973634618708999242019",
+    "overflow": false
+  },
+  {
+    "principal": "3882971939250091066",
+    "rate_bps": 1224,
+    "seconds": 3287721980,
+    "expected": "49548914901992633550",
+    "overflow": false
+  },
+  {
+    "principal": "8683744835443952795",
+    "rate_bps": 4037,
+    "seconds": 3274483013,
+    "expected": "364000464500277968041",
+    "overflow": false
+  },
+  {
+    "principal": "1851480515340061040",
+    "rate_bps": 4406,
+    "seconds": 251163682,
+    "expected": "6497015052226662037",
+    "overflow": false
+  },
+  {
+    "principal": "12875227497963899209",
+    "rate_bps": 5941,
+    "seconds": 1095300515,
+    "expected": "265669163813818056618",
+    "overflow": false
+  },
+  {
+    "principal": "18138316609535970294",
+    "rate_bps": 6677,
+    "seconds": 2788560408,
+    "expected": "1070907116566183393726",
+    "overflow": false
+  },
+  {
+    "principal": "7221021442637161351",
+    "rate_bps": 1781,
+    "seconds": 1809432081,
+    "expected": "73790122816310916874",
+    "overflow": false
+  },
+  {
+    "principal": "2321503098278598988",
+    "rate_bps": 9377,
+    "seconds": 4127002462,
+    "expected": "284879569676030818508",
+    "overflow": false
+  },
+  {
+    "principal": "13556216853872301781",
+    "rate_bps": 3316,
+    "seconds": 949937679,
+    "expected": "135407131068010720090",
+    "overflow": false
+  },
+  {
+    "principal": "8403828724586406642",
+    "rate_bps": 9838,
+    "seconds": 2694972788,
+    "expected": "706531921428944318655",
+    "overflow": false
+  },
+  {
+    "principal": "17985425275107345075",
+    "rate_bps": 2515,
+    "seconds": 2887768349,
+    "expected": "414204150049753982251",
+    "overflow": false
+  },
+  {
+    "principal": "9854974392500948584",
+    "rate_bps": 1652,
+    "seconds": 2919944666,
+    "expected": "150741751689779815384",
+    "overflow": false
+  },
+  {
+    "principal": "84278115107048097",
+    "rate_bps": 5543,
+    "seconds": 3625543355,
+    "expected": "5370641810562799858",
+    "overflow": false
+  },
+  {
+    "principal": "10167663472946205998",
+    "rate_bps": 3686,
+    "seconds": 2513832464,
+    "expected": "298748833376402897410",
+    "overflow": false
+  },
+  {
+    "principal": "1537420137132799519",
+    "rate_bps": 6568,
+    "seconds": 2586616425,
+    "expected": "82823033557135053225",
+    "overflow": false
+  },
+  {
+    "principal": "15430538087808050372",
+    "rate_bps": 1078,
+    "seconds": 1874286486,
+    "expected": "98861955962844016894",
+    "overflow": false
+  },
+  {
+    "principal": "3037258047180460205",
+    "rate_bps": 4446,
+    "seconds": 860275623,
+    "expected": "36836822346531600895",
+    "overflow": false
+  },
+  {
+    "principal": "15702811825640488618",
+    "rate_bps": 1298,
+    "seconds": 1960892396,
+    "expected": "126735789407417145246",
+    "overflow": false
+  },
+  {
+    "principal": "3660941581460408779",
+    "rate_bps": 2406,
+    "seconds": 2021262837,
+    "expected": "56455285235551881909",
+    "overflow": false
+  },
+  {
+    "principal": "9956380871955585120",
+    "rate_bps": 5729,
+    "seconds": 43089042,
+    "expected": "7793643847613739096",
+    "overflow": false
+  },
+  {
+    "principal": "16698196669593867513",
+    "rate_bps": 5318,
+    "seconds": 1681885395,
+    "expected": "473595641785235279865",
+    "overflow": false
+  },
+  {
+    "principal": "7478712900748720998",
+    "rate_bps": 7381,
+    "seconds": 1226861320,
+    "expected": "214748893244786013649",
+    "overflow": false
+  },
+  {
+    "principal": "15168868195992553911",
+    "rate_bps": 9029,
+    "seconds": 1129983937,
+    "expected": "490747949582033530176",
+    "overflow": false
+  },
+  {
+    "principal": "93007210296616252",
+    "rate_bps": 2033,
+    "seconds": 337468622,
+    "expected": "202339553804721855",
+    "overflow": false
+  },
+  {
+    "principal": "15514063194405536645",
+    "rate_bps": 3252,
+    "seconds": 718438975,
+    "expected": "114936871222124718398",
+    "overflow": false
+  },
+  {
+    "principal": "18020486726282159970",
+    "rate_bps": 4572,
+    "seconds": 1868431204,
+    "expected": "488138703567691907962",
+    "overflow": false
+  },
+  {
+    "principal": "178529620735558115",
+    "rate_bps": 544,
+    "seconds": 3838020557,
+    "expected": "1181979302392719797",
+    "overflow": false
+  },
+  {
+    "principal": "10006216397697501016",
+    "rate_bps": 5604,
+    "seconds": 2853196874,
+    "expected": "507333044018464599514",
+    "overflow": false
+  },
+  {
+    "principal": "10215467967029250129",
+    "rate_bps": 9530,
+    "seconds": 2683354091,
+    "expected": "828366534311562787041",
+    "overflow": false
+  },
+  {
+    "principal": "11966801864746933918",
+    "rate_bps": 8599,
+    "seconds": 740954368,
+    "expected": "241774728928495953716",
+    "overflow": false
+  },
+  {
+    "principal": "2642522680166415951",
+    "rate_bps": 3166,
+    "seconds": 2052900377,
+    "expected": "54461663378003789372",
+    "overflow": false
+  },
+  {
+    "principal": "8249929992361327284",
+    "rate_bps": 4783,
+    "seconds": 197984006,
+    "expected": "24772745708079505061",
+    "overflow": false
+  },
+  {
+    "principal": "4176253858562068317",
+    "rate_bps": 5832,
+    "seconds": 156860887,
+    "expected": "12114694441070480603",
+    "overflow": false
+  },
+  {
+    "principal": "5598572691963510042",
+    "rate_bps": 5307,
+    "seconds": 527981532,
+    "expected": "49743751368482311780",
+    "overflow": false
+  },
+  {
+    "principal": "370501917751495419",
+    "rate_bps": 7604,
+    "seconds": 1506331301,
+    "expected": "13456944528615414441",
+    "overflow": false
+  },
+  {
+    "principal": "6449530558883298128",
+    "rate_bps": 9793,
+    "seconds": 3206494466,
+    "expected": "642196223224831586368",
+    "overflow": false
+  },
+  {
+    "principal": "8163953773418808489",
+    "rate_bps": 2957,
+    "seconds": 428236803,
+    "expected": "32781531761681629040",
+    "overflow": false
+  },
+  {
+    "principal": "3760779535489359574",
+    "rate_bps": 3729,
+    "seconds": 1367071736,
+    "expected": "60793193231643146081",
+    "overflow": false
+  },
+  {
+    "principal": "16801497577804870631",
+    "rate_bps": 2174,
+    "seconds": 3207775601,
+    "expected": "371539426354026570541",
+    "overflow": false
+  },
+  {
+    "principal": "10142072487405176108",
+    "rate_bps": 6881,
+    "seconds": 1949834814,
+    "expected": "431488754432251629297",
+    "overflow": false
+  },
+  {
+    "principal": "2412971460401009717",
+    "rate_bps": 6759,
+    "seconds": 668410479,
+    "expected": "34567762918225921695",
+    "overflow": false
+  },
+  {
+    "principal": "13253150918048260050",
+    "rate_bps": 6304,
+    "seconds": 3569536340,
+    "expected": "945672039861095113757",
+    "overflow": false
+  },
+  {
+    "principal": "4741670289294116115",
+    "rate_bps": 1017,
+    "seconds": 1377444477,
+    "expected": "21062979262185459167",
+    "overflow": false
+  },
+  {
+    "principal": "11591117978260509768",
+    "rate_bps": 5650,
+    "seconds": 4243196602,
+    "expected": "881171255599502133399",
+    "overflow": false
+  },
+  {
+    "principal": "9842297573163903489",
+    "rate_bps": 140,
+    "seconds": 754832667,
+    "expected": "3298136357554068892",
+    "overflow": false
+  },
+  {
+    "principal": "14402433675502640142",
+    "rate_bps": 7793,
+    "seconds": 965913584,
+    "expected": "343773366401389479207",
+    "overflow": false
+  },
+  {
+    "principal": "3249347209198291583",
+    "rate_bps": 1934,
+    "seconds": 3965619657,
+    "expected": "79023642090073228780",
+    "overflow": false
+  },
+  {
+    "principal": "11857016534827934884",
+    "rate_bps": 6268,
+    "seconds": 2871302774,
+    "expected": "676669804173853396876",
+    "overflow": false
+  },
+  {
+    "principal": "15656116342487331341",
+    "rate_bps": 4824,
+    "seconds": 2410333191,
+    "expected": "577247171183668370157",
+    "overflow": false
+  },
+  {
+    "principal": "10853390440585916298",
+    "rate_bps": 5875,
+    "seconds": 1317286860,
+    "expected": "266346534456720730791",
+    "overflow": false
+  },
+  {
+    "principal": "7879559950837665835",
+    "rate_bps": 4110,
+    "seconds": 1334571861,
+    "expected": "137050032465821673489",
+    "overflow": false
+  },
+  {
+    "principal": "10137116477450449472",
+    "rate_bps": 7255,
+    "seconds": 2997922162,
+    "expected": "699142332550203479875",
+    "overflow": false
+  },
+  {
+    "principal": "11533380633847847001",
+    "rate_bps": 4103,
+    "seconds": 225999667,
+    "expected": "33912463119440440213",
+    "overflow": false
+  },
+  {
+    "principal": "13510305574841120326",
+    "rate_bps": 5862,
+    "seconds": 3932119272,
+    "expected": "987486260735324315026",
+    "overflow": false
+  },
+  {
+    "principal": "10038567196651069975",
+    "rate_bps": 6005,
+    "seconds": 3026616097,
+    "expected": "578542772877165013749",
+    "overflow": false
+  },
+  {
+    "principal": "9009898355277576476",
+    "rate_bps": 6144,
+    "seconds": 1781289902,
+    "expected": "312679275899954564553",
+    "overflow": false
+  },
+  {
+    "principal": "15222296169267562725",
+    "rate_bps": 3243,
+    "seconds": 1276626591,
+    "expected": "199840908476896162305",
+    "overflow": false
+  },
+  {
+    "principal": "12423966585963236418",
+    "rate_bps": 2800,
+    "seconds": 3140972356,
+    "expected": "346478119214418521751",
+    "overflow": false
+  },
+  {
+    "principal": "10437115425135053891",
+    "rate_bps": 5698,
+    "seconds": 1622580525,
+    "expected": "305986723642044111430",
+    "overflow": false
+  },
+  {
+    "principal": "4765214810170946872",
+    "rate_bps": 528,
+    "seconds": 2269574442,
+    "expected": "18107322249899922281",
+    "overflow": false
+  },
+  {
+    "principal": "2075325041095110577",
+    "rate_bps": 2908,
+    "seconds": 3736842827,
+    "expected": "71511971838934348326",
+    "overflow": false
+  },
+  {
+    "principal": "9089580598409825662",
+    "rate_bps": 4272,
+    "seconds": 1455872736,
+    "expected": "179263509766521960743",
+    "overflow": false
+  },
+  {
+    "principal": "649990870565722799",
+    "rate_bps": 5571,
+    "seconds": 2941581689,
+    "expected": "33776505974274321912",
+    "overflow": false
+  },
+  {
+    "principal": "1317660498850177684",
+    "rate_bps": 3937,
+    "seconds": 2990352870,
+    "expected": "49190900611556442591",
+    "overflow": false
+  },
+  {
+    "principal": "5162798725475530941",
+    "rate_bps": 2527,
+    "seconds": 3418720823,
+    "expected": "141431929515669882305",
+    "overflow": false
+  },
+  {
+    "principal": "7472556959228827130",
+    "rate_bps": 5851,
+    "seconds": 134963132,
+    "expected": "18711468523582226603",
+    "overflow": false
+  },
+  {
+    "principal": "15004593814332610907",
+    "rate_bps": 1077,
+    "seconds": 913735685,
+    "expected": "46822427489953040383",
+    "overflow": false
+  },
+  {
+    "principal": "17025446397922999600",
+    "rate_bps": 7491,
+    "seconds": 211078626,
+    "expected": "85364235714207185268",
+    "overflow": false
+  },
+  {
+    "principal": "11258239095106490377",
+    "rate_bps": 7900,
+    "seconds": 3736132195,
+    "expected": "1053690795863954536538",
+    "overflow": false
+  },
+  {
+    "principal": "16382553569778467254",
+    "rate_bps": 5184,
+    "seconds": 371325400,
+    "expected": "99998765873743845443",
+    "overflow": false
+  },
+  {
+    "principal": "14269152028772701255",
+    "rate_bps": 5228,
+    "seconds": 4164443345,
+    "expected": "985108565359659457211",
+    "overflow": false
+  },
+  {
+    "principal": "9144823053421674764",
+    "rate_bps": 7164,
+    "seconds": 2266561822,
+    "expected": "470860051776755235501",
+    "overflow": false
+  },
+  {
+    "principal": "2250968846344380821",
+    "rate_bps": 253,
+    "seconds": 1379888847,
+    "expected": "2491882172507014705",
+    "overflow": false
+  },
+  {
+    "principal": "11944307021605612722",
+    "rate_bps": 3845,
+    "seconds": 2153964852,
+    "expected": "313681790051705057721",
+    "overflow": false
+  },
+  {
+    "principal": "5857791826853009267",
+    "rate_bps": 5409,
+    "seconds": 3379297245,
+    "expected": "339524174918464687009",
+    "overflow": false
+  },
+  {
+    "principal": "9055549613472639528",
+    "rate_bps": 5812,
+    "seconds": 588649370,
+    "expected": "98240484708749641747",
+    "overflow": false
+  },
+  {
+    "principal": "8982925457710405985",
+    "rate_bps": 5467,
+    "seconds": 2665829243,
+    "expected": "415138097264682943518",
+    "overflow": false
+  },
+  {
+    "principal": "8616468697096663790",
+    "rate_bps": 1626,
+    "seconds": 1807588816,
+    "expected": "80305056963993754344",
+    "overflow": false
+  },
+  {
+    "principal": "12539023239203417823",
+    "rate_bps": 2268,
+    "seconds": 1520634153,
+    "expected": "137127605013240246156",
+    "overflow": false
+  },
+  {
+    "principal": "8541811511888737412",
+    "rate_bps": 5282,
+    "seconds": 2060823894,
+    "expected": "294837455734826375655",
+    "overflow": false
+  },
+  {
+    "principal": "9189257145898673005",
+    "rate_bps": 9358,
+    "seconds": 2037699687,
+    "expected": "555644496779578638759",
+    "overflow": false
+  },
+  {
+    "principal": "12438567110534426730",
+    "rate_bps": 8960,
+    "seconds": 3176456108,
+    "expected": "1122573058594317347602",
+    "overflow": false
+  },
+  {
+    "principal": "9435221301303518859",
+    "rate_bps": 4156,
+    "seconds": 2407231669,
+    "expected": "299322187948015591325",
+    "overflow": false
+  },
+  {
+    "principal": "10841607088935607328",
+    "rate_bps": 5393,
+    "seconds": 760915538,
+    "expected": "141076257418883319777",
+    "overflow": false
+  },
+  {
+    "principal": "389204894316456889",
+    "rate_bps": 1613,
+    "seconds": 1309310355,
+    "expected": "2606445545823300583",
+    "overflow": false
+  },
+  {
+    "principal": "14601164989568549158",
+    "rate_bps": 7181,
+    "seconds": 2656741064,
+    "expected": "883313883861605658762",
+    "overflow": false
+  },
+  {
+    "principal": "2209931193531239031",
+    "rate_bps": 9631,
+    "seconds": 271277697,
+    "expected": "18308704609330003743",
+    "overflow": false
+  },
+  {
+    "principal": "9441494277243673852",
+    "rate_bps": 7841,
+    "seconds": 157096590,
+    "expected": "36878422822672204032",
+    "overflow": false
+  },
+  {
+    "principal": "16835368879706840645",
+    "rate_bps": 660,
+    "seconds": 3275299583,
+    "expected": "115401378117371559283",
+    "overflow": false
+  },
+  {
+    "principal": "5854496550096519458",
+    "rate_bps": 623,
+    "seconds": 3844878116,
+    "expected": "44468611712672584139",
+    "overflow": false
+  },
+  {
+    "principal": "5621392136168711843",
+    "rate_bps": 6627,
+    "seconds": 1095581325,
+    "expected": "129419246280044232473",
+    "overflow": false
+  },
+  {
+    "principal": "4386317754418098968",
+    "rate_bps": 6995,
+    "seconds": 327575050,
+    "expected": "31870730475479383720",
+    "overflow": false
+  },
+  {
+    "principal": "6818814772473521937",
+    "rate_bps": 8478,
+    "seconds": 292927659,
+    "expected": "53697748871143830139",
+    "overflow": false
+  },
+  {
+    "principal": "13060353714458250334",
+    "rate_bps": 3108,
+    "seconds": 2678977728,
+    "expected": "344824762203061361329",
+    "overflow": false
+  },
+  {
+    "principal": "6523217695706892047",
+    "rate_bps": 432,
+    "seconds": 233553113,
+    "expected": "2087010684395933387",
+    "overflow": false
+  },
+  {
+    "principal": "1418627043739064948",
+    "rate_bps": 3469,
+    "seconds": 3287098566,
+    "expected": "51295427605010719022",
+    "overflow": false
+  },
+  {
+    "principal": "13771044334710501917",
+    "rate_bps": 6621,
+    "seconds": 985899671,
+    "expected": "285047068589905988094",
+    "overflow": false
+  },
+  {
+    "principal": "15806869856362888922",
+    "rate_bps": 8084,
+    "seconds": 988263324,
+    "expected": "400440738676321140625",
+    "overflow": false
+  },
+  {
+    "principal": "10870922114874505147",
+    "rate_bps": 6610,
+    "seconds": 802014565,
+    "expected": "182744153754556097723",
+    "overflow": false
+  },
+  {
+    "principal": "1691504971788930832",
+    "rate_bps": 2335,
+    "seconds": 382808770,
+    "expected": "4794412923414863654",
+    "overflow": false
+  },
+  {
+    "principal": "7901637314676632425",
+    "rate_bps": 1158,
+    "seconds": 1856005315,
+    "expected": "53851556405550539505",
+    "overflow": false
+  },
+  {
+    "principal": "14633583161780794518",
+    "rate_bps": 5564,
+    "seconds": 65038264,
+    "expected": "16791911432193289540",
+    "overflow": false
+  },
+  {
+    "principal": "8390777782973891751",
+    "rate_bps": 9605,
+    "seconds": 3791815729,
+    "expected": "969036656220547855398",
+    "overflow": false
+  },
+  {
+    "principal": "18117248546975649004",
+    "rate_bps": 1374,
+    "seconds": 1285008382,
+    "expected": "101432780048245734510",
+    "overflow": false
+  },
+  {
+    "principal": "15340581412016865013",
+    "rate_bps": 9,
+    "seconds": 640666415,
+    "expected": "280485025606520628",
+    "overflow": false
+  },
+  {
+    "principal": "12183625463057713554",
+    "rate_bps": 7385,
+    "seconds": 4256845076,
+    "expected": "1214530085473467251217",
+    "overflow": false
+  },
+  {
+    "principal": "11211697798120995283",
+    "rate_bps": 1796,
+    "seconds": 699229501,
+    "expected": "44646852938579161325",
+    "overflow": false
+  },
+  {
+    "principal": "3780768439805448200",
+    "rate_bps": 2374,
+    "seconds": 1963388026,
+    "expected": "55880505322564416378",
+    "overflow": false
+  },
+  {
+    "principal": "174945806912166081",
+    "rate_bps": 5960,
+    "seconds": 3299336667,
+    "expected": "10908620269786723530",
+    "overflow": false
+  },
+  {
+    "principal": "936147539989420494",
+    "rate_bps": 7048,
+    "seconds": 1225711536,
+    "expected": "25644359850397021546",
+    "overflow": false
+  },
+  {
+    "principal": "18229963401812845375",
+    "rate_bps": 5806,
+    "seconds": 554833033,
+    "expected": "186216659222519626329",
+    "overflow": false
+  },
+  {
+    "principal": "13948221679105872996",
+    "rate_bps": 6668,
+    "seconds": 566399030,
+    "expected": "167043786595560456616",
+    "overflow": false
+  },
+  {
+    "principal": "7704140229305935053",
+    "rate_bps": 2238,
+    "seconds": 3355243719,
+    "expected": "183443245943177063391",
+    "overflow": false
+  },
+  {
+    "principal": "1678536197055463754",
+    "rate_bps": 9416,
+    "seconds": 2559237004,
+    "expected": "128262901645459297460",
+    "overflow": false
+  },
+  {
+    "principal": "2373723000285859051",
+    "rate_bps": 9646,
+    "seconds": 4041244181,
+    "expected": "293417343522603268259",
+    "overflow": false
+  },
+  {
+    "principal": "17362300867514144256",
+    "rate_bps": 2666,
+    "seconds": 3691475762,
+    "expected": "541827242489208453441",
+    "overflow": false
+  },
+  {
+    "principal": "279285265933438745",
+    "rate_bps": 598,
+    "seconds": 3587018739,
+    "expected": "1899661613689263625",
+    "overflow": false
+  },
+  {
+    "principal": "14427312018449128454",
+    "rate_bps": 4077,
+    "seconds": 1858747560,
+    "expected": "346688902633501700958",
+    "overflow": false
+  },
+  {
+    "principal": "16674102991872295639",
+    "rate_bps": 5037,
+    "seconds": 1673580001,
+    "expected": "445711973570604173006",
+    "overflow": false
+  },
+  {
+    "principal": "18059714631146098908",
+    "rate_bps": 7260,
+    "seconds": 967291246,
+    "expected": "402159335620976900858",
+    "overflow": false
+  },
+  {
+    "principal": "5501783129212142501",
+    "rate_bps": 9732,
+    "seconds": 814645087,
+    "expected": "138314401952709292013",
+    "overflow": false
+  },
+  {
+    "principal": "6970923195762148866",
+    "rate_bps": 9411,
+    "seconds": 561266436,
+    "expected": "116758507876450062424",
+    "overflow": false
+  },
+  {
+    "principal": "17281227892674367747",
+    "rate_bps": 2795,
+    "seconds": 1075802093,
+    "expected": "164771534997002265379",
+    "overflow": false
+  },
+  {
+    "principal": "4840228024335319288",
+    "rate_bps": 4417,
+    "seconds": 2907088618,
+    "expected": "197081057940368009672",
+    "overflow": false
+  },
+  {
+    "principal": "15773268606140477041",
+    "rate_bps": 1106,
+    "seconds": 1626787595,
+    "expected": "89991413043461216954",
+    "overflow": false
+  },
+  {
+    "principal": "10663366600975407934",
+    "rate_bps": 3513,
+    "seconds": 3717684896,
+    "expected": "441609553576035033076",
+    "overflow": false
+  },
+  {
+    "principal": "16946089727140070255",
+    "rate_bps": 7154,
+    "seconds": 3560509497,
+    "expected": "1368749517182556287415",
+    "overflow": false
+  },
+  {
+    "principal": "9313369807831736916",
+    "rate_bps": 242,
+    "seconds": 1842671526,
+    "expected": "13169325495154462475",
+    "overflow": false
+  },
+  {
+    "principal": "3806475087492086653",
+    "rate_bps": 6057,
+    "seconds": 531352311,
+    "expected": "38846914729463936224",
+    "overflow": false
+  },
+  {
+    "principal": "371890554697267130",
+    "rate_bps": 2012,
+    "seconds": 692410236,
+    "expected": "1642857887522642541",
+    "overflow": false
+  },
+  {
+    "principal": "15630063703136298523",
+    "rate_bps": 4614,
+    "seconds": 1617337029,
+    "expected": "369855653150588128959",
+    "overflow": false
+  },
+  {
+    "principal": "2484959257504608496",
+    "rate_bps": 563,
+    "seconds": 290219938,
+    "expected": "1287503165545484866",
+    "overflow": false
+  },
+  {
+    "principal": "11370934357155452617",
+    "rate_bps": 868,
+    "seconds": 3408723747,
+    "expected": "106684438752316484566",
+    "overflow": false
+  },
+  {
+    "principal": "10367892481885976438",
+    "rate_bps": 543,
+    "seconds": 2658084248,
+    "expected": "47451773554810043889",
+    "overflow": false
+  },
+  {
+    "principal": "7067659553471431943",
+    "rate_bps": 5479,
+    "seconds": 1269382033,
+    "expected": "155870045433322632773",
+    "overflow": false
+  },
+  {
+    "principal": "14889588297026824396",
+    "rate_bps": 7353,
+    "seconds": 3064736478,
+    "expected": "1063980788007337507623",
+    "overflow": false
+  },
+  {
+    "principal": "937645856740682837",
+    "rate_bps": 4797,
+    "seconds": 4127209359,
+    "expected": "58865176444377695833",
+    "overflow": false
+  },
+  {
+    "principal": "16732583877137938034",
+    "rate_bps": 2286,
+    "seconds": 3674277108,
+    "expected": "445660903937051478603",
+    "overflow": false
+  },
+  {
+    "principal": "17992447856292555827",
+    "rate_bps": 2577,
+    "seconds": 1316380317,
+    "expected": "193543880504999634773",
+    "overflow": false
+  },
+  {
+    "principal": "4156347356050556392",
+    "rate_bps": 4403,
+    "seconds": 3677656410,
+    "expected": "213415061629941571661",
+    "overflow": false
+  },
+  {
+    "principal": "5269569752402978849",
+    "rate_bps": 5017,
+    "seconds": 3642589243,
+    "expected": "305367527284142320754",
+    "overflow": false
+  },
+  {
+    "principal": "9209249153233408174",
+    "rate_bps": 4350,
+    "seconds": 3795743120,
+    "expected": "482173886652775166518",
+    "overflow": false
+  },
+  {
+    "principal": "2828637554856159135",
+    "rate_bps": 8862,
+    "seconds": 4291014633,
+    "expected": "341084855989475510832",
+    "overflow": false
+  },
+  {
+    "principal": "12541279703294477380",
+    "rate_bps": 5666,
+    "seconds": 920863510,
+    "expected": "207494734899007221420",
+    "overflow": false
+  },
+  {
+    "principal": "11875257674611308077",
+    "rate_bps": 9475,
+    "seconds": 3063620903,
+    "expected": "1093076802363227140222",
+    "overflow": false
+  },
+  {
+    "principal": "15622906122448298538",
+    "rate_bps": 6480,
+    "seconds": 1801332588,
+    "expected": "578261299677345996609",
+    "overflow": false
+  },
+  {
+    "principal": "16110496164467376971",
+    "rate_bps": 618,
+    "seconds": 1884494709,
+    "expected": "59495717512828524878",
+    "overflow": false
+  },
+  {
+    "principal": "13342039681311399904",
+    "rate_bps": 928,
+    "seconds": 1009717266,
+    "expected": "39642714060521611584",
+    "overflow": false
+  },
+  {
+    "principal": "18312320584951808633",
+    "rate_bps": 8283,
+    "seconds": 2023338579,
+    "expected": "973179606410058511482",
+    "overflow": false
+  },
+  {
+    "principal": "3847437003078633190",
+    "rate_bps": 1408,
+    "seconds": 3647349384,
+    "expected": "62653441629521764610",
+    "overflow": false
+  },
+  {
+    "principal": "11967927067475249975",
+    "rate_bps": 2637,
+    "seconds": 3225341249,
+    "expected": "322773690321780773375",
+    "overflow": false
+  },
+  {
+    "principal": "18200448330916025532",
+    "rate_bps": 7909,
+    "seconds": 386144334,
+    "expected": "176257141026169238665",
+    "overflow": false
+  },
+  {
+    "principal": "15178165111288527109",
+    "rate_bps": 4900,
+    "seconds": 409990079,
+    "expected": "96690118765715095141",
+    "overflow": false
+  },
+  {
+    "principal": "7298319833268755170",
+    "rate_bps": 4312,
+    "seconds": 3628572388,
+    "expected": "362101920449055387605",
+    "overflow": false
+  },
+  {
+    "principal": "7443826665094220643",
+    "rate_bps": 6275,
+    "seconds": 3670356301,
+    "expected": "543640246230409513209",
+    "overflow": false
+  },
+  {
+    "principal": "3950383366072131288",
+    "rate_bps": 631,
+    "seconds": 1191163850,
+    "expected": "9415285658366194784",
+    "overflow": false
+  },
+  {
+    "principal": "2653762256333571537",
+    "rate_bps": 1592,
+    "seconds": 2585195883,
+    "expected": "34633144511601563232",
+    "overflow": false
+  },
+  {
+    "principal": "4096065647039461918",
+    "rate_bps": 4846,
+    "seconds": 3678083200,
+    "expected": "231507603992339025231",
+    "overflow": false
+  },
+  {
+    "principal": "5814450756286304207",
+    "rate_bps": 6177,
+    "seconds": 3293901721,
+    "expected": "375137369077413330699",
+    "overflow": false
+  },
+  {
+    "principal": "13861158334565726772",
+    "rate_bps": 2748,
+    "seconds": 820808326,
+    "expected": "99140567150099994196",
+    "overflow": false
+  },
+  {
+    "principal": "3699366173636449501",
+    "rate_bps": 2739,
+    "seconds": 2815820631,
+    "expected": "90472737868413965706",
+    "overflow": false
+  },
+  {
+    "principal": "6258390276915675290",
+    "rate_bps": 9695,
+    "seconds": 4166798172,
+    "expected": "801689718606247079649",
+    "overflow": false
+  },
+  {
+    "principal": "9299714443100251259",
+    "rate_bps": 1813,
+    "seconds": 651755557,
+    "expected": "34845407938911710606",
+    "overflow": false
+  },
+  {
+    "principal": "13515731662858085072",
+    "rate_bps": 4360,
+    "seconds": 1132358786,
+    "expected": "211594072456174014810",
+    "overflow": false
+  },
+  {
+    "principal": "14939064079847723561",
+    "rate_bps": 1180,
+    "seconds": 439265667,
+    "expected": "24554214795536088366",
+    "overflow": false
+  },
+  {
+    "principal": "4757341567615912534",
+    "rate_bps": 1438,
+    "seconds": 3716559736,
+    "expected": "80622772848247738739",
+    "overflow": false
+  },
+  {
+    "principal": "1941832810186610023",
+    "rate_bps": 4221,
+    "seconds": 138707697,
+    "expected": "3605131754028273428",
+    "overflow": false
+  },
+  {
+    "principal": "5057275230992274604",
+    "rate_bps": 4521,
+    "seconds": 2337175998,
+    "expected": "169447789419032156024",
+    "overflow": false
+  },
+  {
+    "principal": "2907612868414155189",
+    "rate_bps": 3260,
+    "seconds": 4161319919,
+    "expected": "125077352702297414923",
+    "overflow": false
+  },
+  {
+    "principal": "14657234138118861650",
+    "rate_bps": 6504,
+    "seconds": 3664710868,
+    "expected": "1107810984798529851886",
+    "overflow": false
+  },
+  {
+    "principal": "4611119859524038291",
+    "rate_bps": 8631,
+    "seconds": 3613321213,
+    "expected": "456002781356607658306",
+    "overflow": false
+  },
+  {
+    "principal": "8688954238550526920",
+    "rate_bps": 6667,
+    "seconds": 3524726330,
+    "expected": "647465691993771826430",
+    "overflow": false
+  },
+  {
+    "principal": "13905229122873182081",
+    "rate_bps": 90,
+    "seconds": 3139317403,
+    "expected": "12458027333943551903",
+    "overflow": false
+  },
+  {
+    "principal": "12465860495956219790",
+    "rate_bps": 278,
+    "seconds": 1006916464,
+    "expected": "11065063063238633403",
+    "overflow": false
+  },
+  {
+    "principal": "9066758259766901759",
+    "rate_bps": 3442,
+    "seconds": 986700617,
+    "expected": "97643130662254444597",
+    "overflow": false
+  },
+  {
+    "principal": "8617254001608967204",
+    "rate_bps": 2779,
+    "seconds": 2771371510,
+    "expected": "210448377725947793416",
+    "overflow": false
+  },
+  {
+    "principal": "9036148682737604493",
+    "rate_bps": 6201,
+    "seconds": 3836175751,
+    "expected": "681611624496386385820",
+    "overflow": false
+  },
+  {
+    "principal": "17480078869792117514",
+    "rate_bps": 8356,
+    "seconds": 1963377484,
+    "expected": "909366640590448878487",
+    "overflow": false
+  },
+  {
+    "principal": "2662533150256040363",
+    "rate_bps": 9326,
+    "seconds": 1315653845,
+    "expected": "103591820946004975875",
+    "overflow": false
+  },
+  {
+    "principal": "652834838291544512",
+    "rate_bps": 9793,
+    "seconds": 3746135282,
+    "expected": "75944429962174505487",
+    "overflow": false
+  },
+  {
+    "principal": "9105586609942201817",
+    "rate_bps": 1180,
+    "seconds": 776398003,
+    "expected": "26452561919460759813",
+    "overflow": false
+  },
+  {
+    "principal": "14465353948548137414",
+    "rate_bps": 8743,
+    "seconds": 3487979624,
+    "expected": "1398804031782560503215",
+    "overflow": false
+  },
+  {
+    "principal": "2187100860621300631",
+    "rate_bps": 6328,
+    "seconds": 985488545,
+    "expected": "43249416801558327845",
+    "overflow": false
+  },
+  {
+    "principal": "8390649728422488220",
+    "rate_bps": 4679,
+    "seconds": 2439663406,
+    "expected": "303718986439266674494",
+    "overflow": false
+  },
+  {
+    "principal": "14645943310957756005",
+    "rate_bps": 1570,
+    "seconds": 3811932191,
+    "expected": "277942884817743402003",
+    "overflow": false
+  },
+  {
+    "principal": "4203123017618816962",
+    "rate_bps": 6548,
+    "seconds": 2782809796,
+    "expected": "242860949418107558363",
+    "overflow": false
+  },
+  {
+    "principal": "14635970622088451523",
+    "rate_bps": 1702,
+    "seconds": 1389789869,
+    "expected": "109780099335487659017",
+    "overflow": false
+  },
+  {
+    "principal": "6035411771016170680",
+    "rate_bps": 4037,
+    "seconds": 1730779306,
+    "expected": "133721346779311099609",
+    "overflow": false
+  },
+  {
+    "principal": "6242370945041149233",
+    "rate_bps": 5631,
+    "seconds": 766389195,
+    "expected": "85423599246358349562",
+    "overflow": false
+  },
+  {
+    "principal": "6990475345571211518",
+    "rate_bps": 1753,
+    "seconds": 1464935008,
+    "expected": "56924650794879357364",
+    "overflow": false
+  },
+  {
+    "principal": "2033457579477707823",
+    "rate_bps": 969,
+    "seconds": 609707769,
+    "expected": "3809552964013093372",
+    "overflow": false
+  },
+  {
+    "principal": "8735046700265579028",
+    "rate_bps": 6853,
+    "seconds": 3794531686,
+    "expected": "720273671017103657646",
+    "overflow": false
+  },
+  {
+    "principal": "1871474415065972285",
+    "rate_bps": 3898,
+    "seconds": 1687833527,
+    "expected": "39043499016653346778",
+    "overflow": false
+  },
+  {
+    "principal": "10301852784283720058",
+    "rate_bps": 5915,
+    "seconds": 2170851132,
+    "expected": "419462869814145489013",
+    "overflow": false
+  },
+  {
+    "principal": "10852563657960682203",
+    "rate_bps": 5965,
+    "seconds": 633140613,
+    "expected": "129967975912895407649",
+    "overflow": false
+  },
+  {
+    "principal": "623212144453002416",
+    "rate_bps": 6132,
+    "seconds": 148848994,
+    "expected": "1803754181258012859",
+    "overflow": false
+  },
+  {
+    "principal": "935421454892113289",
+    "rate_bps": 3274,
+    "seconds": 2776458211,
+    "expected": "26963144305675590670",
+    "overflow": false
+  },
+  {
+    "principal": "6051174315714325814",
+    "rate_bps": 1546,
+    "seconds": 752718168,
+    "expected": "22329291586243264492",
+    "overflow": false
+  },
+  {
+    "principal": "4052352128930067911",
+    "rate_bps": 1025,
+    "seconds": 4008467025,
+    "expected": "52796210297968492821",
+    "overflow": false
+  },
+  {
+    "principal": "15522056431731118220",
+    "rate_bps": 1416,
+    "seconds": 1685493918,
+    "expected": "117471656843348503523",
+    "overflow": false
+  },
+  {
+    "principal": "8640183141810353941",
+    "rate_bps": 9885,
+    "seconds": 1184972879,
+    "expected": "320923430101247468197",
+    "overflow": false
+  },
+  {
+    "principal": "3884572825408897074",
+    "rate_bps": 103,
+    "seconds": 4064044212,
+    "expected": "5156230333083263612",
+    "overflow": false
+  },
+  {
+    "principal": "3111664101374198003",
+    "rate_bps": 5692,
+    "seconds": 671023453,
+    "expected": "37686750588528727063",
+    "overflow": false
+  },
+  {
+    "principal": "9498230461425050024",
+    "rate_bps": 4703,
+    "seconds": 1780897562,
+    "expected": "252260942558112725764",
+    "overflow": false
+  },
+  {
+    "principal": "16590532317571495649",
+    "rate_bps": 329,
+    "seconds": 3984715003,
+    "expected": "68967880067380045818",
+    "overflow": false
+  },
+  {
+    "principal": "4453102973671026286",
+    "rate_bps": 6337,
+    "seconds": 1327007056,
+    "expected": "118744381622805010523",
+    "overflow": false
+  },
+  {
+    "principal": "2083571280667844703",
+    "rate_bps": 6077,
+    "seconds": 2588841641,
+    "expected": "103943294455537491342",
+    "overflow": false
+  },
+  {
+    "principal": "6348428169687782404",
+    "rate_bps": 9407,
+    "seconds": 2879396054,
+    "expected": "545270688323249222864",
+    "overflow": false
+  },
+  {
+    "principal": "11984198702352566509",
+    "rate_bps": 9150,
+    "seconds": 1434039783,
+    "expected": "498637214659238926954",
+    "overflow": false
+  },
+  {
+    "principal": "7802089743490814954",
+    "rate_bps": 4916,
+    "seconds": 2830937900,
+    "expected": "344307554286234715759",
+    "overflow": false
+  },
+  {
+    "principal": "12043595697905541131",
+    "rate_bps": 9138,
+    "seconds": 264308277,
+    "expected": "92238339960738084619",
+    "overflow": false
+  },
+  {
+    "principal": "7138949292739453856",
+    "rate_bps": 3025,
+    "seconds": 1791932882,
+    "expected": "122708545444210348333",
+    "overflow": false
+  },
+  {
+    "principal": "4348271691842410809",
+    "rate_bps": 8542,
+    "seconds": 313337619,
+    "expected": "36904741809311191293",
+    "overflow": false
+  },
+  {
+    "principal": "13114880415276518566",
+    "rate_bps": 3794,
+    "seconds": 3087195720,
+    "expected": "487101220801703271951",
+    "overflow": false
+  },
+  {
+    "principal": "7001456599106997239",
+    "rate_bps": 7848,
+    "seconds": 3964959745,
+    "expected": "690843333180091169646",
+    "overflow": false
+  },
+  {
+    "principal": "10733730911328324732",
+    "rate_bps": 7052,
+    "seconds": 1825723918,
+    "expected": "438219304605955721710",
+    "overflow": false
+  },
+  {
+    "principal": "4920458517425918917",
+    "rate_bps": 8815,
+    "seconds": 3711372415,
+    "expected": "510453069839398767441",
+    "overflow": false
+  },
+  {
+    "principal": "5921526799483974818",
+    "rate_bps": 89,
+    "seconds": 1517309604,
+    "expected": "2535661669218788476",
+    "overflow": false
+  },
+  {
+    "principal": "16544560117112942627",
+    "rate_bps": 5026,
+    "seconds": 2917884941,
+    "expected": "769377115992251007678",
+    "overflow": false
+  },
+  {
+    "principal": "14368774732159617688",
+    "rate_bps": 6987,
+    "seconds": 675039626,
+    "expected": "214898379150020201846",
+    "overflow": false
+  },
+  {
+    "principal": "6191049623437436049",
+    "rate_bps": 2633,
+    "seconds": 815034923,
+    "expected": "42129349672389437474",
+    "overflow": false
+  },
+  {
+    "principal": "11051627977240078302",
+    "rate_bps": 421,
+    "seconds": 76643392,
+    "expected": "1130775689625712538",
+    "overflow": false
+  },
+  {
+    "principal": "11764599179364407439",
+    "rate_bps": 7966,
+    "seconds": 3193465433,
+    "expected": "949014941373609851805",
+    "overflow": false
+  },
+  {
+    "principal": "15801382021160327668",
+    "rate_bps": 6074,
+    "seconds": 2861248582,
+    "expected": "870800849412850076236",
+    "overflow": false
+  },
+  {
+    "principal": "2004806311351400349",
+    "rate_bps": 997,
+    "seconds": 1263576087,
+    "expected": "8008706361453688535",
+    "overflow": false
+  },
+  {
+    "principal": "2842780439710450266",
+    "rate_bps": 7821,
+    "seconds": 1368793884,
+    "expected": "96502164287246010353",
+    "overflow": false
+  },
+  {
+    "principal": "2681310976682398011",
+    "rate_bps": 8017,
+    "seconds": 1135246053,
+    "expected": "77382447793339648522",
+    "overflow": false
+  },
+  {
+    "principal": "10314901334542759568",
+    "rate_bps": 1562,
+    "seconds": 3504793154,
+    "expected": "179061365735314652091",
+    "overflow": false
+  },
+  {
+    "principal": "4406648853196093673",
+    "rate_bps": 3623,
+    "seconds": 3673239107,
+    "expected": "185959928833137992242",
+    "overflow": false
+  },
+  {
+    "principal": "8401574961176567830",
+    "rate_bps": 65,
+    "seconds": 1814904632,
+    "expected": "3142832716114114830",
+    "overflow": false
+  },
+  {
+    "principal": "9321977600489317927",
+    "rate_bps": 4296,
+    "seconds": 3669541297,
+    "expected": "465990969381439040924",
+    "overflow": false
+  },
+  {
+    "principal": "15327499389027310700",
+    "rate_bps": 9,
+    "seconds": 2954659710,
+    "expected": "1292452765405496889",
+    "overflow": false
+  },
+  {
+    "principal": "12929949946017797237",
+    "rate_bps": 1580,
+    "seconds": 3760315567,
+    "expected": "243596820962758820150",
+    "overflow": false
+  },
+  {
+    "principal": "14531310911080176914",
+    "rate_bps": 8807,
+    "seconds": 1285622932,
+    "expected": "521722774136454346566",
+    "overflow": false
+  },
+  {
+    "principal": "9577076576333865811",
+    "rate_bps": 2044,
+    "seconds": 1743694525,
+    "expected": "108237474020012726580",
+    "overflow": false
+  },
+  {
+    "principal": "6321736683894097800",
+    "rate_bps": 3275,
+    "seconds": 1205497850,
+    "expected": "79142094548433603885",
+    "overflow": false
+  },
+  {
+    "principal": "9016036632513230401",
+    "rate_bps": 1045,
+    "seconds": 2535504731,
+    "expected": "75751245230066911740",
+    "overflow": false
+  },
+  {
+    "principal": "8418227962063721806",
+    "rate_bps": 3274,
+    "seconds": 137561904,
+    "expected": "12022393221070769806",
+    "overflow": false
+  },
+  {
+    "principal": "12433743530166359231",
+    "rate_bps": 664,
+    "seconds": 1784144393,
+    "expected": "46708226425107709357",
+    "overflow": false
+  },
+  {
+    "principal": "10723075250355549156",
+    "rate_bps": 9628,
+    "seconds": 3710663606,
+    "expected": "1214787775972552958848",
+    "overflow": false
+  },
+  {
+    "principal": "15326755892485638733",
+    "rate_bps": 2629,
+    "seconds": 1886000711,
+    "expected": "240977265443428177993",
+    "overflow": false
+  },
+  {
+    "principal": "1721694864169346250",
+    "rate_bps": 7727,
+    "seconds": 2914511628,
+    "expected": "122949362612280899536",
+    "overflow": false
+  },
+  {
+    "principal": "9850439289770526315",
+    "rate_bps": 1325,
+    "seconds": 2095862677,
+    "expected": "86741652964284865067",
+    "overflow": false
+  },
+  {
+    "principal": "14149345465646325120",
+    "rate_bps": 2770,
+    "seconds": 2553726642,
+    "expected": "317383189169449765021",
+    "overflow": false
+  },
+  {
+    "principal": "9436556141870234777",
+    "rate_bps": 7791,
+    "seconds": 1705277811,
+    "expected": "397553211883213900484",
+    "overflow": false
+  },
+  {
+    "principal": "5262883321653749638",
+    "rate_bps": 3835,
+    "seconds": 1802744872,
+    "expected": "115376343713137262063",
+    "overflow": false
+  },
+  {
+    "principal": "8581668759874700375",
+    "rate_bps": 5322,
+    "seconds": 4061932385,
+    "expected": "588264580869102716017",
+    "overflow": false
+  },
+  {
+    "principal": "7590757293836550236",
+    "rate_bps": 5530,
+    "seconds": 1093938414,
+    "expected": "145611777342668814067",
+    "overflow": false
+  },
+  {
+    "principal": "7085886317315455269",
+    "rate_bps": 7744,
+    "seconds": 919384287,
+    "expected": "159974217613918457064",
+    "overflow": false
+  },
+  {
+    "principal": "6166023010385672578",
+    "rate_bps": 634,
+    "seconds": 4197817988,
+    "expected": "52036897586579066663",
+    "overflow": false
+  },
+  {
+    "principal": "2470165803657058947",
+    "rate_bps": 9470,
+    "seconds": 3046888813,
+    "expected": "226009182016955272774",
+    "overflow": false
+  },
+  {
+    "principal": "14816268948283988088",
+    "rate_bps": 3189,
+    "seconds": 951044714,
+    "expected": "142491087548794704101",
+    "overflow": false
+  },
+  {
+    "principal": "10348728370143603697",
+    "rate_bps": 1164,
+    "seconds": 1537329291,
+    "expected": "58721922186391622087",
+    "overflow": false
+  },
+  {
+    "principal": "5622943727576921790",
+    "rate_bps": 6649,
+    "seconds": 2310284832,
+    "expected": "273891774707365649691",
+    "overflow": false
+  },
+  {
+    "principal": "4064171499863151855",
+    "rate_bps": 9595,
+    "seconds": 3765435833,
+    "expected": "465613591725705951743",
+    "overflow": false
+  },
+  {
+    "principal": "13331608485295743444",
+    "rate_bps": 5223,
+    "seconds": 117586726,
+    "expected": "25962963831123069946",
+    "overflow": false
+  },
+  {
+    "principal": "3447235296939327741",
+    "rate_bps": 5413,
+    "seconds": 3041987703,
+    "expected": "179994735166837959433",
+    "overflow": false
+  },
+  {
+    "principal": "9272110735727049530",
+    "rate_bps": 2106,
+    "seconds": 2854815484,
+    "expected": "176769939488173340212",
+    "overflow": false
+  },
+  {
+    "principal": "13620192326671450011",
+    "rate_bps": 7469,
+    "seconds": 2872676421,
+    "expected": "926671491411785859442",
+    "overflow": false
+  },
+  {
+    "principal": "669794631101257840",
+    "rate_bps": 4919,
+    "seconds": 520968994,
+    "expected": "5442817271403639488",
+    "overflow": false
+  },
+  {
+    "principal": "10632130106836935753",
+    "rate_bps": 5003,
+    "seconds": 1281493155,
+    "expected": "216152602678747153091",
+    "overflow": false
+  },
+  {
+    "principal": "8395098964508730102",
+    "rate_bps": 3497,
+    "seconds": 4012719384,
+    "expected": "373554210046145151837",
+    "overflow": false
+  },
+  {
+    "principal": "5706961559195100807",
+    "rate_bps": 2415,
+    "seconds": 2864822545,
+    "expected": "125202557755665276451",
+    "overflow": false
+  },
+  {
+    "principal": "11206373636655642700",
+    "rate_bps": 3313,
+    "seconds": 2956478046,
+    "expected": "348060376569530170965",
+    "overflow": false
+  },
+  {
+    "principal": "7658840351673319893",
+    "rate_bps": 3837,
+    "seconds": 2799864079,
+    "expected": "260906655555015693590",
+    "overflow": false
+  },
+  {
+    "principal": "13497382219935844850",
+    "rate_bps": 6242,
+    "seconds": 1205142644,
+    "expected": "321962401478978193943",
+    "overflow": false
+  },
+  {
+    "principal": "12620307418242536883",
+    "rate_bps": 306,
+    "seconds": 2194007069,
+    "expected": "26867222757181136593",
+    "overflow": false
+  },
+  {
+    "principal": "783775969696284008",
+    "rate_bps": 7810,
+    "seconds": 2745915610,
+    "expected": "53299551788965760468",
+    "overflow": false
+  },
+  {
+    "principal": "10872599871076713889",
+    "rate_bps": 9430,
+    "seconds": 2194839995,
+    "expected": "713577843575937578685",
+    "overflow": false
+  },
+  {
+    "principal": "2909042236891548718",
+    "rate_bps": 1100,
+    "seconds": 1208736016,
+    "expected": "12265000431810060577",
+    "overflow": false
+  },
+  {
+    "principal": "16286130154898168095",
+    "rate_bps": 6600,
+    "seconds": 2063842665,
+    "expected": "703447703340260423312",
+    "overflow": false
+  },
+  {
+    "principal": "267606269012206532",
+    "rate_bps": 5754,
+    "seconds": 550252182,
+    "expected": "2686713188161547908",
+    "overflow": false
+  },
+  {
+    "principal": "17005990115961871277",
+    "rate_bps": 7534,
+    "seconds": 13665959,
+    "expected": "5552148132796302969",
+    "overflow": false
+  },
+  {
+    "principal": "12019787295131370922",
+    "rate_bps": 7033,
+    "seconds": 3744495340,
+    "expected": "1003746600199295764520",
+    "overflow": false
+  },
+  {
+    "principal": "8154507506937724107",
+    "rate_bps": 9076,
+    "seconds": 2726637813,
+    "expected": "639901414765361146353",
+    "overflow": false
+  },
+  {
+    "principal": "11390858270277347168",
+    "rate_bps": 8956,
+    "seconds": 888775570,
+    "expected": "287512039064271471338",
+    "overflow": false
+  },
+  {
+    "principal": "15266324509044027385",
+    "rate_bps": 6361,
+    "seconds": 2332351443,
+    "expected": "718203090630135830198",
+    "overflow": false
+  },
+  {
+    "principal": "16745871072689050214",
+    "rate_bps": 5222,
+    "seconds": 938531336,
+    "expected": "260247628888404743450",
+    "overflow": false
+  },
+  {
+    "principal": "17263071056643476663",
+    "rate_bps": 5071,
+    "seconds": 1831627457,
+    "expected": "508442923193032643206",
+    "overflow": false
+  },
+  {
+    "principal": "337064629429666876",
+    "rate_bps": 5299,
+    "seconds": 2055721934,
+    "expected": "11642999092741916605",
+    "overflow": false
+  },
+  {
+    "principal": "4683149375055130245",
+    "rate_bps": 3668,
+    "seconds": 72246591,
+    "expected": "3935302214100938212",
+    "overflow": false
+  },
+  {
+    "principal": "953008834078871138",
+    "rate_bps": 7490,
+    "seconds": 3177594468,
+    "expected": "71923465998984936328",
+    "overflow": false
+  },
+  {
+    "principal": "1509071613034239203",
+    "rate_bps": 80,
+    "seconds": 4152350413,
+    "expected": "1589597700565524946",
+    "overflow": false
+  },
+  {
+    "principal": "6127711848331540056",
+    "rate_bps": 860,
+    "seconds": 3673955146,
+    "expected": "61393731263981597122",
+    "overflow": false
+  },
+  {
+    "principal": "438510600571847505",
+    "rate_bps": 6705,
+    "seconds": 195964651,
+    "expected": "1827048222506922376",
+    "overflow": false
+  },
+  {
+    "principal": "9792390841360405918",
+    "rate_bps": 6878,
+    "seconds": 2171674624,
+    "expected": "463808880999788143729",
+    "overflow": false
+  },
+  {
+    "principal": "2043678641256800591",
+    "rate_bps": 578,
+    "seconds": 1555439897,
+    "expected": "5826222579461187227",
+    "overflow": false
+  },
+  {
+    "principal": "11883695779390667188",
+    "rate_bps": 978,
+    "seconds": 3364427270,
+    "expected": "123992357576412403754",
+    "overflow": false
+  },
+  {
+    "principal": "8861001174273972829",
+    "rate_bps": 3706,
+    "seconds": 1609794775,
+    "expected": "167630143040733074537",
+    "overflow": false
+  },
+  {
+    "principal": "11761451026425545754",
+    "rate_bps": 1609,
+    "seconds": 2153069276,
+    "expected": "129201734917225996395",
+    "overflow": false
+  },
+  {
+    "principal": "9509504628046298619",
+    "rate_bps": 6011,
+    "seconds": 3405919653,
+    "expected": "617351366417670571855",
+    "overflow": false
+  },
+  {
+    "principal": "765801026689223248",
+    "rate_bps": 1623,
+    "seconds": 2328535042,
+    "expected": "9177209270190064355",
+    "overflow": false
+  },
+  {
+    "principal": "10233621976108277673",
+    "rate_bps": 2289,
+    "seconds": 2947019523,
+    "expected": "218902927176126413036",
+    "overflow": false
+  },
+  {
+    "principal": "17269001246547293654",
+    "rate_bps": 2900,
+    "seconds": 2106952440,
+    "expected": "334590298411497969384",
+    "overflow": false
+  },
+  {
+    "principal": "4877538961007441639",
+    "rate_bps": 1244,
+    "seconds": 1109344369,
+    "expected": "21344250234426733387",
+    "overflow": false
+  },
+  {
+    "principal": "14683335820818179116",
+    "rate_bps": 9297,
+    "seconds": 2059523390,
+    "expected": "891513007816338046743",
+    "overflow": false
+  },
+  {
+    "principal": "15892080716508938037",
+    "rate_bps": 8266,
+    "seconds": 1631274351,
+    "expected": "679511113228143550236",
+    "overflow": false
+  },
+  {
+    "principal": "14493151102756701906",
+    "rate_bps": 226,
+    "seconds": 1980779604,
+    "expected": "20573150719999086212",
+    "overflow": false
+  },
+  {
+    "principal": "8330242715178932243",
+    "rate_bps": 6937,
+    "seconds": 672968061,
+    "expected": "123315365977703921218",
+    "overflow": false
+  },
+  {
+    "principal": "10092381760634749768",
+    "rate_bps": 5057,
+    "seconds": 1242632634,
+    "expected": "201104955161710415803",
+    "overflow": false
+  },
+  {
+    "principal": "10750806567846995201",
+    "rate_bps": 4804,
+    "seconds": 527403035,
+    "expected": "86373409729948082955",
+    "overflow": false
+  },
+  {
+    "principal": "18010120108113842958",
+    "rate_bps": 5966,
+    "seconds": 3814390512,
+    "expected": "1299626040396266380130",
+    "overflow": false
+  },
+  {
+    "principal": "16417766314523929983",
+    "rate_bps": 236,
+    "seconds": 543828169,
+    "expected": "6681610652460022704",
+    "overflow": false
+  },
+  {
+    "principal": "18380485049474180004",
+    "rate_bps": 2179,
+    "seconds": 2977427830,
+    "expected": "378136704247298644546",
+    "overflow": false
+  },
+  {
+    "principal": "1897506807097883917",
+    "rate_bps": 5575,
+    "seconds": 906299143,
+    "expected": "30401371516949970507",
+    "overflow": false
+  },
+  {
+    "principal": "7547142384473683594",
+    "rate_bps": 955,
+    "seconds": 1281249996,
+    "expected": "29282839368252195511",
+    "overflow": false
+  },
+  {
+    "principal": "14507347469081985835",
+    "rate_bps": 8167,
+    "seconds": 3508772437,
+    "expected": "1318254202447572874981",
+    "overflow": false
+  },
+  {
+    "principal": "12744611869901160768",
+    "rate_bps": 3352,
+    "seconds": 579817586,
+    "expected": "78544431437203514531",
+    "overflow": false
+  },
+  {
+    "principal": "15865807424798274393",
+    "rate_bps": 4773,
+    "seconds": 178671155,
+    "expected": "42904362261374493669",
+    "overflow": false
+  },
+  {
+    "principal": "10727209970305961286",
+    "rate_bps": 8999,
+    "seconds": 3744616424,
+    "expected": "1146256375126521404664",
+    "overflow": false
+  },
+  {
+    "principal": "905023540869965079",
+    "rate_bps": 2176,
+    "seconds": 2191342113,
+    "expected": "13684292388513619192",
+    "overflow": false
+  },
+  {
+    "principal": "16714373161895204892",
+    "rate_bps": 7197,
+    "seconds": 1489324718,
+    "expected": "568099473944362063801",
+    "overflow": false
+  },
+  {
+    "principal": "1641417592506151909",
+    "rate_bps": 596,
+    "seconds": 1041508767,
+    "expected": "3230886239505015429",
+    "overflow": false
+  },
+  {
+    "principal": "192388053420192578",
+    "rate_bps": 3561,
+    "seconds": 272248388,
+    "expected": "591437400214450248",
+    "overflow": false
+  },
+  {
+    "principal": "12881528340643143491",
+    "rate_bps": 3268,
+    "seconds": 3308218413,
+    "expected": "441608077783196798171",
+    "overflow": false
+  },
+  {
+    "principal": "16148251523663275064",
+    "rate_bps": 4097,
+    "seconds": 3852024874,
+    "expected": "808116446021978044446",
+    "overflow": false
+  },
+  {
+    "principal": "1759493717844159153",
+    "rate_bps": 4927,
+    "seconds": 1100064075,
+    "expected": "30239991027435203611",
+    "overflow": false
+  },
+  {
+    "principal": "6991576382176806014",
+    "rate_bps": 734,
+    "seconds": 2055236064,
+    "expected": "33444620449161425708",
+    "overflow": false
+  },
+  {
+    "principal": "4214886369452899759",
+    "rate_bps": 1838,
+    "seconds": 2302858361,
+    "expected": "56570758022058739498",
+    "overflow": false
+  },
+  {
+    "principal": "14503937062752477588",
+    "rate_bps": 6845,
+    "seconds": 337101030,
+    "expected": "106123809555150759167",
+    "overflow": false
+  },
+  {
+    "principal": "15393568752765535165",
+    "rate_bps": 6995,
+    "seconds": 1821379895,
+    "expected": "621900585955475212240",
+    "overflow": false
+  },
+  {
+    "principal": "12116067190563347706",
+    "rate_bps": 9600,
+    "seconds": 2102574780,
+    "expected": "775492764312448976529",
+    "overflow": false
+  },
+  {
+    "principal": "14350308298928835675",
+    "rate_bps": 2871,
+    "seconds": 1436314373,
+    "expected": "187645141189718060266",
+    "overflow": false
+  },
+  {
+    "principal": "45244565839858736",
+    "rate_bps": 4839,
+    "seconds": 3214324962,
+    "expected": "2231542802360326513",
+    "overflow": false
+  },
+  {
+    "principal": "17110020348971805449",
+    "rate_bps": 7911,
+    "seconds": 3734695267,
+    "expected": "1602988751760664058832",
+    "overflow": false
+  },
+  {
+    "principal": "16505263161256335542",
+    "rate_bps": 4375,
+    "seconds": 1394485464,
+    "expected": "319306599808683994558",
+    "overflow": false
+  },
+  {
+    "principal": "14589407060550473543",
+    "rate_bps": 6417,
+    "seconds": 2280216529,
+    "expected": "676922833393397258704",
+    "overflow": false
+  },
+  {
+    "principal": "2373877497833037836",
+    "rate_bps": 2327,
+    "seconds": 4189139998,
+    "expected": "73379196936113007004",
+    "overflow": false
+  },
+  {
+    "principal": "11163343815993887893",
+    "rate_bps": 5709,
+    "seconds": 3112440271,
+    "expected": "628997273032727517608",
+    "overflow": false
+  },
+  {
+    "principal": "15341925074193044402",
+    "rate_bps": 8268,
+    "seconds": 2643125300,
+    "expected": "1063142476657361673511",
+    "overflow": false
+  },
+  {
+    "principal": "197127135419918963",
+    "rate_bps": 3183,
+    "seconds": 3414886109,
+    "expected": "6794424335578787868",
+    "overflow": false
+  },
+  {
+    "principal": "3518207863298218280",
+    "rate_bps": 7436,
+    "seconds": 2609093274,
+    "expected": "216443164214672491887",
+    "overflow": false
+  },
+  {
+    "principal": "11291851227284771937",
+    "rate_bps": 5680,
+    "seconds": 2144306811,
+    "expected": "436107746874187374575",
+    "overflow": false
+  },
+  {
+    "principal": "9546220193750985198",
+    "rate_bps": 2581,
+    "seconds": 2732092624,
+    "expected": "213455949473997571671",
+    "overflow": false
+  },
+  {
+    "principal": "12429846946363855327",
+    "rate_bps": 9551,
+    "seconds": 849552425,
+    "expected": "319814538895834057302",
+    "overflow": false
+  },
+  {
+    "principal": "4321252027782017924",
+    "rate_bps": 8010,
+    "seconds": 505906262,
+    "expected": "55527172656285888883",
+    "overflow": false
+  },
+  {
+    "principal": "1721446074004958829",
+    "rate_bps": 983,
+    "seconds": 2740950887,
+    "expected": "14707592459499074177",
+    "overflow": false
+  },
+  {
+    "principal": "12899451058816038762",
+    "rate_bps": 5908,
+    "seconds": 3094970028,
+    "expected": "747931038504882319673",
+    "overflow": false
+  },
+  {
+    "principal": "7600475215309969803",
+    "rate_bps": 3326,
+    "seconds": 2640288693,
+    "expected": "211644896680094204747",
+    "overflow": false
+  },
+  {
+    "principal": "7002348685016017696",
+    "rate_bps": 4115,
+    "seconds": 1450167634,
+    "expected": "132502835914018638524",
+    "overflow": false
+  },
+  {
+    "principal": "7019964283142555321",
+    "rate_bps": 3161,
+    "seconds": 2422263955,
+    "expected": "170441072372939819281",
+    "overflow": false
+  },
+  {
+    "principal": "15907200728774744102",
+    "rate_bps": 6358,
+    "seconds": 2532316616,
+    "expected": "812130241370912637772",
+    "overflow": false
+  },
+  {
+    "principal": "15291759816411811191",
+    "rate_bps": 739,
+    "seconds": 1535547777,
+    "expected": "55024820328082869293",
+    "overflow": false
+  },
+  {
+    "principal": "3348435125356231676",
+    "rate_bps": 9905,
+    "seconds": 4024734094,
+    "expected": "423279226311770352020",
+    "overflow": false
+  },
+  {
+    "principal": "17802886283999086917",
+    "rate_bps": 2373,
+    "seconds": 3228958207,
+    "expected": "432557625932555254229",
+    "overflow": false
+  },
+  {
+    "principal": "11746207079748184098",
+    "rate_bps": 2826,
+    "seconds": 2464771620,
+    "expected": "259441763863619003599",
+    "overflow": false
+  },
+  {
+    "principal": "10670451699992738211",
+    "rate_bps": 4029,
+    "seconds": 876775821,
+    "expected": "119525901909719914825",
+    "overflow": false
+  },
+  {
+    "principal": "16931734230569296408",
+    "rate_bps": 9322,
+    "seconds": 3271503114,
+    "expected": "1637386753527730186199",
+    "overflow": false
+  },
+  {
+    "principal": "6209016215951401489",
+    "rate_bps": 3471,
+    "seconds": 2720279467,
+    "expected": "185902112216121471545",
+    "overflow": false
+  },
+  {
+    "principal": "5900765741282755422",
+    "rate_bps": 2219,
+    "seconds": 4154065856,
+    "expected": "172477499044172120507",
+    "overflow": false
+  },
+  {
+    "principal": "17129009392798558735",
+    "rate_bps": 6793,
+    "seconds": 1076762585,
+    "expected": "397289613788913085747",
+    "overflow": false
+  },
+  {
+    "principal": "11744638598696360308",
+    "rate_bps": 3081,
+    "seconds": 1655061446,
+    "expected": "189906080693847685740",
+    "overflow": false
+  },
+  {
+    "principal": "9655480627746913565",
+    "rate_bps": 6439,
+    "seconds": 1618912663,
+    "expected": "319160498764196753623",
+    "overflow": false
+  },
+  {
+    "principal": "17051183983606597082",
+    "rate_bps": 672,
+    "seconds": 4267283100,
+    "expected": "155048890331094600132",
+    "overflow": false
+  },
+  {
+    "principal": "5867738628887521979",
+    "rate_bps": 6007,
+    "seconds": 1101017189,
+    "expected": "123059709263773062704",
+    "overflow": false
+  },
+  {
+    "principal": "12084184418203934224",
+    "rate_bps": 7756,
+    "seconds": 2095684034,
+    "expected": "622836911783174688229",
+    "overflow": false
+  },
+  {
+    "principal": "6920141883438581353",
+    "rate_bps": 9773,
+    "seconds": 3608344515,
+    "expected": "773827726938828100152",
+    "overflow": false
+  },
+  {
+    "principal": "13263983923306023830",
+    "rate_bps": 9981,
+    "seconds": 528422584,
+    "expected": "221831290602357307960",
+    "overflow": false
+  },
+  {
+    "principal": "11030876194359461799",
+    "rate_bps": 8029,
+    "seconds": 1731723057,
+    "expected": "486343706919626467701",
+    "overflow": false
+  },
+  {
+    "principal": "7783813580228242412",
+    "rate_bps": 260,
+    "seconds": 3942540030,
+    "expected": "25300859724720764155",
+    "overflow": false
+  },
+  {
+    "principal": "11229214696425974261",
+    "rate_bps": 6895,
+    "seconds": 1041559087,
+    "expected": "255717801036360398622",
+    "overflow": false
+  },
+  {
+    "principal": "7931753775467442322",
+    "rate_bps": 1022,
+    "seconds": 3095186452,
+    "expected": "79561017493049417636",
+    "overflow": false
+  },
+  {
+    "principal": "8932888615453281491",
+    "rate_bps": 820,
+    "seconds": 2762534973,
+    "expected": "64166292847173565006",
+    "overflow": false
+  },
+  {
+    "principal": "6508010152254832392",
+    "rate_bps": 2596,
+    "seconds": 2356867962,
+    "expected": "126264585047169984580",
+    "overflow": false
+  },
+  {
+    "principal": "9531122646743241665",
+    "rate_bps": 625,
+    "seconds": 1523225819,
+    "expected": "28772775755436092814",
+    "overflow": false
+  },
+  {
+    "principal": "14117945088731730126",
+    "rate_bps": 4741,
+    "seconds": 1128017584,
+    "expected": "239414641552130513564",
+    "overflow": false
+  },
+  {
+    "principal": "16284257512517338687",
+    "rate_bps": 9625,
+    "seconds": 231124873,
+    "expected": "114870570582013281528",
+    "overflow": false
+  },
+  {
+    "principal": "6332409667626881892",
+    "rate_bps": 7140,
+    "seconds": 1238558518,
+    "expected": "177573084486924274383",
+    "overflow": false
+  },
+  {
+    "principal": "16363722229098999757",
+    "rate_bps": 6965,
+    "seconds": 1077426119,
+    "expected": "389389388556462212958",
+    "overflow": false
+  },
+  {
+    "principal": "8337440146291427402",
+    "rate_bps": 6698,
+    "seconds": 2595879564,
+    "expected": "459680207744433724190",
+    "overflow": false
+  },
+  {
+    "principal": "10220199293669605355",
+    "rate_bps": 5161,
+    "seconds": 3755026709,
+    "expected": "628057848577897369314",
+    "overflow": false
+  },
+  {
+    "principal": "10827878369677681920",
+    "rate_bps": 2675,
+    "seconds": 3658684978,
+    "expected": "336035813436892964632",
+    "overflow": false
+  },
+  {
+    "principal": "13978717589704796697",
+    "rate_bps": 1314,
+    "seconds": 3960234739,
+    "expected": "230662512522580352643",
+    "overflow": false
+  },
+  {
+    "principal": "18073618018220012294",
+    "rate_bps": 465,
+    "seconds": 149040040,
+    "expected": "3971864313346041295",
+    "overflow": false
+  },
+  {
+    "principal": "4932880985895830999",
+    "rate_bps": 1065,
+    "seconds": 620792033,
+    "expected": "10341648512199083185",
+    "overflow": false
+  },
+  {
+    "principal": "16681250763428343772",
+    "rate_bps": 739,
+    "seconds": 668837998,
+    "expected": "26144923818963462591",
+    "overflow": false
+  },
+  {
+    "principal": "10129233564851678885",
+    "rate_bps": 9037,
+    "seconds": 1271652959,
+    "expected": "369115996639434917613",
+    "overflow": false
+  },
+  {
+    "principal": "16970382654045580546",
+    "rate_bps": 5058,
+    "seconds": 430702084,
+    "expected": "117230556408695319793",
+    "overflow": false
+  },
+  {
+    "principal": "3723728149481726979",
+    "rate_bps": 1943,
+    "seconds": 508639981,
+    "expected": "11669564689677236006",
+    "overflow": false
+  },
+  {
+    "principal": "10531337738749964280",
+    "rate_bps": 8713,
+    "seconds": 1906699754,
+    "expected": "554787871788256493038",
+    "overflow": false
+  },
+  {
+    "principal": "18371104928787294577",
+    "rate_bps": 2104,
+    "seconds": 1983758859,
+    "expected": "243143847945266225586",
+    "overflow": false
+  },
+  {
+    "principal": "8264582511115178558",
+    "rate_bps": 2501,
+    "seconds": 1869999520,
+    "expected": "122565855172796905755",
+    "overflow": false
+  },
+  {
+    "principal": "10766130319144035951",
+    "rate_bps": 9751,
+    "seconds": 3750751033,
+    "expected": "1248591630612162414931",
+    "overflow": false
+  },
+  {
+    "principal": "1683090818032869716",
+    "rate_bps": 2924,
+    "seconds": 2167178918,
+    "expected": "33819959203699557706",
+    "overflow": false
+  },
+  {
+    "principal": "2372293744262481533",
+    "rate_bps": 6332,
+    "seconds": 622284279,
+    "expected": "29640914064199948300",
+    "overflow": false
+  },
+  {
+    "principal": "3118696806220873402",
+    "rate_bps": 1978,
+    "seconds": 346142332,
+    "expected": "6770917950709516292",
+    "overflow": false
+  },
+  {
+    "principal": "9430825055426189595",
+    "rate_bps": 4511,
+    "seconds": 3383068101,
+    "expected": "456380047271625787333",
+    "overflow": false
+  },
+  {
+    "principal": "8642959493170577392",
+    "rate_bps": 9419,
+    "seconds": 2520469154,
+    "expected": "650641940259477237913",
+    "overflow": false
+  },
+  {
+    "principal": "3926278656067940809",
+    "rate_bps": 8146,
+    "seconds": 3135771171,
+    "expected": "318026479005769004022",
+    "overflow": false
+  },
+  {
+    "principal": "5178501313122602614",
+    "rate_bps": 9758,
+    "seconds": 108024984,
+    "expected": "17309419694123927336",
+    "overflow": false
+  },
+  {
+    "principal": "9791834220821596167",
+    "rate_bps": 4475,
+    "seconds": 3475191441,
+    "expected": "482868882165170803428",
+    "overflow": false
+  },
+  {
+    "principal": "17655719046002182092",
+    "rate_bps": 385,
+    "seconds": 3768672734,
+    "expected": "81232151771358677104",
+    "overflow": false
+  },
+  {
+    "principal": "2637220697176856405",
+    "rate_bps": 6300,
+    "seconds": 1631967887,
+    "expected": "85978928142324967146",
+    "overflow": false
+  },
+  {
+    "principal": "5079824536062844274",
+    "rate_bps": 217,
+    "seconds": 4112385012,
+    "expected": "14374594622005798640",
+    "overflow": false
+  },
+  {
+    "principal": "2836496615385612083",
+    "rate_bps": 9072,
+    "seconds": 2936957341,
+    "expected": "239649398223078035632",
+    "overflow": false
+  },
+  {
+    "principal": "15694571468865533160",
+    "rate_bps": 2312,
+    "seconds": 2775522394,
+    "expected": "319356250443535285297",
+    "overflow": false
+  },
+  {
+    "principal": "5359934447647073057",
+    "rate_bps": 4341,
+    "seconds": 188265275,
+    "expected": "13890340124768424224",
+    "overflow": false
+  },
+  {
+    "principal": "7060843607617456046",
+    "rate_bps": 7177,
+    "seconds": 1967014032,
+    "expected": "316082454857733481302",
+    "overflow": false
+  },
+  {
+    "principal": "5978784510235396767",
+    "rate_bps": 3146,
+    "seconds": 2448214761,
+    "expected": "146020732978328399688",
+    "overflow": false
+  },
+  {
+    "principal": "3530271228311749444",
+    "rate_bps": 3872,
+    "seconds": 1802639894,
+    "expected": "78135031769478656501",
+    "overflow": false
+  },
+  {
+    "principal": "15798019824404463917",
+    "rate_bps": 4605,
+    "seconds": 1743185959,
+    "expected": "402132710508799023038",
+    "overflow": false
+  },
+  {
+    "principal": "15662729077454580010",
+    "rate_bps": 5999,
+    "seconds": 509068908,
+    "expected": "151675789314339621833",
+    "overflow": false
+  },
+  {
+    "principal": "14687778527464453707",
+    "rate_bps": 5060,
+    "seconds": 3037742709,
+    "expected": "715897774587938281823",
+    "overflow": false
+  },
+  {
+    "principal": "10442484384594456288",
+    "rate_bps": 4528,
+    "seconds": 3404805906,
+    "expected": "510500304373025590671",
+    "overflow": false
+  },
+  {
+    "principal": "17944561373599636857",
+    "rate_bps": 2001,
+    "seconds": 293668179,
+    "expected": "33437224345950744564",
+    "overflow": false
+  },
+  {
+    "principal": "8803086314687208934",
+    "rate_bps": 1899,
+    "seconds": 1388351880,
+    "expected": "73595772909315995050",
+    "overflow": false
+  },
+  {
+    "principal": "3926997068662148663",
+    "rate_bps": 3769,
+    "seconds": 270731329,
+    "expected": "12706285893073665796",
+    "overflow": false
+  },
+  {
+    "principal": "13520053648792302524",
+    "rate_bps": 2104,
+    "seconds": 3165163342,
+    "expected": "285504968651473471104",
+    "overflow": false
+  },
+  {
+    "principal": "9761606756941063173",
+    "rate_bps": 5673,
+    "seconds": 2221790911,
+    "expected": "390149155053262424333",
+    "overflow": false
+  },
+  {
+    "principal": "14201494955891491298",
+    "rate_bps": 1663,
+    "seconds": 2897862116,
+    "expected": "217018832868002224670",
+    "overflow": false
+  },
+  {
+    "principal": "2219982491389501027",
+    "rate_bps": 9261,
+    "seconds": 552827981,
+    "expected": "36040502947738121054",
+    "overflow": false
+  },
+  {
+    "principal": "9839151293857238488",
+    "rate_bps": 5314,
+    "seconds": 2214952650,
+    "expected": "367229049306421935420",
+    "overflow": false
+  },
+  {
+    "principal": "8766726701567115473",
+    "rate_bps": 9272,
+    "seconds": 2864081003,
+    "expected": "738226414352079417830",
+    "overflow": false
+  },
+  {
+    "principal": "11919045970304430366",
+    "rate_bps": 6215,
+    "seconds": 1288447872,
+    "expected": "302651529759151219115",
+    "overflow": false
+  },
+  {
+    "principal": "12392065157132645071",
+    "rate_bps": 569,
+    "seconds": 1233145497,
+    "expected": "27571707916256725459",
+    "overflow": false
+  },
+  {
+    "principal": "10085187833770817844",
+    "rate_bps": 956,
+    "seconds": 2426577286,
+    "expected": "74187272522460206292",
+    "overflow": false
+  },
+  {
+    "principal": "13503720539199201245",
+    "rate_bps": 5740,
+    "seconds": 129107543,
+    "expected": "31732942396633868931",
+    "overflow": false
+  },
+  {
+    "principal": "7664652840144127898",
+    "rate_bps": 8526,
+    "seconds": 2237868636,
+    "expected": "463730648509020851139",
+    "overflow": false
+  },
+  {
+    "principal": "4223259602535683963",
+    "rate_bps": 3643,
+    "seconds": 1816423205,
+    "expected": "88617069457018537210",
+    "overflow": false
+  },
+  {
+    "principal": "15593507831739757008",
+    "rate_bps": 2683,
+    "seconds": 4077114242,
+    "expected": "540892262851461117371",
+    "overflow": false
+  },
+  {
+    "principal": "9361950016856075561",
+    "rate_bps": 6352,
+    "seconds": 3488758915,
+    "expected": "657871632343335385717",
+    "overflow": false
+  },
+  {
+    "principal": "15765737379735806294",
+    "rate_bps": 8106,
+    "seconds": 2678710904,
+    "expected": "1085525740132647149687",
+    "overflow": false
+  },
+  {
+    "principal": "11444775463960303719",
+    "rate_bps": 4063,
+    "seconds": 2999123441,
+    "expected": "442223516074167697729",
+    "overflow": false
+  },
+  {
+    "principal": "3596396708489966508",
+    "rate_bps": 6679,
+    "seconds": 1083322558,
+    "expected": "82514489018592623812",
+    "overflow": false
+  },
+  {
+    "principal": "17705393645456086197",
+    "rate_bps": 4049,
+    "seconds": 2037307119,
+    "expected": "463130368390889310369",
+    "overflow": false
+  },
+  {
+    "principal": "1857411819008612946",
+    "rate_bps": 6890,
+    "seconds": 3047590868,
+    "expected": "123673736812948923306",
+    "overflow": false
+  },
+  {
+    "principal": "13175286571822236051",
+    "rate_bps": 9076,
+    "seconds": 2857595645,
+    "expected": "1083549424529490247310",
+    "overflow": false
+  },
+  {
+    "principal": "100092900039146184",
+    "rate_bps": 3252,
+    "seconds": 47715642,
+    "expected": "49250197219848733",
+    "overflow": false
+  },
+  {
+    "principal": "8550951472679682689",
+    "rate_bps": 5928,
+    "seconds": 2414993819,
+    "expected": "388179014719431059514",
+    "overflow": false
+  },
+  {
+    "principal": "15948762539652746894",
+    "rate_bps": 9772,
+    "seconds": 3717636720,
+    "expected": "1837260729836926430803",
+    "overflow": false
+  },
+  {
+    "principal": "7218551549162135295",
+    "rate_bps": 4314,
+    "seconds": 590181961,
+    "expected": "58278655926051858488",
+    "overflow": false
+  },
+  {
+    "principal": "4298712199193461540",
+    "rate_bps": 3172,
+    "seconds": 234691830,
+    "expected": "10147590026749443736",
+    "overflow": false
+  },
+  {
+    "principal": "280121451614413453",
+    "rate_bps": 5865,
+    "seconds": 3653478535,
+    "expected": "19033310733948038101",
+    "overflow": false
+  },
+  {
+    "principal": "4433553677801363978",
+    "rate_bps": 132,
+    "seconds": 579527244,
+    "expected": "1075457252064123778",
+    "overflow": false
+  },
+  {
+    "principal": "652681824124861611",
+    "rate_bps": 682,
+    "seconds": 2109010901,
+    "expected": "2976857946154802077",
+    "overflow": false
+  },
+  {
+    "principal": "7077651936721635520",
+    "rate_bps": 408,
+    "seconds": 1518478322,
+    "expected": "13904371204090032561",
+    "overflow": false
+  },
+  {
+    "principal": "14511584781880713433",
+    "rate_bps": 581,
+    "seconds": 412530611,
+    "expected": "11029112050330504720",
+    "overflow": false
+  },
+  {
+    "principal": "4141299005948074182",
+    "rate_bps": 1438,
+    "seconds": 105072488,
+    "expected": "1984165450829874399",
+    "overflow": false
+  },
+  {
+    "principal": "3656756870652077719",
+    "rate_bps": 6038,
+    "seconds": 1376130977,
+    "expected": "96347923432787260502",
+    "overflow": false
+  },
+  {
+    "principal": "10596759005762652060",
+    "rate_bps": 8039,
+    "seconds": 1044203054,
+    "expected": "282067752686109126940",
+    "overflow": false
+  },
+  {
+    "principal": "4195808972894349669",
+    "rate_bps": 1136,
+    "seconds": 4071873311,
+    "expected": "61543428858933564872",
+    "overflow": false
+  },
+  {
+    "principal": "3538276661802067650",
+    "rate_bps": 6737,
+    "seconds": 2286620100,
+    "expected": "172840591949385164927",
+    "overflow": false
+  },
+  {
+    "principal": "7443506512544213187",
+    "rate_bps": 9096,
+    "seconds": 2646691245,
+    "expected": "568230705756820730663",
+    "overflow": false
+  },
+  {
+    "principal": "11474216130820438968",
+    "rate_bps": 4440,
+    "seconds": 546693034,
+    "expected": "88316719591023123089",
+    "overflow": false
+  },
+  {
+    "principal": "1966012057134770225",
+    "rate_bps": 4343,
+    "seconds": 3496353483,
+    "expected": "94663974152909739887",
+    "overflow": false
+  },
+  {
+    "principal": "6211831985477296126",
+    "rate_bps": 9863,
+    "seconds": 3998527840,
+    "expected": "776823313750449519962",
+    "overflow": false
+  },
+  {
+    "principal": "6547844371724193583",
+    "rate_bps": 8457,
+    "seconds": 3826729465,
+    "expected": "671948258385013248945",
+    "overflow": false
+  },
+  {
+    "principal": "13168964440422719764",
+    "rate_bps": 5079,
+    "seconds": 100699238,
+    "expected": "21357450824663542835",
+    "overflow": false
+  },
+  {
+    "principal": "3380840442383092029",
+    "rate_bps": 2454,
+    "seconds": 3114716855,
+    "expected": "81942875387597330705",
+    "overflow": false
+  },
+  {
+    "principal": "7196208431593267322",
+    "rate_bps": 9450,
+    "seconds": 3386240572,
+    "expected": "730208264937531073863",
+    "overflow": false
+  },
+  {
+    "principal": "1950129183692563931",
+    "rate_bps": 536,
+    "seconds": 3960791173,
+    "expected": "13128149381471501399",
+    "overflow": false
+  },
+  {
+    "principal": "1352715300018975664",
+    "rate_bps": 6946,
+    "seconds": 2394630242,
+    "expected": "71346559815809718442",
+    "overflow": false
+  },
+  {
+    "principal": "6666627790665693321",
+    "rate_bps": 7645,
+    "seconds": 2148103907,
+    "expected": "347162155510706808016",
+    "overflow": false
+  },
+  {
+    "principal": "10154277949208724534",
+    "rate_bps": 5216,
+    "seconds": 4142121048,
+    "expected": "695669253431510548200",
+    "overflow": false
+  },
+  {
+    "principal": "1412801207194613959",
+    "rate_bps": 7039,
+    "seconds": 154096977,
+    "expected": "4859365148796865861",
+    "overflow": false
+  },
+  {
+    "principal": "5190134742585028492",
+    "rate_bps": 6324,
+    "seconds": 1154011038,
+    "expected": "120108529525485802056",
+    "overflow": false
+  },
+  {
+    "principal": "11070266430462714389",
+    "rate_bps": 7284,
+    "seconds": 3236422479,
+    "expected": "827535459981341395224",
+    "overflow": false
+  },
+  {
+    "principal": "18156558867535341362",
+    "rate_bps": 8974,
+    "seconds": 2421056436,
+    "expected": "1250886523086267899879",
+    "overflow": false
+  },
+  {
+    "principal": "8327101129228375027",
+    "rate_bps": 1193,
+    "seconds": 437259357,
+    "expected": "13774212780093750609",
+    "overflow": false
+  },
+  {
+    "principal": "8115687779154579624",
+    "rate_bps": 2649,
+    "seconds": 1429069338,
+    "expected": "97421314081245278182",
+    "overflow": false
+  },
+  {
+    "principal": "9910959710755385825",
+    "rate_bps": 9569,
+    "seconds": 2345541627,
+    "expected": "705372953448153602530",
+    "overflow": false
+  },
+  {
+    "principal": "12216962480921355630",
+    "rate_bps": 3187,
+    "seconds": 352146512,
+    "expected": "43477252125281085094",
+    "overflow": false
+  },
+  {
+    "principal": "3688177680040264543",
+    "rate_bps": 8479,
+    "seconds": 2845880745,
+    "expected": "282206206498244814787",
+    "overflow": false
+  },
+  {
+    "principal": "507820170159756036",
+    "rate_bps": 1475,
+    "seconds": 275509206,
+    "expected": "654382196570463711",
+    "overflow": false
+  },
+  {
+    "principal": "9458583367561368557",
+    "rate_bps": 8082,
+    "seconds": 3106306279,
+    "expected": "752978558812230535721",
+    "overflow": false
+  },
+  {
+    "principal": "11905140165596175082",
+    "rate_bps": 6705,
+    "seconds": 982208044,
+    "expected": "248616629695178685495",
+    "overflow": false
+  },
+  {
+    "principal": "1938387721840497419",
+    "rate_bps": 3062,
+    "seconds": 3730256181,
+    "expected": "70206591432348471841",
+    "overflow": false
+  },
+  {
+    "principal": "14267169018430190240",
+    "rate_bps": 1916,
+    "seconds": 3460161746,
+    "expected": "299932207876169429755",
+    "overflow": false
+  },
+  {
+    "principal": "14412004560284038201",
+    "rate_bps": 6042,
+    "seconds": 1025866259,
+    "expected": "283262608968230078584",
+    "overflow": false
+  },
+  {
+    "principal": "671641312090153894",
+    "rate_bps": 3182,
+    "seconds": 690113864,
+    "expected": "4676831487466568607",
+    "overflow": false
+  },
+  {
+    "principal": "9777155390049210103",
+    "rate_bps": 7394,
+    "seconds": 599897857,
+    "expected": "137518987891133849701",
+    "overflow": false
+  },
+  {
+    "principal": "7618631299239193468",
+    "rate_bps": 4335,
+    "seconds": 278121742,
+    "expected": "29126908556194678615",
+    "overflow": false
+  },
+  {
+    "principal": "48674059952750277",
+    "rate_bps": 3083,
+    "seconds": 49672063,
+    "expected": "23636147317442877",
+    "overflow": false
+  },
+  {
+    "principal": "5124355986254830498",
+    "rate_bps": 7910,
+    "seconds": 479694244,
+    "expected": "61655762938019653028",
+    "overflow": false
+  },
+  {
+    "principal": "7449052612172956451",
+    "rate_bps": 399,
+    "seconds": 3125980941,
+    "expected": "29461418699801533669",
+    "overflow": false
+  },
+  {
+    "principal": "3765416938782112152",
+    "rate_bps": 7179,
+    "seconds": 30347402,
+    "expected": "2601308954931702282",
+    "overflow": false
+  },
+  {
+    "principal": "107274846690598801",
+    "rate_bps": 4886,
+    "seconds": 472180011,
+    "expected": "784788004461081900",
+    "overflow": false
+  },
+  {
+    "principal": "1827445716287168222",
+    "rate_bps": 7734,
+    "seconds": 2798095168,
+    "expected": "125402018640967882910",
+    "overflow": false
+  },
+  {
+    "principal": "3634314616169806735",
+    "rate_bps": 3621,
+    "seconds": 2574042457,
+    "expected": "107413815732580923683",
+    "overflow": false
+  },
+  {
+    "principal": "14704492331646212340",
+    "rate_bps": 3947,
+    "seconds": 2856208198,
+    "expected": "525654535541651305235",
+    "overflow": false
+  },
+  {
+    "principal": "3108218195403850397",
+    "rate_bps": 840,
+    "seconds": 1347266327,
+    "expected": "11154179597204793242",
+    "overflow": false
+  },
+  {
+    "principal": "11607872534608169306",
+    "rate_bps": 9064,
+    "seconds": 254935580,
+    "expected": "85054319116206631375",
+    "overflow": false
+  },
+  {
+    "principal": "9721179340771279931",
+    "rate_bps": 7582,
+    "seconds": 1336862181,
+    "expected": "312451609369386442295",
+    "overflow": false
+  },
+  {
+    "principal": "918435284863649168",
+    "rate_bps": 9446,
+    "seconds": 2027507010,
+    "expected": "55776628484747490710",
+    "overflow": false
+  },
+  {
+    "principal": "16370352689648227305",
+    "rate_bps": 3349,
+    "seconds": 1493549379,
+    "expected": "259648705871334078947",
+    "overflow": false
+  },
+  {
+    "principal": "13972836289029453590",
+    "rate_bps": 9649,
+    "seconds": 2346053176,
+    "expected": "1002993507690704175154",
+    "overflow": false
+  },
+  {
+    "principal": "4105873651122317607",
+    "rate_bps": 4987,
+    "seconds": 3447733425,
+    "expected": "223857691772167047958",
+    "overflow": false
+  },
+  {
+    "principal": "3775018510385871724",
+    "rate_bps": 2544,
+    "seconds": 4215094910,
+    "expected": "128362138407764583273",
+    "overflow": false
+  },
+  {
+    "principal": "9622939365412044661",
+    "rate_bps": 6452,
+    "seconds": 1443430319,
+    "expected": "284178569918672387796",
+    "overflow": false
+  },
+  {
+    "principal": "5911237536108200978",
+    "rate_bps": 2055,
+    "seconds": 1330482068,
+    "expected": "51249856791420450700",
+    "overflow": false
+  },
+  {
+    "principal": "3039536048375559763",
+    "rate_bps": 1775,
+    "seconds": 1172059581,
+    "expected": "20051586413768015582",
+    "overflow": false
+  },
+  {
+    "principal": "12692176384098219656",
+    "rate_bps": 180,
+    "seconds": 3773331194,
+    "expected": "27335493761340147139",
+    "overflow": false
+  },
+  {
+    "principal": "13287462959091315009",
+    "rate_bps": 7888,
+    "seconds": 1168469595,
+    "expected": "388346842006938442180",
+    "overflow": false
+  },
+  {
+    "principal": "8037504665005460558",
+    "rate_bps": 6148,
+    "seconds": 2821346864,
+    "expected": "442084178703636929474",
+    "overflow": false
+  },
+  {
+    "principal": "998278990668658623",
+    "rate_bps": 7898,
+    "seconds": 2438888713,
+    "expected": "60975369048491801992",
+    "overflow": false
+  },
+  {
+    "principal": "155595282787594980",
+    "rate_bps": 1369,
+    "seconds": 2780205750,
+    "expected": "1877890239517628277",
+    "overflow": false
+  },
+  {
+    "principal": "1616209276344571213",
+    "rate_bps": 181,
+    "seconds": 2372360519,
+    "expected": "2200646325003479422",
+    "overflow": false
+  },
+  {
+    "principal": "3460843373054618570",
+    "rate_bps": 5335,
+    "seconds": 2911963660,
+    "expected": "170488744519772528642",
+    "overflow": false
+  },
+  {
+    "principal": "13569824668509944171",
+    "rate_bps": 5933,
+    "seconds": 3213819541,
+    "expected": "820471433569689756088",
+    "overflow": false
+  },
+  {
+    "principal": "2282331297320742016",
+    "rate_bps": 918,
+    "seconds": 2140958130,
+    "expected": "14224038987669336853",
+    "overflow": false
+  },
+  {
+    "principal": "8217180241683814297",
+    "rate_bps": 7614,
+    "seconds": 3741666419,
+    "expected": "742325099153114230804",
+    "overflow": false
+  },
+  {
+    "principal": "7104232254296161926",
+    "rate_bps": 4755,
+    "seconds": 890610472,
+    "expected": "95400107223137187491",
+    "overflow": false
+  },
+  {
+    "principal": "7534848718096172887",
+    "rate_bps": 8898,
+    "seconds": 3261982305,
+    "expected": "693492761600165255541",
+    "overflow": false
+  },
+  {
+    "principal": "15361900192424533852",
+    "rate_bps": 5447,
+    "seconds": 1805919214,
+    "expected": "479174861674144021659",
+    "overflow": false
+  },
+  {
+    "principal": "10156729718965724197",
+    "rate_bps": 2779,
+    "seconds": 93066207,
+    "expected": "8329671026101756484",
+    "overflow": false
+  },
+  {
+    "principal": "13861526599564632194",
+    "rate_bps": 6203,
+    "seconds": 232217988,
+    "expected": "63314341566212701797",
+    "overflow": false
+  },
+  {
+    "principal": "370426729505451395",
+    "rate_bps": 9915,
+    "seconds": 1614782573,
+    "expected": "18806262019471972496",
+    "overflow": false
+  },
+  {
+    "principal": "15063392207067006840",
+    "rate_bps": 51,
+    "seconds": 1982402922,
+    "expected": "4829234364068381639",
+    "overflow": false
+  },
+  {
+    "principal": "10487737668005603057",
+    "rate_bps": 3881,
+    "seconds": 1724562315,
+    "expected": "222585947825735071344",
+    "overflow": false
+  },
+  {
+    "principal": "16638769271240617406",
+    "rate_bps": 3330,
+    "seconds": 3168580896,
+    "expected": "556703081762208879474",
+    "overflow": false
+  },
+  {
+    "principal": "13103658095419996143",
+    "rate_bps": 637,
+    "seconds": 3617118393,
+    "expected": "95738827016361332757",
+    "overflow": false
+  },
+  {
+    "principal": "9164935496738431188",
+    "rate_bps": 7218,
+    "seconds": 2589184550,
+    "expected": "543128622451517710656",
+    "overflow": false
+  },
+  {
+    "principal": "2860573319814597629",
+    "rate_bps": 399,
+    "seconds": 1157533559,
+    "expected": "4189410948282943712",
+    "overflow": false
+  },
+  {
+    "principal": "17955603758173241914",
+    "rate_bps": 4530,
+    "seconds": 917464572,
+    "expected": "236636051927900945497",
+    "overflow": false
+  },
+  {
+    "principal": "16935415162213528219",
+    "rate_bps": 3413,
+    "seconds": 3786046277,
+    "expected": "693923263047308831333",
+    "overflow": false
+  },
+  {
+    "principal": "13219166404125615984",
+    "rate_bps": 7303,
+    "seconds": 3570811426,
+    "expected": "1093114560023648680373",
+    "overflow": false
+  },
+  {
+    "principal": "10002550921598992201",
+    "rate_bps": 6321,
+    "seconds": 213851043,
+    "expected": "42874722991288802138",
+    "overflow": false
+  },
+  {
+    "principal": "14697452799974980086",
+    "rate_bps": 4002,
+    "seconds": 1379429400,
+    "expected": "257283555893537616672",
+    "overflow": false
+  },
+  {
+    "principal": "83765071224400263",
+    "rate_bps": 879,
+    "seconds": 4274893841,
+    "expected": "998091976892672173",
+    "overflow": false
+  },
+  {
+    "principal": "13723195531793635148",
+    "rate_bps": 165,
+    "seconds": 1172798814,
+    "expected": "8420853400102474340",
+    "overflow": false
+  },
+  {
+    "principal": "17005450677939350741",
+    "rate_bps": 9441,
+    "seconds": 992619535,
+    "expected": "505338462587821665301",
+    "overflow": false
+  },
+  {
+    "principal": "16388892851480015090",
+    "rate_bps": 1044,
+    "seconds": 4040950644,
+    "expected": "219243665132011385456",
+    "overflow": false
+  },
+  {
+    "principal": "17804113959596239027",
+    "rate_bps": 2837,
+    "seconds": 961539869,
+    "expected": "154006975051373683882",
+    "overflow": false
+  },
+  {
+    "principal": "10549439016832658536",
+    "rate_bps": 3742,
+    "seconds": 2122309594,
+    "expected": "265665573416692383651",
+    "overflow": false
+  },
+  {
+    "principal": "12747816606391926945",
+    "rate_bps": 2792,
+    "seconds": 2823802043,
+    "expected": "318697650719043092540",
+    "overflow": false
+  },
+  {
+    "principal": "9176854353382097710",
+    "rate_bps": 6496,
+    "seconds": 399878160,
+    "expected": "75589406147533218759",
+    "overflow": false
+  },
+  {
+    "principal": "1728223052613155871",
+    "rate_bps": 5851,
+    "seconds": 3397310569,
+    "expected": "108932766988521434376",
+    "overflow": false
+  },
+  {
+    "principal": "5876986792391779012",
+    "rate_bps": 83,
+    "seconds": 1423246742,
+    "expected": "2201437694441388504",
+    "overflow": false
+  },
+  {
+    "principal": "4466593666620516013",
+    "rate_bps": 8518,
+    "seconds": 1105086887,
+    "expected": "133322638581989339827",
+    "overflow": false
+  },
+  {
+    "principal": "12943546622439541930",
+    "rate_bps": 7597,
+    "seconds": 1993610732,
+    "expected": "621626005486039890629",
+    "overflow": false
+  },
+  {
+    "principal": "17094787934389497803",
+    "rate_bps": 8131,
+    "seconds": 1307859957,
+    "expected": "576450891078875741612",
+    "overflow": false
+  },
+  {
+    "principal": "3726793911374657120",
+    "rate_bps": 3046,
+    "seconds": 3692415634,
+    "expected": "132913547773680713106",
+    "overflow": false
+  },
+  {
+    "principal": "5721286493070461689",
+    "rate_bps": 3205,
+    "seconds": 2181967571,
+    "expected": "126871307087955365020",
+    "overflow": false
+  },
+  {
+    "principal": "15212154801336838502",
+    "rate_bps": 9501,
+    "seconds": 399853832,
+    "expected": "183254526084987826333",
+    "overflow": false
+  },
+  {
+    "principal": "12328173310013099959",
+    "rate_bps": 8262,
+    "seconds": 1864541633,
+    "expected": "602211992549640859467",
+    "overflow": false
+  },
+  {
+    "principal": "17832401982419002172",
+    "rate_bps": 9812,
+    "seconds": 1533430478,
+    "expected": "850794882683539016890",
+    "overflow": false
+  },
+  {
+    "principal": "1608325182620227973",
+    "rate_bps": 2039,
+    "seconds": 785270847,
+    "expected": "8165898088131434637",
+    "overflow": false
+  },
+  {
+    "principal": "7728058790048462178",
+    "rate_bps": 9438,
+    "seconds": 876772708,
+    "expected": "202782655532822906923",
+    "overflow": false
+  },
+  {
+    "principal": "2437109836152842211",
+    "rate_bps": 2879,
+    "seconds": 1025515981,
+    "expected": "22816687430445912471",
+    "overflow": false
+  },
+  {
+    "principal": "1476869237604820312",
+    "rate_bps": 3966,
+    "seconds": 1612440138,
+    "expected": "29948270545084902938",
+    "overflow": false
+  },
+  {
+    "principal": "6357563601336860241",
+    "rate_bps": 2819,
+    "seconds": 758096363,
+    "expected": "43082767736655296741",
+    "overflow": false
+  },
+  {
+    "principal": "977819950903299230",
+    "rate_bps": 9496,
+    "seconds": 1800154880,
+    "expected": "53003294571866622822",
+    "overflow": false
+  },
+  {
+    "principal": "15413883282959156303",
+    "rate_bps": 2529,
+    "seconds": 2427681817,
+    "expected": "300086220698843005954",
+    "overflow": false
+  },
+  {
+    "principal": "17993515880676440244",
+    "rate_bps": 5703,
+    "seconds": 1194929414,
+    "expected": "388825776416193326245",
+    "overflow": false
+  },
+  {
+    "principal": "83740084771775837",
+    "rate_bps": 8512,
+    "seconds": 1964083159,
+    "expected": "4439338650644845913",
+    "overflow": false
+  },
+  {
+    "principal": "8565816590266993434",
+    "rate_bps": 5764,
+    "seconds": 3582335452,
+    "expected": "560857313440041397404",
+    "overflow": false
+  },
+  {
+    "principal": "9244546038320738555",
+    "rate_bps": 3818,
+    "seconds": 815767717,
+    "expected": "91302237639991230338",
+    "overflow": false
+  },
+  {
+    "principal": "17344076401693792592",
+    "rate_bps": 2036,
+    "seconds": 3660187394,
+    "expected": "409850685328268930056",
+    "overflow": false
+  },
+  {
+    "principal": "18437810854569097897",
+    "rate_bps": 2292,
+    "seconds": 1896711683,
+    "expected": "254166718038426011613",
+    "overflow": false
+  },
+  {
+    "principal": "9985399236767943894",
+    "rate_bps": 9374,
+    "seconds": 2982361592,
+    "expected": "885205438534490770004",
+    "overflow": false
+  },
+  {
+    "principal": "13228363488131463655",
+    "rate_bps": 4252,
+    "seconds": 2687482737,
+    "expected": "479334239211575608520",
+    "overflow": false
+  },
+  {
+    "principal": "9237513768354546476",
+    "rate_bps": 2351,
+    "seconds": 3669986366,
+    "expected": "252735106150881525390",
+    "overflow": false
+  },
+  {
+    "principal": "12784220799992850997",
+    "rate_bps": 9871,
+    "seconds": 1453549679,
+    "expected": "581645921790255889433",
+    "overflow": false
+  },
+  {
+    "principal": "9352117916382457298",
+    "rate_bps": 7775,
+    "seconds": 2805058388,
+    "expected": "646763749916774398861",
+    "overflow": false
+  },
+  {
+    "principal": "13961334879836367635",
+    "rate_bps": 1291,
+    "seconds": 3288545405,
+    "expected": "187953502073113201084",
+    "overflow": false
+  },
+  {
+    "principal": "1390370773050290760",
+    "rate_bps": 1950,
+    "seconds": 2590775482,
+    "expected": "22273497253712440782",
+    "overflow": false
+  },
+  {
+    "principal": "18034478818817613825",
+    "rate_bps": 8519,
+    "seconds": 1118124827,
+    "expected": "544723232182093040936",
+    "overflow": false
+  },
+  {
+    "principal": "5576071210791094798",
+    "rate_bps": 1230,
+    "seconds": 3635890672,
+    "expected": "79074714361743396117",
+    "overflow": false
+  },
+  {
+    "principal": "10590067083003662463",
+    "rate_bps": 3703,
+    "seconds": 3373908937,
+    "expected": "419545602082045801011",
+    "overflow": false
+  },
+  {
+    "principal": "2707163858808382116",
+    "rate_bps": 4087,
+    "seconds": 4173285494,
+    "expected": "146416718778427670771",
+    "overflow": false
+  },
+  {
+    "principal": "5658062521830459405",
+    "rate_bps": 6860,
+    "seconds": 635652615,
+    "expected": "78235720927030311697",
+    "overflow": false
+  },
+  {
+    "principal": "9705536690036669834",
+    "rate_bps": 1941,
+    "seconds": 1166832076,
+    "expected": "69702257386796874220",
+    "overflow": false
+  },
+  {
+    "principal": "10768717456232396331",
+    "rate_bps": 5986,
+    "seconds": 4196354389,
+    "expected": "857760900562884722986",
+    "overflow": false
+  },
+  {
+    "principal": "17504587349030441024",
+    "rate_bps": 4253,
+    "seconds": 1696724850,
+    "expected": "400545699731857149475",
+    "overflow": false
+  },
+  {
+    "principal": "6246409328408628825",
+    "rate_bps": 4752,
+    "seconds": 3457687859,
+    "expected": "325451329683577337629",
+    "overflow": false
+  },
+  {
+    "principal": "13839388274072527942",
+    "rate_bps": 7241,
+    "seconds": 857292520,
+    "expected": "272419297681736733375",
+    "overflow": false
+  },
+  {
+    "principal": "17103579127158712343",
+    "rate_bps": 4262,
+    "seconds": 1861743905,
+    "expected": "430342046021797705127",
+    "overflow": false
+  },
+  {
+    "principal": "12787311937248425756",
+    "rate_bps": 1386,
+    "seconds": 3218227630,
+    "expected": "180864212638178748032",
+    "overflow": false
+  },
+  {
+    "principal": "11960796917332991717",
+    "rate_bps": 5080,
+    "seconds": 2534706335,
+    "expected": "488365383078079082574",
+    "overflow": false
+  },
+  {
+    "principal": "6774571375199918658",
+    "rate_bps": 3724,
+    "seconds": 2618355012,
+    "expected": "209465941695996894891",
+    "overflow": false
+  },
+  {
+    "principal": "13777937533212684867",
+    "rate_bps": 8144,
+    "seconds": 3263968045,
+    "expected": "1161345035399080454775",
+    "overflow": false
+  },
+  {
+    "principal": "13234451846650712888",
+    "rate_bps": 1755,
+    "seconds": 908034858,
+    "expected": "66877340257986785996",
+    "overflow": false
+  },
+  {
+    "principal": "10643009777559758257",
+    "rate_bps": 471,
+    "seconds": 2418776139,
+    "expected": "38448060514131685923",
+    "overflow": false
+  },
+  {
+    "principal": "3438501226801888126",
+    "rate_bps": 9846,
+    "seconds": 3771594976,
+    "expected": "404899701582807264750",
+    "overflow": false
+  },
+  {
+    "principal": "4582500959811494063",
+    "rate_bps": 3615,
+    "seconds": 987017081,
+    "expected": "51847632218841050345",
+    "overflow": false
+  },
+  {
+    "principal": "8991765190429401236",
+    "rate_bps": 1940,
+    "seconds": 1978030054,
+    "expected": "109414017831208632329",
+    "overflow": false
+  },
+  {
+    "principal": "2614499547184762557",
+    "rate_bps": 6958,
+    "seconds": 568234039,
+    "expected": "32778844060253492083",
+    "overflow": false
+  },
+  {
+    "principal": "16082722591123776506",
+    "rate_bps": 7111,
+    "seconds": 888020412,
+    "expected": "322037607273152001286",
+    "overflow": false
+  },
+  {
+    "principal": "11970219369665855323",
+    "rate_bps": 7702,
+    "seconds": 254170629,
+    "expected": "74306085083979443987",
+    "overflow": false
+  },
+  {
+    "principal": "4391321533767359280",
+    "rate_bps": 52,
+    "seconds": 3561790434,
+    "expected": "2579053417182651540",
+    "overflow": false
+  },
+  {
+    "principal": "11775274341413815817",
+    "rate_bps": 1058,
+    "seconds": 2143879267,
+    "expected": "84693566026681317956",
+    "overflow": false
+  },
+  {
+    "principal": "3835212198646165430",
+    "rate_bps": 3515,
+    "seconds": 2251184088,
+    "expected": "96231915572902510766",
+    "overflow": false
+  },
+  {
+    "principal": "17904868123775408711",
+    "rate_bps": 2729,
+    "seconds": 3099480785,
+    "expected": "480238532968806456516",
+    "overflow": false
+  },
+  {
+    "principal": "6175645746379276044",
+    "rate_bps": 9107,
+    "seconds": 1136487198,
+    "expected": "202682220321582132517",
+    "overflow": false
+  },
+  {
+    "principal": "16347551548039837589",
+    "rate_bps": 221,
+    "seconds": 1926018255,
+    "expected": "22064738324591864227",
+    "overflow": false
+  },
+  {
+    "principal": "12704698187350342322",
+    "rate_bps": 1812,
+    "seconds": 3632718644,
+    "expected": "265184234768214216912",
+    "overflow": false
+  },
+  {
+    "principal": "4966349422374436211",
+    "rate_bps": 5565,
+    "seconds": 2039353821,
+    "expected": "178726279581378744284",
+    "overflow": false
+  },
+  {
+    "principal": "1377717601024493608",
+    "rate_bps": 437,
+    "seconds": 891625882,
+    "expected": "1702227896046073220",
+    "overflow": false
+  },
+  {
+    "principal": "14380500566679474017",
+    "rate_bps": 5088,
+    "seconds": 1199421819,
+    "expected": "278282851091115053978",
+    "overflow": false
+  },
+  {
+    "principal": "9122264144632619246",
+    "rate_bps": 3473,
+    "seconds": 1401371600,
+    "expected": "140784269528960310886",
+    "overflow": false
+  },
+  {
+    "principal": "3856838782937019615",
+    "rate_bps": 7320,
+    "seconds": 2236038953,
+    "expected": "200177529299613981695",
+    "overflow": false
+  },
+  {
+    "principal": "9208503451374318212",
+    "rate_bps": 9062,
+    "seconds": 3228392278,
+    "expected": "854265378989436437300",
+    "overflow": false
+  },
+  {
+    "principal": "6350820186420820333",
+    "rate_bps": 1169,
+    "seconds": 3972946535,
+    "expected": "93529893848880246114",
+    "overflow": false
+  },
+  {
+    "principal": "2566996907188125290",
+    "rate_bps": 1107,
+    "seconds": 2096242092,
+    "expected": "18888949113197276490",
+    "overflow": false
+  },
+  {
+    "principal": "7715400177498655883",
+    "rate_bps": 8611,
+    "seconds": 2024261301,
+    "expected": "426453822472562615356",
+    "overflow": false
+  },
+  {
+    "principal": "5197798647996234272",
+    "rate_bps": 3706,
+    "seconds": 2956522578,
+    "expected": "180592395901628407083",
+    "overflow": false
+  },
+  {
+    "principal": "6598044169079955897",
+    "rate_bps": 4555,
+    "seconds": 2398823315,
+    "expected": "228610016039098127184",
+    "overflow": false
+  },
+  {
+    "principal": "18361977555625553702",
+    "rate_bps": 4640,
+    "seconds": 1553564872,
+    "expected": "419720535776406037692",
+    "overflow": false
+  },
+  {
+    "principal": "9210746680103342199",
+    "rate_bps": 1273,
+    "seconds": 184931457,
+    "expected": "6875866346381268172",
+    "overflow": false
+  },
+  {
+    "principal": "16027111978114669308",
+    "rate_bps": 8900,
+    "seconds": 1289750670,
+    "expected": "583370458733675604654",
+    "overflow": false
+  },
+  {
+    "principal": "6805432677977388101",
+    "rate_bps": 1329,
+    "seconds": 985063679,
+    "expected": "28251299049402264966",
+    "overflow": false
+  },
+  {
+    "principal": "2121913773535432482",
+    "rate_bps": 2337,
+    "seconds": 2239409444,
+    "expected": "35213836438614463421",
+    "overflow": false
+  },
+  {
+    "principal": "11810172890459983011",
+    "rate_bps": 3788,
+    "seconds": 639358093,
+    "expected": "90699268740877963233",
+    "overflow": false
+  },
+  {
+    "principal": "1125469151868932376",
+    "rate_bps": 5008,
+    "seconds": 44823562,
+    "expected": "801120185914147663",
+    "overflow": false
+  },
+  {
+    "principal": "11286034894335270161",
+    "rate_bps": 6577,
+    "seconds": 1419157163,
+    "expected": "334035879037454402025",
+    "overflow": false
+  },
+  {
+    "principal": "13146611389447486046",
+    "rate_bps": 9252,
+    "seconds": 1075450560,
+    "expected": "414794789872957189315",
+    "overflow": false
+  },
+  {
+    "principal": "10199336229179886863",
+    "rate_bps": 5202,
+    "seconds": 3491001049,
+    "expected": "587334658351845276860",
+    "overflow": false
+  },
+  {
+    "principal": "14912936057145546868",
+    "rate_bps": 276,
+    "seconds": 1062425286,
+    "expected": "13866409748062751500",
+    "overflow": false
+  },
+  {
+    "principal": "11759719805020227613",
+    "rate_bps": 1852,
+    "seconds": 4038961303,
+    "expected": "278933734702124863844",
+    "overflow": false
+  },
+  {
+    "principal": "2887495115654565082",
+    "rate_bps": 2958,
+    "seconds": 1377792412,
+    "expected": "37316131050184734328",
+    "overflow": false
+  },
+  {
+    "principal": "5544259167005892027",
+    "rate_bps": 3933,
+    "seconds": 2480315237,
+    "expected": "171501429339135770744",
+    "overflow": false
+  },
+  {
+    "principal": "5493607017421532432",
+    "rate_bps": 4488,
+    "seconds": 582353090,
+    "expected": "45529220478256330036",
+    "overflow": false
+  },
+  {
+    "principal": "18209943639104151913",
+    "rate_bps": 2320,
+    "seconds": 1456048835,
+    "expected": "195058967380229468356",
+    "overflow": false
+  },
+  {
+    "principal": "15521377178480190102",
+    "rate_bps": 2306,
+    "seconds": 523355576,
+    "expected": "59399091739414879273",
+    "overflow": false
+  },
+  {
+    "principal": "12618126285870566055",
+    "rate_bps": 146,
+    "seconds": 1402042929,
+    "expected": "8190349414969379512",
+    "overflow": false
+  },
+  {
+    "principal": "7886831160517282540",
+    "rate_bps": 3623,
+    "seconds": 3738769918,
+    "expected": "338760691310670234171",
+    "overflow": false
+  },
+  {
+    "principal": "6889342468858057973",
+    "rate_bps": 8758,
+    "seconds": 1040060719,
+    "expected": "198991626680089634744",
+    "overflow": false
+  },
+  {
+    "principal": "9413767953661417362",
+    "rate_bps": 5865,
+    "seconds": 521358100,
+    "expected": "91276929799146955777",
+    "overflow": false
+  },
+  {
+    "principal": "17233772233179963347",
+    "rate_bps": 4525,
+    "seconds": 2978511677,
+    "expected": "736532020721283982475",
+    "overflow": false
+  },
+  {
+    "principal": "14781959508024978952",
+    "rate_bps": 3565,
+    "seconds": 3810720378,
+    "expected": "636783817113983552472",
+    "overflow": false
+  },
+  {
+    "principal": "12282792030162259649",
+    "rate_bps": 111,
+    "seconds": 2377205723,
+    "expected": "10277328479977729770",
+    "overflow": false
+  },
+  {
+    "principal": "10395940279481649102",
+    "rate_bps": 8761,
+    "seconds": 3841818032,
+    "expected": "1109551947426816740631",
+    "overflow": false
+  },
+  {
+    "principal": "6615701486733158719",
+    "rate_bps": 926,
+    "seconds": 2065648265,
+    "expected": "40126996409782400617",
+    "overflow": false
+  },
+  {
+    "principal": "13126591127452815972",
+    "rate_bps": 1714,
+    "seconds": 785858102,
+    "expected": "56066094347422909161",
+    "overflow": false
+  },
+  {
+    "principal": "50642677595126477",
+    "rate_bps": 5279,
+    "seconds": 2918677191,
+    "expected": "2474273928681447584",
+    "overflow": false
+  },
+  {
+    "principal": "15031220315057540938",
+    "rate_bps": 2487,
+    "seconds": 876419468,
+    "expected": "103890403907689403393",
+    "overflow": false
+  },
+  {
+    "principal": "11743380596226618091",
+    "rate_bps": 3509,
+    "seconds": 3257259029,
+    "expected": "425620163512973509229",
+    "overflow": false
+  },
+  {
+    "principal": "6070356506140554240",
+    "rate_bps": 3870,
+    "seconds": 1725088050,
+    "expected": "128507898722391933450",
+    "overflow": false
+  },
+  {
+    "principal": "4979344413993288985",
+    "rate_bps": 2894,
+    "seconds": 3029284339,
+    "expected": "138421683313992028241",
+    "overflow": false
+  },
+  {
+    "principal": "9675383334167284230",
+    "rate_bps": 7830,
+    "seconds": 3725466280,
+    "expected": "894960716068417370773",
+    "overflow": false
+  },
+  {
+    "principal": "6986937199747107031",
+    "rate_bps": 2052,
+    "seconds": 2422490081,
+    "expected": "110133539450749440866",
+    "overflow": false
+  },
+  {
+    "principal": "4164311562161032924",
+    "rate_bps": 4917,
+    "seconds": 2324143982,
+    "expected": "150903685091226669484",
+    "overflow": false
+  },
+  {
+    "principal": "11091700476022626725",
+    "rate_bps": 9011,
+    "seconds": 4195173727,
+    "expected": "1329579976970903261467",
+    "overflow": false
+  },
+  {
+    "principal": "2974148978917102594",
+    "rate_bps": 9587,
+    "seconds": 1689763076,
+    "expected": "152779349085112479133",
+    "overflow": false
+  },
+  {
+    "principal": "16521933774067119875",
+    "rate_bps": 8634,
+    "seconds": 1634141677,
+    "expected": "739189894079155586934",
+    "overflow": false
+  },
+  {
+    "principal": "16283937081932455672",
+    "rate_bps": 441,
+    "seconds": 1681470698,
+    "expected": "38289588741892335101",
+    "overflow": false
+  },
+  {
+    "principal": "12677894700228142193",
+    "rate_bps": 8919,
+    "seconds": 3813192971,
+    "expected": "1367242283886022002613",
+    "overflow": false
+  },
+  {
+    "principal": "2303886388013484350",
+    "rate_bps": 9335,
+    "seconds": 2682813600,
+    "expected": "182961315172038057665",
+    "overflow": false
+  },
+  {
+    "principal": "17720389535922702703",
+    "rate_bps": 628,
+    "seconds": 3465201209,
+    "expected": "122279810924421065942",
+    "overflow": false
+  },
+  {
+    "principal": "16738503069231194196",
+    "rate_bps": 7849,
+    "seconds": 276307366,
+    "expected": "115110993229855799983",
+    "overflow": false
+  },
+  {
+    "principal": "7510951241398620541",
+    "rate_bps": 2595,
+    "seconds": 3943092471,
+    "expected": "243704001387519583359",
+    "overflow": false
+  },
+  {
+    "principal": "2524401790028858810",
+    "rate_bps": 788,
+    "seconds": 3729921404,
+    "expected": "23527607724228021155",
+    "overflow": false
+  },
+  {
+    "principal": "11395479763518344219",
+    "rate_bps": 7153,
+    "seconds": 424177861,
+    "expected": "109638284130749470920",
+    "overflow": false
+  },
+  {
+    "principal": "12074390704545992432",
+    "rate_bps": 1477,
+    "seconds": 954086818,
+    "expected": "53954417550520191552",
+    "overflow": false
+  },
+  {
+    "principal": "1958972845461359817",
+    "rate_bps": 8287,
+    "seconds": 937895203,
+    "expected": "48280689373554183650",
+    "overflow": false
+  },
+  {
+    "principal": "3780324302056088950",
+    "rate_bps": 9110,
+    "seconds": 1082491800,
+    "expected": "118213055654689127324",
+    "overflow": false
+  },
+  {
+    "principal": "395781486552288007",
+    "rate_bps": 130,
+    "seconds": 2143367569,
+    "expected": "349694559707261180",
+    "overflow": false
+  },
+  {
+    "principal": "18019192127469725388",
+    "rate_bps": 2549,
+    "seconds": 3725236446,
+    "expected": "542565765831468307275",
+    "overflow": false
+  },
+  {
+    "principal": "1603427565527138901",
+    "rate_bps": 9381,
+    "seconds": 1250917775,
+    "expected": "59665136466364831155",
+    "overflow": false
+  },
+  {
+    "principal": "10894956286599070834",
+    "rate_bps": 9398,
+    "seconds": 1225720564,
+    "expected": "397965842596104518902",
+    "overflow": false
+  },
+  {
+    "principal": "13117145653526794803",
+    "rate_bps": 7190,
+    "seconds": 2273997981,
+    "expected": "680066996598853821642",
+    "overflow": false
+  },
+  {
+    "principal": "5540587423185560552",
+    "rate_bps": 2281,
+    "seconds": 3437077338,
+    "expected": "137741178533587469729",
+    "overflow": false
+  },
+  {
+    "principal": "10519093617963359777",
+    "rate_bps": 1221,
+    "seconds": 2417485371,
+    "expected": "98458050414817306178",
+    "overflow": false
+  },
+  {
+    "principal": "10464100615941865134",
+    "rate_bps": 2210,
+    "seconds": 3721531280,
+    "expected": "272903589066596170232",
+    "overflow": false
+  },
+  {
+    "principal": "10552158450536459679",
+    "rate_bps": 8673,
+    "seconds": 2864309737,
+    "expected": "831235385438786680308",
+    "overflow": false
+  },
+  {
+    "principal": "4679798814654104132",
+    "rate_bps": 2300,
+    "seconds": 452260118,
+    "expected": "15436068738910984611",
+    "overflow": false
+  },
+  {
+    "principal": "17635186393994873901",
+    "rate_bps": 1068,
+    "seconds": 3837176615,
+    "expected": "229169326867050771845",
+    "overflow": false
+  },
+  {
+    "principal": "16122333955169906730",
+    "rate_bps": 3638,
+    "seconds": 916809068,
+    "expected": "170515122264994889591",
+    "overflow": false
+  },
+  {
+    "principal": "15535868333099772235",
+    "rate_bps": 1304,
+    "seconds": 322007413,
+    "expected": "20685803085133511626",
+    "overflow": false
+  },
+  {
+    "principal": "16107988805863767520",
+    "rate_bps": 5798,
+    "seconds": 1181179410,
+    "expected": "349807237733870082848",
+    "overflow": false
+  },
+  {
+    "principal": "2136809626559576185",
+    "rate_bps": 9563,
+    "seconds": 1387026515,
+    "expected": "89874842789454822186",
+    "overflow": false
+  },
+  {
+    "principal": "1994893896942040294",
+    "rate_bps": 8745,
+    "seconds": 1966014600,
+    "expected": "108757633045429311803",
+    "overflow": false
+  },
+  {
+    "principal": "16927630052107358519",
+    "rate_bps": 8184,
+    "seconds": 1345012545,
+    "expected": "590855806623010632050",
+    "overflow": false
+  },
+  {
+    "principal": "5140922613009519292",
+    "rate_bps": 915,
+    "seconds": 3569419854,
+    "expected": "53241856250379468605",
+    "overflow": false
+  },
+  {
+    "principal": "2093340246369128197",
+    "rate_bps": 8520,
+    "seconds": 2574236095,
+    "expected": "145586527212211483023",
+    "overflow": false
+  },
+  {
+    "principal": "9045555035737155810",
+    "rate_bps": 6440,
+    "seconds": 3791658212,
+    "expected": "700396009432961591626",
+    "overflow": false
+  },
+  {
+    "principal": "13575418087795437923",
+    "rate_bps": 6293,
+    "seconds": 839239501,
+    "expected": "227347537899715168717",
+    "overflow": false
+  },
+  {
+    "principal": "13051976757846719704",
+    "rate_bps": 5879,
+    "seconds": 2369734090,
+    "expected": "576597508129383807126",
+    "overflow": false
+  },
+  {
+    "principal": "5120601902147959761",
+    "rate_bps": 4557,
+    "seconds": 1226431339,
+    "expected": "90747918924137290855",
+    "overflow": false
+  },
+  {
+    "principal": "7491090887977740318",
+    "rate_bps": 5014,
+    "seconds": 183580288,
+    "expected": "21864967484661131202",
+    "overflow": false
+  },
+  {
+    "principal": "17892056302811059663",
+    "rate_bps": 6027,
+    "seconds": 944744857,
+    "expected": "323049726027677731811",
+    "overflow": false
+  },
+  {
+    "principal": "9070632900270503988",
+    "rate_bps": 9818,
+    "seconds": 2857154694,
+    "expected": "806840642556156009642",
+    "overflow": false
+  },
+  {
+    "principal": "17464095422882278109",
+    "rate_bps": 4395,
+    "seconds": 2115111255,
+    "expected": "514791757167444884595",
+    "overflow": false
+  },
+  {
+    "principal": "8457894989401706138",
+    "rate_bps": 7111,
+    "seconds": 1052641628,
+    "expected": "200755245270959328185",
+    "overflow": false
+  },
+  {
+    "principal": "2673883747694135931",
+    "rate_bps": 189,
+    "seconds": 1041487397,
+    "expected": "1668982326187156907",
+    "overflow": false
+  },
+  {
+    "principal": "3405115348652490960",
+    "rate_bps": 4173,
+    "seconds": 2654812802,
+    "expected": "119621022198116943413",
+    "overflow": false
+  },
+  {
+    "principal": "16736437530951108649",
+    "rate_bps": 877,
+    "seconds": 2298072963,
+    "expected": "106959612419579847128",
+    "overflow": false
+  },
+  {
+    "principal": "15795760007905146966",
+    "rate_bps": 7298,
+    "seconds": 568430968,
+    "expected": "207785629782781763940",
+    "overflow": false
+  },
+  {
+    "principal": "12897029772341713767",
+    "rate_bps": 6478,
+    "seconds": 1348827377,
+    "expected": "357338994744148171143",
+    "overflow": false
+  },
+  {
+    "principal": "3265814535596036780",
+    "rate_bps": 8065,
+    "seconds": 1196025790,
+    "expected": "99891797235170271217",
+    "overflow": false
+  },
+  {
+    "principal": "5088061162645520309",
+    "rate_bps": 2256,
+    "seconds": 249100783,
+    "expected": "9066922514405449716",
+    "overflow": false
+  },
+  {
+    "principal": "11462283790301528402",
+    "rate_bps": 8466,
+    "seconds": 1488063188,
+    "expected": "457893192739837654935",
+    "overflow": false
+  },
+  {
+    "principal": "2591691774988031123",
+    "rate_bps": 9179,
+    "seconds": 3677093373,
+    "expected": "277381039575321149877",
+    "overflow": false
+  },
+  {
+    "principal": "7548713793310992840",
+    "rate_bps": 5741,
+    "seconds": 2932677690,
+    "expected": "403012238539454492766",
+    "overflow": false
+  },
+  {
+    "principal": "15936542135796907393",
+    "rate_bps": 8097,
+    "seconds": 1837733019,
+    "expected": "751958800016486010709",
+    "overflow": false
+  },
+  {
+    "principal": "12365992580696409486",
+    "rate_bps": 7398,
+    "seconds": 2193420656,
+    "expected": "636295175942908980502",
+    "overflow": false
+  },
+  {
+    "principal": "1818541089826832895",
+    "rate_bps": 8794,
+    "seconds": 2553221449,
+    "expected": "129476650798826755669",
+    "overflow": false
+  },
+  {
+    "principal": "9244154287523480100",
+    "rate_bps": 9227,
+    "seconds": 2948494326,
+    "expected": "797482929244472811015",
+    "overflow": false
+  },
+  {
+    "principal": "8862731840114847117",
+    "rate_bps": 5123,
+    "seconds": 1885596551,
+    "expected": "271477682494234157331",
+    "overflow": false
+  },
+  {
+    "principal": "6881778207153119498",
+    "rate_bps": 5886,
+    "seconds": 56820044,
+    "expected": "7298202143429155606",
+    "overflow": false
+  },
+  {
+    "principal": "15653745292278198187",
+    "rate_bps": 7694,
+    "seconds": 3965886165,
+    "expected": "1514621377739109030904",
+    "overflow": false
+  },
+  {
+    "principal": "196852374772520896",
+    "rate_bps": 8104,
+    "seconds": 544131826,
+    "expected": "2752565182272816728",
+    "overflow": false
+  },
+  {
+    "principal": "13998483771065187289",
+    "rate_bps": 6583,
+    "seconds": 2703919795,
+    "expected": "790118174205011459366",
+    "overflow": false
+  },
+  {
+    "principal": "6900821180813389766",
+    "rate_bps": 8119,
+    "seconds": 1404319336,
+    "expected": "249495423597024418150",
+    "overflow": false
+  },
+  {
+    "principal": "9612208386755701143",
+    "rate_bps": 4284,
+    "seconds": 2675102369,
+    "expected": "349306316185055876469",
+    "overflow": false
+  },
+  {
+    "principal": "3263078233277032092",
+    "rate_bps": 6455,
+    "seconds": 1535393070,
+    "expected": "102550244938445671887",
+    "overflow": false
+  },
+  {
+    "principal": "6535936211142710373",
+    "rate_bps": 193,
+    "seconds": 3241557535,
+    "expected": "12966185825048318517",
+    "overflow": false
+  },
+  {
+    "principal": "10750309409097567682",
+    "rate_bps": 7385,
+    "seconds": 3649817796,
+    "expected": "918831850378737279016",
+    "overflow": false
+  },
+  {
+    "principal": "7565144507124267971",
+    "rate_bps": 1121,
+    "seconds": 428873901,
+    "expected": "11533094538950402889",
+    "overflow": false
+  },
+  {
+    "principal": "17878487781251656376",
+    "rate_bps": 1783,
+    "seconds": 1144399530,
+    "expected": "115678643974878461792",
+    "overflow": false
+  },
+  {
+    "principal": "4067713952640705329",
+    "rate_bps": 2637,
+    "seconds": 920785355,
+    "expected": "31319320511551724824",
+    "overflow": false
+  },
+  {
+    "principal": "9330120500017321726",
+    "rate_bps": 688,
+    "seconds": 2146189408,
+    "expected": "43685481942036332182",
+    "overflow": false
+  },
+  {
+    "principal": "15676921531215016495",
+    "rate_bps": 7019,
+    "seconds": 2474319097,
+    "expected": "863346488800738326448",
+    "overflow": false
+  },
+  {
+    "principal": "2089594411269234708",
+    "rate_bps": 8888,
+    "seconds": 566829926,
+    "expected": "33381988867613814201",
+    "overflow": false
+  },
+  {
+    "principal": "11496397607147689021",
+    "rate_bps": 2749,
+    "seconds": 2067222967,
+    "expected": "207165403360579947498",
+    "overflow": false
+  },
+  {
+    "principal": "12435549094912305018",
+    "rate_bps": 1998,
+    "seconds": 2358988092,
+    "expected": "185857286403774263168",
+    "overflow": false
+  },
+  {
+    "principal": "3700138521167714523",
+    "rate_bps": 2297,
+    "seconds": 3838888837,
+    "expected": "103461294414051845313",
+    "overflow": false
+  },
+  {
+    "principal": "4502440594835718832",
+    "rate_bps": 6363,
+    "seconds": 3997896546,
+    "expected": "363190817174183258259",
+    "overflow": false
+  },
+  {
+    "principal": "14795717475484095369",
+    "rate_bps": 2982,
+    "seconds": 3554249187,
+    "expected": "497261613465288357746",
+    "overflow": false
+  },
+  {
+    "principal": "2471537941653707574",
+    "rate_bps": 6478,
+    "seconds": 1862135640,
+    "expected": "94539419420559417075",
+    "overflow": false
+  },
+  {
+    "principal": "17954162640624237511",
+    "rate_bps": 4037,
+    "seconds": 3700838481,
+    "expected": "850584430016544691760",
+    "overflow": false
+  },
+  {
+    "principal": "12358227782861377164",
+    "rate_bps": 3130,
+    "seconds": 4103014046,
+    "expected": "503265234060185827749",
+    "overflow": false
+  },
+  {
+    "principal": "12217148443294567701",
+    "rate_bps": 2632,
+    "seconds": 3845293647,
+    "expected": "392083565792673819534",
+    "overflow": false
+  },
+  {
+    "principal": "5932209550553075250",
+    "rate_bps": 6413,
+    "seconds": 2218025652,
+    "expected": "267570161808388109718",
+    "overflow": false
+  },
+  {
+    "principal": "8610117519838553843",
+    "rate_bps": 7756,
+    "seconds": 1342510941,
+    "expected": "284287723896038363106",
+    "overflow": false
+  },
+  {
+    "principal": "16978897187788603304",
+    "rate_bps": 6329,
+    "seconds": 3647563034,
+    "expected": "1242913121823099115605",
+    "overflow": false
+  },
+  {
+    "principal": "403403613708758241",
+    "rate_bps": 701,
+    "seconds": 3906884347,
+    "expected": "3503335667203543614",
+    "overflow": false
+  },
+  {
+    "principal": "7484758018353896558",
+    "rate_bps": 3813,
+    "seconds": 209068880,
+    "expected": "18920271113543278032",
+    "overflow": false
+  },
+  {
+    "principal": "8414185372350703199",
+    "rate_bps": 2702,
+    "seconds": 1268173993,
+    "expected": "91425986707771076424",
+    "overflow": false
+  },
+  {
+    "principal": "2694429760230937092",
+    "rate_bps": 3972,
+    "seconds": 1814808278,
+    "expected": "61588588525154277111",
+    "overflow": false
+  },
+  {
+    "principal": "18388873881752149741",
+    "rate_bps": 141,
+    "seconds": 2488744935,
+    "expected": "20461997588256556553",
+    "overflow": false
+  },
+  {
+    "principal": "4075328620282225130",
+    "rate_bps": 1076,
+    "seconds": 3450727724,
+    "expected": "47982071324690360938",
+    "overflow": false
+  },
+  {
+    "principal": "13877361848950392331",
+    "rate_bps": 2094,
+    "seconds": 307321909,
+    "expected": "28318516933425005173",
+    "overflow": false
+  },
+  {
+    "principal": "2678534621402759584",
+    "rate_bps": 621,
+    "seconds": 3663792082,
+    "expected": "19324714088779183289",
+    "overflow": false
+  },
+  {
+    "principal": "844435767988129593",
+    "rate_bps": 5041,
+    "seconds": 4225879315,
+    "expected": "57041876120535750505",
+    "overflow": false
+  },
+  {
+    "principal": "109198131578796710",
+    "rate_bps": 3768,
+    "seconds": 525712456,
+    "expected": "685910990641960351",
+    "overflow": false
+  },
+  {
+    "principal": "13868505100077060599",
+    "rate_bps": 6223,
+    "seconds": 3612537345,
+    "expected": "988633198276336290004",
+    "overflow": false
+  },
+  {
+    "principal": "16643583749553883772",
+    "rate_bps": 6595,
+    "seconds": 583615502,
+    "expected": "203133643246033668040",
+    "overflow": false
+  },
+  {
+    "principal": "16625962029503572421",
+    "rate_bps": 5672,
+    "seconds": 4256748159,
+    "expected": "1272900205018556672531",
+    "overflow": false
+  },
+  {
+    "principal": "6319054809043075746",
+    "rate_bps": 6472,
+    "seconds": 1536347300,
+    "expected": "199238574345258856161",
+    "overflow": false
+  },
+  {
+    "principal": "11859037635050657315",
+    "rate_bps": 2564,
+    "seconds": 1570634253,
+    "expected": "151438369732905874784",
+    "overflow": false
+  },
+  {
+    "principal": "8196689474550884504",
+    "rate_bps": 2482,
+    "seconds": 3818248074,
+    "expected": "246318932680305451449",
+    "overflow": false
+  },
+  {
+    "principal": "5101497475101743761",
+    "rate_bps": 4296,
+    "seconds": 24729643,
+    "expected": "1718593594148819225",
+    "overflow": false
+  },
+  {
+    "principal": "8337202925881284062",
+    "rate_bps": 116,
+    "seconds": 4052851264,
+    "expected": "12428892174975790871",
+    "overflow": false
+  },
+  {
+    "principal": "7340847762210381455",
+    "rate_bps": 2283,
+    "seconds": 3928301657,
+    "expected": "208761472885898698698",
+    "overflow": false
+  },
+  {
+    "principal": "8466020085923272692",
+    "rate_bps": 9960,
+    "seconds": 3756351046,
+    "expected": "1004380328246893571515",
+    "overflow": false
+  },
+  {
+    "principal": "9330609041274817949",
+    "rate_bps": 7568,
+    "seconds": 399419927,
+    "expected": "89436385040497850645",
+    "overflow": false
+  },
+  {
+    "principal": "15190518859535732826",
+    "rate_bps": 4211,
+    "seconds": 2502025500,
+    "expected": "507508095538774206127",
+    "overflow": false
+  },
+  {
+    "principal": "1150058386299352891",
+    "rate_bps": 9955,
+    "seconds": 873943269,
+    "expected": "31727641413871015106",
+    "overflow": false
+  },
+  {
+    "principal": "5981373387550446736",
+    "rate_bps": 2209,
+    "seconds": 3632247874,
+    "expected": "152182775786724399695",
+    "overflow": false
+  },
+  {
+    "principal": "15418759483491413737",
+    "rate_bps": 8415,
+    "seconds": 3328070723,
+    "expected": "1369271263999921844971",
+    "overflow": false
+  },
+  {
+    "principal": "10936920903552372246",
+    "rate_bps": 2057,
+    "seconds": 1200790840,
+    "expected": "85662377221560965859",
+    "overflow": false
+  },
+  {
+    "principal": "16196492365580725287",
+    "rate_bps": 3267,
+    "seconds": 1064023985,
+    "expected": "178531525542082268771",
+    "overflow": false
+  },
+  {
+    "principal": "973075126444399212",
+    "rate_bps": 8351,
+    "seconds": 2480010622,
+    "expected": "63904551181803485879",
+    "overflow": false
+  },
+  {
+    "principal": "3486393116736301685",
+    "rate_bps": 260,
+    "seconds": 200549039,
+    "expected": "576452705402704309",
+    "overflow": false
+  },
+  {
+    "principal": "18230003859078605586",
+    "rate_bps": 8882,
+    "seconds": 902695572,
+    "expected": "463481319401270958234",
+    "overflow": false
+  },
+  {
+    "principal": "10990816928456690003",
+    "rate_bps": 6192,
+    "seconds": 1303232701,
+    "expected": "281239478251311800268",
+    "overflow": false
+  },
+  {
+    "principal": "11138523170356667784",
+    "rate_bps": 7492,
+    "seconds": 824868346,
+    "expected": "218274706245673318244",
+    "overflow": false
+  },
+  {
+    "principal": "9392564659491482689",
+    "rate_bps": 5416,
+    "seconds": 1760436571,
+    "expected": "283972721867795677300",
+    "overflow": false
+  },
+  {
+    "principal": "11111491994248446798",
+    "rate_bps": 2471,
+    "seconds": 2813699376,
+    "expected": "244971866064135896122",
+    "overflow": false
+  },
+  {
+    "principal": "18444294176921639615",
+    "rate_bps": 5454,
+    "seconds": 1359550473,
+    "expected": "433676513032685110115",
+    "overflow": false
+  },
+  {
+    "principal": "14577604507374072292",
+    "rate_bps": 6374,
+    "seconds": 590670262,
+    "expected": "174035049902914371930",
+    "overflow": false
+  },
+  {
+    "principal": "1188971748386922573",
+    "rate_bps": 698,
+    "seconds": 4159216711,
+    "expected": "10945406624267019946",
+    "overflow": false
+  },
+  {
+    "principal": "13528887454607946442",
+    "rate_bps": 5182,
+    "seconds": 2092837132,
+    "expected": "465252074003802398836",
+    "overflow": false
+  },
+  {
+    "principal": "11756659607717391467",
+    "rate_bps": 9554,
+    "seconds": 2375395733,
+    "expected": "846054902211415751794",
+    "overflow": false
+  },
+  {
+    "principal": "7582203859994426240",
+    "rate_bps": 9585,
+    "seconds": 1840649394,
+    "expected": "424181808538487716885",
+    "overflow": false
+  },
+  {
+    "principal": "13807615492611338905",
+    "rate_bps": 8522,
+    "seconds": 3802799987,
+    "expected": "1418917324120613138394",
+    "overflow": false
+  },
+  {
+    "principal": "2150452435273389446",
+    "rate_bps": 667,
+    "seconds": 4056650280,
+    "expected": "18450861006289777632",
+    "overflow": false
+  },
+  {
+    "principal": "12617487618036861527",
+    "rate_bps": 1195,
+    "seconds": 1424204129,
+    "expected": "68093620516366360057",
+    "overflow": false
+  },
+  {
+    "principal": "10253938919174241884",
+    "rate_bps": 4934,
+    "seconds": 42474222,
+    "expected": "6814103047271126785",
+    "overflow": false
+  },
+  {
+    "principal": "13045463911434178341",
+    "rate_bps": 39,
+    "seconds": 3209656031,
+    "expected": "5178166618786703622",
+    "overflow": false
+  },
+  {
+    "principal": "1749956552164575106",
+    "rate_bps": 8144,
+    "seconds": 2890734724,
+    "expected": "130637139875912146240",
+    "overflow": false
+  },
+  {
+    "principal": "4990857612454985859",
+    "rate_bps": 8942,
+    "seconds": 130509677,
+    "expected": "18469109373804737231",
+    "overflow": false
+  },
+  {
+    "principal": "6450285437435082360",
+    "rate_bps": 1027,
+    "seconds": 1507219562,
+    "expected": "31660611029820212092",
+    "overflow": false
+  },
+  {
+    "principal": "10469186846580777457",
+    "rate_bps": 5293,
+    "seconds": 2713169547,
+    "expected": "476743929469940508675",
+    "overflow": false
+  },
+  {
+    "principal": "2559994243102745790",
+    "rate_bps": 3987,
+    "seconds": 1184449568,
+    "expected": "38334975609851931054",
+    "overflow": false
+  },
+  {
+    "principal": "8886641427824794351",
+    "rate_bps": 3146,
+    "seconds": 3395662777,
+    "expected": "301033149427156055173",
+    "overflow": false
+  },
+  {
+    "principal": "4764890227135078356",
+    "rate_bps": 6345,
+    "seconds": 2711185702,
+    "expected": "259918495720968909455",
+    "overflow": false
+  },
+  {
+    "principal": "1265252736222811901",
+    "rate_bps": 7871,
+    "seconds": 3979350647,
+    "expected": "125664555688935699100",
+    "overflow": false
+  },
+  {
+    "principal": "6686642776702372154",
+    "rate_bps": 1077,
+    "seconds": 3649684732,
+    "expected": "83343660198994245929",
+    "overflow": false
+  },
+  {
+    "principal": "13315962419554821531",
+    "rate_bps": 2351,
+    "seconds": 2524931653,
+    "expected": "250650289043444047463",
+    "overflow": false
+  },
+  {
+    "principal": "260114109900633712",
+    "rate_bps": 7509,
+    "seconds": 542320930,
+    "expected": "3358889944316466964",
+    "overflow": false
+  },
+  {
+    "principal": "11178001727330163273",
+    "rate_bps": 4136,
+    "seconds": 845164195,
+    "expected": "123902247892714175264",
+    "overflow": false
+  },
+  {
+    "principal": "2261768334302351606",
+    "rate_bps": 1436,
+    "seconds": 1062705944,
+    "expected": "10944831054797788483",
+    "overflow": false
+  },
+  {
+    "principal": "16908301683039579271",
+    "rate_bps": 1331,
+    "seconds": 2549985041,
+    "expected": "181973885958207487584",
+    "overflow": false
+  },
+  {
+    "principal": "5709770791390656076",
+    "rate_bps": 309,
+    "seconds": 2802496606,
+    "expected": "15678901885300185600",
+    "overflow": false
+  },
+  {
+    "principal": "4446522104128067541",
+    "rate_bps": 8364,
+    "seconds": 2775961359,
+    "expected": "327371817331439354915",
+    "overflow": false
+  },
+  {
+    "principal": "18320252126280833010",
+    "rate_bps": 4518,
+    "seconds": 196543092,
+    "expected": "51585643195138193744",
+    "overflow": false
+  },
+  {
+    "principal": "17783065642493967283",
+    "rate_bps": 1459,
+    "seconds": 4290640413,
+    "expected": "353002219128783820802",
+    "overflow": false
+  },
+  {
+    "principal": "12026314171571362664",
+    "rate_bps": 9158,
+    "seconds": 780691162,
+    "expected": "272650212271336397911",
+    "overflow": false
+  },
+  {
+    "principal": "18429231758576303009",
+    "rate_bps": 5813,
+    "seconds": 4170252219,
+    "expected": "1416652295684737014023",
+    "overflow": false
+  },
+  {
+    "principal": "15401476775894137390",
+    "rate_bps": 4089,
+    "seconds": 1966307088,
+    "expected": "392666827539928127252",
+    "overflow": false
+  },
+  {
+    "principal": "12203463829150261023",
+    "rate_bps": 1282,
+    "seconds": 3097359209,
+    "expected": "153658330782215713363",
+    "overflow": false
+  },
+  {
+    "principal": "206108336377651652",
+    "rate_bps": 5557,
+    "seconds": 4224834710,
+    "expected": "15344016973521989310",
+    "overflow": false
+  },
+  {
+    "principal": "6384452677422002605",
+    "rate_bps": 8592,
+    "seconds": 2792361127,
+    "expected": "485716567393480128784",
+    "overflow": false
+  },
+  {
+    "principal": "9796755212098311082",
+    "rate_bps": 9951,
+    "seconds": 2882254060,
+    "expected": "890993704693700066460",
+    "overflow": false
+  },
+  {
+    "principal": "12607047266299241163",
+    "rate_bps": 4741,
+    "seconds": 2865202933,
+    "expected": "543040369987153420725",
+    "overflow": false
+  },
+  {
+    "principal": "8843307800647353696",
+    "rate_bps": 101,
+    "seconds": 3890606482,
+    "expected": "11019117503182063567",
+    "overflow": false
+  },
+  {
+    "principal": "7800431211488503289",
+    "rate_bps": 8660,
+    "seconds": 4183523795,
+    "expected": "896132317992033597816",
+    "overflow": false
+  },
+  {
+    "principal": "17599565212253683814",
+    "rate_bps": 1856,
+    "seconds": 1489877000,
+    "expected": "154320534788913154482",
+    "overflow": false
+  },
+  {
+    "principal": "3072255803160580791",
+    "rate_bps": 8499,
+    "seconds": 2034032833,
+    "expected": "168413365418423236445",
+    "overflow": false
+  },
+  {
+    "principal": "12744826999666623036",
+    "rate_bps": 2558,
+    "seconds": 2797126094,
+    "expected": "289161136238700308985",
+    "overflow": false
+  },
+  {
+    "principal": "11753836788574897285",
+    "rate_bps": 834,
+    "seconds": 1515334463,
+    "expected": "47102894980792719278",
+    "overflow": false
+  },
+  {
+    "principal": "7726406353773157474",
+    "rate_bps": 6256,
+    "seconds": 1139981412,
+    "expected": "174729183831572672435",
+    "overflow": false
+  },
+  {
+    "principal": "3350209905473370851",
+    "rate_bps": 7756,
+    "seconds": 3852758221,
+    "expected": "317449734103217237145",
+    "overflow": false
+  },
+  {
+    "principal": "5769713913110811736",
+    "rate_bps": 6130,
+    "seconds": 695183690,
+    "expected": "77966443053181042750",
+    "overflow": false
+  },
+  {
+    "principal": "9488441888384350545",
+    "rate_bps": 5416,
+    "seconds": 3027571947,
+    "expected": "493357146279102882111",
+    "overflow": false
+  },
+  {
+    "principal": "3297620513616282526",
+    "rate_bps": 6970,
+    "seconds": 1505443328,
+    "expected": "109721379310889056304",
+    "overflow": false
+  },
+  {
+    "principal": "5314773104156960591",
+    "rate_bps": 5442,
+    "seconds": 1179965209,
+    "expected": "108219584331567182700",
+    "overflow": false
+  },
+  {
+    "principal": "17080157287824471988",
+    "rate_bps": 9649,
+    "seconds": 2010989574,
+    "expected": "1050938698258783334476",
+    "overflow": false
+  },
+  {
+    "principal": "15049556979222147165",
+    "rate_bps": 5656,
+    "seconds": 4172516055,
+    "expected": "1126223346228419312366",
+    "overflow": false
+  },
+  {
+    "principal": "11485945605880713754",
+    "rate_bps": 446,
+    "seconds": 2399860956,
+    "expected": "38983523247788649364",
+    "overflow": false
+  },
+  {
+    "principal": "10530645237382407163",
+    "rate_bps": 2081,
+    "seconds": 3131116453,
+    "expected": "217580352386446274876",
+    "overflow": false
+  },
+  {
+    "principal": "15776516208444467280",
+    "rate_bps": 6943,
+    "seconds": 2638048770,
+    "expected": "916293248214184836978",
+    "overflow": false
+  },
+  {
+    "principal": "14397281934616090025",
+    "rate_bps": 7398,
+    "seconds": 230103299,
+    "expected": "77716113623457577399",
+    "overflow": false
+  },
+  {
+    "principal": "10118331181360374742",
+    "rate_bps": 6553,
+    "seconds": 1577380088,
+    "expected": "331649086469714256296",
+    "overflow": false
+  },
+  {
+    "principal": "7709703065622772967",
+    "rate_bps": 2914,
+    "seconds": 157562481,
+    "expected": "11224665377024056263",
+    "overflow": false
+  },
+  {
+    "principal": "3406371318307496492",
+    "rate_bps": 9192,
+    "seconds": 2217820990,
+    "expected": "220202317582148939788",
+    "overflow": false
+  },
+  {
+    "principal": "14528893963865298229",
+    "rate_bps": 9937,
+    "seconds": 3088026479,
+    "expected": "1413716258643836075172",
+    "overflow": false
+  },
+  {
+    "principal": "11566428137972176082",
+    "rate_bps": 1501,
+    "seconds": 3626453588,
+    "expected": "199643636944321819038",
+    "overflow": false
+  },
+  {
+    "principal": "1334724638371167763",
+    "rate_bps": 5000,
+    "seconds": 1439548285,
+    "expected": "30463606102778725055",
+    "overflow": false
+  },
+  {
+    "principal": "16138321889462247752",
+    "rate_bps": 155,
+    "seconds": 3724222394,
+    "expected": "29540583670278198987",
+    "overflow": false
+  },
+  {
+    "principal": "16502944491981462273",
+    "rate_bps": 1223,
+    "seconds": 1184820763,
+    "expected": "75828758438712198932",
+    "overflow": false
+  },
+  {
+    "principal": "678363192860983566",
+    "rate_bps": 365,
+    "seconds": 2309462256,
+    "expected": "1813257164088067361",
+    "overflow": false
+  },
+  {
+    "principal": "11656599505031951231",
+    "rate_bps": 4891,
+    "seconds": 376266441,
+    "expected": "68023412746455826394",
+    "overflow": false
+  },
+  {
+    "principal": "15017372344700363172",
+    "rate_bps": 8569,
+    "seconds": 1895473014,
+    "expected": "773455069863836784245",
+    "overflow": false
+  },
+  {
+    "principal": "8690285450608186125",
+    "rate_bps": 9714,
+    "seconds": 256216327,
+    "expected": "68585504134973021348",
+    "overflow": false
+  },
+  {
+    "principal": "8419685083332134026",
+    "rate_bps": 9793,
+    "seconds": 2853081292,
+    "expected": "745966186062709116531",
+    "overflow": false
+  },
+  {
+    "principal": "4133641915944413483",
+    "rate_bps": 870,
+    "seconds": 4202624085,
+    "expected": "47925432759388564604",
+    "overflow": false
+  },
+  {
+    "principal": "7994497142698254144",
+    "rate_bps": 7352,
+    "seconds": 1785241202,
+    "expected": "332726157474745936440",
+    "overflow": false
+  },
+  {
+    "principal": "9659256678339570009",
+    "rate_bps": 7722,
+    "seconds": 130937907,
+    "expected": "30969364371090828957",
+    "overflow": false
+  },
+  {
+    "principal": "1866408952719194950",
+    "rate_bps": 7480,
+    "seconds": 1444163048,
+    "expected": "63931961371008798496",
+    "overflow": false
+  },
+  {
+    "principal": "15737355105839721239",
+    "rate_bps": 2806,
+    "seconds": 2843127841,
+    "expected": "398115597161963011371",
+    "overflow": false
+  },
+  {
+    "principal": "13659410273643648540",
+    "rate_bps": 6836,
+    "seconds": 2404595886,
+    "expected": "711982790834159239338",
+    "overflow": false
+  },
+  {
+    "principal": "727616830984473061",
+    "rate_bps": 973,
+    "seconds": 119074719,
+    "expected": "267318204298388077",
+    "overflow": false
+  },
+  {
+    "principal": "1318508875966873922",
+    "rate_bps": 8737,
+    "seconds": 3468405828,
+    "expected": "126697689146800644032",
+    "overflow": false
+  },
+  {
+    "principal": "10102801645637109059",
+    "rate_bps": 5548,
+    "seconds": 2295135789,
+    "expected": "407924750829006175415",
+    "overflow": false
+  },
+  {
+    "principal": "2352312768678953528",
+    "rate_bps": 7855,
+    "seconds": 1759103530,
+    "expected": "103068522052878988195",
+    "overflow": false
+  },
+  {
+    "principal": "8152371989305942193",
+    "rate_bps": 8192,
+    "seconds": 2055834443,
+    "expected": "435366955322930229120",
+    "overflow": false
+  },
+  {
+    "principal": "7967083275503415934",
+    "rate_bps": 7923,
+    "seconds": 4189030368,
+    "expected": "838486190519624135130",
+    "overflow": false
+  },
+  {
+    "principal": "18359924825336218543",
+    "rate_bps": 6508,
+    "seconds": 4094331513,
+    "expected": "1551296597782732855811",
+    "overflow": false
+  },
+  {
+    "principal": "11345832138565017492",
+    "rate_bps": 860,
+    "seconds": 3349737190,
+    "expected": "103642751283617726408",
+    "overflow": false
+  },
+  {
+    "principal": "17992974921398720957",
+    "rate_bps": 7631,
+    "seconds": 2612073271,
+    "expected": "1137268935042759247393",
+    "overflow": false
+  },
+  {
+    "principal": "3507455912486054650",
+    "rate_bps": 3526,
+    "seconds": 2665315516,
+    "expected": "104524127097979068627",
+    "overflow": false
+  },
+  {
+    "principal": "6326434725542212187",
+    "rate_bps": 9885,
+    "seconds": 2467578117,
+    "expected": "489327933494166343837",
+    "overflow": false
+  },
+  {
+    "principal": "6322431889095354928",
+    "rate_bps": 4991,
+    "seconds": 985039586,
+    "expected": "98564110354907098195",
+    "overflow": false
+  },
+  {
+    "principal": "17049154994402795785",
+    "rate_bps": 7786,
+    "seconds": 1916474211,
+    "expected": "806702923749270328982",
+    "overflow": false
+  },
+  {
+    "principal": "17674541131901634230",
+    "rate_bps": 7576,
+    "seconds": 525502168,
+    "expected": "223128999746546173638",
+    "overflow": false
+  },
+  {
+    "principal": "2835463286366297415",
+    "rate_bps": 1057,
+    "seconds": 3132575185,
+    "expected": "29771033545135844724",
+    "overflow": false
+  },
+  {
+    "principal": "10068415051701673484",
+    "rate_bps": 2728,
+    "seconds": 1430102558,
+    "expected": "124556401498515843132",
+    "overflow": false
+  },
+  {
+    "principal": "15262260293676294805",
+    "rate_bps": 561,
+    "seconds": 773412815,
+    "expected": "20998413045453273825",
+    "overflow": false
+  },
+  {
+    "principal": "11424328638446084530",
+    "rate_bps": 5824,
+    "seconds": 2706825780,
+    "expected": "571091572252495713419",
+    "overflow": false
+  },
+  {
+    "principal": "9163857265695461491",
+    "rate_bps": 8973,
+    "seconds": 58006749,
+    "expected": "15124739485678478205",
+    "overflow": false
+  },
+  {
+    "principal": "11218783520458553128",
+    "rate_bps": 3848,
+    "seconds": 3757746330,
+    "expected": "514400857207344480369",
+    "overflow": false
+  },
+  {
+    "principal": "6675483515170949729",
+    "rate_bps": 5198,
+    "seconds": 2783964283,
+    "expected": "306320495022191538353",
+    "overflow": false
+  },
+  {
+    "principal": "10663866776082454510",
+    "rate_bps": 5134,
+    "seconds": 3989441232,
+    "expected": "692589718416112010085",
+    "overflow": false
+  },
+  {
+    "principal": "13582124880183728095",
+    "rate_bps": 9355,
+    "seconds": 2190432809,
+    "expected": "882540897466056275537",
+    "overflow": false
+  },
+  {
+    "principal": "16230433371555213700",
+    "rate_bps": 6244,
+    "seconds": 1369911894,
+    "expected": "440229397103634719787",
+    "overflow": false
+  },
+  {
+    "principal": "9296046586164544621",
+    "rate_bps": 9893,
+    "seconds": 96542055,
+    "expected": "28153748883417563007",
+    "overflow": false
+  },
+  {
+    "principal": "15342891396988323178",
+    "rate_bps": 3481,
+    "seconds": 2059320492,
+    "expected": "348761525331916986488",
+    "overflow": false
+  },
+  {
+    "principal": "8303155524130832267",
+    "rate_bps": 3945,
+    "seconds": 1364455861,
+    "expected": "141723890067529641724",
+    "overflow": false
+  },
+  {
+    "principal": "42786010318948640",
+    "rate_bps": 6781,
+    "seconds": 716577618,
+    "expected": "659253080876176092",
+    "overflow": false
+  },
+  {
+    "principal": "12816041119988186297",
+    "rate_bps": 9073,
+    "seconds": 4191778451,
+    "expected": "1545597892280637678626",
+    "overflow": false
+  },
+  {
+    "principal": "3892443881954035238",
+    "rate_bps": 9187,
+    "seconds": 1599534024,
+    "expected": "181377308038020817327",
+    "overflow": false
+  },
+  {
+    "principal": "7873294650382521207",
+    "rate_bps": 5161,
+    "seconds": 1319702401,
+    "expected": "170043393619760519102",
+    "overflow": false
+  },
+  {
+    "principal": "10243262843569125884",
+    "rate_bps": 1769,
+    "seconds": 273645454,
+    "expected": "15723447706228703836",
+    "overflow": false
+  },
+  {
+    "principal": "13251324517471379269",
+    "rate_bps": 6341,
+    "seconds": 3791373311,
+    "expected": "1010199117013814383987",
+    "overflow": false
+  },
+  {
+    "principal": "11472298738044597794",
+    "rate_bps": 3016,
+    "seconds": 752872484,
+    "expected": "82603148760384107553",
+    "overflow": false
+  },
+  {
+    "principal": "10587565749010554787",
+    "rate_bps": 5684,
+    "seconds": 1188634509,
+    "expected": "226825521158545372572",
+    "overflow": false
+  },
+  {
+    "principal": "14382338994581667864",
+    "rate_bps": 4586,
+    "seconds": 3264002826,
+    "expected": "682664769257932914969",
+    "overflow": false
+  },
+  {
+    "principal": "17373915766969096209",
+    "rate_bps": 7282,
+    "seconds": 3637318059,
+    "expected": "1459227676494380443379",
+    "overflow": false
+  },
+  {
+    "principal": "17019598389932618078",
+    "rate_bps": 2534,
+    "seconds": 3912114624,
+    "expected": "535008747023576041282",
+    "overflow": false
+  },
+  {
+    "principal": "13781225048943734799",
+    "rate_bps": 3118,
+    "seconds": 3986607577,
+    "expected": "543201319993145291383",
+    "overflow": false
+  },
+  {
+    "principal": "14655524359678809972",
+    "rate_bps": 4808,
+    "seconds": 1240754630,
+    "expected": "277233123600048466265",
+    "overflow": false
+  },
+  {
+    "principal": "16146920914550084381",
+    "rate_bps": 8053,
+    "seconds": 2608901015,
+    "expected": "1075717941330541453513",
+    "overflow": false
+  },
+  {
+    "principal": "12486312416651023322",
+    "rate_bps": 2530,
+    "seconds": 2788774044,
+    "expected": "279358209827699000296",
+    "overflow": false
+  },
+  {
+    "principal": "17927479782489198779",
+    "rate_bps": 3488,
+    "seconds": 1450247781,
+    "expected": "287561884049622346752",
+    "overflow": false
+  },
+  {
+    "principal": "16038558650766900240",
+    "rate_bps": 5181,
+    "seconds": 4164315074,
+    "expected": "1097276057408977201078",
+    "overflow": false
+  },
+  {
+    "principal": "11178857824406666345",
+    "rate_bps": 4557,
+    "seconds": 2646875587,
+    "expected": "427566216423156960456",
+    "overflow": false
+  },
+  {
+    "principal": "5769516989355882902",
+    "rate_bps": 2808,
+    "seconds": 1928885432,
+    "expected": "99091496243688904596",
+    "overflow": false
+  },
+  {
+    "principal": "10529619578929237415",
+    "rate_bps": 2967,
+    "seconds": 3608081713,
+    "expected": "357437393847583208524",
+    "overflow": false
+  },
+  {
+    "principal": "12671366385225492972",
+    "rate_bps": 1942,
+    "seconds": 405262590,
+    "expected": "31622964663064902374",
+    "overflow": false
+  },
+  {
+    "principal": "15407654236202942453",
+    "rate_bps": 4645,
+    "seconds": 3588961327,
+    "expected": "814487481842658514689",
+    "overflow": false
+  },
+  {
+    "principal": "8545607946417864338",
+    "rate_bps": 4836,
+    "seconds": 2709375508,
+    "expected": "355051907572712306024",
+    "overflow": false
+  },
+  {
+    "principal": "11363506365783339731",
+    "rate_bps": 1480,
+    "seconds": 2152465981,
+    "expected": "114789922939795345502",
+    "overflow": false
+  },
+  {
+    "principal": "14960877160793758984",
+    "rate_bps": 4139,
+    "seconds": 1761542522,
+    "expected": "345890797498935030864",
+    "overflow": false
+  },
+  {
+    "principal": "12756878757004331457",
+    "rate_bps": 8271,
+    "seconds": 224131803,
+    "expected": "74989304660574701299",
+    "overflow": false
+  },
+  {
+    "principal": "11952545679957311182",
+    "rate_bps": 2577,
+    "seconds": 2656226480,
+    "expected": "259437843443512108862",
+    "overflow": false
+  },
+  {
+    "principal": "11186982591216536639",
+    "rate_bps": 5290,
+    "seconds": 2568742281,
+    "expected": "482039426992060670196",
+    "overflow": false
+  },
+  {
+    "principal": "7199629914179031396",
+    "rate_bps": 4109,
+    "seconds": 3234829622,
+    "expected": "303452778575917592524",
+    "overflow": false
+  },
+  {
+    "principal": "16322396056104502733",
+    "rate_bps": 239,
+    "seconds": 3241852359,
+    "expected": "40102222095397349600",
+    "overflow": false
+  },
+  {
+    "principal": "16600739039119906378",
+    "rate_bps": 608,
+    "seconds": 3574872204,
+    "expected": "114415514011094978867",
+    "overflow": false
+  },
+  {
+    "principal": "18055277239095715307",
+    "rate_bps": 8690,
+    "seconds": 3353247509,
+    "expected": "1668333773067495213135",
+    "overflow": false
+  },
+  {
+    "principal": "17128059434510598912",
+    "rate_bps": 2100,
+    "seconds": 1917216818,
+    "expected": "218671447158324799118",
+    "overflow": false
+  },
+  {
+    "principal": "1977186740742561817",
+    "rate_bps": 7144,
+    "seconds": 3746957555,
+    "expected": "167826795350404700686",
+    "overflow": false
+  },
+  {
+    "principal": "1389039411565863174",
+    "rate_bps": 713,
+    "seconds": 1582172584,
+    "expected": "4968798051523578998",
+    "overflow": false
+  },
+  {
+    "principal": "7268969870944996311",
+    "rate_bps": 9195,
+    "seconds": 3589013217,
+    "expected": "760664333176758871415",
+    "overflow": false
+  },
+  {
+    "principal": "16716102342508408284",
+    "rate_bps": 7609,
+    "seconds": 1369806446,
+    "expected": "552478273885309253803",
+    "overflow": false
+  },
+  {
+    "principal": "12541340580655498405",
+    "rate_bps": 2631,
+    "seconds": 3948062815,
+    "expected": "413087693568663378462",
+    "overflow": false
+  },
+  {
+    "principal": "12088817414096108290",
+    "rate_bps": 5758,
+    "seconds": 1922530308,
+    "expected": "424347909294711005384",
+    "overflow": false
+  },
+  {
+    "principal": "11372947559965411843",
+    "rate_bps": 326,
+    "seconds": 962646253,
+    "expected": "11317506549524924104",
+    "overflow": false
+  },
+  {
+    "principal": "12524908488327089656",
+    "rate_bps": 2404,
+    "seconds": 1962965994,
+    "expected": "187419680793624578756",
+    "overflow": false
+  },
+  {
+    "principal": "7037477286708797297",
+    "rate_bps": 3726,
+    "seconds": 1477945355,
+    "expected": "122888608529082130820",
+    "overflow": false
+  },
+  {
+    "principal": "15303352292218273854",
+    "rate_bps": 6480,
+    "seconds": 3740208032,
+    "expected": "1176117558079734225326",
+    "overflow": false
+  },
+  {
+    "principal": "6435292745384914031",
+    "rate_bps": 5147,
+    "seconds": 3509166393,
+    "expected": "368569871168495634894",
+    "overflow": false
+  },
+  {
+    "principal": "14189277434869784404",
+    "rate_bps": 6859,
+    "seconds": 196588710,
+    "expected": "60669867868404122231",
+    "overflow": false
+  },
+  {
+    "principal": "8555790107023416445",
+    "rate_bps": 1425,
+    "seconds": 561665015,
+    "expected": "21714295946814359126",
+    "overflow": false
+  },
+  {
+    "principal": "5797750861104073914",
+    "rate_bps": 7365,
+    "seconds": 4132861052,
+    "expected": "559598443351442922358",
+    "overflow": false
+  },
+  {
+    "principal": "13634277262433943323",
+    "rate_bps": 4295,
+    "seconds": 2135907269,
+    "expected": "396616772779466559981",
+    "overflow": false
+  },
+  {
+    "principal": "15322910256242777584",
+    "rate_bps": 9908,
+    "seconds": 3912572066,
+    "expected": "1883575352756440577989",
+    "overflow": false
+  },
+  {
+    "principal": "7419690277691713481",
+    "rate_bps": 1890,
+    "seconds": 4062853155,
+    "expected": "180664198952823826742",
+    "overflow": false
+  },
+  {
+    "principal": "1781548970674994294",
+    "rate_bps": 9863,
+    "seconds": 3165565592,
+    "expected": "176380881004564420986",
+    "overflow": false
+  },
+  {
+    "principal": "2349359256528899591",
+    "rate_bps": 2769,
+    "seconds": 2374184081,
+    "expected": "48975645677806685250",
+    "overflow": false
+  },
+  {
+    "principal": "5537563645698328012",
+    "rate_bps": 2161,
+    "seconds": 2665992158,
+    "expected": "101163945362716719706",
+    "overflow": false
+  },
+  {
+    "principal": "11004810795438320981",
+    "rate_bps": 758,
+    "seconds": 1641881743,
+    "expected": "43429722320811805781",
+    "overflow": false
+  },
+  {
+    "principal": "6511397256307420018",
+    "rate_bps": 8277,
+    "seconds": 1188299252,
+    "expected": "203079630341999079445",
+    "overflow": false
+  },
+  {
+    "principal": "1914704774983836979",
+    "rate_bps": 6357,
+    "seconds": 132808605,
+    "expected": "5125941433152827298",
+    "overflow": false
+  },
+  {
+    "principal": "4027151632022098664",
+    "rate_bps": 4722,
+    "seconds": 1098918490,
+    "expected": "66264791938626186536",
+    "overflow": false
+  },
+  {
+    "principal": "14630810656930240801",
+    "rate_bps": 9690,
+    "seconds": 398137659,
+    "expected": "178985899492375760865",
+    "overflow": false
+  },
+  {
+    "principal": "3505052111482533294",
+    "rate_bps": 8903,
+    "seconds": 2348408464,
+    "expected": "232379537309421961132",
+    "overflow": false
+  },
+  {
+    "principal": "8828999712230936735",
+    "rate_bps": 8565,
+    "seconds": 2049638633,
+    "expected": "491484200553346100835",
+    "overflow": false
+  },
+  {
+    "principal": "8491217163045519684",
+    "rate_bps": 417,
+    "seconds": 896256022,
+    "expected": "10063092920395862822",
+    "overflow": false
+  },
+  {
+    "principal": "4427972502394410797",
+    "rate_bps": 2907,
+    "seconds": 3708448295,
+    "expected": "151368521284534642479",
+    "overflow": false
+  },
+  {
+    "principal": "12649975542155917098",
+    "rate_bps": 9481,
+    "seconds": 608633964,
+    "expected": "231469305928068125747",
+    "overflow": false
+  },
+  {
+    "principal": "7524800583445830731",
+    "rate_bps": 5915,
+    "seconds": 3132529781,
+    "expected": "442118151569204628868",
+    "overflow": false
+  },
+  {
+    "principal": "10985388362276801760",
+    "rate_bps": 6079,
+    "seconds": 2660336914,
+    "expected": "563349083423878654020",
+    "overflow": false
+  },
+  {
+    "principal": "851876607449224057",
+    "rate_bps": 1316,
+    "seconds": 3961236307,
+    "expected": "14081753117737184612",
+    "overflow": false
+  },
+  {
+    "principal": "8336386573059869670",
+    "rate_bps": 840,
+    "seconds": 2964418440,
+    "expected": "65824873120635309785",
+    "overflow": false
+  },
+  {
+    "principal": "2647710884039005239",
+    "rate_bps": 6889,
+    "seconds": 2958523969,
+    "expected": "171117816797603851847",
+    "overflow": false
+  },
+  {
+    "principal": "9648988904094691772",
+    "rate_bps": 4611,
+    "seconds": 1330478414,
+    "expected": "187706000043062452965",
+    "overflow": false
+  },
+  {
+    "principal": "7290103522452191749",
+    "rate_bps": 4665,
+    "seconds": 125148351,
+    "expected": "13495962667201816882",
+    "overflow": false
+  },
+  {
+    "principal": "9579138869169868770",
+    "rate_bps": 2501,
+    "seconds": 3894041572,
+    "expected": "295824499036820946976",
+    "overflow": false
+  },
+  {
+    "principal": "9348083533405733987",
+    "rate_bps": 4047,
+    "seconds": 1039929933,
+    "expected": "124753650015135226894",
+    "overflow": false
+  },
+  {
+    "principal": "6621365844420848600",
+    "rate_bps": 7733,
+    "seconds": 1387072714,
+    "expected": "225210282833721341863",
+    "overflow": false
+  },
+  {
+    "principal": "11458337093835355857",
+    "rate_bps": 2477,
+    "seconds": 625036907,
+    "expected": "56253125377270998001",
+    "overflow": false
+  },
+  {
+    "principal": "1497624590339301150",
+    "rate_bps": 635,
+    "seconds": 2242528640,
+    "expected": "6762512470622892386",
+    "overflow": false
+  },
+  {
+    "principal": "370940538705164495",
+    "rate_bps": 5607,
+    "seconds": 3234006169,
+    "expected": "21328931109715151544",
+    "overflow": false
+  },
+  {
+    "principal": "13854744358697580340",
+    "rate_bps": 4307,
+    "seconds": 1844105094,
+    "expected": "348941359775133401740",
+    "overflow": false
+  },
+  {
+    "principal": "12029889684564833757",
+    "rate_bps": 3683,
+    "seconds": 3136687191,
+    "expected": "440684694479479693767",
+    "overflow": false
+  },
+  {
+    "principal": "11673816501339149722",
+    "rate_bps": 5593,
+    "seconds": 2490165340,
+    "expected": "515560051989494152549",
+    "overflow": false
+  },
+  {
+    "principal": "3156216918468066683",
+    "rate_bps": 4326,
+    "seconds": 3427221797,
+    "expected": "148384645302957829504",
+    "overflow": false
+  },
+  {
+    "principal": "7366734482227351504",
+    "rate_bps": 8898,
+    "seconds": 891986306,
+    "expected": "185403956818869012855",
+    "overflow": false
+  },
+  {
+    "principal": "7917569715599270697",
+    "rate_bps": 5970,
+    "seconds": 4114965123,
+    "expected": "616773603927301518694",
+    "overflow": false
+  },
+  {
+    "principal": "15182047419773210454",
+    "rate_bps": 2744,
+    "seconds": 3559735416,
+    "expected": "470246490548767979903",
+    "overflow": false
+  },
+  {
+    "principal": "13450624422598631015",
+    "rate_bps": 3685,
+    "seconds": 288093169,
+    "expected": "45279986872261353142",
+    "overflow": false
+  },
+  {
+    "principal": "9211832479003636140",
+    "rate_bps": 2641,
+    "seconds": 2406850238,
+    "expected": "185676479752316176998",
+    "overflow": false
+  },
+  {
+    "principal": "16195620680151771829",
+    "rate_bps": 9375,
+    "seconds": 1749490927,
+    "expected": "842313886423227436436",
+    "overflow": false
+  },
+  {
+    "principal": "1679943624388585554",
+    "rate_bps": 3452,
+    "seconds": 865176020,
+    "expected": "15909750230352679649",
+    "overflow": false
+  },
+  {
+    "principal": "7618484777401771923",
+    "rate_bps": 8511,
+    "seconds": 2582153469,
+    "expected": "530914563311899647928",
+    "overflow": false
+  },
+  {
+    "principal": "12433648804941404360",
+    "rate_bps": 5270,
+    "seconds": 3321242426,
+    "expected": "690085944074822306207",
+    "overflow": false
+  },
+  {
+    "principal": "18159171414218209409",
+    "rate_bps": 8532,
+    "seconds": 65357723,
+    "expected": "32109769013972386087",
+    "overflow": false
+  },
+  {
+    "principal": "17107984437002501262",
+    "rate_bps": 6101,
+    "seconds": 2608283760,
+    "expected": "863272888494127999129",
+    "overflow": false
+  },
+  {
+    "principal": "10160680587757970687",
+    "rate_bps": 2416,
+    "seconds": 3386158153,
+    "expected": "263584798744398181091",
+    "overflow": false
+  },
+  {
+    "principal": "6043315277645414692",
+    "rate_bps": 22,
+    "seconds": 2054408950,
+    "expected": "866120312878812934",
+    "overflow": false
+  },
+  {
+    "principal": "6770582288299210893",
+    "rate_bps": 7640,
+    "seconds": 1485319815,
+    "expected": "243631111883901873712",
+    "overflow": false
+  },
+  {
+    "principal": "14489635562153027594",
+    "rate_bps": 5439,
+    "seconds": 2274304076,
+    "expected": "568353375928561614848",
+    "overflow": false
+  },
+  {
+    "principal": "4593605774459134635",
+    "rate_bps": 9409,
+    "seconds": 3396618709,
+    "expected": "465518966608453820767",
+    "overflow": false
+  },
+  {
+    "principal": "5139067700339943104",
+    "rate_bps": 5093,
+    "seconds": 554660338,
+    "expected": "46033979521660937631",
+    "overflow": false
+  },
+  {
+    "principal": "12066928955366545113",
+    "rate_bps": 1804,
+    "seconds": 2013420979,
+    "expected": "138982868693401040219",
+    "overflow": false
+  },
+  {
+    "principal": "10757743231752783558",
+    "rate_bps": 9300,
+    "seconds": 674833768,
+    "expected": "214088984406456500533",
+    "overflow": false
+  },
+  {
+    "principal": "12214147607052266647",
+    "rate_bps": 7369,
+    "seconds": 1392741793,
+    "expected": "397498708250218463813",
+    "overflow": false
+  },
+  {
+    "principal": "15350299717695128988",
+    "rate_bps": 3190,
+    "seconds": 3644797998,
+    "expected": "565945224373474747838",
+    "overflow": false
+  },
+  {
+    "principal": "1467506532532649829",
+    "rate_bps": 1048,
+    "seconds": 4273774879,
+    "expected": "20842334462438939531",
+    "overflow": false
+  },
+  {
+    "principal": "10606999600852710594",
+    "rate_bps": 9090,
+    "seconds": 161516484,
+    "expected": "49381773234369992841",
+    "overflow": false
+  },
+  {
+    "principal": "5376958591847255747",
+    "rate_bps": 5301,
+    "seconds": 4131578797,
+    "expected": "373425463956598323521",
+    "overflow": false
+  },
+  {
+    "principal": "1950967429300312504",
+    "rate_bps": 4610,
+    "seconds": 3255463338,
+    "expected": "92844706215454892020",
+    "overflow": false
+  },
+  {
+    "principal": "883995557093580337",
+    "rate_bps": 5307,
+    "seconds": 287442123,
+    "expected": "4276051969436107833",
+    "overflow": false
+  },
+  {
+    "principal": "15017942660107865598",
+    "rate_bps": 1573,
+    "seconds": 2081935200,
+    "expected": "155955166082424836582",
+    "overflow": false
+  },
+  {
+    "principal": "15277217616072512815",
+    "rate_bps": 3041,
+    "seconds": 1652750329,
+    "expected": "243478899694296137174",
+    "overflow": false
+  },
+  {
+    "principal": "2659328973147643668",
+    "rate_bps": 7966,
+    "seconds": 629520998,
+    "expected": "42287886595945672473",
+    "overflow": false
+  },
+  {
+    "principal": "13928797360093126461",
+    "rate_bps": 1371,
+    "seconds": 1498141879,
+    "expected": "90718824150607794270",
+    "overflow": false
+  },
+  {
+    "principal": "3670394407737470586",
+    "rate_bps": 6099,
+    "seconds": 968141884,
+    "expected": "68723262730581511857",
+    "overflow": false
+  },
+  {
+    "principal": "11193619945806597083",
+    "rate_bps": 283,
+    "seconds": 1072739973,
+    "expected": "10775684065948829935",
+    "overflow": false
+  },
+  {
+    "principal": "12024010952357482928",
+    "rate_bps": 7897,
+    "seconds": 395245154,
+    "expected": "119006709735730122282",
+    "overflow": false
+  },
+  {
+    "principal": "7886755118267068041",
+    "rate_bps": 2903,
+    "seconds": 1357749475,
+    "expected": "98573103166469426042",
+    "overflow": false
+  },
+  {
+    "principal": "2960509952455586358",
+    "rate_bps": 7414,
+    "seconds": 86777432,
+    "expected": "6039754611684309452",
+    "overflow": false
+  },
+  {
+    "principal": "2722099993378717383",
+    "rate_bps": 4028,
+    "seconds": 2569096017,
+    "expected": "89323815380784425743",
+    "overflow": false
+  },
+  {
+    "principal": "14845948415720025484",
+    "rate_bps": 9517,
+    "seconds": 1674132894,
+    "expected": "750051940959856361863",
+    "overflow": false
+  },
+  {
+    "principal": "15183935068127016981",
+    "rate_bps": 2901,
+    "seconds": 1669409103,
+    "expected": "233178356555965808477",
+    "overflow": false
+  },
+  {
+    "principal": "13865424672487961906",
+    "rate_bps": 8332,
+    "seconds": 1039032756,
+    "expected": "380631800421208405888",
+    "overflow": false
+  },
+  {
+    "principal": "649238150287915507",
+    "rate_bps": 2299,
+    "seconds": 4192084573,
+    "expected": "19841131332520088203",
+    "overflow": false
+  },
+  {
+    "principal": "16798980032509816488",
+    "rate_bps": 6309,
+    "seconds": 3872975898,
+    "expected": "1301612254240939976318",
+    "overflow": false
+  },
+  {
+    "principal": "17991793457924663265",
+    "rate_bps": 6240,
+    "seconds": 3031598587,
+    "expected": "1079255164566702116265",
+    "overflow": false
+  },
+  {
+    "principal": "3208980291705607022",
+    "rate_bps": 4998,
+    "seconds": 2776822352,
+    "expected": "141222791315562460973",
+    "overflow": false
+  },
+  {
+    "principal": "5711018382022789471",
+    "rate_bps": 3423,
+    "seconds": 2955995049,
+    "expected": "183238847914292175771",
+    "overflow": false
+  },
+  {
+    "principal": "8268817755219300612",
+    "rate_bps": 2080,
+    "seconds": 2933890518,
+    "expected": "160008867626790139010",
+    "overflow": false
+  },
+  {
+    "principal": "18117371974061746669",
+    "rate_bps": 6242,
+    "seconds": 2534145767,
+    "expected": "908749010228717792090",
+    "overflow": false
+  },
+  {
+    "principal": "13623613209279391978",
+    "rate_bps": 9123,
+    "seconds": 3525610540,
+    "expected": "1389497304964043142541",
+    "overflow": false
+  },
+  {
+    "principal": "5210253532979656971",
+    "rate_bps": 4752,
+    "seconds": 3685713717,
+    "expected": "289367852152135848465",
+    "overflow": false
+  },
+  {
+    "principal": "8935914579111612576",
+    "rate_bps": 6388,
+    "seconds": 2134388434,
+    "expected": "386340971862175073465",
+    "overflow": false
+  },
+  {
+    "principal": "15012325413625784889",
+    "rate_bps": 1768,
+    "seconds": 4276232211,
+    "expected": "359902533702766768163",
+    "overflow": false
+  },
+  {
+    "principal": "13214373773892882854",
+    "rate_bps": 6508,
+    "seconds": 178072392,
+    "expected": "48560608113642239322",
+    "overflow": false
+  },
+  {
+    "principal": "6847626701315822839",
+    "rate_bps": 3890,
+    "seconds": 923282689,
+    "expected": "77986200865327857032",
+    "overflow": false
+  },
+  {
+    "principal": "354333372496996732",
+    "rate_bps": 7273,
+    "seconds": 2473769742,
+    "expected": "20215212529010778958",
+    "overflow": false
+  },
+  {
+    "principal": "11229527556162344133",
+    "rate_bps": 9600,
+    "seconds": 2105521535,
+    "expected": "719756837058622146974",
+    "overflow": false
+  },
+  {
+    "principal": "14395289203016427938",
+    "rate_bps": 8717,
+    "seconds": 2271349668,
+    "expected": "903784379958435217593",
+    "overflow": false
+  },
+  {
+    "principal": "6285145322374949155",
+    "rate_bps": 2053,
+    "seconds": 3352118541,
+    "expected": "137156702184581558730",
+    "overflow": false
+  },
+  {
+    "principal": "979471548036355992",
+    "rate_bps": 34,
+    "seconds": 3180371594,
+    "expected": "335847408070792505",
+    "overflow": false
+  },
+  {
+    "principal": "8468812040084641169",
+    "rate_bps": 6316,
+    "seconds": 2425473835,
+    "expected": "411390825779570087646",
+    "overflow": false
+  },
+  {
+    "principal": "10154295730233773278",
+    "rate_bps": 1889,
+    "seconds": 1424992576,
+    "expected": "86673784566346654243",
+    "overflow": false
+  },
+  {
+    "principal": "1715676665369002383",
+    "rate_bps": 3474,
+    "seconds": 3766582105,
+    "expected": "71187885043879955269",
+    "overflow": false
+  },
+  {
+    "principal": "11898067343737640692",
+    "rate_bps": 6380,
+    "seconds": 998274374,
+    "expected": "240292611470831558230",
+    "overflow": false
+  },
+  {
+    "principal": "5033121541909895325",
+    "rate_bps": 150,
+    "seconds": 1372826903,
+    "expected": "3286531896310286484",
+    "overflow": false
+  },
+  {
+    "principal": "17780693438650275674",
+    "rate_bps": 2755,
+    "seconds": 1399177244,
+    "expected": "217338379069740396124",
+    "overflow": false
+  },
+  {
+    "principal": "3603735500887960123",
+    "rate_bps": 1724,
+    "seconds": 551795685,
+    "expected": "10870808934372476125",
+    "overflow": false
+  },
+  {
+    "principal": "14146656206330995600",
+    "rate_bps": 7304,
+    "seconds": 3755612994,
+    "expected": "1230520320635327385695",
+    "overflow": false
+  },
+  {
+    "principal": "3479574991768259049",
+    "rate_bps": 140,
+    "seconds": 3539658563,
+    "expected": "5467754433440652497",
+    "overflow": false
+  },
+  {
+    "principal": "4736868526877009174",
+    "rate_bps": 6335,
+    "seconds": 258165816,
+    "expected": "24565752927485126734",
+    "overflow": false
+  },
+  {
+    "principal": "10298518469431504679",
+    "rate_bps": 9775,
+    "seconds": 1618686641,
+    "expected": "516710984193237292615",
+    "overflow": false
+  },
+  {
+    "principal": "7456263689566042476",
+    "rate_bps": 6483,
+    "seconds": 1775938686,
+    "expected": "272219129452672801570",
+    "overflow": false
+  },
+  {
+    "principal": "14291681896499795317",
+    "rate_bps": 6948,
+    "seconds": 2984461743,
+    "expected": "939728850183020510624",
+    "overflow": false
+  },
+  {
+    "principal": "3430383075702837778",
+    "rate_bps": 3110,
+    "seconds": 1881311636,
+    "expected": "63643952766235244497",
+    "overflow": false
+  },
+  {
+    "principal": "4600661330542599251",
+    "rate_bps": 8233,
+    "seconds": 2942520253,
+    "expected": "353420090558992020891",
+    "overflow": false
+  },
+  {
+    "principal": "957056578768311432",
+    "rate_bps": 9778,
+    "seconds": 681608442,
+    "expected": "20226279281871016983",
+    "overflow": false
+  },
+  {
+    "principal": "1024604925760956225",
+    "rate_bps": 3676,
+    "seconds": 2969228379,
+    "expected": "35462466450826702468",
+    "overflow": false
+  },
+  {
+    "principal": "3030593383460436558",
+    "rate_bps": 4959,
+    "seconds": 1993667632,
+    "expected": "95009696342223131323",
+    "overflow": false
+  },
+  {
+    "principal": "1648486603186388415",
+    "rate_bps": 1679,
+    "seconds": 3646403337,
+    "expected": "32003259761515915656",
+    "overflow": false
+  },
+  {
+    "principal": "9559607213314568420",
+    "rate_bps": 4420,
+    "seconds": 1168588982,
+    "expected": "156573225345110056228",
+    "overflow": false
+  },
+  {
+    "principal": "8764918435358845773",
+    "rate_bps": 7916,
+    "seconds": 1609424711,
+    "expected": "354093310969265340508",
+    "overflow": false
+  },
+  {
+    "principal": "12087176360050489802",
+    "rate_bps": 7921,
+    "seconds": 2336180236,
+    "expected": "709258600304352740790",
+    "overflow": false
+  },
+  {
+    "principal": "7427396695702445931",
+    "rate_bps": 3589,
+    "seconds": 385897621,
+    "expected": "32619370283090316236",
+    "overflow": false
+  },
+  {
+    "principal": "15286573767877544576",
+    "rate_bps": 8388,
+    "seconds": 1384364978,
+    "expected": "562875797303894927642",
+    "overflow": false
+  },
+  {
+    "principal": "11270815218861002137",
+    "rate_bps": 2438,
+    "seconds": 546501235,
+    "expected": "47618265462784892692",
+    "overflow": false
+  },
+  {
+    "principal": "3552957054378454150",
+    "rate_bps": 3788,
+    "seconds": 295010600,
+    "expected": "12590151100836378810",
+    "overflow": false
+  },
+  {
+    "principal": "18316538116922019159",
+    "rate_bps": 2229,
+    "seconds": 3648871521,
+    "expected": "472395147103536518722",
+    "overflow": false
+  },
+  {
+    "principal": "7156674369844534620",
+    "rate_bps": 370,
+    "seconds": 4125102574,
+    "expected": "34637068333968929363",
+    "overflow": false
+  },
+  {
+    "principal": "3643887145283074597",
+    "rate_bps": 4962,
+    "seconds": 337041887,
+    "expected": "19324085421507881574",
+    "overflow": false
+  },
+  {
+    "principal": "3142116503068634754",
+    "rate_bps": 8543,
+    "seconds": 1167514500,
+    "expected": "99377568417178177792",
+    "overflow": false
+  },
+  {
+    "principal": "16468702619278676867",
+    "rate_bps": 2966,
+    "seconds": 3694343789,
+    "expected": "572217630737222055551",
+    "overflow": false
+  },
+  {
+    "principal": "4235566301069256056",
+    "rate_bps": 4171,
+    "seconds": 3552026474,
+    "expected": "198985422363322650839",
+    "overflow": false
+  },
+  {
+    "principal": "2300142945639472369",
+    "rate_bps": 9307,
+    "seconds": 3160973707,
+    "expected": "214574849737563572402",
+    "overflow": false
+  },
+  {
+    "principal": "7790485512624987070",
+    "rate_bps": 481,
+    "seconds": 2531906336,
+    "expected": "30085042497453733938",
+    "overflow": false
+  },
+  {
+    "principal": "1708661650508119535",
+    "rate_bps": 7840,
+    "seconds": 3906375353,
+    "expected": "165935572881735000414",
+    "overflow": false
+  },
+  {
+    "principal": "10454102080931585748",
+    "rate_bps": 7608,
+    "seconds": 215154726,
+    "expected": "54262715495375970667",
+    "overflow": false
+  },
+  {
+    "principal": "11134047325481034237",
+    "rate_bps": 6123,
+    "seconds": 1575327095,
+    "expected": "340550449783748659885",
+    "overflow": false
+  },
+  {
+    "principal": "4362636737792167994",
+    "rate_bps": 8443,
+    "seconds": 45622268,
+    "expected": "5328636630916167996",
+    "overflow": false
+  },
+  {
+    "principal": "5414980712015845531",
+    "rate_bps": 8143,
+    "seconds": 4189606213,
+    "expected": "585798083910464728584",
+    "overflow": false
+  },
+  {
+    "principal": "17362600303148926320",
+    "rate_bps": 6893,
+    "seconds": 4051963938,
+    "expected": "1537736810774849752962",
+    "overflow": false
+  },
+  {
+    "principal": "4711825188485412169",
+    "rate_bps": 6065,
+    "seconds": 1833255331,
+    "expected": "166125508895057339409",
+    "overflow": false
+  },
+  {
+    "principal": "9853976118091245558",
+    "rate_bps": 3768,
+    "seconds": 646629912,
+    "expected": "76132761528489852704",
+    "overflow": false
+  },
+  {
+    "principal": "17977426955733495687",
+    "rate_bps": 5749,
+    "seconds": 2790369809,
+    "expected": "914481657471058447205",
+    "overflow": false
+  },
+  {
+    "principal": "5191988072426100044",
+    "rate_bps": 6448,
+    "seconds": 3282168670,
+    "expected": "348427964296866894532",
+    "overflow": false
+  },
+  {
+    "principal": "7613151721620472533",
+    "rate_bps": 711,
+    "seconds": 2512744975,
+    "expected": "43129645829359042692",
+    "overflow": false
+  },
+  {
+    "principal": "11696921020981903090",
+    "rate_bps": 303,
+    "seconds": 140902772,
+    "expected": "1583532992464454442",
+    "overflow": false
+  },
+  {
+    "principal": "7004496236993728179",
+    "rate_bps": 8078,
+    "seconds": 101713181,
+    "expected": "18249517430351136462",
+    "overflow": false
+  },
+  {
+    "principal": "64707743484922472",
+    "rate_bps": 137,
+    "seconds": 2747592154,
+    "expected": "77236481790346941",
+    "overflow": false
+  },
+  {
+    "principal": "18075419483276998305",
+    "rate_bps": 4896,
+    "seconds": 597045947,
+    "expected": "167544795459233994500",
+    "overflow": false
+  },
+  {
+    "principal": "10103006437905019182",
+    "rate_bps": 4022,
+    "seconds": 3492103696,
+    "expected": "449959287496115823164",
+    "overflow": false
+  },
+  {
+    "principal": "6538518197963244063",
+    "rate_bps": 2981,
+    "seconds": 1969294953,
+    "expected": "121715384053727195844",
+    "overflow": false
+  },
+  {
+    "principal": "3472834093563650244",
+    "rate_bps": 8169,
+    "seconds": 96646038,
+    "expected": "8694215093923873362",
+    "overflow": false
+  },
+  {
+    "principal": "17483252667018280109",
+    "rate_bps": 6089,
+    "seconds": 3733311399,
+    "expected": "1260247421348267018708",
+    "overflow": false
+  },
+  {
+    "principal": "12363715702226672298",
+    "rate_bps": 4781,
+    "seconds": 3994506220,
+    "expected": "748728299952711388749",
+    "overflow": false
+  },
+  {
+    "principal": "7753247166994273739",
+    "rate_bps": 152,
+    "seconds": 3909005813,
+    "expected": "14607871046745853827",
+    "overflow": false
+  },
+  {
+    "principal": "13953835043363116128",
+    "rate_bps": 5758,
+    "seconds": 1214912658,
+    "expected": "309530675266594119438",
+    "overflow": false
+  },
+  {
+    "principal": "11898757377882079481",
+    "rate_bps": 3070,
+    "seconds": 2699875539,
+    "expected": "312735456133788655735",
+    "overflow": false
+  },
+  {
+    "principal": "14768032868419278694",
+    "rate_bps": 8829,
+    "seconds": 1792681736,
+    "expected": "741192052701642020406",
+    "overflow": false
+  },
+  {
+    "principal": "3274767067169248695",
+    "rate_bps": 1738,
+    "seconds": 3145407425,
+    "expected": "56767593907298688694",
+    "overflow": false
+  },
+  {
+    "principal": "3644194347146355004",
+    "rate_bps": 6347,
+    "seconds": 1283406030,
+    "expected": "94129878248938527551",
+    "overflow": false
+  },
+  {
+    "principal": "15483069737610030981",
+    "rate_bps": 1755,
+    "seconds": 920260159,
+    "expected": "79293612517566027430",
+    "overflow": false
+  },
+  {
+    "principal": "7656943355057161058",
+    "rate_bps": 5715,
+    "seconds": 1551301476,
+    "expected": "215258974900152380669",
+    "overflow": false
+  },
+  {
+    "principal": "11065338551745662435",
+    "rate_bps": 7049,
+    "seconds": 554481613,
+    "expected": "137142720039322425271",
+    "overflow": false
+  },
+  {
+    "principal": "16071720617176695640",
+    "rate_bps": 6237,
+    "seconds": 653750346,
+    "expected": "207798995137162004401",
+    "overflow": false
+  },
+  {
+    "principal": "9813654268336206929",
+    "rate_bps": 8277,
+    "seconds": 1367246827,
+    "expected": "352163244415863339753",
+    "overflow": false
+  },
+  {
+    "principal": "2253138868253096606",
+    "rate_bps": 8114,
+    "seconds": 3166588160,
+    "expected": "183572634039687008831",
+    "overflow": false
+  },
+  {
+    "principal": "15021072988857305679",
+    "rate_bps": 4914,
+    "seconds": 2912563737,
+    "expected": "681718280053769763103",
+    "overflow": false
+  },
+  {
+    "principal": "8879250300195157684",
+    "rate_bps": 6220,
+    "seconds": 1249204998,
+    "expected": "218773033893804040536",
+    "overflow": false
+  },
+  {
+    "principal": "18353176007993621341",
+    "rate_bps": 9731,
+    "seconds": 2597948887,
+    "expected": "1471271077126541169588",
+    "overflow": false
+  },
+  {
+    "principal": "11548421849891608858",
+    "rate_bps": 8062,
+    "seconds": 484693980,
+    "expected": "143095656796011774380",
+    "overflow": false
+  },
+  {
+    "principal": "15144320621591566075",
+    "rate_bps": 3232,
+    "seconds": 2567337637,
+    "expected": "398471741875122628618",
+    "overflow": false
+  },
+  {
+    "principal": "8431467844196054864",
+    "rate_bps": 793,
+    "seconds": 3288651010,
+    "expected": "69724844960004812353",
+    "overflow": false
+  },
+  {
+    "principal": "6374887347721793705",
+    "rate_bps": 8904,
+    "seconds": 899984387,
+    "expected": "161989190210061762966",
+    "overflow": false
+  },
+  {
+    "principal": "14653073747316980438",
+    "rate_bps": 4487,
+    "seconds": 4066023416,
+    "expected": "847711497164184231144",
+    "overflow": false
+  },
+  {
+    "principal": "6583591865446055911",
+    "rate_bps": 1761,
+    "seconds": 2914824561,
+    "expected": "107158856192010625676",
+    "overflow": false
+  },
+  {
+    "principal": "17686385908294533420",
+    "rate_bps": 8376,
+    "seconds": 1729559102,
+    "expected": "812464821573987542094",
+    "overflow": false
+  },
+  {
+    "principal": "12205012458610114613",
+    "rate_bps": 5308,
+    "seconds": 897560175,
+    "expected": "184385221307554459222",
+    "overflow": false
+  },
+  {
+    "principal": "13986330553775635410",
+    "rate_bps": 1584,
+    "seconds": 2029046100,
+    "expected": "142542467624631153580",
+    "overflow": false
+  },
+  {
+    "principal": "4834587845182066963",
+    "rate_bps": 7222,
+    "seconds": 226250365,
+    "expected": "25049532296168120105",
+    "overflow": false
+  },
+  {
+    "principal": "12191641912980164680",
+    "rate_bps": 2568,
+    "seconds": 79570618,
+    "expected": "7899567999635245815",
+    "overflow": false
+  },
+  {
+    "principal": "16729115501146183169",
+    "rate_bps": 3181,
+    "seconds": 3680280859,
+    "expected": "621027747292645447139",
+    "overflow": false
+  },
+  {
+    "principal": "8768379806989629454",
+    "rate_bps": 2261,
+    "seconds": 1714153456,
+    "expected": "107761345988102913780",
+    "overflow": false
+  },
+  {
+    "principal": "14704128134620337791",
+    "rate_bps": 7185,
+    "seconds": 946141641,
+    "expected": "316968132372713783926",
+    "overflow": false
+  },
+  {
+    "principal": "15887744907525169316",
+    "rate_bps": 1923,
+    "seconds": 170522230,
+    "expected": "16520224278203930303",
+    "overflow": false
+  },
+  {
+    "principal": "4061932313581870605",
+    "rate_bps": 7504,
+    "seconds": 2720780295,
+    "expected": "262973734746713366763",
+    "overflow": false
+  },
+  {
+    "principal": "10358590203230260106",
+    "rate_bps": 9597,
+    "seconds": 3924078540,
+    "expected": "1236992969426932814416",
+    "overflow": false
+  },
+  {
+    "principal": "1166194501510536235",
+    "rate_bps": 8803,
+    "seconds": 37920597,
+    "expected": "1234440751746065531",
+    "overflow": false
+  },
+  {
+    "principal": "2613239944866541120",
+    "rate_bps": 173,
+    "seconds": 576931186,
+    "expected": "827071012113572029",
+    "overflow": false
+  },
+  {
+    "principal": "12164324618423256153",
+    "rate_bps": 1443,
+    "seconds": 1741145907,
+    "expected": "96913190582177909308",
+    "overflow": false
+  },
+  {
+    "principal": "1763527360294343238",
+    "rate_bps": 7848,
+    "seconds": 3089308904,
+    "expected": "135580092385830465349",
+    "overflow": false
+  },
+  {
+    "principal": "15099817267521826327",
+    "rate_bps": 8760,
+    "seconds": 1645832993,
+    "expected": "690327151309959142127",
+    "overflow": false
+  },
+  {
+    "principal": "4700805966918694172",
+    "rate_bps": 9468,
+    "seconds": 3074961326,
+    "expected": "433973914665207791196",
+    "overflow": false
+  },
+  {
+    "principal": "13988469624489194725",
+    "rate_bps": 8014,
+    "seconds": 1042371231,
+    "expected": "370540217258090011252",
+    "overflow": false
+  },
+  {
+    "principal": "2311098497455810626",
+    "rate_bps": 9059,
+    "seconds": 406481732,
+    "expected": "26985665970636596793",
+    "overflow": false
+  },
+  {
+    "principal": "9323206953175291971",
+    "rate_bps": 7118,
+    "seconds": 1207028013,
+    "expected": "254000195446610901353",
+    "overflow": false
+  },
+  {
+    "principal": "195391385332232504",
+    "rate_bps": 9064,
+    "seconds": 1841828138,
+    "expected": "10343506828198661661",
+    "overflow": false
+  },
+  {
+    "principal": "15917381873857747889",
+    "rate_bps": 1731,
+    "seconds": 2964029003,
+    "expected": "258967071351482798154",
+    "overflow": false
+  },
+  {
+    "principal": "8854664869351975294",
+    "rate_bps": 9995,
+    "seconds": 891623136,
+    "expected": "250224395833685888514",
+    "overflow": false
+  },
+  {
+    "principal": "5277406922212222639",
+    "rate_bps": 5377,
+    "seconds": 3840173433,
+    "expected": "345545188994934748519",
+    "overflow": false
+  },
+  {
+    "principal": "15374653311576792724",
+    "rate_bps": 90,
+    "seconds": 4183786982,
+    "expected": "18357384240222081989",
+    "overflow": false
+  },
+  {
+    "principal": "2547211733374411965",
+    "rate_bps": 5000,
+    "seconds": 2315753015,
+    "expected": "93523485086966809864",
+    "overflow": false
+  },
+  {
+    "principal": "9369495271396159994",
+    "rate_bps": 8052,
+    "seconds": 723573692,
+    "expected": "173099623733072444979",
+    "overflow": false
+  },
+  {
+    "principal": "1699653685369136475",
+    "rate_bps": 306,
+    "seconds": 291908613,
+    "expected": "481417828076457269",
+    "overflow": false
+  },
+  {
+    "principal": "140596681360849200",
+    "rate_bps": 3161,
+    "seconds": 3805571554,
+    "expected": "5363062408802342656",
+    "overflow": false
+  },
+  {
+    "principal": "15439973018676182025",
+    "rate_bps": 9034,
+    "seconds": 1710302819,
+    "expected": "756472296458087904482",
+    "overflow": false
+  },
+  {
+    "principal": "16872582266670636470",
+    "rate_bps": 2622,
+    "seconds": 2391455192,
+    "expected": "335482509337927775404",
+    "overflow": false
+  },
+  {
+    "principal": "10428600555729821767",
+    "rate_bps": 4620,
+    "seconds": 3184806097,
+    "expected": "486568957143469596255",
+    "overflow": false
+  },
+  {
+    "principal": "11553009822345264396",
+    "rate_bps": 2797,
+    "seconds": 506583326,
+    "expected": "51907712800281550745",
+    "overflow": false
+  },
+  {
+    "principal": "14020055951618772373",
+    "rate_bps": 3664,
+    "seconds": 2607413967,
+    "expected": "424725750520509807506",
+    "overflow": false
+  },
+  {
+    "principal": "6263423969486981298",
+    "rate_bps": 9439,
+    "seconds": 1744494900,
+    "expected": "327040014415189853495",
+    "overflow": false
+  },
+  {
+    "principal": "12473510336269247347",
+    "rate_bps": 2759,
+    "seconds": 2571118557,
+    "expected": "280579468164890415887",
+    "overflow": false
+  },
+  {
+    "principal": "9185001321056839208",
+    "rate_bps": 4041,
+    "seconds": 2349084570,
+    "expected": "276477706922008631488",
+    "overflow": false
+  },
+  {
+    "principal": "18089145187180954977",
+    "rate_bps": 1399,
+    "seconds": 1260789627,
+    "expected": "101174665943681238103",
+    "overflow": false
+  },
+  {
+    "principal": "6875852326839521006",
+    "rate_bps": 2493,
+    "seconds": 3785415120,
+    "expected": "205757523829076049726",
+    "overflow": false
+  },
+  {
+    "principal": "5937260152935414495",
+    "rate_bps": 9617,
+    "seconds": 1518040361,
+    "expected": "274854218195222103075",
+    "overflow": false
+  },
+  {
+    "principal": "8463666970789113988",
+    "rate_bps": 4856,
+    "seconds": 3251964246,
+    "expected": "423815074177772611178",
+    "overflow": false
+  },
+  {
+    "principal": "5016038565034446701",
+    "rate_bps": 6913,
+    "seconds": 2654462055,
+    "expected": "291875296010460960640",
+    "overflow": false
+  },
+  {
+    "principal": "9610959960288529514",
+    "rate_bps": 5218,
+    "seconds": 568286124,
+    "expected": "90371457727091744007",
+    "overflow": false
+  },
+  {
+    "principal": "10451131307109970571",
+    "rate_bps": 6991,
+    "seconds": 1466178741,
+    "expected": "339690121620726501057",
+    "overflow": false
+  },
+  {
+    "principal": "7544940897244764192",
+    "rate_bps": 2494,
+    "seconds": 3051831890,
+    "expected": "182098467619583017930",
+    "overflow": false
+  },
+  {
+    "principal": "10031731283122378681",
+    "rate_bps": 5060,
+    "seconds": 2163984787,
+    "expected": "348316464525561312988",
+    "overflow": false
+  },
+  {
+    "principal": "4898133787784305958",
+    "rate_bps": 9422,
+    "seconds": 254304968,
+    "expected": "37215339112634169497",
+    "overflow": false
+  },
+  {
+    "principal": "10238721463480358519",
+    "rate_bps": 8988,
+    "seconds": 1450199681,
+    "expected": "423184732098177881904",
+    "overflow": false
+  },
+  {
+    "principal": "9268657422672566524",
+    "rate_bps": 8080,
+    "seconds": 707982990,
+    "expected": "168129688314137788255",
+    "overflow": false
+  },
+  {
+    "principal": "13840600072025492037",
+    "rate_bps": 7430,
+    "seconds": 1715775231,
+    "expected": "559496688794340098350",
+    "overflow": false
+  },
+  {
+    "principal": "17305653034620837154",
+    "rate_bps": 2003,
+    "seconds": 4179176228,
+    "expected": "459359835318124802276",
+    "overflow": false
+  },
+  {
+    "principal": "2353410983351743139",
+    "rate_bps": 7799,
+    "seconds": 3329911437,
+    "expected": "193804016093863479765",
+    "overflow": false
+  },
+  {
+    "principal": "17168161435840753432",
+    "rate_bps": 220,
+    "seconds": 4070670858,
+    "expected": "48753505762650958204",
+    "overflow": false
+  },
+  {
+    "principal": "3271202632275874577",
+    "rate_bps": 8848,
+    "seconds": 3737617579,
+    "expected": "343036883204695891573",
+    "overflow": false
+  },
+  {
+    "principal": "12324594362050783326",
+    "rate_bps": 7245,
+    "seconds": 1658204352,
+    "expected": "469507428261094589261",
+    "overflow": false
+  },
+  {
+    "principal": "3484953304423551759",
+    "rate_bps": 9077,
+    "seconds": 3368888537,
+    "expected": "337924230830471327663",
+    "overflow": false
+  },
+  {
+    "principal": "11316737530286069364",
+    "rate_bps": 2155,
+    "seconds": 1921614022,
+    "expected": "148603168692332198152",
+    "overflow": false
+  },
+  {
+    "principal": "5115813452873686557",
+    "rate_bps": 518,
+    "seconds": 281521815,
+    "expected": "2365646815764168291",
+    "overflow": false
+  },
+  {
+    "principal": "11973727507133307610",
+    "rate_bps": 9622,
+    "seconds": 1789341596,
+    "expected": "653704348531475015650",
+    "overflow": false
+  },
+  {
+    "principal": "18109618908002862011",
+    "rate_bps": 7724,
+    "seconds": 3111088485,
+    "expected": "1379930878387044193211",
+    "overflow": false
+  },
+  {
+    "principal": "17143498292115049232",
+    "rate_bps": 2886,
+    "seconds": 3983199938,
+    "expected": "624915468450856646976",
+    "overflow": false
+  },
+  {
+    "principal": "17016900436481415017",
+    "rate_bps": 9095,
+    "seconds": 1543680195,
+    "expected": "757589395022313699046",
+    "overflow": false
+  },
+  {
+    "principal": "13559892068759785622",
+    "rate_bps": 7669,
+    "seconds": 2329093048,
+    "expected": "768024727062145071017",
+    "overflow": false
+  },
+  {
+    "principal": "1457150859544957095",
+    "rate_bps": 9108,
+    "seconds": 565211185,
+    "expected": "23786562203645543537",
+    "overflow": false
+  },
+  {
+    "principal": "6199154276314941676",
+    "rate_bps": 4339,
+    "seconds": 2263517182,
+    "expected": "193063103549076853579",
+    "overflow": false
+  },
+  {
+    "principal": "3616694574110370549",
+    "rate_bps": 3412,
+    "seconds": 3051116335,
+    "expected": "119391392407270913023",
+    "overflow": false
+  },
+  {
+    "principal": "12601422192098289042",
+    "rate_bps": 6276,
+    "seconds": 2948352276,
+    "expected": "739392877925261702805",
+    "overflow": false
+  },
+  {
+    "principal": "17137315974041912787",
+    "rate_bps": 391,
+    "seconds": 1089704253,
+    "expected": "23153763907439304908",
+    "overflow": false
+  },
+  {
+    "principal": "11357159415792159752",
+    "rate_bps": 8527,
+    "seconds": 235866234,
+    "expected": "72431111663634442218",
+    "overflow": false
+  },
+  {
+    "principal": "13946204473304188097",
+    "rate_bps": 1975,
+    "seconds": 2311761371,
+    "expected": "201910788075747542430",
+    "overflow": false
+  },
+  {
+    "principal": "456580234766890446",
+    "rate_bps": 8351,
+    "seconds": 3745258416,
+    "expected": "45282539269661469954",
+    "overflow": false
+  },
+  {
+    "principal": "6258380295324872511",
+    "rate_bps": 8721,
+    "seconds": 2545713289,
+    "expected": "440586432276715755572",
+    "overflow": false
+  },
+  {
+    "principal": "7655332393817673828",
+    "rate_bps": 8775,
+    "seconds": 4022070326,
+    "expected": "856750231889828666209",
+    "overflow": false
+  },
+  {
+    "principal": "13658902719762321613",
+    "rate_bps": 5736,
+    "seconds": 704774343,
+    "expected": "175092858562459314771",
+    "overflow": false
+  },
+  {
+    "principal": "10739195501224615242",
+    "rate_bps": 3571,
+    "seconds": 3980351372,
+    "expected": "484034596004678642590",
+    "overflow": false
+  },
+  {
+    "principal": "14169075993774676203",
+    "rate_bps": 896,
+    "seconds": 553331221,
+    "expected": "22275533167139486504",
+    "overflow": false
+  },
+  {
+    "principal": "5569665632244814336",
+    "rate_bps": 7143,
+    "seconds": 3966635826,
+    "expected": "500409443457090658574",
+    "overflow": false
+  },
+  {
+    "principal": "13153006149683116825",
+    "rate_bps": 1956,
+    "seconds": 476109811,
+    "expected": "38841357280716021050",
+    "overflow": false
+  },
+  {
+    "principal": "16213298833532827654",
+    "rate_bps": 959,
+    "seconds": 4188141736,
+    "expected": "206492726371504422878",
+    "overflow": false
+  },
+  {
+    "principal": "16689612955662388951",
+    "rate_bps": 7215,
+    "seconds": 630700513,
+    "expected": "240823674127121903479",
+    "overflow": false
+  },
+  {
+    "principal": "12631127430979833052",
+    "rate_bps": 2328,
+    "seconds": 1832357230,
+    "expected": "170855369414543427585",
+    "overflow": false
+  },
+  {
+    "principal": "5357626625604906917",
+    "rate_bps": 4714,
+    "seconds": 3483110239,
+    "expected": "278947603986528670702",
+    "overflow": false
+  },
+  {
+    "principal": "12122939345091207682",
+    "rate_bps": 8121,
+    "seconds": 3008051972,
+    "expected": "939066118250634081024",
+    "overflow": false
+  },
+  {
+    "principal": "17364235235079478531",
+    "rate_bps": 652,
+    "seconds": 3594427373,
+    "expected": "129040596622900369055",
+    "overflow": false
+  },
+  {
+    "principal": "9611769738207460600",
+    "rate_bps": 5672,
+    "seconds": 2482750186,
+    "expected": "429206209580784743147",
+    "overflow": false
+  },
+  {
+    "principal": "10600681087582394993",
+    "rate_bps": 1380,
+    "seconds": 2225773323,
+    "expected": "103249315623771878009",
+    "overflow": false
+  },
+  {
+    "principal": "112465069106149182",
+    "rate_bps": 8373,
+    "seconds": 2626263712,
+    "expected": "7842065613034586918",
+    "overflow": false
+  },
+  {
+    "principal": "18241581372586921839",
+    "rate_bps": 5069,
+    "seconds": 392985657,
+    "expected": "115227162960155040709",
+    "overflow": false
+  },
+  {
+    "principal": "9003815984989380180",
+    "rate_bps": 4098,
+    "seconds": 1659587494,
+    "expected": "194174462289907736082",
+    "overflow": false
+  },
+  {
+    "principal": "10199200286215055229",
+    "rate_bps": 6989,
+    "seconds": 2020726519,
+    "expected": "456753721769500402693",
+    "overflow": false
+  },
+  {
+    "principal": "10838822997927777210",
+    "rate_bps": 171,
+    "seconds": 3434009468,
+    "expected": "20182414244872788101",
+    "overflow": false
+  },
+  {
+    "principal": "18287135364830802459",
+    "rate_bps": 3195,
+    "seconds": 733628101,
+    "expected": "135920791056019439126",
+    "overflow": false
+  },
+  {
+    "principal": "7551505206298193136",
+    "rate_bps": 2838,
+    "seconds": 2537554850,
+    "expected": "172446644723610636314",
+    "overflow": false
+  },
+  {
+    "principal": "12572943700960707273",
+    "rate_bps": 7612,
+    "seconds": 2578533155,
+    "expected": "782531562854264915943",
+    "overflow": false
+  },
+  {
+    "principal": "17094428175770260342",
+    "rate_bps": 4628,
+    "seconds": 3941327256,
+    "expected": "988743901560078926475",
+    "overflow": false
+  },
+  {
+    "principal": "9988558358174535943",
+    "rate_bps": 83,
+    "seconds": 677980049,
+    "expected": "1782342696171061988",
+    "overflow": false
+  },
+  {
+    "principal": "13211074058124879052",
+    "rate_bps": 7676,
+    "seconds": 322504414,
+    "expected": "103705585862009293053",
+    "overflow": false
+  },
+  {
+    "principal": "16675215902040119381",
+    "rate_bps": 4422,
+    "seconds": 1462682511,
+    "expected": "342005953075067687315",
+    "overflow": false
+  },
+  {
+    "principal": "8315142428774290034",
+    "rate_bps": 7357,
+    "seconds": 1584201972,
+    "expected": "307308371539514711241",
+    "overflow": false
+  },
+  {
+    "principal": "10743048150274914355",
+    "rate_bps": 294,
+    "seconds": 1613662877,
+    "expected": "16161477193877191501",
+    "overflow": false
+  },
+  {
+    "principal": "13229685199118975464",
+    "rate_bps": 6325,
+    "seconds": 4082544986,
+    "expected": "1083264253466947375951",
+    "overflow": false
+  },
+  {
+    "principal": "12069090681503765537",
+    "rate_bps": 3122,
+    "seconds": 1377979451,
+    "expected": "164643118487348403663",
+    "overflow": false
+  },
+  {
+    "principal": "219702464848800942",
+    "rate_bps": 5388,
+    "seconds": 4021661072,
+    "expected": "15095982259775004959",
+    "overflow": false
+  },
+  {
+    "principal": "9588149690982036383",
+    "rate_bps": 7719,
+    "seconds": 809507817,
+    "expected": "189981051262325027827",
+    "overflow": false
+  },
+  {
+    "principal": "7442627677672046660",
+    "rate_bps": 7555,
+    "seconds": 2866192150,
+    "expected": "511045369560990700651",
+    "overflow": false
+  },
+  {
+    "principal": "11690394884788412973",
+    "rate_bps": 9500,
+    "seconds": 14823719,
+    "expected": "5220394860875943935",
+    "overflow": false
+  },
+  {
+    "principal": "11198260295996767786",
+    "rate_bps": 3054,
+    "seconds": 1463591788,
+    "expected": "158720472618638226227",
+    "overflow": false
+  },
+  {
+    "principal": "9651081821957312331",
+    "rate_bps": 2521,
+    "seconds": 3684681589,
+    "expected": "284277312252080111946",
+    "overflow": false
+  },
+  {
+    "principal": "14351776768825334752",
+    "rate_bps": 3670,
+    "seconds": 3278875666,
+    "expected": "547633587687016032179",
+    "overflow": false
+  },
+  {
+    "principal": "3646427531577372281",
+    "rate_bps": 2857,
+    "seconds": 2379152979,
+    "expected": "78594759313743013293",
+    "overflow": false
+  },
+  {
+    "principal": "8879519820941648614",
+    "rate_bps": 9693,
+    "seconds": 1967644296,
+    "expected": "537016559345481564354",
+    "overflow": false
+  },
+  {
+    "principal": "14667763411796301623",
+    "rate_bps": 145,
+    "seconds": 1621604673,
+    "expected": "10936296566460424198",
+    "overflow": false
+  },
+  {
+    "principal": "16400397286022009020",
+    "rate_bps": 1916,
+    "seconds": 474870862,
+    "expected": "47317172900233328458",
+    "overflow": false
+  },
+  {
+    "principal": "12196536076175942917",
+    "rate_bps": 42,
+    "seconds": 2122284991,
+    "expected": "3447330254882185203",
+    "overflow": false
+  },
+  {
+    "principal": "15366371678411798242",
+    "rate_bps": 3769,
+    "seconds": 789093092,
+    "expected": "144916923465538520833",
+    "overflow": false
+  },
+  {
+    "principal": "10053216808614614883",
+    "rate_bps": 7207,
+    "seconds": 1960205645,
+    "expected": "450354596158956133865",
+    "overflow": false
+  },
+  {
+    "principal": "16577619120232602328",
+    "rate_bps": 4186,
+    "seconds": 3293500362,
+    "expected": "724723743293453354458",
+    "overflow": false
+  },
+  {
+    "principal": "5102456550273184209",
+    "rate_bps": 4367,
+    "seconds": 4012687723,
+    "expected": "283524937504107937411",
+    "overflow": false
+  },
+  {
+    "principal": "3498766471494931998",
+    "rate_bps": 6882,
+    "seconds": 754406528,
+    "expected": "57600792031043913681",
+    "overflow": false
+  },
+  {
+    "principal": "13741612609668176847",
+    "rate_bps": 2830,
+    "seconds": 316301209,
+    "expected": "39004829306807968906",
+    "overflow": false
+  },
+  {
+    "principal": "17895708160610809396",
+    "rate_bps": 8369,
+    "seconds": 3413960326,
+    "expected": "1621340829612987751788",
+    "overflow": false
+  },
+  {
+    "principal": "9494636539070021853",
+    "rate_bps": 6101,
+    "seconds": 1851658071,
+    "expected": "340121084255897731424",
+    "overflow": false
+  },
+  {
+    "principal": "3568788234855996570",
+    "rate_bps": 6891,
+    "seconds": 4134520668,
+    "expected": "322419714253450688014",
+    "overflow": false
+  },
+  {
+    "principal": "16100678528625815675",
+    "rate_bps": 9127,
+    "seconds": 1188998181,
+    "expected": "554047261513853045775",
+    "overflow": false
+  },
+  {
+    "principal": "553078147478396624",
+    "rate_bps": 4926,
+    "seconds": 2815166594,
+    "expected": "24320830466890683938",
+    "overflow": false
+  },
+  {
+    "principal": "6169121850483244585",
+    "rate_bps": 2556,
+    "seconds": 3302290819,
+    "expected": "165117425321707849401",
+    "overflow": false
+  },
+  {
+    "principal": "12929541291286570582",
+    "rate_bps": 9914,
+    "seconds": 646770552,
+    "expected": "262890966440664226798",
+    "overflow": false
+  },
+  {
+    "principal": "12903797324589965671",
+    "rate_bps": 8278,
+    "seconds": 622227185,
+    "expected": "210758611965931714331",
+    "overflow": false
+  },
+  {
+    "principal": "5785747239249350828",
+    "rate_bps": 8644,
+    "seconds": 152393150,
+    "expected": "24167573839875689773",
+    "overflow": false
+  },
+  {
+    "principal": "3289019037358937525",
+    "rate_bps": 7285,
+    "seconds": 901332975,
+    "expected": "68481710016635799711",
+    "overflow": false
+  },
+  {
+    "principal": "3596034505322418002",
+    "rate_bps": 2813,
+    "seconds": 3057977556,
+    "expected": "98089217302636525687",
+    "overflow": false
+  },
+  {
+    "principal": "9175394878456019603",
+    "rate_bps": 1062,
+    "seconds": 378082301,
+    "expected": "11682317927259461524",
+    "overflow": false
+  },
+  {
+    "principal": "13580873947912308680",
+    "rate_bps": 5276,
+    "seconds": 944974394,
+    "expected": "214706869001064504132",
+    "overflow": false
+  },
+  {
+    "principal": "18334045462962287489",
+    "rate_bps": 9125,
+    "seconds": 50657947,
+    "expected": "26873990259211053895",
+    "overflow": false
+  },
+  {
+    "principal": "15180666446541845390",
+    "rate_bps": 9705,
+    "seconds": 2546306928,
+    "expected": "1189571422444960889237",
+    "overflow": false
+  },
+  {
+    "principal": "4808378677391411199",
+    "rate_bps": 7204,
+    "seconds": 3894298441,
+    "expected": "427754897493309604983",
+    "overflow": false
+  },
+  {
+    "principal": "7840394319681044516",
+    "rate_bps": 9445,
+    "seconds": 1578967542,
+    "expected": "370771601822829387154",
+    "overflow": false
+  },
+  {
+    "principal": "5889173139934249869",
+    "rate_bps": 8249,
+    "seconds": 1110471047,
+    "expected": "171063068907726441629",
+    "overflow": false
+  },
+  {
+    "principal": "77219405084258058",
+    "rate_bps": 9685,
+    "seconds": 521092940,
+    "expected": "1235761494341836609",
+    "overflow": false
+  },
+  {
+    "principal": "9747609415912543659",
+    "rate_bps": 217,
+    "seconds": 1206514901,
+    "expected": "8092522875588301385",
+    "overflow": false
+  },
+  {
+    "principal": "13719274427445032384",
+    "rate_bps": 1397,
+    "seconds": 1281628402,
+    "expected": "77890244261101728153",
+    "overflow": false
+  },
+  {
+    "principal": "8949816002367582681",
+    "rate_bps": 1028,
+    "seconds": 1293824179,
+    "expected": "37746429525067542207",
+    "overflow": false
+  },
+  {
+    "principal": "9414291862900825542",
+    "rate_bps": 2011,
+    "seconds": 4090631272,
+    "expected": "245574606037271045735",
+    "overflow": false
+  },
+  {
+    "principal": "17600546888874766231",
+    "rate_bps": 7673,
+    "seconds": 2629322913,
+    "expected": "1125974823351981177231",
+    "overflow": false
+  },
+  {
+    "principal": "6484575798581339292",
+    "rate_bps": 6836,
+    "seconds": 2809015086,
+    "expected": "394849043085921415690",
+    "overflow": false
+  },
+  {
+    "principal": "1941770588032264805",
+    "rate_bps": 1682,
+    "seconds": 1531380767,
+    "expected": "15859901708403773952",
+    "overflow": false
+  },
+  {
+    "principal": "2977400190819474370",
+    "rate_bps": 3116,
+    "seconds": 2290698948,
+    "expected": "67390095265417894529",
+    "overflow": false
+  },
+  {
+    "principal": "3047612889972400579",
+    "rate_bps": 6450,
+    "seconds": 1675210413,
+    "expected": "104419659659063886748",
+    "overflow": false
+  },
+  {
+    "principal": "15809308168246528184",
+    "rate_bps": 2690,
+    "seconds": 2316481706,
+    "expected": "312383015570579425391",
+    "overflow": false
+  },
+  {
+    "principal": "11517083606589872433",
+    "rate_bps": 2442,
+    "seconds": 254146507,
+    "expected": "22665521570829599543",
+    "overflow": false
+  },
+  {
+    "principal": "9012151708316910846",
+    "rate_bps": 298,
+    "seconds": 1389846112,
+    "expected": "11835997576555074035",
+    "overflow": false
+  },
+  {
+    "principal": "682627279237724207",
+    "rate_bps": 1899,
+    "seconds": 2167329529,
+    "expected": "8908958697890724544",
+    "overflow": false
+  },
+  {
+    "principal": "4972051253438258708",
+    "rate_bps": 3168,
+    "seconds": 20336998,
+    "expected": "1015783160153228278",
+    "overflow": false
+  },
+  {
+    "principal": "6255648745056332349",
+    "rate_bps": 3363,
+    "seconds": 65296311,
+    "expected": "4355933704961918819",
+    "overflow": false
+  },
+  {
+    "principal": "10092350673582667130",
+    "rate_bps": 8218,
+    "seconds": 1092750140,
+    "expected": "287390715154732683895",
+    "overflow": false
+  },
+  {
+    "principal": "17062999450200456923",
+    "rate_bps": 2572,
+    "seconds": 762618245,
+    "expected": "106127253538559860736",
+    "overflow": false
+  },
+  {
+    "principal": "3348253176971255984",
+    "rate_bps": 763,
+    "seconds": 4203142498,
+    "expected": "34049468304579017394",
+    "overflow": false
+  },
+  {
+    "principal": "6162509862698355081",
+    "rate_bps": 2444,
+    "seconds": 2806362083,
+    "expected": "134028120028371538012",
+    "overflow": false
+  },
+  {
+    "principal": "2958854770540415286",
+    "rate_bps": 6453,
+    "seconds": 695094616,
+    "expected": "42084544598144296240",
+    "overflow": false
+  },
+  {
+    "principal": "3428393383207485895",
+    "rate_bps": 7356,
+    "seconds": 1859143249,
+    "expected": "148675228894857857555",
+    "overflow": false
+  },
+  {
+    "principal": "3749287284710247564",
+    "rate_bps": 5645,
+    "seconds": 2188866718,
+    "expected": "146901211053289874537",
+    "overflow": false
+  },
+  {
+    "principal": "3723563669871092501",
+    "rate_bps": 9102,
+    "seconds": 3956526159,
+    "expected": "425209589172713579851",
+    "overflow": false
+  },
+  {
+    "principal": "5399329298458385458",
+    "rate_bps": 9164,
+    "seconds": 763125940,
+    "expected": "119733176714504950907",
+    "overflow": false
+  },
+  {
+    "principal": "17052539915188948211",
+    "rate_bps": 3235,
+    "seconds": 1201352029,
+    "expected": "210148860303860316162",
+    "overflow": false
+  },
+  {
+    "principal": "18202648367233801640",
+    "rate_bps": 8745,
+    "seconds": 1836872474,
+    "expected": "927185844759762672141",
+    "overflow": false
+  },
+  {
+    "principal": "16228139614127497953",
+    "rate_bps": 8663,
+    "seconds": 2672474363,
+    "expected": "1191362677435940278043",
+    "overflow": false
+  },
+  {
+    "principal": "2386188727126166126",
+    "rate_bps": 3591,
+    "seconds": 1344520528,
+    "expected": "36532637305765553656",
+    "overflow": false
+  },
+  {
+    "principal": "11010367814239726687",
+    "rate_bps": 2084,
+    "seconds": 124715689,
+    "expected": "9074318643051607362",
+    "overflow": false
+  },
+  {
+    "principal": "16244284501001883652",
+    "rate_bps": 4469,
+    "seconds": 3364320470,
+    "expected": "774464816583034378178",
+    "overflow": false
+  },
+  {
+    "principal": "2490428956637607149",
+    "rate_bps": 469,
+    "seconds": 1900331495,
+    "expected": "7038332169983845840",
+    "overflow": false
+  },
+  {
+    "principal": "9136148863569244138",
+    "rate_bps": 1557,
+    "seconds": 3085904684,
+    "expected": "139196296544607936294",
+    "overflow": false
+  },
+  {
+    "principal": "5405043800889945099",
+    "rate_bps": 6544,
+    "seconds": 1785836085,
+    "expected": "200298407133416590574",
+    "overflow": false
+  },
+  {
+    "principal": "8250201770662633376",
+    "rate_bps": 2616,
+    "seconds": 2898482642,
+    "expected": "198365621168470360497",
+    "overflow": false
+  },
+  {
+    "principal": "4220932670676976953",
+    "rate_bps": 6899,
+    "seconds": 4129714963,
+    "expected": "381336204736722808433",
+    "overflow": false
+  },
+  {
+    "principal": "6998924623296276646",
+    "rate_bps": 5649,
+    "seconds": 1526241864,
+    "expected": "191346113678015172708",
+    "overflow": false
+  },
+  {
+    "principal": "12807357762976372727",
+    "rate_bps": 5680,
+    "seconds": 1927374849,
+    "expected": "444597951712302145216",
+    "overflow": false
+  },
+  {
+    "principal": "7029429546423437436",
+    "rate_bps": 9040,
+    "seconds": 1385181710,
+    "expected": "279118520562314962972",
+    "overflow": false
+  },
+  {
+    "principal": "2479312401686282181",
+    "rate_bps": 5476,
+    "seconds": 843749503,
+    "expected": "36324664796784767725",
+    "overflow": false
+  },
+  {
+    "principal": "17332096905048903842",
+    "rate_bps": 717,
+    "seconds": 268782244,
+    "expected": "10591664915792573570",
+    "overflow": false
+  },
+  {
+    "principal": "16549064096848346147",
+    "rate_bps": 4415,
+    "seconds": 685805581,
+    "expected": "158890727697642659553",
+    "overflow": false
+  },
+  {
+    "principal": "14414136329265235608",
+    "rate_bps": 8362,
+    "seconds": 2143249802,
+    "expected": "819152901444028164360",
+    "overflow": false
+  },
+  {
+    "principal": "7461525833442513041",
+    "rate_bps": 5130,
+    "seconds": 2037268011,
+    "expected": "247278621558842783126",
+    "overflow": false
+  },
+  {
+    "principal": "1075575568669787102",
+    "rate_bps": 4229,
+    "seconds": 1088534592,
+    "expected": "15700527425676600032",
+    "overflow": false
+  },
+  {
+    "principal": "2295951418592109711",
+    "rate_bps": 6927,
+    "seconds": 2894190169,
+    "expected": "145958146269565827690",
+    "overflow": false
+  },
+  {
+    "principal": "7414987511037777396",
+    "rate_bps": 793,
+    "seconds": 2903477318,
+    "expected": "54137156598428173576",
+    "overflow": false
+  },
+  {
+    "principal": "4627285926018016157",
+    "rate_bps": 7310,
+    "seconds": 2925309975,
+    "expected": "313768251825330300011",
+    "overflow": false
+  },
+  {
+    "principal": "15730305119804251738",
+    "rate_bps": 8707,
+    "seconds": 3120406300,
+    "expected": "1355221335661416985466",
+    "overflow": false
+  },
+  {
+    "principal": "16935559755017444667",
+    "rate_bps": 472,
+    "seconds": 1175725797,
+    "expected": "29801696979856204538",
+    "overflow": false
+  },
+  {
+    "principal": "16940072599583912592",
+    "rate_bps": 2418,
+    "seconds": 2129166914,
+    "expected": "276550638626639856423",
+    "overflow": false
+  },
+  {
+    "principal": "13283992001613604073",
+    "rate_bps": 3654,
+    "seconds": 786135619,
+    "expected": "121000737033153573416",
+    "overflow": false
+  },
+  {
+    "principal": "16789587911575223318",
+    "rate_bps": 5017,
+    "seconds": 1397226296,
+    "expected": "373202274095246976888",
+    "overflow": false
+  },
+  {
+    "principal": "15799258956763197991",
+    "rate_bps": 5641,
+    "seconds": 1622060465,
+    "expected": "458409120163888405881",
+    "overflow": false
+  },
+  {
+    "principal": "16653918184512673900",
+    "rate_bps": 674,
+    "seconds": 1834443646,
+    "expected": "65294122723075310068",
+    "overflow": false
+  },
+  {
+    "principal": "16537112501296660597",
+    "rate_bps": 7529,
+    "seconds": 4158023855,
+    "expected": "1641637815794646897890",
+    "overflow": false
+  },
+  {
+    "principal": "5175125515574556946",
+    "rate_bps": 8512,
+    "seconds": 1850411156,
+    "expected": "258472375112467130534",
+    "overflow": false
+  },
+  {
+    "principal": "5492710836675637075",
+    "rate_bps": 9826,
+    "seconds": 2600261309,
+    "expected": "445014214160082720844",
+    "overflow": false
+  },
+  {
+    "principal": "13134029922976793480",
+    "rate_bps": 1406,
+    "seconds": 3075116026,
+    "expected": "180068696912626628166",
+    "overflow": false
+  },
+  {
+    "principal": "6297883405060481601",
+    "rate_bps": 4709,
+    "seconds": 3452667739,
+    "expected": "324691923883491738759",
+    "overflow": false
+  },
+  {
+    "principal": "13727586368136900942",
+    "rate_bps": 9875,
+    "seconds": 2240299824,
+    "expected": "963010066524793082775",
+    "overflow": false
+  },
+  {
+    "principal": "2561823096103248063",
+    "rate_bps": 5290,
+    "seconds": 1514819081,
+    "expected": "65096699353038929046",
+    "overflow": false
+  },
+  {
+    "principal": "2329486386667368420",
+    "rate_bps": 2122,
+    "seconds": 4245526454,
+    "expected": "66547309358433319652",
+    "overflow": false
+  },
+  {
+    "principal": "11528307448712296013",
+    "rate_bps": 1794,
+    "seconds": 1970741831,
+    "expected": "129244216157002595932",
+    "overflow": false
+  },
+  {
+    "principal": "4958861662819762378",
+    "rate_bps": 2338,
+    "seconds": 1226073868,
+    "expected": "45075082369852136869",
+    "overflow": false
+  },
+  {
+    "principal": "378373280640832107",
+    "rate_bps": 9445,
+    "seconds": 2345598869,
+    "expected": "26580892519951400352",
+    "overflow": false
+  },
+  {
+    "principal": "6077061653135776128",
+    "rate_bps": 5599,
+    "seconds": 503669426,
+    "expected": "54342935171276763959",
+    "overflow": false
+  },
+  {
+    "principal": "7323224745869715609",
+    "rate_bps": 5495,
+    "seconds": 1220527475,
+    "expected": "155743888123403964638",
+    "overflow": false
+  },
+  {
+    "principal": "15432040446079026054",
+    "rate_bps": 3586,
+    "seconds": 74674216,
+    "expected": "13103813484354998030",
+    "overflow": false
+  },
+  {
+    "principal": "1302156668093468759",
+    "rate_bps": 6459,
+    "seconds": 2151356257,
+    "expected": "57376526198681292438",
+    "overflow": false
+  },
+  {
+    "principal": "11022146689767619676",
+    "rate_bps": 1208,
+    "seconds": 900466926,
+    "expected": "38018438881178963615",
+    "overflow": false
+  },
+  {
+    "principal": "11532339864986527013",
+    "rate_bps": 8319,
+    "seconds": 3017948383,
+    "expected": "918107970696252176569",
+    "overflow": false
+  },
+  {
+    "principal": "10339103623457920386",
+    "rate_bps": 8024,
+    "seconds": 1236572804,
+    "expected": "325302118761578857181",
+    "overflow": false
+  },
+  {
+    "principal": "3600781729081730691",
+    "rate_bps": 2077,
+    "seconds": 226689389,
+    "expected": "5375982889245847617",
+    "overflow": false
+  },
+  {
+    "principal": "11416616931547206776",
+    "rate_bps": 9616,
+    "seconds": 3553420906,
+    "expected": "1237006352790076240777",
+    "overflow": false
+  },
+  {
+    "principal": "13221725702051370993",
+    "rate_bps": 71,
+    "seconds": 1725797515,
+    "expected": "5137238446865309293",
+    "overflow": false
+  },
+  {
+    "principal": "18159375378357064382",
+    "rate_bps": 2652,
+    "seconds": 500064800,
+    "expected": "76364955711239497338",
+    "overflow": false
+  },
+  {
+    "principal": "8950298815911207151",
+    "rate_bps": 313,
+    "seconds": 1659595193,
+    "expected": "14742713770992983250",
+    "overflow": false
+  },
+  {
+    "principal": "17353526482553069012",
+    "rate_bps": 338,
+    "seconds": 3422590758,
+    "expected": "63657973563445906896",
+    "overflow": false
+  },
+  {
+    "principal": "18383072864482618621",
+    "rate_bps": 1720,
+    "seconds": 1193220215,
+    "expected": "119635632762037099232",
+    "overflow": false
+  },
+  {
+    "principal": "10408446042285856570",
+    "rate_bps": 6925,
+    "seconds": 574259964,
+    "expected": "131252506367509205085",
+    "overflow": false
+  },
+  {
+    "principal": "14967942494033513371",
+    "rate_bps": 7208,
+    "seconds": 995441733,
+    "expected": "340554106259519571329",
+    "overflow": false
+  },
+  {
+    "principal": "13874070176287315056",
+    "rate_bps": 8071,
+    "seconds": 946403106,
+    "expected": "336047589238486111738",
+    "overflow": false
+  },
+  {
+    "principal": "5506453861776150601",
+    "rate_bps": 3696,
+    "seconds": 1835947171,
+    "expected": "118483408829876111461",
+    "overflow": false
+  },
+  {
+    "principal": "4424328586746937078",
+    "rate_bps": 4432,
+    "seconds": 2010249496,
+    "expected": "124994378200205938292",
+    "overflow": false
+  },
+  {
+    "principal": "475371645945197191",
+    "rate_bps": 8186,
+    "seconds": 1506387217,
+    "expected": "18588101241670196301",
+    "overflow": false
+  },
+  {
+    "principal": "16854643745858122828",
+    "rate_bps": 2070,
+    "seconds": 2343379550,
+    "expected": "259254289943300345730",
+    "overflow": false
+  },
+  {
+    "principal": "18345282842874424789",
+    "rate_bps": 3950,
+    "seconds": 3155760399,
+    "expected": "725135091834059912043",
+    "overflow": false
+  },
+  {
+    "principal": "14168638686958036466",
+    "rate_bps": 4112,
+    "seconds": 1458110580,
+    "expected": "269379836997882343667",
+    "overflow": false
+  },
+  {
+    "principal": "12914918278565601715",
+    "rate_bps": 9502,
+    "seconds": 2084966429,
+    "expected": "811333013891811894578",
+    "overflow": false
+  },
+  {
+    "principal": "14747188714821630312",
+    "rate_bps": 1386,
+    "seconds": 3459609818,
+    "expected": "224229620585534817617",
+    "overflow": false
+  },
+  {
+    "principal": "11046705451225264545",
+    "rate_bps": 5578,
+    "seconds": 3646907835,
+    "expected": "712573168236673265028",
+    "overflow": false
+  },
+  {
+    "principal": "12878397779486648366",
+    "rate_bps": 6555,
+    "seconds": 2561348880,
+    "expected": "685640813900033400697",
+    "overflow": false
+  },
+  {
+    "principal": "15649257144610268447",
+    "rate_bps": 56,
+    "seconds": 818424169,
+    "expected": "2274330591535129438",
+    "overflow": false
+  },
+  {
+    "principal": "13914333239272464324",
+    "rate_bps": 6160,
+    "seconds": 1655147158,
+    "expected": "449855586495788940928",
+    "overflow": false
+  },
+  {
+    "principal": "7995959519763580845",
+    "rate_bps": 8011,
+    "seconds": 2585760423,
+    "expected": "525217267102008154542",
+    "overflow": false
+  },
+  {
+    "principal": "13912879983579636138",
+    "rate_bps": 9451,
+    "seconds": 2914448108,
+    "expected": "1215190937679972992622",
+    "overflow": false
+  },
+  {
+    "principal": "10396007577554995403",
+    "rate_bps": 7476,
+    "seconds": 949607669,
+    "expected": "234031052876615421162",
+    "overflow": false
+  },
+  {
+    "principal": "18254129309984351072",
+    "rate_bps": 9155,
+    "seconds": 3986833298,
+    "expected": "2112715123883948806111",
+    "overflow": false
+  },
+  {
+    "principal": "4859621520670989305",
+    "rate_bps": 8832,
+    "seconds": 683812819,
+    "expected": "93066233546948197586",
+    "overflow": false
+  },
+  {
+    "principal": "15357670249735990886",
+    "rate_bps": 3136,
+    "seconds": 3187316232,
+    "expected": "486765668586841979870",
+    "overflow": false
+  },
+  {
+    "principal": "3924802143877978295",
+    "rate_bps": 2908,
+    "seconds": 1709004481,
+    "expected": "61851290408715229200",
+    "overflow": false
+  },
+  {
+    "principal": "16500858371456270396",
+    "rate_bps": 795,
+    "seconds": 1018802126,
+    "expected": "42379604654310356628",
+    "overflow": false
+  },
+  {
+    "principal": "3869765809599978117",
+    "rate_bps": 7759,
+    "seconds": 1952837951,
+    "expected": "185930242015301786887",
+    "overflow": false
+  },
+  {
+    "principal": "11796372908709522018",
+    "rate_bps": 9980,
+    "seconds": 3989781092,
+    "expected": "1489434794970179873212",
+    "overflow": false
+  },
+  {
+    "principal": "11492858307878609123",
+    "rate_bps": 7825,
+    "seconds": 525927117,
+    "expected": "149979311473633769602",
+    "overflow": false
+  },
+  {
+    "principal": "5844777718121607768",
+    "rate_bps": 7128,
+    "seconds": 1219704650,
+    "expected": "161132729118703678481",
+    "overflow": false
+  },
+  {
+    "principal": "14184227020013563729",
+    "rate_bps": 5612,
+    "seconds": 3024878315,
+    "expected": "763527418838282194335",
+    "overflow": false
+  },
+  {
+    "principal": "469987409917129118",
+    "rate_bps": 5811,
+    "seconds": 72702976,
+    "expected": "629626039895866123",
+    "overflow": false
+  },
+  {
+    "principal": "5540673716210150735",
+    "rate_bps": 752,
+    "seconds": 4135816473,
+    "expected": "54643067096394886928",
+    "overflow": false
+  },
+  {
+    "principal": "8904737308496082356",
+    "rate_bps": 4957,
+    "seconds": 2936107526,
+    "expected": "410965514633482171155",
+    "overflow": false
+  },
+  {
+    "principal": "17278709367712482909",
+    "rate_bps": 5188,
+    "seconds": 193171671,
+    "expected": "54909576841525022591",
+    "overflow": false
+  },
+  {
+    "principal": "4287748982358515738",
+    "rate_bps": 9746,
+    "seconds": 4010850012,
+    "expected": "531478345341484695709",
+    "overflow": false
+  },
+  {
+    "principal": "318152391203146235",
+    "rate_bps": 1912,
+    "seconds": 4224704933,
+    "expected": "8149160182603779078",
+    "overflow": false
+  },
+  {
+    "principal": "12363748282871842384",
+    "rate_bps": 2007,
+    "seconds": 1048591362,
+    "expected": "82508215817741708457",
+    "overflow": false
+  },
+  {
+    "principal": "13435002566670879657",
+    "rate_bps": 2140,
+    "seconds": 2564177667,
+    "expected": "233772291255538486343",
+    "overflow": false
+  },
+  {
+    "principal": "13934439684438626774",
+    "rate_bps": 4284,
+    "seconds": 3737405176,
+    "expected": "707461072277672022006",
+    "overflow": false
+  },
+  {
+    "principal": "17563391559002817255",
+    "rate_bps": 9157,
+    "seconds": 3174640753,
+    "expected": "1619010173889534681902",
+    "overflow": false
+  },
+  {
+    "principal": "6614538309203222572",
+    "rate_bps": 3694,
+    "seconds": 1936765246,
+    "expected": "150060643202143233972",
+    "overflow": false
+  },
+  {
+    "principal": "14609920779106282293",
+    "rate_bps": 9074,
+    "seconds": 2129908079,
+    "expected": "895366600212416509493",
+    "overflow": false
+  },
+  {
+    "principal": "2948902693021967058",
+    "rate_bps": 138,
+    "seconds": 4186851412,
+    "expected": "5402819640315475312",
+    "overflow": false
+  },
+  {
+    "principal": "11848070392120861715",
+    "rate_bps": 7340,
+    "seconds": 453958013,
+    "expected": "125185135905917898723",
+    "overflow": false
+  },
+  {
+    "principal": "3536676233253863240",
+    "rate_bps": 8303,
+    "seconds": 4273286586,
+    "expected": "397910825336143822383",
+    "overflow": false
+  },
+  {
+    "principal": "3549116394156183809",
+    "rate_bps": 3165,
+    "seconds": 2967360539,
+    "expected": "105695784558938039285",
+    "overflow": false
+  },
+  {
+    "principal": "12038679098817294094",
+    "rate_bps": 870,
+    "seconds": 3729012464,
+    "expected": "123846950901635591963",
+    "overflow": false
+  },
+  {
+    "principal": "1197909092746017151",
+    "rate_bps": 6939,
+    "seconds": 1593873609,
+    "expected": "42011483908357499122",
+    "overflow": false
+  },
+  {
+    "principal": "8593195744449421220",
+    "rate_bps": 3623,
+    "seconds": 3024964982,
+    "expected": "298632302861463798134",
+    "overflow": false
+  },
+  {
+    "principal": "5549116034941298957",
+    "rate_bps": 9481,
+    "seconds": 2392199943,
+    "expected": "399088139863771184614",
+    "overflow": false
+  },
+  {
+    "principal": "377728220193903242",
+    "rate_bps": 4719,
+    "seconds": 1963904716,
+    "expected": "11100517242361218673",
+    "overflow": false
+  },
+  {
+    "principal": "7165106970600738603",
+    "rate_bps": 2324,
+    "seconds": 1097484885,
+    "expected": "57949640086152504340",
+    "overflow": false
+  },
+  {
+    "principal": "12057889758990286144",
+    "rate_bps": 8106,
+    "seconds": 2098326642,
+    "expected": "650345884390634731048",
+    "overflow": false
+  },
+  {
+    "principal": "15564879838982741849",
+    "rate_bps": 4772,
+    "seconds": 2651167283,
+    "expected": "624419895106218446952",
+    "overflow": false
+  },
+  {
+    "principal": "2558025567707457862",
+    "rate_bps": 7862,
+    "seconds": 3376810984,
+    "expected": "215346622830903021622",
+    "overflow": false
+  },
+  {
+    "principal": "15308684234880168215",
+    "rate_bps": 2592,
+    "seconds": 3370133025,
+    "expected": "424046320350135713580",
+    "overflow": false
+  },
+  {
+    "principal": "11607355234915816476",
+    "rate_bps": 8528,
+    "seconds": 665921198,
+    "expected": "209024262843414381650",
+    "overflow": false
+  },
+  {
+    "principal": "13287276380145426405",
+    "rate_bps": 7648,
+    "seconds": 3962418591,
+    "expected": "1276843275254589303715",
+    "overflow": false
+  },
+  {
+    "principal": "15804238034667654978",
+    "rate_bps": 5921,
+    "seconds": 3901565508,
+    "expected": "1157713025266298782315",
+    "overflow": false
+  },
+  {
+    "principal": "13626105893430209347",
+    "rate_bps": 7156,
+    "seconds": 804951085,
+    "expected": "248888582773707731340",
+    "overflow": false
+  },
+  {
+    "principal": "15555423334641885240",
+    "rate_bps": 5250,
+    "seconds": 887773226,
+    "expected": "229898731186108561880",
+    "overflow": false
+  },
+  {
+    "principal": "9827946405153986225",
+    "rate_bps": 1122,
+    "seconds": 3801182539,
+    "expected": "132913090114085643690",
+    "overflow": false
+  },
+  {
+    "principal": "4538283872643948670",
+    "rate_bps": 1548,
+    "seconds": 53388768,
+    "expected": "1189339674220703293",
+    "overflow": false
+  },
+  {
+    "principal": "4427591731630098863",
+    "rate_bps": 8018,
+    "seconds": 1029849209,
+    "expected": "115931285749366680346",
+    "overflow": false
+  },
+  {
+    "principal": "8453830608619429268",
+    "rate_bps": 2259,
+    "seconds": 4211743974,
+    "expected": "255049883016280766363",
+    "overflow": false
+  },
+  {
+    "principal": "7686126263829966781",
+    "rate_bps": 6948,
+    "seconds": 2632063287,
+    "expected": "445714789537300570081",
+    "overflow": false
+  },
+  {
+    "principal": "14600995553520859386",
+    "rate_bps": 3329,
+    "seconds": 1236810428,
+    "expected": "190630679193604366478",
+    "overflow": false
+  },
+  {
+    "principal": "17071110077875296347",
+    "rate_bps": 5292,
+    "seconds": 3122403077,
+    "expected": "894466248326442880778",
+    "overflow": false
+  },
+  {
+    "principal": "6198222084736026672",
+    "rate_bps": 5579,
+    "seconds": 3165016290,
+    "expected": "347050630090249307818",
+    "overflow": false
+  },
+  {
+    "principal": "9016324869705291529",
+    "rate_bps": 9825,
+    "seconds": 183187811,
+    "expected": "51457902139257183863",
+    "overflow": false
+  },
+  {
+    "principal": "14404394154217419958",
+    "rate_bps": 2803,
+    "seconds": 1138156760,
+    "expected": "145718123416592752457",
+    "overflow": false
+  },
+  {
+    "principal": "5723863357949010759",
+    "rate_bps": 6620,
+    "seconds": 4061479889,
+    "expected": "488005759011585871738",
+    "overflow": false
+  },
+  {
+    "principal": "4002330749782858764",
+    "rate_bps": 6348,
+    "seconds": 2392461342,
+    "expected": "192747261213186065969",
+    "overflow": false
+  },
+  {
+    "principal": "18144648257856419989",
+    "rate_bps": 2571,
+    "seconds": 1790877135,
+    "expected": "264916991859627456214",
+    "overflow": false
+  },
+  {
+    "principal": "6302503882512527282",
+    "rate_bps": 8376,
+    "seconds": 2624774196,
+    "expected": "439374786666060528351",
+    "overflow": false
+  },
+  {
+    "principal": "15852950601615193715",
+    "rate_bps": 4199,
+    "seconds": 1794061021,
+    "expected": "378692395853888705480",
+    "overflow": false
+  },
+  {
+    "principal": "2947705340118963496",
+    "rate_bps": 5651,
+    "seconds": 692172442,
+    "expected": "36560916414747474467",
+    "overflow": false
+  },
+  {
+    "principal": "17538748876577374305",
+    "rate_bps": 2302,
+    "seconds": 3877655163,
+    "expected": "496439703031631352958",
+    "overflow": false
+  },
+  {
+    "principal": "9772489297127540206",
+    "rate_bps": 682,
+    "seconds": 2668341456,
+    "expected": "56392892992554703085",
+    "overflow": false
+  },
+  {
+    "principal": "3227808762274471391",
+    "rate_bps": 9005,
+    "seconds": 1024167977,
+    "expected": "94396544976105660660",
+    "overflow": false
+  },
+  {
+    "principal": "16576797989051379588",
+    "rate_bps": 4712,
+    "seconds": 16179286,
+    "expected": "4007362888521875314",
+    "overflow": false
+  },
+  {
+    "principal": "7080237729197693549",
+    "rate_bps": 7193,
+    "seconds": 1714594663,
+    "expected": "276893500008444882391",
+    "overflow": false
+  },
+  {
+    "principal": "8287574657072190314",
+    "rate_bps": 8994,
+    "seconds": 3797154476,
+    "expected": "897494912580374104383",
+    "overflow": false
+  },
+  {
+    "principal": "11722926022706980235",
+    "rate_bps": 1964,
+    "seconds": 3134736309,
+    "expected": "228861065308096904369",
+    "overflow": false
+  },
+  {
+    "principal": "2585443024718260000",
+    "rate_bps": 8890,
+    "seconds": 1103915346,
+    "expected": "80457381897909801383",
+    "overflow": false
+  },
+  {
+    "principal": "17753706074567848633",
+    "rate_bps": 8295,
+    "seconds": 3563199635,
+    "expected": "1663944989043616100200",
+    "overflow": false
+  },
+  {
+    "principal": "15397116698148631590",
+    "rate_bps": 4442,
+    "seconds": 3691893192,
+    "expected": "800682758803365092770",
+    "overflow": false
+  },
+  {
+    "principal": "8411063854159599991",
+    "rate_bps": 2172,
+    "seconds": 1381729665,
+    "expected": "80043712934238245218",
+    "overflow": false
+  },
+  {
+    "principal": "9344349677103740924",
+    "rate_bps": 2452,
+    "seconds": 2324327822,
+    "expected": "168873040016770942215",
+    "overflow": false
+  },
+  {
+    "principal": "1306556762198652229",
+    "rate_bps": 3668,
+    "seconds": 2006026751,
+    "expected": "30485106898614856238",
+    "overflow": false
+  },
+  {
+    "principal": "17769386581935604770",
+    "rate_bps": 7644,
+    "seconds": 1512466980,
+    "expected": "651436981089832902911",
+    "overflow": false
+  },
+  {
+    "principal": "4338544469415822755",
+    "rate_bps": 7195,
+    "seconds": 3573527949,
+    "expected": "353724733226623248974",
+    "overflow": false
+  },
+  {
+    "principal": "8828038640165477912",
+    "rate_bps": 7543,
+    "seconds": 2196392202,
+    "expected": "463779576123856086924",
+    "overflow": false
+  },
+  {
+    "principal": "2158706885822533137",
+    "rate_bps": 5782,
+    "seconds": 377878443,
+    "expected": "14956062606931894028",
+    "overflow": false
+  },
+  {
+    "principal": "15278652407930216286",
+    "rate_bps": 2978,
+    "seconds": 487735232,
+    "expected": "70369953750625842152",
+    "overflow": false
+  },
+  {
+    "principal": "1289365706004821519",
+    "rate_bps": 4425,
+    "seconds": 2443150297,
+    "expected": "44201088814324193368",
+    "overflow": false
+  },
+  {
+    "principal": "6451132420923544948",
+    "rate_bps": 2606,
+    "seconds": 2836568006,
+    "expected": "151215726810263517889",
+    "overflow": false
+  },
+  {
+    "principal": "10114576784528075037",
+    "rate_bps": 8455,
+    "seconds": 9613719,
+    "expected": "2607030695499533795",
+    "overflow": false
+  },
+  {
+    "principal": "1569516324385563098",
+    "rate_bps": 8751,
+    "seconds": 258543260,
+    "expected": "11260304494081092841",
+    "overflow": false
+  },
+  {
+    "principal": "13659242768477353659",
+    "rate_bps": 2417,
+    "seconds": 3973176421,
+    "expected": "415943667533830712312",
+    "overflow": false
+  },
+  {
+    "principal": "17924315757897472528",
+    "rate_bps": 5721,
+    "seconds": 4065539522,
+    "expected": "1321983741667189283310",
+    "overflow": false
+  },
+  {
+    "principal": "17811754426493121129",
+    "rate_bps": 9291,
+    "seconds": 1099252675,
+    "expected": "576846262492144513647",
+    "overflow": false
+  },
+  {
+    "principal": "3106354050202937238",
+    "rate_bps": 2373,
+    "seconds": 3603026616,
+    "expected": "84218898120110932346",
+    "overflow": false
+  },
+  {
+    "principal": "2687570842570380199",
+    "rate_bps": 4957,
+    "seconds": 1668672305,
+    "expected": "70492561317879457742",
+    "overflow": false
+  },
+  {
+    "principal": "10370201132001929196",
+    "rate_bps": 2246,
+    "seconds": 455163646,
+    "expected": "33616917805084667634",
+    "overflow": false
+  },
+  {
+    "principal": "5386007978238645749",
+    "rate_bps": 2202,
+    "seconds": 2379315759,
+    "expected": "89480784122627826748",
+    "overflow": false
+  },
+  {
+    "principal": "5335962360394960018",
+    "rate_bps": 92,
+    "seconds": 3117336596,
+    "expected": "4852635553546020385",
+    "overflow": false
+  },
+  {
+    "principal": "4715436878800001235",
+    "rate_bps": 7937,
+    "seconds": 595532861,
+    "expected": "70676891402237789619",
+    "overflow": false
+  },
+  {
+    "principal": "2187834744669125384",
+    "rate_bps": 8872,
+    "seconds": 3260223354,
+    "expected": "200667386898847456211",
+    "overflow": false
+  },
+  {
+    "principal": "7010189565012000705",
+    "rate_bps": 3476,
+    "seconds": 3002949851,
+    "expected": "232033666409935531266",
+    "overflow": false
+  },
+  {
+    "principal": "14324977142938807502",
+    "rate_bps": 8561,
+    "seconds": 398027440,
+    "expected": "154783563562363058510",
+    "overflow": false
+  },
+  {
+    "principal": "12275955658634596927",
+    "rate_bps": 5870,
+    "seconds": 2801867657,
+    "expected": "640227645569305511724",
+    "overflow": false
+  },
+  {
+    "principal": "2662986352827518820",
+    "rate_bps": 863,
+    "seconds": 2879144758,
+    "expected": "20981504693659156063",
+    "overflow": false
+  },
+  {
+    "principal": "5218982345853705165",
+    "rate_bps": 663,
+    "seconds": 2555200455,
+    "expected": "28036108069943687319",
+    "overflow": false
+  },
+  {
+    "principal": "15724767788892365898",
+    "rate_bps": 2744,
+    "seconds": 3971905164,
+    "expected": "543451274213775756798",
+    "overflow": false
+  },
+  {
+    "principal": "16357829351241010155",
+    "rate_bps": 2691,
+    "seconds": 4252751125,
+    "expected": "593612082638082751106",
+    "overflow": false
+  },
+  {
+    "principal": "14728216915077652736",
+    "rate_bps": 2545,
+    "seconds": 3309942322,
+    "expected": "393415781707559734557",
+    "overflow": false
+  },
+  {
+    "principal": "1630783053906925081",
+    "rate_bps": 6414,
+    "seconds": 464498419,
+    "expected": "15406457089811830440",
+    "overflow": false
+  },
+  {
+    "principal": "9979772900552658694",
+    "rate_bps": 3713,
+    "seconds": 537520040,
+    "expected": "63158769657687017728",
+    "overflow": false
+  },
+  {
+    "principal": "17554753511287787991",
+    "rate_bps": 8987,
+    "seconds": 2942792929,
+    "expected": "1472185630617887476348",
+    "overflow": false
+  },
+  {
+    "principal": "8601358612075883484",
+    "rate_bps": 5018,
+    "seconds": 3443360878,
+    "expected": "471274179298949918634",
+    "overflow": false
+  },
+  {
+    "principal": "17766399823410387621",
+    "rate_bps": 1727,
+    "seconds": 1458138719,
+    "expected": "141867855636502086843",
+    "overflow": false
+  },
+  {
+    "principal": "11758541481164146946",
+    "rate_bps": 962,
+    "seconds": 2530408964,
+    "expected": "90763793297623217888",
+    "overflow": false
+  },
+  {
+    "principal": "1371085106484703235",
+    "rate_bps": 7900,
+    "seconds": 1744856813,
+    "expected": "59930057062075256427",
+    "overflow": false
+  },
+  {
+    "principal": "9549786822813035512",
+    "rate_bps": 265,
+    "seconds": 2972387818,
+    "expected": "23852747825995667429",
+    "overflow": false
+  },
+  {
+    "principal": "217955299625358705",
+    "rate_bps": 2336,
+    "seconds": 419532299,
+    "expected": "677328058748596860",
+    "overflow": false
+  },
+  {
+    "principal": "6002844931143233086",
+    "rate_bps": 716,
+    "seconds": 1220028832,
+    "expected": "16627755661003856373",
+    "overflow": false
+  },
+  {
+    "principal": "2573094543898260079",
+    "rate_bps": 3722,
+    "seconds": 3511899961,
+    "expected": "106651665521235442674",
+    "overflow": false
+  },
+  {
+    "principal": "12776606962515189076",
+    "rate_bps": 1719,
+    "seconds": 101900966,
+    "expected": "7096808818817953746",
+    "overflow": false
+  },
+  {
+    "principal": "6955801878932730493",
+    "rate_bps": 8160,
+    "seconds": 2683132407,
+    "expected": "482917407072466203803",
+    "overflow": false
+  },
+  {
+    "principal": "7200267847946525370",
+    "rate_bps": 1481,
+    "seconds": 3512414844,
+    "expected": "118768947485815585488",
+    "overflow": false
+  },
+  {
+    "principal": "7278309588513252635",
+    "rate_bps": 1660,
+    "seconds": 1317614021,
+    "expected": "50480100794603981731",
+    "overflow": false
+  },
+  {
+    "principal": "15567994609305844720",
+    "rate_bps": 4718,
+    "seconds": 855567010,
+    "expected": "199268215832122213805",
+    "overflow": false
+  },
+  {
+    "principal": "9917107863529397705",
+    "rate_bps": 1728,
+    "seconds": 3732692515,
+    "expected": "202835694754212735868",
+    "overflow": false
+  },
+  {
+    "principal": "6395477346049485430",
+    "rate_bps": 2084,
+    "seconds": 993857688,
+    "expected": "42003770234720728431",
+    "overflow": false
+  },
+  {
+    "principal": "17325873781689209863",
+    "rate_bps": 4705,
+    "seconds": 2155029137,
+    "expected": "557059151714495679502",
+    "overflow": false
+  },
+  {
+    "principal": "18110440922447578060",
+    "rate_bps": 2833,
+    "seconds": 721305054,
+    "expected": "117351316666070819624",
+    "overflow": false
+  },
+  {
+    "principal": "5413002265457820501",
+    "rate_bps": 510,
+    "seconds": 3666110095,
+    "expected": "32092775708152335816",
+    "overflow": false
+  },
+  {
+    "principal": "4324348360703703410",
+    "rate_bps": 1069,
+    "seconds": 4292476916,
+    "expected": "62921597335116823639",
+    "overflow": false
+  },
+  {
+    "principal": "17247726542683343667",
+    "rate_bps": 6616,
+    "seconds": 3226899869,
+    "expected": "1167632667503215289038",
+    "overflow": false
+  },
+  {
+    "principal": "967197740318175464",
+    "rate_bps": 9680,
+    "seconds": 3529586778,
+    "expected": "104787115948391594451",
+    "overflow": false
+  },
+  {
+    "principal": "781738901882867489",
+    "rate_bps": 4486,
+    "seconds": 4014833467,
+    "expected": "44645934978208883084",
+    "overflow": false
+  },
+  {
+    "principal": "1667687160724857774",
+    "rate_bps": 8014,
+    "seconds": 2030402704,
+    "expected": "86047746181451472185",
+    "overflow": false
+  },
+  {
+    "principal": "633442767224821407",
+    "rate_bps": 1393,
+    "seconds": 4244190953,
+    "expected": "11875360610810275882",
+    "overflow": false
+  },
+  {
+    "principal": "17303732262102155076",
+    "rate_bps": 9208,
+    "seconds": 1798665750,
+    "expected": "908759482055610296960",
+    "overflow": false
+  },
+  {
+    "principal": "12718392876140080429",
+    "rate_bps": 4869,
+    "seconds": 4060199,
+    "expected": "797283403715333716",
+    "overflow": false
+  },
+  {
+    "principal": "11061056873831449898",
+    "rate_bps": 9810,
+    "seconds": 1065763436,
+    "expected": "366707542175061836064",
+    "overflow": false
+  },
+  {
+    "principal": "2763964207464497739",
+    "rate_bps": 4215,
+    "seconds": 2783769205,
+    "expected": "102838708280716984502",
+    "overflow": false
+  },
+  {
+    "principal": "4661719937288448736",
+    "rate_bps": 544,
+    "seconds": 2768360210,
+    "expected": "22261840663358866072",
+    "overflow": false
+  },
+  {
+    "principal": "7511313032617232761",
+    "rate_bps": 2746,
+    "seconds": 3888533843,
+    "expected": "254328875206721375458",
+    "overflow": false
+  },
+  {
+    "principal": "16612229826654960102",
+    "rate_bps": 5917,
+    "seconds": 854740360,
+    "expected": "266414037672895902810",
+    "overflow": false
+  },
+  {
+    "principal": "1815118787609729591",
+    "rate_bps": 5919,
+    "seconds": 2434528321,
+    "expected": "82939538815457898241",
+    "overflow": false
+  },
+  {
+    "principal": "11025508586482741180",
+    "rate_bps": 7423,
+    "seconds": 734161742,
+    "expected": "190529941716478837232",
+    "overflow": false
+  },
+  {
+    "principal": "3270060464426848261",
+    "rate_bps": 2454,
+    "seconds": 2928501439,
+    "expected": "74519370267458764802",
+    "overflow": false
+  },
+  {
+    "principal": "18322754964799725026",
+    "rate_bps": 3099,
+    "seconds": 650828260,
+    "expected": "117185032670355937734",
+    "overflow": false
+  },
+  {
+    "principal": "6351221448855251555",
+    "rate_bps": 3632,
+    "seconds": 110405709,
+    "expected": "8075845829855392287",
+    "overflow": false
+  },
+  {
+    "principal": "15623552499793283544",
+    "rate_bps": 6367,
+    "seconds": 3525614282,
+    "expected": "1112097413908787518974",
+    "overflow": false
+  },
+  {
+    "principal": "581797219644140753",
+    "rate_bps": 7643,
+    "seconds": 1457271915,
+    "expected": "20547996791339044413",
+    "overflow": false
+  },
+  {
+    "principal": "8636675354215632158",
+    "rate_bps": 1834,
+    "seconds": 1893229440,
+    "expected": "95091690617989697413",
+    "overflow": false
+  },
+  {
+    "principal": "13408323312049553103",
+    "rate_bps": 2136,
+    "seconds": 1586870937,
+    "expected": "144115509392952859767",
+    "overflow": false
+  },
+  {
+    "principal": "7724984090039432500",
+    "rate_bps": 8646,
+    "seconds": 3003317638,
+    "expected": "636073766724600608015",
+    "overflow": false
+  },
+  {
+    "principal": "11630523962654559197",
+    "rate_bps": 7361,
+    "seconds": 1212813911,
+    "expected": "329248390701495590002",
+    "overflow": false
+  },
+  {
+    "principal": "9813235006639235994",
+    "rate_bps": 2495,
+    "seconds": 3569788508,
+    "expected": "277152390965071983261",
+    "overflow": false
+  },
+  {
+    "principal": "7136980884382966651",
+    "rate_bps": 1568,
+    "seconds": 3722057509,
+    "expected": "132080001148964689081",
+    "overflow": false
+  },
+  {
+    "principal": "10431417185887972816",
+    "rate_bps": 8756,
+    "seconds": 3860950914,
+    "expected": "1118244422793924202919",
+    "overflow": false
+  },
+  {
+    "principal": "10362309581069326633",
+    "rate_bps": 8389,
+    "seconds": 2812840067,
+    "expected": "775363209428890855765",
+    "overflow": false
+  },
+  {
+    "principal": "9334543487418203478",
+    "rate_bps": 3896,
+    "seconds": 2298519160,
+    "expected": "265065712230291434254",
+    "overflow": false
+  },
+  {
+    "principal": "16982955336811471975",
+    "rate_bps": 9543,
+    "seconds": 3156535793,
+    "expected": "1622192176860452357770",
+    "overflow": false
+  },
+  {
+    "principal": "314051754150342572",
+    "rate_bps": 2093,
+    "seconds": 2754153662,
+    "expected": "5740530279221186986",
+    "overflow": false
+  },
+  {
+    "principal": "16700156182148874421",
+    "rate_bps": 4928,
+    "seconds": 657416943,
+    "expected": "171563744924727862575",
+    "overflow": false
+  },
+  {
+    "principal": "10598837902826501714",
+    "rate_bps": 5224,
+    "seconds": 1355581396,
+    "expected": "238001893065200248227",
+    "overflow": false
+  },
+  {
+    "principal": "8050487295031217555",
+    "rate_bps": 2471,
+    "seconds": 2165153533,
+    "expected": "136576822785876743782",
+    "overflow": false
+  },
+  {
+    "principal": "16236430397342021320",
+    "rate_bps": 1031,
+    "seconds": 4125372730,
+    "expected": "218980683462530797352",
+    "overflow": false
+  },
+  {
+    "principal": "15755646970241347201",
+    "rate_bps": 2734,
+    "seconds": 451456411,
+    "expected": "61665743082876112100",
+    "overflow": false
+  },
+  {
+    "principal": "13287057883090184846",
+    "rate_bps": 8711,
+    "seconds": 3886538352,
+    "expected": "1426438957626299637549",
+    "overflow": false
+  },
+  {
+    "principal": "2401824398650845951",
+    "rate_bps": 5961,
+    "seconds": 587981385,
+    "expected": "26694226678246207690",
+    "overflow": false
+  },
+  {
+    "principal": "11500840702825037604",
+    "rate_bps": 4689,
+    "seconds": 1253734646,
+    "expected": "214392131136466991847",
+    "overflow": false
+  },
+  {
+    "principal": "8741122543431110285",
+    "rate_bps": 2263,
+    "seconds": 3713840263,
+    "expected": "232953036623600493018",
+    "overflow": false
+  },
+  {
+    "principal": "10923279526726546954",
+    "rate_bps": 7760,
+    "seconds": 971202124,
+    "expected": "261046446196866084572",
+    "overflow": false
+  },
+  {
+    "principal": "15560971358952409259",
+    "rate_bps": 5828,
+    "seconds": 2495848405,
+    "expected": "717741144358687485994",
+    "overflow": false
+  },
+  {
+    "principal": "282176050347001024",
+    "rate_bps": 2320,
+    "seconds": 2456600562,
+    "expected": "5099599561668215958",
+    "overflow": false
+  },
+  {
+    "principal": "5542325086450109657",
+    "rate_bps": 7419,
+    "seconds": 3497919411,
+    "expected": "456079507984799701827",
+    "overflow": false
+  },
+  {
+    "principal": "5892969348415550662",
+    "rate_bps": 5163,
+    "seconds": 645858152,
+    "expected": "62311304856629531953",
+    "overflow": false
+  },
+  {
+    "principal": "15087385322112397975",
+    "rate_bps": 8306,
+    "seconds": 2895184801,
+    "expected": "1150470778109887061197",
+    "overflow": false
+  },
+  {
+    "principal": "12851347302025462684",
+    "rate_bps": 7768,
+    "seconds": 3054576174,
+    "expected": "966946020133478985501",
+    "overflow": false
+  },
+  {
+    "principal": "17705584605729740133",
+    "rate_bps": 6637,
+    "seconds": 2262132511,
+    "expected": "842933905764365286728",
+    "overflow": false
+  },
+  {
+    "principal": "9800877693533553346",
+    "rate_bps": 2552,
+    "seconds": 3326478788,
+    "expected": "263829765313841498249",
+    "overflow": false
+  },
+  {
+    "principal": "17358459453663573187",
+    "rate_bps": 2416,
+    "seconds": 2455009709,
+    "expected": "326478597681180267724",
+    "overflow": false
+  },
+  {
+    "principal": "1113230181848233912",
+    "rate_bps": 6016,
+    "seconds": 2353986474,
+    "expected": "49990807977435713295",
+    "overflow": false
+  },
+  {
+    "principal": "15329653106419242033",
+    "rate_bps": 9911,
+    "seconds": 3773688523,
+    "expected": "1818064335964013429852",
+    "overflow": false
+  },
+  {
+    "principal": "6629803166078303230",
+    "rate_bps": 2911,
+    "seconds": 1948970336,
+    "expected": "119272813067421975962",
+    "overflow": false
+  },
+  {
+    "principal": "9324827794445032239",
+    "rate_bps": 9080,
+    "seconds": 528395769,
+    "expected": "141866349389282975591",
+    "overflow": false
+  },
+  {
+    "principal": "2932027489224465684",
+    "rate_bps": 141,
+    "seconds": 2765809766,
+    "expected": "3625791689519043824",
+    "overflow": false
+  },
+  {
+    "principal": "15455922676732458301",
+    "rate_bps": 7861,
+    "seconds": 721476279,
+    "expected": "277963763035139714158",
+    "overflow": false
+  },
+  {
+    "principal": "16333768742357023866",
+    "rate_bps": 4915,
+    "seconds": 316893756,
+    "expected": "80670918122972127963",
+    "overflow": false
+  },
+  {
+    "principal": "15896472803864539611",
+    "rate_bps": 509,
+    "seconds": 3713830021,
+    "expected": "95287069206126666541",
+    "overflow": false
+  },
+  {
+    "principal": "10982339824061198256",
+    "rate_bps": 8250,
+    "seconds": 2268251234,
+    "expected": "651678473267398483144",
+    "overflow": false
+  },
+  {
+    "principal": "10050627565976724617",
+    "rate_bps": 613,
+    "seconds": 2262942435,
+    "expected": "44210004000140407202",
+    "overflow": false
+  },
+  {
+    "principal": "14014335799141883958",
+    "rate_bps": 7316,
+    "seconds": 1271168088,
+    "expected": "413278289106068268497",
+    "overflow": false
+  },
+  {
+    "principal": "12018849084218082503",
+    "rate_bps": 4152,
+    "seconds": 2376286545,
+    "expected": "376021284640932208864",
+    "overflow": false
+  },
+  {
+    "principal": "18167588065447914380",
+    "rate_bps": 1911,
+    "seconds": 1083812766,
+    "expected": "119317904175696332886",
+    "overflow": false
+  },
+  {
+    "principal": "8080022267800849941",
+    "rate_bps": 2111,
+    "seconds": 774532943,
+    "expected": "41892287777529249494",
+    "overflow": false
+  },
+  {
+    "principal": "2573085552527033138",
+    "rate_bps": 5819,
+    "seconds": 3269353396,
+    "expected": "155223633092478112779",
+    "overflow": false
+  },
+  {
+    "principal": "15622995713082564595",
+    "rate_bps": 3187,
+    "seconds": 1765554269,
+    "expected": "278753828876457909533",
+    "overflow": false
+  },
+  {
+    "principal": "4211949038856342696",
+    "rate_bps": 4680,
+    "seconds": 1565784602,
+    "expected": "97871078016951477265",
+    "overflow": false
+  },
+  {
+    "principal": "17833955175121772001",
+    "rate_bps": 9581,
+    "seconds": 1487334395,
+    "expected": "805861717695471092858",
+    "overflow": false
+  },
+  {
+    "principal": "11407651091541098862",
+    "rate_bps": 8961,
+    "seconds": 2086178896,
+    "expected": "676235004450455255216",
+    "overflow": false
+  },
+  {
+    "principal": "17948347833100832607",
+    "rate_bps": 8802,
+    "seconds": 2169576873,
+    "expected": "1086861681483322352584",
+    "overflow": false
+  },
+  {
+    "principal": "18374366501919362820",
+    "rate_bps": 6381,
+    "seconds": 2837662678,
+    "expected": "1055006852869934468865",
+    "overflow": false
+  },
+  {
+    "principal": "5860822598191480813",
+    "rate_bps": 6282,
+    "seconds": 3540092135,
+    "expected": "413299106312002644468",
+    "overflow": false
+  },
+  {
+    "principal": "1198861568915109610",
+    "rate_bps": 9467,
+    "seconds": 4010658348,
+    "expected": "144341254812475791608",
+    "overflow": false
+  },
+  {
+    "principal": "4035273745831288587",
+    "rate_bps": 6914,
+    "seconds": 4002929973,
+    "expected": "354139005002732781578",
+    "overflow": false
+  },
+  {
+    "principal": "2561433513948589728",
+    "rate_bps": 953,
+    "seconds": 1392671954,
+    "expected": "10779986351842373422",
+    "overflow": false
+  },
+  {
+    "principal": "8929739694728388665",
+    "rate_bps": 6143,
+    "seconds": 2444150291,
+    "expected": "425148464423032654049",
+    "overflow": false
+  },
+  {
+    "principal": "6574742388637613990",
+    "rate_bps": 9340,
+    "seconds": 2154301768,
+    "expected": "419493801622128434315",
+    "overflow": false
+  },
+  {
+    "principal": "11445922371319618295",
+    "rate_bps": 6840,
+    "seconds": 3135152897,
+    "expected": "778321480530041563013",
+    "overflow": false
+  },
+  {
+    "principal": "10077078131182446460",
+    "rate_bps": 1671,
+    "seconds": 1344383246,
+    "expected": "71783984394638811385",
+    "overflow": false
+  },
+  {
+    "principal": "2725988436666624709",
+    "rate_bps": 5996,
+    "seconds": 3424222079,
+    "expected": "177476538535095023933",
+    "overflow": false
+  },
+  {
+    "principal": "3435133552504682402",
+    "rate_bps": 18,
+    "seconds": 1702660516,
+    "expected": "333839398803455230",
+    "overflow": false
+  },
+  {
+    "principal": "16876731841313771299",
+    "rate_bps": 1892,
+    "seconds": 2966936333,
+    "expected": "300407728834652843227",
+    "overflow": false
+  },
+  {
+    "principal": "15773150135469831576",
+    "rate_bps": 9850,
+    "seconds": 438447242,
+    "expected": "216005795342796927900",
+    "overflow": false
+  },
+  {
+    "principal": "5401145054063741841",
+    "rate_bps": 8731,
+    "seconds": 1812902187,
+    "expected": "271092557715651662410",
+    "overflow": false
+  },
+  {
+    "principal": "9047244271952329438",
+    "rate_bps": 7842,
+    "seconds": 627558208,
+    "expected": "141185651260589455103",
+    "overflow": false
+  },
+  {
+    "principal": "1170758362032129935",
+    "rate_bps": 7755,
+    "seconds": 2116432217,
+    "expected": "60932195587463509860",
+    "overflow": false
+  },
+  {
+    "principal": "1080401227623585012",
+    "rate_bps": 8490,
+    "seconds": 613589830,
+    "expected": "17846962250930855528",
+    "overflow": false
+  },
+  {
+    "principal": "10717157646406512285",
+    "rate_bps": 9479,
+    "seconds": 3714691863,
+    "expected": "1196625710869394622068",
+    "overflow": false
+  },
+  {
+    "principal": "2801861465269036378",
+    "rate_bps": 5024,
+    "seconds": 954826268,
+    "expected": "42620058390129656261",
+    "overflow": false
+  },
+  {
+    "principal": "1373020189696626747",
+    "rate_bps": 7419,
+    "seconds": 3551039973,
+    "expected": "114702068158138262632",
+    "overflow": false
+  },
+  {
+    "principal": "6725344014535672208",
+    "rate_bps": 6151,
+    "seconds": 2779441474,
+    "expected": "364595377339317830918",
+    "overflow": false
+  },
+  {
+    "principal": "10308408268633161705",
+    "rate_bps": 9738,
+    "seconds": 2315259203,
+    "expected": "736977778408602460779",
+    "overflow": false
+  },
+  {
+    "principal": "17339156721401926422",
+    "rate_bps": 3514,
+    "seconds": 2202053176,
+    "expected": "425452347723624922009",
+    "overflow": false
+  },
+  {
+    "principal": "2925001362054788391",
+    "rate_bps": 5960,
+    "seconds": 1879451825,
+    "expected": "103895544527925204328",
+    "overflow": false
+  },
+  {
+    "principal": "17515429236225177452",
+    "rate_bps": 9194,
+    "seconds": 2387090046,
+    "expected": "1218954455055965788660",
+    "overflow": false
+  },
+  {
+    "principal": "17142621224318184309",
+    "rate_bps": 2464,
+    "seconds": 2379058095,
+    "expected": "318651797877112127567",
+    "overflow": false
+  },
+  {
+    "principal": "13468229395859628050",
+    "rate_bps": 620,
+    "seconds": 2689042324,
+    "expected": "71202169274418581676",
+    "overflow": false
+  },
+  {
+    "principal": "7337681409384956499",
+    "rate_bps": 6989,
+    "seconds": 1081762237,
+    "expected": "175913472531244222281",
+    "overflow": false
+  },
+  {
+    "principal": "1700551408507974280",
+    "rate_bps": 7513,
+    "seconds": 3441988346,
+    "expected": "139445962042191951179",
+    "overflow": false
+  },
+  {
+    "principal": "122771592575278401",
+    "rate_bps": 3726,
+    "seconds": 1868577371,
+    "expected": "2710473828503079033",
+    "overflow": false
+  },
+  {
+    "principal": "13898643097312290894",
+    "rate_bps": 497,
+    "seconds": 1137676848,
+    "expected": "24919602174664892741",
+    "overflow": false
+  },
+  {
+    "principal": "17681584329238119359",
+    "rate_bps": 4264,
+    "seconds": 65071369,
+    "expected": "15556851619563346649",
+    "overflow": false
+  },
+  {
+    "principal": "18382048652895514340",
+    "rate_bps": 952,
+    "seconds": 963112630,
+    "expected": "53444292326801130284",
+    "overflow": false
+  },
+  {
+    "principal": "11995651417508856141",
+    "rate_bps": 6470,
+    "seconds": 3900990791,
+    "expected": "960055712059267159647",
+    "overflow": false
+  },
+  {
+    "principal": "4035705604717578186",
+    "rate_bps": 9564,
+    "seconds": 641566220,
+    "expected": "78522465552192626752",
+    "overflow": false
+  },
+  {
+    "principal": "12406813808779330923",
+    "rate_bps": 8312,
+    "seconds": 469871253,
+    "expected": "153651947004605064422",
+    "overflow": false
+  },
+  {
+    "principal": "1106005765363820672",
+    "rate_bps": 3251,
+    "seconds": 3225094578,
+    "expected": "36771403677732768581",
+    "overflow": false
+  },
+  {
+    "principal": "9396139357774119833",
+    "rate_bps": 4861,
+    "seconds": 187734131,
+    "expected": "27190156054978665274",
+    "overflow": false
+  },
+  {
+    "principal": "7469539316730059398",
+    "rate_bps": 1004,
+    "seconds": 979722024,
+    "expected": "23298276466404389454",
+    "overflow": false
+  },
+  {
+    "principal": "6145559653682385751",
+    "rate_bps": 8980,
+    "seconds": 2031932001,
+    "expected": "355582466808910513493",
+    "overflow": false
+  },
+  {
+    "principal": "6321427071198010204",
+    "rate_bps": 7164,
+    "seconds": 2985033710,
+    "expected": "428660377587179620802",
+    "overflow": false
+  },
+  {
+    "principal": "3098469211842842661",
+    "rate_bps": 5681,
+    "seconds": 1320263647,
+    "expected": "73692965382332813445",
+    "overflow": false
+  },
+  {
+    "principal": "15972819925282274434",
+    "rate_bps": 6607,
+    "seconds": 681990532,
+    "expected": "228222070360982721059",
+    "overflow": false
+  },
+  {
+    "principal": "8192738524406069635",
+    "rate_bps": 1512,
+    "seconds": 3417754733,
+    "expected": "134250271285028742166",
+    "overflow": false
+  },
+  {
+    "principal": "7308173804354962296",
+    "rate_bps": 6883,
+    "seconds": 1242967402,
+    "expected": "198262130572457102279",
+    "overflow": false
+  },
+  {
+    "principal": "16252700776441778929",
+    "rate_bps": 5506,
+    "seconds": 1360430987,
+    "expected": "386039420787224816857",
+    "overflow": false
+  },
+  {
+    "principal": "8985447116071651774",
+    "rate_bps": 2684,
+    "seconds": 1262940448,
+    "expected": "96582505971524411050",
+    "overflow": false
+  },
+  {
+    "principal": "8218063177626076143",
+    "rate_bps": 2631,
+    "seconds": 1755595961,
+    "expected": "120367236526745962414",
+    "overflow": false
+  },
+  {
+    "principal": "8645666069480758484",
+    "rate_bps": 2733,
+    "seconds": 3475123750,
+    "expected": "260376483045837135197",
+    "overflow": false
+  },
+  {
+    "principal": "18083924797861689341",
+    "rate_bps": 6147,
+    "seconds": 1490852727,
+    "expected": "525513700160750026527",
+    "overflow": false
+  },
+  {
+    "principal": "4528646063486262842",
+    "rate_bps": 4990,
+    "seconds": 2819678716,
+    "expected": "202051437463127557296",
+    "overflow": false
+  },
+  {
+    "principal": "11186256410900381339",
+    "rate_bps": 1934,
+    "seconds": 2337679173,
+    "expected": "160368674788335657217",
+    "overflow": false
+  },
+  {
+    "principal": "6875209291262894960",
+    "rate_bps": 6290,
+    "seconds": 3842104866,
+    "expected": "526864790104861295882",
+    "overflow": false
+  },
+  {
+    "principal": "1772708244296854345",
+    "rate_bps": 3112,
+    "seconds": 3806029731,
+    "expected": "66579790202157445551",
+    "overflow": false
+  },
+  {
+    "principal": "6966965571812431350",
+    "rate_bps": 11,
+    "seconds": 2737645592,
+    "expected": "665283829465273603",
+    "overflow": false
+  },
+  {
+    "principal": "9787327070659114375",
+    "rate_bps": 136,
+    "seconds": 3798310929,
+    "expected": "16031970913980090796",
+    "overflow": false
+  },
+  {
+    "principal": "16400158915789198156",
+    "rate_bps": 7804,
+    "seconds": 4012661086,
+    "expected": "1628512852313698284942",
+    "overflow": false
+  },
+  {
+    "principal": "12287954377619986645",
+    "rate_bps": 9183,
+    "seconds": 3362830351,
+    "expected": "1203268440450818216156",
+    "overflow": false
+  },
+  {
+    "principal": "388347621607099634",
+    "rate_bps": 7264,
+    "seconds": 1732247412,
+    "expected": "15495293240401072770",
+    "overflow": false
+  },
+  {
+    "principal": "8365854740665726131",
+    "rate_bps": 6795,
+    "seconds": 2455771933,
+    "expected": "442671136047369360602",
+    "overflow": false
+  },
+  {
+    "principal": "13900409013924833384",
+    "rate_bps": 7231,
+    "seconds": 2648308698,
+    "expected": "844088417357393139198",
+    "overflow": false
+  },
+  {
+    "principal": "17203290938425470113",
+    "rate_bps": 107,
+    "seconds": 3387726011,
+    "expected": "19774111719935275241",
+    "overflow": false
+  },
+  {
+    "principal": "14901874795323465518",
+    "rate_bps": 436,
+    "seconds": 1053090832,
+    "expected": "21696347313493213638",
+    "overflow": false
+  },
+  {
+    "principal": "10671700662648539167",
+    "rate_bps": 5390,
+    "seconds": 450053225,
+    "expected": "82087999378764932726",
+    "overflow": false
+  },
+  {
+    "principal": "17987452612573109956",
+    "rate_bps": 5887,
+    "seconds": 41968022,
+    "expected": "14092095984345263892",
+    "overflow": false
+  },
+  {
+    "principal": "12573475954379199149",
+    "rate_bps": 114,
+    "seconds": 2302498215,
+    "expected": "10465329392784760692",
+    "overflow": false
+  },
+  {
+    "principal": "10694902311272081578",
+    "rate_bps": 2514,
+    "seconds": 1521127916,
+    "expected": "129688427714124100348",
+    "overflow": false
+  },
+  {
+    "principal": "15020914217440197579",
+    "rate_bps": 3686,
+    "seconds": 3382249461,
+    "expected": "593814401483189928640",
+    "overflow": false
+  },
+  {
+    "principal": "11836127905842819680",
+    "rate_bps": 4410,
+    "seconds": 3347998354,
+    "expected": "554149400849961796888",
+    "overflow": false
+  },
+  {
+    "principal": "2971205077970974457",
+    "rate_bps": 3340,
+    "seconds": 1088125651,
+    "expected": "34241401875540289244",
+    "overflow": false
+  },
+  {
+    "principal": "8167670790812714342",
+    "rate_bps": 9910,
+    "seconds": 3257861384,
+    "expected": "836176338572233722562",
+    "overflow": false
+  },
+  {
+    "principal": "18046274102029867959",
+    "rate_bps": 7405,
+    "seconds": 2825097665,
+    "expected": "1197124920593409613044",
+    "overflow": false
+  },
+  {
+    "principal": "16676533651920117564",
+    "rate_bps": 3671,
+    "seconds": 1734878926,
+    "expected": "336784994582059808660",
+    "overflow": false
+  },
+  {
+    "principal": "17103313266934580613",
+    "rate_bps": 2358,
+    "seconds": 3270890559,
+    "expected": "418295755245952364400",
+    "overflow": false
+  },
+  {
+    "principal": "9034323611436192098",
+    "rate_bps": 1393,
+    "seconds": 1744533860,
+    "expected": "69617681491598975899",
+    "overflow": false
+  },
+  {
+    "principal": "16375728866721297379",
+    "rate_bps": 6532,
+    "seconds": 277433805,
+    "expected": "94102158752032434736",
+    "overflow": false
+  },
+  {
+    "principal": "3057337672393810264",
+    "rate_bps": 1132,
+    "seconds": 2124611146,
+    "expected": "23316463672330857154",
+    "overflow": false
+  },
+  {
+    "principal": "4257170772302686801",
+    "rate_bps": 5906,
+    "seconds": 2363321835,
+    "expected": "188421638041409446026",
+    "overflow": false
+  },
+  {
+    "principal": "15502258296741587102",
+    "rate_bps": 4983,
+    "seconds": 2692770560,
+    "expected": "659596890392163759053",
+    "overflow": false
+  },
+  {
+    "principal": "1905903081314275407",
+    "rate_bps": 9854,
+    "seconds": 1360062489,
+    "expected": "80996383122527044786",
+    "overflow": false
+  },
+  {
+    "principal": "10316613274859320500",
+    "rate_bps": 2579,
+    "seconds": 2508294406,
+    "expected": "211621795983691140498",
+    "overflow": false
+  },
+  {
+    "principal": "4449412271443317085",
+    "rate_bps": 7565,
+    "seconds": 4205941719,
+    "expected": "448919245295985881263",
+    "overflow": false
+  },
+  {
+    "principal": "17837271747520964378",
+    "rate_bps": 5431,
+    "seconds": 1972475356,
+    "expected": "605917101802869447687",
+    "overflow": false
+  },
+  {
+    "principal": "5120667828262993147",
+    "rate_bps": 8045,
+    "seconds": 318590117,
+    "expected": "41617725892659636853",
+    "overflow": false
+  },
+  {
+    "principal": "7277763678210676048",
+    "rate_bps": 4895,
+    "seconds": 4239368962,
+    "expected": "478900460041279371583",
+    "overflow": false
+  },
+  {
+    "principal": "1468486323878700713",
+    "rate_bps": 8039,
+    "seconds": 3880505859,
+    "expected": "145262552609540182318",
+    "overflow": false
+  },
+  {
+    "principal": "10773017769477269718",
+    "rate_bps": 7477,
+    "seconds": 2470573560,
+    "expected": "631038620035082843076",
+    "overflow": false
+  },
+  {
+    "principal": "16652221093047551463",
+    "rate_bps": 5418,
+    "seconds": 1742317425,
+    "expected": "498461754999209924402",
+    "overflow": false
+  },
+  {
+    "principal": "4716184274410143532",
+    "rate_bps": 1376,
+    "seconds": 2571003966,
+    "expected": "52906050165144433003",
+    "overflow": false
+  },
+  {
+    "principal": "6698770928369440309",
+    "rate_bps": 1131,
+    "seconds": 1147925615,
+    "expected": "27578133638794846262",
+    "overflow": false
+  },
+  {
+    "principal": "17903176619514628562",
+    "rate_bps": 5345,
+    "seconds": 3388983124,
+    "expected": "1028349177228623953437",
+    "overflow": false
+  },
+  {
+    "principal": "8946043212479608595",
+    "rate_bps": 2415,
+    "seconds": 2927977597,
+    "expected": "200589995784694014957",
+    "overflow": false
+  },
+  {
+    "principal": "1581502609094946376",
+    "rate_bps": 103,
+    "seconds": 3152032954,
+    "expected": "1628138251815505652",
+    "overflow": false
+  },
+  {
+    "principal": "11671811121932340225",
+    "rate_bps": 6299,
+    "seconds": 1998849819,
+    "expected": "465997318486346994055",
+    "overflow": false
+  },
+  {
+    "principal": "4931343193984345614",
+    "rate_bps": 5873,
+    "seconds": 1643152880,
+    "expected": "150902555431274598711",
+    "overflow": false
+  },
+  {
+    "principal": "7180543649553390719",
+    "rate_bps": 1948,
+    "seconds": 3124768713,
+    "expected": "138598187131249585721",
+    "overflow": false
+  },
+  {
+    "principal": "16052710881945034404",
+    "rate_bps": 6375,
+    "seconds": 1600431222,
+    "expected": "519348619178638479257",
+    "overflow": false
+  },
+  {
+    "principal": "13506620391818064909",
+    "rate_bps": 6859,
+    "seconds": 2223265287,
+    "expected": "653118788038407281598",
+    "overflow": false
+  },
+  {
+    "principal": "13943404768860510602",
+    "rate_bps": 5015,
+    "seconds": 3146575308,
+    "expected": "697704132968850959956",
+    "overflow": false
+  },
+  {
+    "principal": "16869183979299897899",
+    "rate_bps": 9618,
+    "seconds": 3891656021,
+    "expected": "2002196450305287229802",
+    "overflow": false
+  },
+  {
+    "principal": "2853264640594529344",
+    "rate_bps": 7613,
+    "seconds": 1786024818,
+    "expected": "123020862246973216101",
+    "overflow": false
+  },
+  {
+    "principal": "9046906348396411481",
+    "rate_bps": 587,
+    "seconds": 1518824755,
+    "expected": "25576390606707350235",
+    "overflow": false
+  },
+  {
+    "principal": "11583127634914115654",
+    "rate_bps": 4025,
+    "seconds": 4185717480,
+    "expected": "618806734378131549884",
+    "overflow": false
+  },
+  {
+    "principal": "16073472417562932247",
+    "rate_bps": 3000,
+    "seconds": 231399713,
+    "expected": "35382390642479820028",
+    "overflow": false
+  },
+  {
+    "principal": "7207364153327317788",
+    "rate_bps": 4984,
+    "seconds": 3498974638,
+    "expected": "398555389860933470357",
+    "overflow": false
+  },
+  {
+    "principal": "15851928797426354917",
+    "rate_bps": 2558,
+    "seconds": 3242072223,
+    "expected": "416868165822586298525",
+    "overflow": false
+  },
+  {
+    "principal": "446344354174580290",
+    "rate_bps": 9394,
+    "seconds": 2947803460,
+    "expected": "39193362012718900735",
+    "overflow": false
+  },
+  {
+    "principal": "4435785972379303491",
+    "rate_bps": 7855,
+    "seconds": 1894211373,
+    "expected": "209285242396696115427",
+    "overflow": false
+  },
+  {
+    "principal": "9438163022116523832",
+    "rate_bps": 4602,
+    "seconds": 2923470634,
+    "expected": "402648622468147306143",
+    "overflow": false
+  },
+  {
+    "principal": "14540708815783547313",
+    "rate_bps": 2352,
+    "seconds": 3225117771,
+    "expected": "349753336656206134353",
+    "overflow": false
+  },
+  {
+    "principal": "1887261740828219262",
+    "rate_bps": 7454,
+    "seconds": 3553375456,
+    "expected": "158509762612733040719",
+    "overflow": false
+  },
+  {
+    "principal": "7926883338091490479",
+    "rate_bps": 7728,
+    "seconds": 763632505,
+    "expected": "148336278634678881853",
+    "overflow": false
+  },
+  {
+    "principal": "8513834688202038420",
+    "rate_bps": 2596,
+    "seconds": 3165172710,
+    "expected": "221830218555859267905",
+    "overflow": false
+  },
+  {
+    "principal": "3291532320584776381",
+    "rate_bps": 1420,
+    "seconds": 2218826807,
+    "expected": "32885410361520154887",
+    "overflow": false
+  },
+  {
+    "principal": "6351675352129290234",
+    "rate_bps": 8901,
+    "seconds": 1789106620,
+    "expected": "320742647030790681129",
+    "overflow": false
+  },
+  {
+    "principal": "12282397176270277467",
+    "rate_bps": 198,
+    "seconds": 3174433285,
+    "expected": "24479803343342819087",
+    "overflow": false
+  },
+  {
+    "principal": "11171079664864024368",
+    "rate_bps": 1643,
+    "seconds": 3089905634,
+    "expected": "179833800154356655737",
+    "overflow": false
+  },
+  {
+    "principal": "11673004812616626697",
+    "rate_bps": 8763,
+    "seconds": 287919203,
+    "expected": "93389811925916997457",
+    "overflow": false
+  },
+  {
+    "principal": "3558734023657130934",
+    "rate_bps": 6266,
+    "seconds": 2939622360,
+    "expected": "207859968063382193385",
+    "overflow": false
+  },
+  {
+    "principal": "2472039443484517959",
+    "rate_bps": 5011,
+    "seconds": 2272935633,
+    "expected": "89281263756650509640",
+    "overflow": false
+  },
+  {
+    "principal": "2885533963616729868",
+    "rate_bps": 2791,
+    "seconds": 2524333854,
+    "expected": "64465330225100274996",
+    "overflow": false
+  },
+  {
+    "principal": "7475406287060067221",
+    "rate_bps": 6151,
+    "seconds": 1276592335,
+    "expected": "186134190144146291253",
+    "overflow": false
+  },
+  {
+    "principal": "14905455822260639410",
+    "rate_bps": 7050,
+    "seconds": 2931744564,
+    "expected": "976908526826567089862",
+    "overflow": false
+  },
+  {
+    "principal": "12410153905763354995",
+    "rate_bps": 1941,
+    "seconds": 2827107805,
+    "expected": "215942669334550281173",
+    "overflow": false
+  },
+  {
+    "principal": "270561678764934184",
+    "rate_bps": 1779,
+    "seconds": 2813541786,
+    "expected": "4294266526017908681",
+    "overflow": false
+  },
+  {
+    "principal": "11362231338718116705",
+    "rate_bps": 1221,
+    "seconds": 702449019,
+    "expected": "30902064505481110191",
+    "overflow": false
+  },
+  {
+    "principal": "10561395292875521262",
+    "rate_bps": 8348,
+    "seconds": 2517268432,
+    "expected": "703763373459266952058",
+    "overflow": false
+  },
+  {
+    "principal": "17347028198843400415",
+    "rate_bps": 425,
+    "seconds": 1514122025,
+    "expected": "35397149043220670472",
+    "overflow": false
+  },
+  {
+    "principal": "2569682868282257028",
+    "rate_bps": 1786,
+    "seconds": 4279023446,
+    "expected": "62272893107894004685",
+    "overflow": false
+  },
+  {
+    "principal": "15516109325870654829",
+    "rate_bps": 3866,
+    "seconds": 229729895,
+    "expected": "43697399057226280768",
+    "overflow": false
+  },
+  {
+    "principal": "16646442099441834602",
+    "rate_bps": 2754,
+    "seconds": 740071852,
+    "expected": "107585226870030654402",
+    "overflow": false
+  },
+  {
+    "principal": "9581926753291917451",
+    "rate_bps": 1708,
+    "seconds": 2880467637,
+    "expected": "149484824617385978705",
+    "overflow": false
+  },
+  {
+    "principal": "10026560686096414240",
+    "rate_bps": 5746,
+    "seconds": 3194327122,
+    "expected": "583566550278748550821",
+    "overflow": false
+  },
+  {
+    "principal": "14758814682791054777",
+    "rate_bps": 2789,
+    "seconds": 2752278419,
+    "expected": "359240880129214530818",
+    "overflow": false
+  },
+  {
+    "principal": "7376034355279301414",
+    "rate_bps": 4841,
+    "seconds": 906445000,
+    "expected": "102634380268675544070",
+    "overflow": false
+  },
+  {
+    "principal": "10630798078371241079",
+    "rate_bps": 4248,
+    "seconds": 1919598721,
+    "expected": "274887013075933980860",
+    "overflow": false
+  },
+  {
+    "principal": "4265546720106010364",
+    "rate_bps": 8389,
+    "seconds": 559277198,
+    "expected": "63460779725717532449",
+    "overflow": false
+  },
+  {
+    "principal": "411129661100728389",
+    "rate_bps": 318,
+    "seconds": 3319950591,
+    "expected": "1376356517342021024",
+    "overflow": false
+  },
+  {
+    "principal": "6949754524696455970",
+    "rate_bps": 9217,
+    "seconds": 3221727524,
+    "expected": "654396929493937085718",
+    "overflow": false
+  },
+  {
+    "principal": "10231395834631362723",
+    "rate_bps": 4076,
+    "seconds": 2724790413,
+    "expected": "360325964715450181087",
+    "overflow": false
+  },
+  {
+    "principal": "12670153818633375000",
+    "rate_bps": 8254,
+    "seconds": 1667698698,
+    "expected": "553041006998866981709",
+    "overflow": false
+  },
+  {
+    "principal": "4468966981936892177",
+    "rate_bps": 9482,
+    "seconds": 805857963,
+    "expected": "108282678925901362854",
+    "overflow": false
+  },
+  {
+    "principal": "2300055302131947102",
+    "rate_bps": 4518,
+    "seconds": 2279755456,
+    "expected": "75121830459954094991",
+    "overflow": false
+  },
+  {
+    "principal": "4003038566274865423",
+    "rate_bps": 5429,
+    "seconds": 2014699225,
+    "expected": "138839559889204397888",
+    "overflow": false
+  },
+  {
+    "principal": "18085906373695657076",
+    "rate_bps": 957,
+    "seconds": 3717181126,
+    "expected": "204013700078296872079",
+    "overflow": false
+  },
+  {
+    "principal": "2004724246657070109",
+    "rate_bps": 5277,
+    "seconds": 450999447,
+    "expected": "15129031938183707697",
+    "overflow": false
+  },
+  {
+    "principal": "11180085412080003290",
+    "rate_bps": 6444,
+    "seconds": 75427228,
+    "expected": "17231464658347190966",
+    "overflow": false
+  },
+  {
+    "principal": "8863528764716591547",
+    "rate_bps": 2565,
+    "seconds": 546850661,
+    "expected": "39423589345795312387",
+    "overflow": false
+  },
+  {
+    "principal": "18052974766618323216",
+    "rate_bps": 5060,
+    "seconds": 4142898370,
+    "expected": "1200043433077839165456",
+    "overflow": false
+  },
+  {
+    "principal": "8890691966442163561",
+    "rate_bps": 4543,
+    "seconds": 4266383043,
+    "expected": "546426229382066130255",
+    "overflow": false
+  },
+  {
+    "principal": "15537785642842193558",
+    "rate_bps": 3080,
+    "seconds": 3334767032,
+    "expected": "506056182017573146485",
+    "overflow": false
+  },
+  {
+    "principal": "4496078935697954471",
+    "rate_bps": 6956,
+    "seconds": 3428804145,
+    "expected": "340039659363190438159",
+    "overflow": false
+  },
+  {
+    "principal": "5258329243223574252",
+    "rate_bps": 9960,
+    "seconds": 3301701118,
+    "expected": "548325273179817210668",
+    "overflow": false
+  },
+  {
+    "principal": "16146428216354062581",
+    "rate_bps": 8201,
+    "seconds": 231382319,
+    "expected": "97155376816951953901",
+    "overflow": false
+  },
+  {
+    "principal": "8699379371025789842",
+    "rate_bps": 5718,
+    "seconds": 800409364,
+    "expected": "126251915300766196132",
+    "overflow": false
+  },
+  {
+    "principal": "4031218635403684819",
+    "rate_bps": 2109,
+    "seconds": 1475258173,
+    "expected": "39771718341300635540",
+    "overflow": false
+  },
+  {
+    "principal": "7694758383816223240",
+    "rate_bps": 5610,
+    "seconds": 1976243834,
+    "expected": "270515260416243083910",
+    "overflow": false
+  },
+  {
+    "principal": "14098174639775873729",
+    "rate_bps": 1910,
+    "seconds": 955519963,
+    "expected": "81588586892495579909",
+    "overflow": false
+  },
+  {
+    "principal": "9923813667200017358",
+    "rate_bps": 839,
+    "seconds": 3083516336,
+    "expected": "81410460005568487561",
+    "overflow": false
+  },
+  {
+    "principal": "13415588412897391935",
+    "rate_bps": 3102,
+    "seconds": 4142511753,
+    "expected": "546649130372417779789",
+    "overflow": false
+  },
+  {
+    "principal": "12079632341724008036",
+    "rate_bps": 5840,
+    "seconds": 3832584758,
+    "expected": "857337311021023715582",
+    "overflow": false
+  },
+  {
+    "principal": "14606599846134638285",
+    "rate_bps": 3643,
+    "seconds": 3155986119,
+    "expected": "532521050958163808882",
+    "overflow": false
+  },
+  {
+    "principal": "13501587528919739210",
+    "rate_bps": 5082,
+    "seconds": 1133614476,
+    "expected": "246648383291181864611",
+    "overflow": false
+  },
+  {
+    "principal": "9897538698112351979",
+    "rate_bps": 9402,
+    "seconds": 2371911701,
+    "expected": "699905434924329186142",
+    "overflow": false
+  },
+  {
+    "principal": "14840060175282434048",
+    "rate_bps": 3477,
+    "seconds": 3973668146,
+    "expected": "650167625888114719386",
+    "overflow": false
+  },
+  {
+    "principal": "15715906948911247641",
+    "rate_bps": 7327,
+    "seconds": 2369946099,
+    "expected": "865361365691138080605",
+    "overflow": false
+  },
+  {
+    "principal": "9228140947634578950",
+    "rate_bps": 2890,
+    "seconds": 1099290280,
+    "expected": "92964650930782375429",
+    "overflow": false
+  },
+  {
+    "principal": "5616485842113762519",
+    "rate_bps": 4267,
+    "seconds": 2740662241,
+    "expected": "208274557675308358990",
+    "overflow": false
+  },
+  {
+    "principal": "14553370644887931612",
+    "rate_bps": 2677,
+    "seconds": 1639414638,
+    "expected": "202532238515391649392",
+    "overflow": false
+  },
+  {
+    "principal": "2532299011036661157",
+    "rate_bps": 3904,
+    "seconds": 825938271,
+    "expected": "25892010690343667143",
+    "overflow": false
+  },
+  {
+    "principal": "4613885208597852162",
+    "rate_bps": 7090,
+    "seconds": 2368649476,
+    "expected": "245701161789816157145",
+    "overflow": false
+  },
+  {
+    "principal": "9443459187028460291",
+    "rate_bps": 3988,
+    "seconds": 514208237,
+    "expected": "61407112966059459177",
+    "overflow": false
+  },
+  {
+    "principal": "11432040819236002552",
+    "rate_bps": 6605,
+    "seconds": 3163443434,
+    "expected": "757443171465709371780",
+    "overflow": false
+  },
+  {
+    "principal": "14441597564258209905",
+    "rate_bps": 2265,
+    "seconds": 3306979595,
+    "expected": "343011241347733248740",
+    "overflow": false
+  },
+  {
+    "principal": "16468573603346359614",
+    "rate_bps": 3455,
+    "seconds": 1400551584,
+    "expected": "252694936118303624043",
+    "overflow": false
+  },
+  {
+    "principal": "16976976563082974575",
+    "rate_bps": 9510,
+    "seconds": 786313785,
+    "expected": "402559563512003292166",
+    "overflow": false
+  },
+  {
+    "principal": "4206847750866574420",
+    "rate_bps": 3247,
+    "seconds": 3845028262,
+    "expected": "166545158760003107484",
+    "overflow": false
+  },
+  {
+    "principal": "6336561447581662589",
+    "rate_bps": 1706,
+    "seconds": 1206705399,
+    "expected": "41364456888241480985",
+    "overflow": false
+  },
+  {
+    "principal": "13077339792003031482",
+    "rate_bps": 5736,
+    "seconds": 1952158076,
+    "expected": "464340886036957067857",
+    "overflow": false
+  },
+  {
+    "principal": "13816385265496266779",
+    "rate_bps": 4324,
+    "seconds": 398204101,
+    "expected": "75436102446570659530",
+    "overflow": false
+  },
+  {
+    "principal": "13329417129056226032",
+    "rate_bps": 2684,
+    "seconds": 2893140386,
+    "expected": "328213598896745936227",
+    "overflow": false
+  },
+  {
+    "principal": "9310201521724635337",
+    "rate_bps": 3117,
+    "seconds": 1888186659,
+    "expected": "173753756086880815871",
+    "overflow": false
+  },
+  {
+    "principal": "15916967530592846198",
+    "rate_bps": 1124,
+    "seconds": 497172376,
+    "expected": "28205059804893647225",
+    "overflow": false
+  },
+  {
+    "principal": "14867104168429033223",
+    "rate_bps": 6355,
+    "seconds": 3315670417,
+    "expected": "993360042715927537956",
+    "overflow": false
+  },
+  {
+    "principal": "9466500187863753420",
+    "rate_bps": 6199,
+    "seconds": 3593958622,
+    "expected": "668771180892067833292",
+    "overflow": false
+  },
+  {
+    "principal": "14321073273399881301",
+    "rate_bps": 1979,
+    "seconds": 2615019919,
+    "expected": "235011846821090376830",
+    "overflow": false
+  },
+  {
+    "principal": "808063249666285682",
+    "rate_bps": 1458,
+    "seconds": 2602237684,
+    "expected": "9721722818853072551",
+    "overflow": false
+  },
+  {
+    "principal": "4553238795438612019",
+    "rate_bps": 3406,
+    "seconds": 1482858653,
+    "expected": "72921941010441571694",
+    "overflow": false
+  },
+  {
+    "principal": "2313141509514108904",
+    "rate_bps": 7167,
+    "seconds": 3466575706,
+    "expected": "182235796286497594580",
+    "overflow": false
+  },
+  {
+    "principal": "1803050432022170145",
+    "rate_bps": 4250,
+    "seconds": 2671555131,
+    "expected": "64916386639911625652",
+    "overflow": false
+  },
+  {
+    "principal": "12093158585712057006",
+    "rate_bps": 1076,
+    "seconds": 2548648848,
+    "expected": "105161171407966214619",
+    "overflow": false
+  },
+  {
+    "principal": "17677107031728077215",
+    "rate_bps": 6121,
+    "seconds": 274092521,
+    "expected": "94042496462287380384",
+    "overflow": false
+  },
+  {
+    "principal": "434746590563106372",
+    "rate_bps": 1967,
+    "seconds": 1720208662,
+    "expected": "4664607089183195450",
+    "overflow": false
+  },
+  {
+    "principal": "4183835554110568493",
+    "rate_bps": 32,
+    "seconds": 2333980455,
+    "expected": "990866606821731280",
+    "overflow": false
+  },
+  {
+    "principal": "5492459606140521514",
+    "rate_bps": 7179,
+    "seconds": 1294197100,
+    "expected": "161817184445045213948",
+    "overflow": false
+  },
+  {
+    "principal": "18377274590849578315",
+    "rate_bps": 6164,
+    "seconds": 1235098997,
+    "expected": "443648376612540299515",
+    "overflow": false
+  },
+  {
+    "principal": "12168004437757442528",
+    "rate_bps": 5085,
+    "seconds": 860355090,
+    "expected": "168803498074756569159",
+    "overflow": false
+  },
+  {
+    "principal": "16577427811943801977",
+    "rate_bps": 1671,
+    "seconds": 2852234323,
+    "expected": "250537183085050057550",
+    "overflow": false
+  },
+  {
+    "principal": "17652399875067056358",
+    "rate_bps": 7696,
+    "seconds": 1504754824,
+    "expected": "648228249117989666763",
+    "overflow": false
+  },
+  {
+    "principal": "12236369808570457399",
+    "rate_bps": 3446,
+    "seconds": 1907633985,
+    "expected": "255068196172333350993",
+    "overflow": false
+  },
+  {
+    "principal": "374056557913706172",
+    "rate_bps": 6889,
+    "seconds": 1839915598,
+    "expected": "15034353313938136203",
+    "overflow": false
+  },
+  {
+    "principal": "15506581286861667077",
+    "rate_bps": 8032,
+    "seconds": 1201620415,
+    "expected": "474570186192657286717",
+    "overflow": false
+  },
+  {
+    "principal": "3162993196731696354",
+    "rate_bps": 7975,
+    "seconds": 1063327972,
+    "expected": "85052989130234750459",
+    "overflow": false
+  },
+  {
+    "principal": "5930983090456755555",
+    "rate_bps": 7019,
+    "seconds": 590803789,
+    "expected": "77989941256728390713",
+    "overflow": false
+  },
+  {
+    "principal": "18106124712484829400",
+    "rate_bps": 1377,
+    "seconds": 1814979018,
+    "expected": "143490929706593634265",
+    "overflow": false
+  },
+  {
+    "principal": "16560169286004631505",
+    "rate_bps": 6241,
+    "seconds": 206546795,
+    "expected": "67690980998682326383",
+    "overflow": false
+  },
+  {
+    "principal": "6536632678458655774",
+    "rate_bps": 7926,
+    "seconds": 3243078272,
+    "expected": "532793566869547197433",
+    "overflow": false
+  },
+  {
+    "principal": "9619594830217880015",
+    "rate_bps": 1190,
+    "seconds": 3556054425,
+    "expected": "129081954869409769692",
+    "overflow": false
+  },
+  {
+    "principal": "13157656534060119092",
+    "rate_bps": 8359,
+    "seconds": 343741574,
+    "expected": "119883199479856119829",
+    "overflow": false
+  },
+  {
+    "principal": "13587104595428021981",
+    "rate_bps": 3139,
+    "seconds": 4172944727,
+    "expected": "564357446411486065566",
+    "overflow": false
+  },
+  {
+    "principal": "3246374748570413722",
+    "rate_bps": 1821,
+    "seconds": 2675017052,
+    "expected": "50145105026941572324",
+    "overflow": false
+  },
+  {
+    "principal": "15899931779366164091",
+    "rate_bps": 4467,
+    "seconds": 3241771557,
+    "expected": "730107843305536143692",
+    "overflow": false
+  },
+  {
+    "principal": "15287514660163337424",
+    "rate_bps": 245,
+    "seconds": 3760903810,
+    "expected": "44667185667350304351",
+    "overflow": false
+  },
+  {
+    "principal": "17613976870515356713",
+    "rate_bps": 1072,
+    "seconds": 1304435587,
+    "expected": "78103094029384738501",
+    "overflow": false
+  },
+  {
+    "principal": "13129395396014068822",
+    "rate_bps": 9244,
+    "seconds": 1804094840,
+    "expected": "694316396978273133137",
+    "overflow": false
+  },
+  {
+    "principal": "184318165891917671",
+    "rate_bps": 6886,
+    "seconds": 106390769,
+    "expected": "428186035669219382",
+    "overflow": false
+  },
+  {
+    "principal": "12969558161871392428",
+    "rate_bps": 4700,
+    "seconds": 1353761726,
+    "expected": "261672849380264767046",
+    "overflow": false
+  },
+  {
+    "principal": "16994344537648999349",
+    "rate_bps": 8252,
+    "seconds": 3970532847,
+    "expected": "1765654901084968215224",
+    "overflow": false
+  },
+  {
+    "principal": "5290251670670843218",
+    "rate_bps": 9359,
+    "seconds": 1932003028,
+    "expected": "303324140810816396842",
+    "overflow": false
+  },
+  {
+    "principal": "6661429095575314579",
+    "rate_bps": 2214,
+    "seconds": 158738941,
+    "expected": "7423725377963483236",
+    "overflow": false
+  },
+  {
+    "principal": "17888811388546213320",
+    "rate_bps": 3923,
+    "seconds": 4004067386,
+    "expected": "891034590750519898836",
+    "overflow": false
+  },
+  {
+    "principal": "15934851351986383233",
+    "rate_bps": 9877,
+    "seconds": 4220543131,
+    "expected": "2106370705539747177389",
+    "overflow": false
+  },
+  {
+    "principal": "3422139893402067342",
+    "rate_bps": 309,
+    "seconds": 4213058928,
+    "expected": "14126909571618554558",
+    "overflow": false
+  },
+  {
+    "principal": "567904442044648959",
+    "rate_bps": 6436,
+    "seconds": 2862447945,
+    "expected": "33175867796386439758",
+    "overflow": false
+  },
+  {
+    "principal": "16782895994084441636",
+    "rate_bps": 405,
+    "seconds": 810274806,
+    "expected": "17464158128071423066",
+    "overflow": false
+  },
+  {
+    "principal": "7935319922422585741",
+    "rate_bps": 1327,
+    "seconds": 3658282887,
+    "expected": "122153535688153799305",
+    "overflow": false
+  },
+  {
+    "principal": "949559256486378762",
+    "rate_bps": 1310,
+    "seconds": 1208712524,
+    "expected": "4767709465150084541",
+    "overflow": false
+  },
+  {
+    "principal": "17896968038340705195",
+    "rate_bps": 1982,
+    "seconds": 3774958293,
+    "expected": "424608480115722826940",
+    "overflow": false
+  },
+  {
+    "principal": "17385399251679990720",
+    "rate_bps": 2922,
+    "seconds": 3811141362,
+    "expected": "613922190013360565493",
+    "overflow": false
+  },
+  {
+    "principal": "15537714509674883033",
+    "rate_bps": 8157,
+    "seconds": 2988562099,
+    "expected": "1201083711268706176001",
+    "overflow": false
+  },
+  {
+    "principal": "10692048010093530054",
+    "rate_bps": 9860,
+    "seconds": 809497192,
+    "expected": "270611690801855074606",
+    "overflow": false
+  },
+  {
+    "principal": "6609523918261630359",
+    "rate_bps": 2873,
+    "seconds": 2995633825,
+    "expected": "180379809253403915433",
+    "overflow": false
+  },
+  {
+    "principal": "17829162769448493724",
+    "rate_bps": 8992,
+    "seconds": 4113045806,
+    "expected": "2090952597270155620954",
+    "overflow": false
+  },
+  {
+    "principal": "3094276135471005797",
+    "rate_bps": 6695,
+    "seconds": 828885535,
+    "expected": "54449964761755126200",
+    "overflow": false
+  },
+  {
+    "principal": "16627855746254924226",
+    "rate_bps": 1800,
+    "seconds": 852936900,
+    "expected": "80950409439827977620",
+    "overflow": false
+  },
+  {
+    "principal": "9024890136966858691",
+    "rate_bps": 1283,
+    "seconds": 2981315757,
+    "expected": "109463655884684408532",
+    "overflow": false
+  },
+  {
+    "principal": "5849510932470654648",
+    "rate_bps": 5070,
+    "seconds": 3099542186,
+    "expected": "291486510421395312762",
+    "overflow": false
+  },
+  {
+    "principal": "8549163672600743729",
+    "rate_bps": 3498,
+    "seconds": 913956299,
+    "expected": "86668695586518490627",
+    "overflow": false
+  },
+  {
+    "principal": "6797380162330702590",
+    "rate_bps": 5764,
+    "seconds": 1343388768,
+    "expected": "166901652933783104646",
+    "overflow": false
+  },
+  {
+    "principal": "1456287350244703791",
+    "rate_bps": 659,
+    "seconds": 1836222713,
+    "expected": "5587933638209054689",
+    "overflow": false
+  },
+  {
+    "principal": "8903835140152237076",
+    "rate_bps": 5585,
+    "seconds": 7569254,
+    "expected": "1193566881511298407",
+    "overflow": false
+  },
+  {
+    "principal": "6134593124682858557",
+    "rate_bps": 8791,
+    "seconds": 2124504503,
+    "expected": "363308110024114320808",
+    "overflow": false
+  },
+  {
+    "principal": "13076663347964134266",
+    "rate_bps": 8593,
+    "seconds": 519620924,
+    "expected": "185149174002505541318",
+    "overflow": false
+  },
+  {
+    "principal": "18163980025997796571",
+    "rate_bps": 8172,
+    "seconds": 2141747077,
+    "expected": "1008093813460313517450",
+    "overflow": false
+  },
+  {
+    "principal": "17692328232163507888",
+    "rate_bps": 3079,
+    "seconds": 2912070498,
+    "expected": "503025445577203798627",
+    "overflow": false
+  },
+  {
+    "principal": "5275794602488446857",
+    "rate_bps": 3842,
+    "seconds": 2680280547,
+    "expected": "172273662634680305909",
+    "overflow": false
+  },
+  {
+    "principal": "557974951449376566",
+    "rate_bps": 6413,
+    "seconds": 3694046040,
+    "expected": "41915209379536229049",
+    "overflow": false
+  },
+  {
+    "principal": "18055310335028774855",
+    "rate_bps": 7404,
+    "seconds": 630864977,
+    "expected": "267424491381601318180",
+    "overflow": false
+  },
+  {
+    "principal": "15350977934665271948",
+    "rate_bps": 6071,
+    "seconds": 2385502878,
+    "expected": "704968347934495074986",
+    "overflow": false
+  },
+  {
+    "principal": "7402945434805909781",
+    "rate_bps": 3291,
+    "seconds": 3666154063,
+    "expected": "283228227900752887868",
+    "overflow": false
+  },
+  {
+    "principal": "14826456433437698610",
+    "rate_bps": 446,
+    "seconds": 1846828724,
+    "expected": "38725072377339141908",
+    "overflow": false
+  },
+  {
+    "principal": "8729721767213101811",
+    "rate_bps": 685,
+    "seconds": 2395030365,
+    "expected": "45414589252526114853",
+    "overflow": false
+  },
+  {
+    "principal": "17127426223508323240",
+    "rate_bps": 5133,
+    "seconds": 2791276826,
+    "expected": "778143461837610851430",
+    "overflow": false
+  },
+  {
+    "principal": "18416392147354720481",
+    "rate_bps": 9061,
+    "seconds": 2428968699,
+    "expected": "1285274809469959982235",
+    "overflow": false
+  },
+  {
+    "principal": "1816745781858498670",
+    "rate_bps": 5651,
+    "seconds": 2585878352,
+    "expected": "84182331804988931128",
+    "overflow": false
+  },
+  {
+    "principal": "1604428218631058015",
+    "rate_bps": 7636,
+    "seconds": 1305950377,
+    "expected": "50734838191466088674",
+    "overflow": false
+  },
+  {
+    "principal": "17351601040003517956",
+    "rate_bps": 4852,
+    "seconds": 1085481686,
+    "expected": "289785225380707475617",
+    "overflow": false
+  },
+  {
+    "principal": "11780370903806429933",
+    "rate_bps": 1736,
+    "seconds": 1816283111,
+    "expected": "117783816613804542699",
+    "overflow": false
+  },
+  {
+    "principal": "15130122946970697194",
+    "rate_bps": 3125,
+    "seconds": 3883952428,
+    "expected": "582317408634431231484",
+    "overflow": false
+  },
+  {
+    "principal": "14299658096505704971",
+    "rate_bps": 7920,
+    "seconds": 2552367157,
+    "expected": "916615877854687845073",
+    "overflow": false
+  },
+  {
+    "principal": "3992285059713220000",
+    "rate_bps": 5905,
+    "seconds": 1643488210,
+    "expected": "122857431456304366809",
+    "overflow": false
+  },
+  {
+    "principal": "16685797534082562873",
+    "rate_bps": 5743,
+    "seconds": 2172328211,
+    "expected": "660092230658314349197",
+    "overflow": false
+  },
+  {
+    "principal": "16531982133553157798",
+    "rate_bps": 2193,
+    "seconds": 3941300296,
+    "expected": "453102520375546742731",
+    "overflow": false
+  },
+  {
+    "principal": "9625470033876442615",
+    "rate_bps": 3412,
+    "seconds": 1056955905,
+    "expected": "110073108501679812546",
+    "overflow": false
+  },
+  {
+    "principal": "7127562594173912700",
+    "rate_bps": 5324,
+    "seconds": 2082938894,
+    "expected": "250639207871933669829",
+    "overflow": false
+  },
+  {
+    "principal": "7673256724183455173",
+    "rate_bps": 1214,
+    "seconds": 4209794687,
+    "expected": "124351985549206634565",
+    "overflow": false
+  },
+  {
+    "principal": "5379343764131159714",
+    "rate_bps": 9280,
+    "seconds": 4157065380,
+    "expected": "658047923024522947705",
+    "overflow": false
+  },
+  {
+    "principal": "13747198186068582947",
+    "rate_bps": 3063,
+    "seconds": 2410882573,
+    "expected": "321907163485461635539",
+    "overflow": false
+  },
+  {
+    "principal": "1480066363683153048",
+    "rate_bps": 9977,
+    "seconds": 2092495754,
+    "expected": "97980384535370165965",
+    "overflow": false
+  },
+  {
+    "principal": "5772748321555596945",
+    "rate_bps": 1627,
+    "seconds": 410199083,
+    "expected": "12216822242707106689",
+    "overflow": false
+  },
+  {
+    "principal": "9157279586321248734",
+    "rate_bps": 4829,
+    "seconds": 1921111616,
+    "expected": "269382680789262571240",
+    "overflow": false
+  },
+  {
+    "principal": "13184393085171526287",
+    "rate_bps": 980,
+    "seconds": 2238614617,
+    "expected": "91718923056836411099",
+    "overflow": false
+  },
+  {
+    "principal": "15531759877570647028",
+    "rate_bps": 3986,
+    "seconds": 2450111046,
+    "expected": "480991191810197309156",
+    "overflow": false
+  },
+  {
+    "principal": "2505644564245903773",
+    "rate_bps": 7808,
+    "seconds": 2398795287,
+    "expected": "148814705496996368731",
+    "overflow": false
+  },
+  {
+    "principal": "11445929661422496858",
+    "rate_bps": 6616,
+    "seconds": 1076452636,
+    "expected": "258484727437996091497",
+    "overflow": false
+  },
+  {
+    "principal": "3313135033105630011",
+    "rate_bps": 5270,
+    "seconds": 4188077285,
+    "expected": "231877085161385913014",
+    "overflow": false
+  },
+  {
+    "principal": "17605534828062740624",
+    "rate_bps": 4195,
+    "seconds": 1143033922,
+    "expected": "267690956940579304842",
+    "overflow": false
+  },
+  {
+    "principal": "4836088669880015593",
+    "rate_bps": 5588,
+    "seconds": 2489884739,
+    "expected": "213365053471490721983",
+    "overflow": false
+  },
+  {
+    "principal": "407696854831852054",
+    "rate_bps": 8925,
+    "seconds": 256727352,
+    "expected": "2962177782820934214",
+    "overflow": false
+  },
+  {
+    "principal": "3604961384847833127",
+    "rate_bps": 7361,
+    "seconds": 3196167089,
+    "expected": "268943035969155447129",
+    "overflow": false
+  },
+  {
+    "principal": "17023457172071847532",
+    "rate_bps": 6595,
+    "seconds": 3165442430,
+    "expected": "1126912963410241708661",
+    "overflow": false
+  },
+  {
+    "principal": "6611332121263593077",
+    "rate_bps": 304,
+    "seconds": 600354479,
+    "expected": "3826165102586819666",
+    "overflow": false
+  },
+  {
+    "principal": "12102333220481271570",
+    "rate_bps": 8338,
+    "seconds": 1981286036,
+    "expected": "633974177545598609382",
+    "overflow": false
+  },
+  {
+    "principal": "8415233122505332051",
+    "rate_bps": 2390,
+    "seconds": 3487296701,
+    "expected": "222405920687336593816",
+    "overflow": false
+  },
+  {
+    "principal": "8618092215081820552",
+    "rate_bps": 9234,
+    "seconds": 1513789946,
+    "expected": "381997056619946189682",
+    "overflow": false
+  },
+  {
+    "principal": "2137088181040420929",
+    "rate_bps": 1959,
+    "seconds": 1169747291,
+    "expected": "15528958153456030373",
+    "overflow": false
+  },
+  {
+    "principal": "17885530546048622414",
+    "rate_bps": 6318,
+    "seconds": 564846896,
+    "expected": "202397707231695836295",
+    "overflow": false
+  },
+  {
+    "principal": "16114138526158153407",
+    "rate_bps": 86,
+    "seconds": 102466569,
+    "expected": "450278417986708126",
+    "overflow": false
+  },
+  {
+    "principal": "11859604989607095780",
+    "rate_bps": 7428,
+    "seconds": 3937813942,
+    "expected": "1099994983425860588629",
+    "overflow": false
+  },
+  {
+    "principal": "7360802222415088717",
+    "rate_bps": 4236,
+    "seconds": 1763027015,
+    "expected": "174314478275381031314",
+    "overflow": false
+  },
+  {
+    "principal": "6820198313602862794",
+    "rate_bps": 325,
+    "seconds": 2461705484,
+    "expected": "17302539532385872399",
+    "overflow": false
+  },
+  {
+    "principal": "11362970133389867115",
+    "rate_bps": 9690,
+    "seconds": 4153955733,
+    "expected": "1450343588492136993164",
+    "overflow": false
+  },
+  {
+    "principal": "2395543027987543936",
+    "rate_bps": 9247,
+    "seconds": 690270386,
+    "expected": "48486124051552047754",
+    "overflow": false
+  },
+  {
+    "principal": "11902821658674388633",
+    "rate_bps": 6474,
+    "seconds": 400911219,
+    "expected": "97963484498392930090",
+    "overflow": false
+  },
+  {
+    "principal": "13152325340870766982",
+    "rate_bps": 2649,
+    "seconds": 594234920,
+    "expected": "65650201580355729956",
+    "overflow": false
+  },
+  {
+    "principal": "14575867027346560599",
+    "rate_bps": 298,
+    "seconds": 4095905121,
+    "expected": "56414915598986871291",
+    "overflow": false
+  },
+  {
+    "principal": "3282793652548696668",
+    "rate_bps": 3770,
+    "seconds": 1520432878,
+    "expected": "59668563235233688010",
+    "overflow": false
+  },
+  {
+    "principal": "610995796766882597",
+    "rate_bps": 4165,
+    "seconds": 2491744991,
+    "expected": "20107135995759969192",
+    "overflow": false
+  },
+  {
+    "principal": "7364932253002015618",
+    "rate_bps": 410,
+    "seconds": 1382815876,
+    "expected": "13240682237751809681",
+    "overflow": false
+  },
+  {
+    "principal": "9888845400262397059",
+    "rate_bps": 5606,
+    "seconds": 1187944301,
+    "expected": "208827722573586473299",
+    "overflow": false
+  },
+  {
+    "principal": "6737359764067988088",
+    "rate_bps": 2963,
+    "seconds": 647197802,
+    "expected": "40968665423111250348",
+    "overflow": false
+  },
+  {
+    "principal": "4736157010171891185",
+    "rate_bps": 6975,
+    "seconds": 722696843,
+    "expected": "75704179006356937820",
+    "overflow": false
+  },
+  {
+    "principal": "15335259490581086398",
+    "rate_bps": 5203,
+    "seconds": 2404614176,
+    "expected": "608392359329902737738",
+    "overflow": false
+  },
+  {
+    "principal": "15289038366226835183",
+    "rate_bps": 8755,
+    "seconds": 704716729,
+    "expected": "299119203106957790512",
+    "overflow": false
+  },
+  {
+    "principal": "18395803950361336788",
+    "rate_bps": 4009,
+    "seconds": 104318246,
+    "expected": "24395431156338841232",
+    "overflow": false
+  },
+  {
+    "principal": "6653029109249147645",
+    "rate_bps": 3003,
+    "seconds": 1126047351,
+    "expected": "71338636133946805526",
+    "overflow": false
+  },
+  {
+    "principal": "10935331757923427642",
+    "rate_bps": 8400,
+    "seconds": 70992124,
+    "expected": "20678299075256718811",
+    "overflow": false
+  },
+  {
+    "principal": "14683176724896346523",
+    "rate_bps": 6827,
+    "seconds": 431690309,
+    "expected": "137219433220579995620",
+    "overflow": false
+  },
+  {
+    "principal": "2934122178641326704",
+    "rate_bps": 7800,
+    "seconds": 3880699170,
+    "expected": "281628218309200623064",
+    "overflow": false
+  },
+  {
+    "principal": "3428574593992230473",
+    "rate_bps": 5333,
+    "seconds": 2106358435,
+    "expected": "122126765654384066321",
+    "overflow": false
+  },
+  {
+    "principal": "9988917854613728502",
+    "rate_bps": 8362,
+    "seconds": 412899096,
+    "expected": "109361870568868266143",
+    "overflow": false
+  },
+  {
+    "principal": "9638994276906940551",
+    "rate_bps": 8495,
+    "seconds": 1881512721,
+    "expected": "488534971208294999376",
+    "overflow": false
+  },
+  {
+    "principal": "10135424614228439628",
+    "rate_bps": 7135,
+    "seconds": 3726610526,
+    "expected": "854561503288872648368",
+    "overflow": false
+  },
+  {
+    "principal": "17975111741839279061",
+    "rate_bps": 8711,
+    "seconds": 1791777551,
+    "expected": "889645726064266540292",
+    "overflow": false
+  },
+  {
+    "principal": "8150496411427468274",
+    "rate_bps": 5026,
+    "seconds": 2842361460,
+    "expected": "369214920971020897582",
+    "overflow": false
+  },
+  {
+    "principal": "8775341820557510579",
+    "rate_bps": 1578,
+    "seconds": 2019436061,
+    "expected": "88673641026812499253",
+    "overflow": false
+  },
+  {
+    "principal": "690806682917115752",
+    "rate_bps": 6384,
+    "seconds": 45253338,
+    "expected": "632839270297722931",
+    "overflow": false
+  },
+  {
+    "principal": "12398787988443932577",
+    "rate_bps": 5690,
+    "seconds": 2772290491,
+    "expected": "620188385366690360370",
+    "overflow": false
+  },
+  {
+    "principal": "15406058341250438702",
+    "rate_bps": 8485,
+    "seconds": 846377744,
+    "expected": "350833464929786253418",
+    "overflow": false
+  },
+  {
+    "principal": "6577178805477436191",
+    "rate_bps": 8736,
+    "seconds": 1669488489,
+    "expected": "304178907711227043585",
+    "overflow": false
+  },
+  {
+    "principal": "11233612314911727044",
+    "rate_bps": 9823,
+    "seconds": 3578607766,
+    "expected": "1252192415562870456470",
+    "overflow": false
+  },
+  {
+    "principal": "9649814530323832237",
+    "rate_bps": 2026,
+    "seconds": 1541347495,
+    "expected": "95554767760179607318",
+    "overflow": false
+  },
+  {
+    "principal": "2129257214337920938",
+    "rate_bps": 7315,
+    "seconds": 1693593836,
+    "expected": "83645987999964880371",
+    "overflow": false
+  },
+  {
+    "principal": "4070428499118862027",
+    "rate_bps": 3356,
+    "seconds": 3422302965,
+    "expected": "148242909163074954295",
+    "overflow": false
+  },
+  {
+    "principal": "15994886961128866144",
+    "rate_bps": 107,
+    "seconds": 3324939666,
+    "expected": "18044386256329470092",
+    "overflow": false
+  },
+  {
+    "principal": "18381764601408377337",
+    "rate_bps": 4833,
+    "seconds": 2570636755,
+    "expected": "724165950975920857789",
+    "overflow": false
+  },
+  {
+    "principal": "11292551140413955174",
+    "rate_bps": 9358,
+    "seconds": 3883365384,
+    "expected": "1301297978017732133842",
+    "overflow": false
+  },
+  {
+    "principal": "1295793432033156791",
+    "rate_bps": 1714,
+    "seconds": 3004026049,
+    "expected": "21156493029716907187",
+    "overflow": false
+  },
+  {
+    "principal": "8377004096833273404",
+    "rate_bps": 9143,
+    "seconds": 3163200974,
+    "expected": "768241256848879445177",
+    "overflow": false
+  },
+  {
+    "principal": "1020669750121099397",
+    "rate_bps": 9237,
+    "seconds": 3532240703,
+    "expected": "105599015931468300405",
+    "overflow": false
+  },
+  {
+    "principal": "5170632794550827106",
+    "rate_bps": 1583,
+    "seconds": 989575268,
+    "expected": "25684246948781725882",
+    "overflow": false
+  },
+  {
+    "principal": "18083218446448101091",
+    "rate_bps": 1145,
+    "seconds": 614308045,
+    "expected": "40333026458528549437",
+    "overflow": false
+  },
+  {
+    "principal": "17550080759362621528",
+    "rate_bps": 8359,
+    "seconds": 3100034378,
+    "expected": "1442093261670995834366",
+    "overflow": false
+  },
+  {
+    "principal": "13095799191216186705",
+    "rate_bps": 1441,
+    "seconds": 2335367403,
+    "expected": "139747676213861830289",
+    "overflow": false
+  },
+  {
+    "principal": "7596755751703715742",
+    "rate_bps": 4263,
+    "seconds": 20937216,
+    "expected": "2150085956423651204",
+    "overflow": false
+  },
+  {
+    "principal": "13780412489232937807",
+    "rate_bps": 4940,
+    "seconds": 3980542745,
+    "expected": "859260507128964968104",
+    "overflow": false
+  },
+  {
+    "principal": "11793422351660725172",
+    "rate_bps": 7677,
+    "seconds": 3992297478,
+    "expected": "1146166418827908753142",
+    "overflow": false
+  },
+  {
+    "principal": "4528603709637499997",
+    "rate_bps": 1243,
+    "seconds": 409179863,
+    "expected": "7303702792824136502",
+    "overflow": false
+  },
+  {
+    "principal": "11028197530123939354",
+    "rate_bps": 3496,
+    "seconds": 543585500,
+    "expected": "66456462032962672750",
+    "overflow": false
+  },
+  {
+    "principal": "4986900102995980283",
+    "rate_bps": 6622,
+    "seconds": 244234149,
+    "expected": "25575234548335318712",
+    "overflow": false
+  },
+  {
+    "principal": "10223931308357297232",
+    "rate_bps": 599,
+    "seconds": 4002613762,
+    "expected": "77728774878829200040",
+    "overflow": false
+  },
+  {
+    "principal": "10890840670598152617",
+    "rate_bps": 8123,
+    "seconds": 3506791683,
+    "expected": "983742011487986296297",
+    "overflow": false
+  },
+  {
+    "principal": "15628291529686499286",
+    "rate_bps": 5830,
+    "seconds": 2144576760,
+    "expected": "619605190386228789097",
+    "overflow": false
+  },
+  {
+    "principal": "5668279155021220071",
+    "rate_bps": 1040,
+    "seconds": 3718128241,
+    "expected": "69502804275501826205",
+    "overflow": false
+  },
+  {
+    "principal": "15639661037824679468",
+    "rate_bps": 4682,
+    "seconds": 3363839806,
+    "expected": "781065480064593445500",
+    "overflow": false
+  },
+  {
+    "principal": "2851691435206558005",
+    "rate_bps": 7549,
+    "seconds": 904402799,
+    "expected": "61737245298125660494",
+    "overflow": false
+  },
+  {
+    "principal": "16479760820820947154",
+    "rate_bps": 9406,
+    "seconds": 1514489428,
+    "expected": "744415689398759268676",
+    "overflow": false
+  },
+  {
+    "principal": "9905343587419982355",
+    "rate_bps": 5634,
+    "seconds": 4158648189,
+    "expected": "735922297979467533524",
+    "overflow": false
+  },
+  {
+    "principal": "8616423034558127432",
+    "rate_bps": 1517,
+    "seconds": 742341562,
+    "expected": "30768743637029248070",
+    "overflow": false
+  },
+  {
+    "principal": "14803276437354202881",
+    "rate_bps": 3570,
+    "seconds": 3727538715,
+    "expected": "624657014598660820530",
+    "overflow": false
+  },
+  {
+    "principal": "14946578901419924750",
+    "rate_bps": 4018,
+    "seconds": 1630590192,
+    "expected": "310520266526283698116",
+    "overflow": false
+  },
+  {
+    "principal": "2679935427184426879",
+    "rate_bps": 7293,
+    "seconds": 2049166025,
+    "expected": "126999228645514073296",
+    "overflow": false
+  },
+  {
+    "principal": "13099431904787619236",
+    "rate_bps": 839,
+    "seconds": 4218420086,
+    "expected": "147013643739560293026",
+    "overflow": false
+  },
+  {
+    "principal": "11002404159118130957",
+    "rate_bps": 1938,
+    "seconds": 871799047,
+    "expected": "58945567043052728424",
+    "overflow": false
+  },
+  {
+    "principal": "5778234941363839114",
+    "rate_bps": 615,
+    "seconds": 761203916,
+    "expected": "8577578846190143326",
+    "overflow": false
+  },
+  {
+    "principal": "14674320289151710507",
+    "rate_bps": 7339,
+    "seconds": 635805781,
+    "expected": "217126457684727487121",
+    "overflow": false
+  },
+  {
+    "principal": "14508285928713739072",
+    "rate_bps": 5977,
+    "seconds": 3666557554,
+    "expected": "1008210605345163292369",
+    "overflow": false
+  },
+  {
+    "principal": "3364522869583861081",
+    "rate_bps": 7638,
+    "seconds": 1296908339,
+    "expected": "105683165839511939769",
+    "overflow": false
+  },
+  {
+    "principal": "13001817367670691654",
+    "rate_bps": 1863,
+    "seconds": 3100109288,
+    "expected": "238115306505590575891",
+    "overflow": false
+  },
+  {
+    "principal": "2469469214258083607",
+    "rate_bps": 5208,
+    "seconds": 1624874017,
+    "expected": "66265530484046607214",
+    "overflow": false
+  },
+  {
+    "principal": "4176912709395239452",
+    "rate_bps": 1316,
+    "seconds": 2715751598,
+    "expected": "47336345423213364410",
+    "overflow": false
+  },
+  {
+    "principal": "16014075519736116709",
+    "rate_bps": 5490,
+    "seconds": 1834122143,
+    "expected": "511323630461117852608",
+    "overflow": false
+  },
+  {
+    "principal": "6893250184210685250",
+    "rate_bps": 783,
+    "seconds": 3719211076,
+    "expected": "63654633613690685452",
+    "overflow": false
+  },
+  {
+    "principal": "1006545341394768195",
+    "rate_bps": 6996,
+    "seconds": 985147949,
+    "expected": "21997736447993793010",
+    "overflow": false
+  },
+  {
+    "principal": "18029386371489349176",
+    "rate_bps": 3019,
+    "seconds": 3385517610,
+    "expected": "584335846241180978456",
+    "overflow": false
+  },
+  {
+    "principal": "11500626032314207409",
+    "rate_bps": 9582,
+    "seconds": 4188624715,
+    "expected": "1463667710802266237537",
+    "overflow": false
+  },
+  {
+    "principal": "18222786478405127806",
+    "rate_bps": 2100,
+    "seconds": 385729504,
+    "expected": "46806948942819460252",
+    "overflow": false
+  },
+  {
+    "principal": "14720794602534539183",
+    "rate_bps": 8198,
+    "seconds": 3846829689,
+    "expected": "1472093921063867713636",
+    "overflow": false
+  },
+  {
+    "principal": "1011846708161338260",
+    "rate_bps": 7994,
+    "seconds": 775637734,
+    "expected": "19894415728252524089",
+    "overflow": false
+  },
+  {
+    "principal": "11212434018192180669",
+    "rate_bps": 3122,
+    "seconds": 4028833591,
+    "expected": "447203837477275706342",
+    "overflow": false
+  },
+  {
+    "principal": "495274630900303610",
+    "rate_bps": 8229,
+    "seconds": 4259510460,
+    "expected": "55048593537462703042",
+    "overflow": false
+  },
+  {
+    "principal": "8174335782910066267",
+    "rate_bps": 738,
+    "seconds": 1253305605,
+    "expected": "23975032820137170079",
+    "overflow": false
+  },
+  {
+    "principal": "6617844913428407856",
+    "rate_bps": 9501,
+    "seconds": 3311804130,
+    "expected": "660304017973227679044",
+    "overflow": false
+  },
+  {
+    "principal": "11709188243486870793",
+    "rate_bps": 3450,
+    "seconds": 682319715,
+    "expected": "87403172402529576946",
+    "overflow": false
+  },
+  {
+    "principal": "7776861583274697398",
+    "rate_bps": 5014,
+    "seconds": 1084965592,
+    "expected": "134152279741377607991",
+    "overflow": false
+  },
+  {
+    "principal": "8286625450359482695",
+    "rate_bps": 2855,
+    "seconds": 2919446993,
+    "expected": "219016991740544915344",
+    "overflow": false
+  },
+  {
+    "principal": "18093129846410205708",
+    "rate_bps": 1736,
+    "seconds": 633765406,
+    "expected": "63122667501111905654",
+    "overflow": false
+  },
+  {
+    "principal": "5899687707903430293",
+    "rate_bps": 4111,
+    "seconds": 4017349583,
+    "expected": "308965166145062246014",
+    "overflow": false
+  },
+  {
+    "principal": "18043671467232935346",
+    "rate_bps": 9996,
+    "seconds": 249486900,
+    "expected": "142689592691362419416",
+    "overflow": false
+  },
+  {
+    "principal": "15461700072702762099",
+    "rate_bps": 2442,
+    "seconds": 2180597981,
+    "expected": "261078977326385480825",
+    "overflow": false
+  },
+  {
+    "principal": "11297115337662657320",
+    "rate_bps": 1940,
+    "seconds": 4149789850,
+    "expected": "288395706022554943736",
+    "overflow": false
+  },
+  {
+    "principal": "10589136923466167905",
+    "rate_bps": 3845,
+    "seconds": 3277895803,
+    "expected": "423199791844466365217",
+    "overflow": false
+  },
+  {
+    "principal": "17061413054748816366",
+    "rate_bps": 5141,
+    "seconds": 916276944,
+    "expected": "254848893861068780784",
+    "overflow": false
+  },
+  {
+    "principal": "13959585871297389535",
+    "rate_bps": 1741,
+    "seconds": 3793208873,
+    "expected": "292328700876157465323",
+    "overflow": false
+  },
+  {
+    "principal": "12431675846387871108",
+    "rate_bps": 7009,
+    "seconds": 2887159382,
+    "expected": "797718914710666108444",
+    "overflow": false
+  },
+  {
+    "principal": "14420827065928986733",
+    "rate_bps": 237,
+    "seconds": 1152657767,
+    "expected": "12492009014501926775",
+    "overflow": false
+  },
+  {
+    "principal": "13065676542209679722",
+    "rate_bps": 4082,
+    "seconds": 1866021036,
+    "expected": "315583894425676964382",
+    "overflow": false
+  },
+  {
+    "principal": "14326491722072181643",
+    "rate_bps": 5469,
+    "seconds": 1508679093,
+    "expected": "374833192286758958237",
+    "overflow": false
+  },
+  {
+    "principal": "17404586900967458080",
+    "rate_bps": 450,
+    "seconds": 464697170,
+    "expected": "11540899369147614200",
+    "overflow": false
+  },
+  {
+    "principal": "17989318565659764921",
+    "rate_bps": 2495,
+    "seconds": 2684011155,
+    "expected": "381999656247441417464",
+    "overflow": false
+  },
+  {
+    "principal": "15450736938756186662",
+    "rate_bps": 8001,
+    "seconds": 2366943176,
+    "expected": "927843423095009029887",
+    "overflow": false
+  },
+  {
+    "principal": "13826244609361485687",
+    "rate_bps": 3252,
+    "seconds": 3869113217,
+    "expected": "551644895770150213121",
+    "overflow": false
+  },
+  {
+    "principal": "11407629588084733436",
+    "rate_bps": 6484,
+    "seconds": 3734330254,
+    "expected": "875879845989066751834",
+    "overflow": false
+  },
+  {
+    "principal": "12747367086456179525",
+    "rate_bps": 5746,
+    "seconds": 20402175,
+    "expected": "4738664652919160243",
+    "overflow": false
+  },
+  {
+    "principal": "13870496731885146658",
+    "rate_bps": 5505,
+    "seconds": 2596071460,
+    "expected": "628578284699058245523",
+    "overflow": false
+  },
+  {
+    "principal": "383989638474902435",
+    "rate_bps": 1925,
+    "seconds": 1589005197,
+    "expected": "3724508331515520079",
+    "overflow": false
+  },
+  {
+    "principal": "2538801429254945816",
+    "rate_bps": 1980,
+    "seconds": 2216154890,
+    "expected": "35325427639272665236",
+    "overflow": false
+  },
+  {
+    "principal": "6312047851939054609",
+    "rate_bps": 9052,
+    "seconds": 3679378859,
+    "expected": "666626739005600472434",
+    "overflow": false
+  },
+  {
+    "principal": "118307160915660126",
+    "rate_bps": 5304,
+    "seconds": 323378624,
+    "expected": "643456584952957237",
+    "overflow": false
+  },
+  {
+    "principal": "18082452944154278927",
+    "rate_bps": 1705,
+    "seconds": 2888841689,
+    "expected": "282422220183579106511",
+    "overflow": false
+  },
+  {
+    "principal": "14414118432102503284",
+    "rate_bps": 6360,
+    "seconds": 50630,
+    "expected": "14717922853698453",
+    "overflow": false
+  },
+  {
+    "principal": "14503361560353013533",
+    "rate_bps": 8127,
+    "seconds": 263501719,
+    "expected": "98486290362319686228",
+    "overflow": false
+  },
+  {
+    "principal": "2893006712915275738",
+    "rate_bps": 5005,
+    "seconds": 3119041692,
+    "expected": "143208269301297541070",
+    "overflow": false
+  },
+  {
+    "principal": "15375619417431923899",
+    "rate_bps": 609,
+    "seconds": 2227352165,
+    "expected": "66135127445961814979",
+    "overflow": false
+  },
+  {
+    "principal": "5568482044975642640",
+    "rate_bps": 9717,
+    "seconds": 3946841026,
+    "expected": "677192365511911100013",
+    "overflow": false
+  },
+  {
+    "principal": "13028023898634938473",
+    "rate_bps": 9515,
+    "seconds": 1112959427,
+    "expected": "437481874858207934286",
+    "overflow": false
+  },
+  {
+    "principal": "10526486460206339478",
+    "rate_bps": 1900,
+    "seconds": 3403362488,
+    "expected": "215843332646187547521",
+    "overflow": false
+  },
+  {
+    "principal": "1226408692873845159",
+    "rate_bps": 465,
+    "seconds": 2355945777,
+    "expected": "4260365477854784549",
+    "overflow": false
+  },
+  {
+    "principal": "16908570154248922604",
+    "rate_bps": 2573,
+    "seconds": 1944759550,
+    "expected": "268290920695575895947",
+    "overflow": false
+  },
+  {
+    "principal": "688905508053052405",
+    "rate_bps": 3190,
+    "seconds": 3855073327,
+    "expected": "26864352435472704932",
+    "overflow": false
+  },
+  {
+    "principal": "5336747731152444050",
+    "rate_bps": 4394,
+    "seconds": 2171586068,
+    "expected": "161475696512040600023",
+    "overflow": false
+  },
+  {
+    "principal": "17593272973483392723",
+    "rate_bps": 6518,
+    "seconds": 239219261,
+    "expected": "86986235194821750303",
+    "overflow": false
+  },
+  {
+    "principal": "2860552426475723016",
+    "rate_bps": 3074,
+    "seconds": 410459514,
+    "expected": "11445044733559110889",
+    "overflow": false
+  },
+  {
+    "principal": "27920859695494593",
+    "rate_bps": 6483,
+    "seconds": 3417229019,
+    "expected": "1961427620468317973",
+    "overflow": false
+  },
+  {
+    "principal": "3217496938869824206",
+    "rate_bps": 4996,
+    "seconds": 795871408,
+    "expected": "40567371383796894121",
+    "overflow": false
+  },
+  {
+    "principal": "1930766917687597119",
+    "rate_bps": 7419,
+    "seconds": 3077984649,
+    "expected": "139808978485500481080",
+    "overflow": false
+  },
+  {
+    "principal": "13162906346626207076",
+    "rate_bps": 1223,
+    "seconds": 2318987574,
+    "expected": "118377745054984738686",
+    "overflow": false
+  },
+  {
+    "principal": "15007812627663532493",
+    "rate_bps": 7279,
+    "seconds": 1164954055,
+    "expected": "403544384951795088454",
+    "overflow": false
+  },
+  {
+    "principal": "2576487835682648650",
+    "rate_bps": 5426,
+    "seconds": 1639494796,
+    "expected": "72679397991442047876",
+    "overflow": false
+  },
+  {
+    "principal": "7002304348070654443",
+    "rate_bps": 8255,
+    "seconds": 11086613,
+    "expected": "2032124638882891563",
+    "overflow": false
+  },
+  {
+    "principal": "12491044051052429056",
+    "rate_bps": 97,
+    "seconds": 1394410546,
+    "expected": "5357405583675141866",
+    "overflow": false
+  },
+  {
+    "principal": "12744476812372872217",
+    "rate_bps": 174,
+    "seconds": 555308275,
+    "expected": "3904800030426789792",
+    "overflow": false
+  },
+  {
+    "principal": "3797269556363197702",
+    "rate_bps": 2068,
+    "seconds": 3457533352,
+    "expected": "86095753845385843962",
+    "overflow": false
+  },
+  {
+    "principal": "130493892185397207",
+    "rate_bps": 9539,
+    "seconds": 829614817,
+    "expected": "3274635206115146365",
+    "overflow": false
+  },
+  {
+    "principal": "6820116807875389916",
+    "rate_bps": 1867,
+    "seconds": 447050350,
+    "expected": "18050363953592535682",
+    "overflow": false
+  },
+  {
+    "principal": "3446424299622576293",
+    "rate_bps": 1132,
+    "seconds": 244331615,
+    "expected": "3022652555477852759",
+    "overflow": false
+  },
+  {
+    "principal": "13898627220911871746",
+    "rate_bps": 9929,
+    "seconds": 106854404,
+    "expected": "46758787051596350829",
+    "overflow": false
+  },
+  {
+    "principal": "13333169518728484355",
+    "rate_bps": 8409,
+    "seconds": 707788013,
+    "expected": "251636913456148778914",
+    "overflow": false
+  },
+  {
+    "principal": "13708960627639290360",
+    "rate_bps": 2205,
+    "seconds": 2787481578,
+    "expected": "267188967601387005688",
+    "overflow": false
+  },
+  {
+    "principal": "5702696023480224625",
+    "rate_bps": 314,
+    "seconds": 956003339,
+    "expected": "5428285394727368032",
+    "overflow": false
+  },
+  {
+    "principal": "12134444243231136830",
+    "rate_bps": 4961,
+    "seconds": 751912864,
+    "expected": "143532426038959000214",
+    "overflow": false
+  },
+  {
+    "principal": "16972059123495041135",
+    "rate_bps": 2281,
+    "seconds": 1611468089,
+    "expected": "197822152990064278124",
+    "overflow": false
+  },
+  {
+    "principal": "2475312127727835988",
+    "rate_bps": 50,
+    "seconds": 4030599334,
+    "expected": "1581841611723417469",
+    "overflow": false
+  },
+  {
+    "principal": "8500121525669644413",
+    "rate_bps": 6496,
+    "seconds": 544235511,
+    "expected": "95290898058167271891",
+    "overflow": false
+  },
+  {
+    "principal": "752776438054578362",
+    "rate_bps": 3953,
+    "seconds": 632287356,
+    "expected": "5966240032324033071",
+    "overflow": false
+  },
+  {
+    "principal": "491687253271005979",
+    "rate_bps": 150,
+    "seconds": 3075672005,
+    "expected": "719305898069338740",
+    "overflow": false
+  },
+  {
+    "principal": "3519953213749172720",
+    "rate_bps": 7944,
+    "seconds": 4086872226,
+    "expected": "362376961768348522897",
+    "overflow": false
+  },
+  {
+    "principal": "6961196630609646537",
+    "rate_bps": 647,
+    "seconds": 4292772899,
+    "expected": "61308330313285798176",
+    "overflow": false
+  },
+  {
+    "principal": "13167392047364118646",
+    "rate_bps": 3964,
+    "seconds": 35352216,
+    "expected": "5851179850643869432",
+    "overflow": false
+  },
+  {
+    "principal": "9774811767574059527",
+    "rate_bps": 6618,
+    "seconds": 670242961,
+    "expected": "137486741950058581295",
+    "overflow": false
+  },
+  {
+    "principal": "2860767145937584588",
+    "rate_bps": 1587,
+    "seconds": 82095070,
+    "expected": "1181870538847099045",
+    "overflow": false
+  },
+  {
+    "principal": "16720283185724971349",
+    "rate_bps": 567,
+    "seconds": 1262201999,
+    "expected": "37944509595738963109",
+    "overflow": false
+  },
+  {
+    "principal": "3476661615409678194",
+    "rate_bps": 9189,
+    "seconds": 2687499764,
+    "expected": "272252892226333266461",
+    "overflow": false
+  },
+  {
+    "principal": "12451789621339566387",
+    "rate_bps": 7772,
+    "seconds": 1481812893,
+    "expected": "454727614494483955283",
+    "overflow": false
+  },
+  {
+    "principal": "15021546576133983976",
+    "rate_bps": 6091,
+    "seconds": 3625076314,
+    "expected": "1051753085844084881989",
+    "overflow": false
+  },
+  {
+    "principal": "2961911172244604193",
+    "rate_bps": 1453,
+    "seconds": 300934459,
+    "expected": "4106794364965851205",
+    "overflow": false
+  },
+  {
+    "principal": "3492434485014827438",
+    "rate_bps": 4238,
+    "seconds": 3160480400,
+    "expected": "148332294483698331416",
+    "overflow": false
+  },
+  {
+    "principal": "5985524558075436191",
+    "rate_bps": 1493,
+    "seconds": 2589420777,
+    "expected": "73376678038822128571",
+    "overflow": false
+  },
+  {
+    "principal": "2664022107635727684",
+    "rate_bps": 2100,
+    "seconds": 2362385430,
+    "expected": "41908418080228066777",
+    "overflow": false
+  },
+  {
+    "principal": "11312253935651504941",
+    "rate_bps": 8891,
+    "seconds": 1367439911,
+    "expected": "436115377459594695537",
+    "overflow": false
+  },
+  {
+    "principal": "18354548989496808234",
+    "rate_bps": 2204,
+    "seconds": 4027940972,
+    "expected": "516692072342133951591",
+    "overflow": false
+  },
+  {
+    "principal": "15631917120214837323",
+    "rate_bps": 9958,
+    "seconds": 4138944629,
+    "expected": "2042995336129580974170",
+    "overflow": false
+  },
+  {
+    "principal": "14681039048541620448",
+    "rate_bps": 5322,
+    "seconds": 1581392146,
+    "expected": "391800183101796970894",
+    "overflow": false
+  },
+  {
+    "principal": "12133840544344915833",
+    "rate_bps": 3989,
+    "seconds": 2223044435,
+    "expected": "341195941322498816457",
+    "overflow": false
+  },
+  {
+    "principal": "17645914035852683238",
+    "rate_bps": 2671,
+    "seconds": 1501768584,
+    "expected": "224447336072447130721",
+    "overflow": false
+  },
+  {
+    "principal": "14988116103278272567",
+    "rate_bps": 1382,
+    "seconds": 846228033,
+    "expected": "55582220508884341927",
+    "overflow": false
+  },
+  {
+    "principal": "2007968471865191868",
+    "rate_bps": 5414,
+    "seconds": 3523696974,
+    "expected": "121469456260363390488",
+    "overflow": false
+  },
+  {
+    "principal": "17939560884756407813",
+    "rate_bps": 4976,
+    "seconds": 4189399231,
+    "expected": "1185870653518452068690",
+    "overflow": false
+  },
+  {
+    "principal": "11547733627141975010",
+    "rate_bps": 6018,
+    "seconds": 3905640420,
+    "expected": "860665888493142758708",
+    "overflow": false
+  },
+  {
+    "principal": "6894440097814679651",
+    "rate_bps": 5027,
+    "seconds": 4206706253,
+    "expected": "462320837225253101589",
+    "overflow": false
+  },
+  {
+    "principal": "5796833968517326808",
+    "rate_bps": 1220,
+    "seconds": 2188126410,
+    "expected": "49070049185360867021",
+    "overflow": false
+  },
+  {
+    "principal": "3853915950138581713",
+    "rate_bps": 711,
+    "seconds": 3213302379,
+    "expected": "27920090924448106445",
+    "overflow": false
+  },
+  {
+    "principal": "12401864653570390814",
+    "rate_bps": 7202,
+    "seconds": 2388033920,
+    "expected": "676353884727133990865",
+    "overflow": false
+  },
+  {
+    "principal": "13583495620003022031",
+    "rate_bps": 8038,
+    "seconds": 2734190745,
+    "expected": "946633241552583996266",
+    "overflow": false
+  },
+  {
+    "principal": "2146612507601285940",
+    "rate_bps": 791,
+    "seconds": 3756731270,
+    "expected": "20227101878856484951",
+    "overflow": false
+  },
+  {
+    "principal": "1160706992282771933",
+    "rate_bps": 7853,
+    "seconds": 799938647,
+    "expected": "23121088196849164538",
+    "overflow": false
+  },
+  {
+    "principal": "13680451347482669466",
+    "rate_bps": 4139,
+    "seconds": 3329254492,
+    "expected": "597772923880144929435",
+    "overflow": false
+  },
+  {
+    "principal": "7645678396940142971",
+    "rate_bps": 8125,
+    "seconds": 553446693,
+    "expected": "109020604465659929923",
+    "overflow": false
+  },
+  {
+    "principal": "12725094711565192144",
+    "rate_bps": 9060,
+    "seconds": 2246589826,
+    "expected": "821308659702664297217",
+    "overflow": false
+  },
+  {
+    "principal": "16237055207952338729",
+    "rate_bps": 1521,
+    "seconds": 1729867395,
+    "expected": "135469861722709376037",
+    "overflow": false
+  },
+  {
+    "principal": "6257291967338064726",
+    "rate_bps": 3750,
+    "seconds": 1042545784,
+    "expected": "77572219366026506407",
+    "overflow": false
+  },
+  {
+    "principal": "2642687176635214439",
+    "rate_bps": 6354,
+    "seconds": 867033073,
+    "expected": "46165976361798544097",
+    "overflow": false
+  },
+  {
+    "principal": "12743440423621848492",
+    "rate_bps": 4638,
+    "seconds": 4272716478,
+    "expected": "800783112531524884641",
+    "overflow": false
+  },
+  {
+    "principal": "3321491007407871669",
+    "rate_bps": 7974,
+    "seconds": 908568815,
+    "expected": "76306323906663281934",
+    "overflow": false
+  },
+  {
+    "principal": "13202193127156859986",
+    "rate_bps": 4514,
+    "seconds": 2371323348,
+    "expected": "448117399149689649839",
+    "overflow": false
+  },
+  {
+    "principal": "9551729584044651411",
+    "rate_bps": 9285,
+    "seconds": 3754079485,
+    "expected": "1055749254952179798617",
+    "overflow": false
+  },
+  {
+    "principal": "9367559051139601608",
+    "rate_bps": 7510,
+    "seconds": 312622906,
+    "expected": "69739778762464881869",
+    "overflow": false
+  },
+  {
+    "principal": "1724942165891376257",
+    "rate_bps": 1062,
+    "seconds": 1425806235,
+    "expected": "8282338151449622568",
+    "overflow": false
+  },
+  {
+    "principal": "4001697619195189390",
+    "rate_bps": 6575,
+    "seconds": 1109949552,
+    "expected": "92605474073435037562",
+    "overflow": false
+  },
+  {
+    "principal": "2740385120034812159",
+    "rate_bps": 3830,
+    "seconds": 2933069897,
+    "expected": "97617162670421150080",
+    "overflow": false
+  },
+  {
+    "principal": "833427873502854436",
+    "rate_bps": 1469,
+    "seconds": 4275119862,
+    "expected": "16597073051789903594",
+    "overflow": false
+  },
+  {
+    "principal": "15880268942270096525",
+    "rate_bps": 3313,
+    "seconds": 3896588935,
+    "expected": "650065735199746761881",
+    "overflow": false
+  },
+  {
+    "principal": "12528579144553513994",
+    "rate_bps": 796,
+    "seconds": 3112672332,
+    "expected": "98433218808247924264",
+    "overflow": false
+  },
+  {
+    "principal": "10563011521125002923",
+    "rate_bps": 5886,
+    "seconds": 1554183637,
+    "expected": "306410565638642221202",
+    "overflow": false
+  },
+  {
+    "principal": "2387622830423040704",
+    "rate_bps": 5520,
+    "seconds": 781848050,
+    "expected": "32675372788690948354",
+    "overflow": false
+  },
+  {
+    "principal": "10981897431616127705",
+    "rate_bps": 5489,
+    "seconds": 2718542259,
+    "expected": "519637034216183599732",
+    "overflow": false
+  },
+  {
+    "principal": "16017943474392867526",
+    "rate_bps": 1169,
+    "seconds": 2165629288,
+    "expected": "128587507207117334123",
+    "overflow": false
+  },
+  {
+    "principal": "4168009046637262999",
+    "rate_bps": 327,
+    "seconds": 3735976353,
+    "expected": "16146333455751815752",
+    "overflow": false
+  },
+  {
+    "principal": "8532090304262488476",
+    "rate_bps": 4373,
+    "seconds": 1421021230,
+    "expected": "168123677126481362611",
+    "overflow": false
+  },
+  {
+    "principal": "10332767989667867493",
+    "rate_bps": 9344,
+    "seconds": 184429855,
+    "expected": "56464323024684038515",
+    "overflow": false
+  },
+  {
+    "principal": "14752959947855810754",
+    "rate_bps": 7875,
+    "seconds": 1044088772,
+    "expected": "384645401138890205416",
+    "overflow": false
+  },
+  {
+    "principal": "15220103655744903875",
+    "rate_bps": 7072,
+    "seconds": 4059434925,
+    "expected": "1385539268963721945153",
+    "overflow": false
+  },
+  {
+    "principal": "10564815663646381496",
+    "rate_bps": 5333,
+    "seconds": 4284713386,
+    "expected": "765506137226529830180",
+    "overflow": false
+  },
+  {
+    "principal": "3514351019228400177",
+    "rate_bps": 214,
+    "seconds": 3217674443,
+    "expected": "7673516032713965352",
+    "overflow": false
+  },
+  {
+    "principal": "5167245873257441790",
+    "rate_bps": 5738,
+    "seconds": 1452149600,
+    "expected": "136528847324933816015",
+    "overflow": false
+  },
+  {
+    "principal": "13250978807393034543",
+    "rate_bps": 5133,
+    "seconds": 2601149433,
+    "expected": "561019451633886920705",
+    "overflow": false
+  },
+  {
+    "principal": "5239838624064772884",
+    "rate_bps": 1638,
+    "seconds": 67114598,
+    "expected": "1826594709951324919",
+    "overflow": false
+  },
+  {
+    "principal": "1478908530368318269",
+    "rate_bps": 6080,
+    "seconds": 2932203703,
+    "expected": "83605033296540989206",
+    "overflow": false
+  },
+  {
+    "principal": "9903453170027055738",
+    "rate_bps": 298,
+    "seconds": 3579979836,
+    "expected": "33502474858349846070",
+    "overflow": false
+  },
+  {
+    "principal": "18314550050120423387",
+    "rate_bps": 5043,
+    "seconds": 1146643077,
+    "expected": "335820240213427757750",
+    "overflow": false
+  },
+  {
+    "principal": "7312490043983646128",
+    "rate_bps": 8296,
+    "seconds": 1571197538,
+    "expected": "302244366028554320634",
+    "overflow": false
+  },
+  {
+    "principal": "12051149218691668617",
+    "rate_bps": 5858,
+    "seconds": 2716199139,
+    "expected": "608040953798558915960",
+    "overflow": false
+  },
+  {
+    "principal": "10015016210178575926",
+    "rate_bps": 3175,
+    "seconds": 1252842072,
+    "expected": "126323778761095394806",
+    "overflow": false
+  },
+  {
+    "principal": "11657352320371624647",
+    "rate_bps": 9116,
+    "seconds": 1723152209,
+    "expected": "580659148706499761304",
+    "overflow": false
+  },
+  {
+    "principal": "543366951953000844",
+    "rate_bps": 9264,
+    "seconds": 1530534302,
+    "expected": "24430267792646873809",
+    "overflow": false
+  },
+  {
+    "principal": "776980245395366933",
+    "rate_bps": 4401,
+    "seconds": 2699277647,
+    "expected": "29268623424201630843",
+    "overflow": false
+  },
+  {
+    "principal": "13056538686170829106",
+    "rate_bps": 8030,
+    "seconds": 2669567412,
+    "expected": "887519472433584131737",
+    "overflow": false
+  },
+  {
+    "principal": "8500014585359517171",
+    "rate_bps": 1842,
+    "seconds": 3895086685,
+    "expected": "193383678568456486684",
+    "overflow": false
+  },
+  {
+    "principal": "2433076866917624488",
+    "rate_bps": 418,
+    "seconds": 949946394,
+    "expected": "3063547390760540290",
+    "overflow": false
+  },
+  {
+    "principal": "17293973525383795681",
+    "rate_bps": 8611,
+    "seconds": 4155199995,
+    "expected": "1962156773145390104288",
+    "overflow": false
+  },
+  {
+    "principal": "4940567520114863982",
+    "rate_bps": 724,
+    "seconds": 427699792,
+    "expected": "4851185005446855004",
+    "overflow": false
+  },
+  {
+    "principal": "9650631650062587231",
+    "rate_bps": 9203,
+    "seconds": 2634109865,
+    "expected": "741843745480976506464",
+    "overflow": false
+  },
+  {
+    "principal": "330582490689375492",
+    "rate_bps": 2059,
+    "seconds": 2134309334,
+    "expected": "4606668390116651587",
+    "overflow": false
+  },
+  {
+    "principal": "2637199832930883053",
+    "rate_bps": 5769,
+    "seconds": 3976661735,
+    "expected": "191847269294764023372",
+    "overflow": false
+  },
+  {
+    "principal": "7508501486804927722",
+    "rate_bps": 3898,
+    "seconds": 289867820,
+    "expected": "26902243747234996617",
+    "overflow": false
+  },
+  {
+    "principal": "16926092683570431243",
+    "rate_bps": 6631,
+    "seconds": 2534421301,
+    "expected": "902002924558123382881",
+    "overflow": false
+  },
+  {
+    "principal": "5907656911091715232",
+    "rate_bps": 6951,
+    "seconds": 3382495954,
+    "expected": "440446570717101237017",
+    "overflow": false
+  },
+  {
+    "principal": "7730272181255362105",
+    "rate_bps": 6883,
+    "seconds": 1972071443,
+    "expected": "332727420002886945725",
+    "overflow": false
+  },
+  {
+    "principal": "10627789454625336742",
+    "rate_bps": 1796,
+    "seconds": 176351048,
+    "expected": "10673840587299472795",
+    "overflow": false
+  },
+  {
+    "principal": "7150066535989436663",
+    "rate_bps": 7173,
+    "seconds": 793057537,
+    "expected": "128976029756423227308",
+    "overflow": false
+  },
+  {
+    "principal": "9886352574905935228",
+    "rate_bps": 3180,
+    "seconds": 3332413198,
+    "expected": "332212105296229941895",
+    "overflow": false
+  },
+  {
+    "principal": "7040964062535483589",
+    "rate_bps": 5614,
+    "seconds": 1858290047,
+    "expected": "232922493039162290010",
+    "overflow": false
+  },
+  {
+    "principal": "5036360539675231650",
+    "rate_bps": 748,
+    "seconds": 921110436,
+    "expected": "11003313993245747865",
+    "overflow": false
+  },
+  {
+    "principal": "902508656363451683",
+    "rate_bps": 2464,
+    "seconds": 4117917965,
+    "expected": "29037763464205411732",
+    "overflow": false
+  },
+  {
+    "principal": "14331008990826976152",
+    "rate_bps": 5801,
+    "seconds": 2541992586,
+    "expected": "670111863347213884960",
+    "overflow": false
+  },
+  {
+    "principal": "4301747556815978897",
+    "rate_bps": 1755,
+    "seconds": 781948715,
+    "expected": "18719476740576358933",
+    "overflow": false
+  },
+  {
+    "principal": "6395552250890447070",
+    "rate_bps": 760,
+    "seconds": 2553275712,
+    "expected": "39353444484206578977",
+    "overflow": false
+  },
+  {
+    "principal": "7135713344413863311",
+    "rate_bps": 6400,
+    "seconds": 4066043737,
+    "expected": "588820346079783112159",
+    "overflow": false
+  },
+  {
+    "principal": "1335712648720044788",
+    "rate_bps": 8187,
+    "seconds": 3849638214,
+    "expected": "133490739468078524214",
+    "overflow": false
+  },
+  {
+    "principal": "9805255850393076893",
+    "rate_bps": 5200,
+    "seconds": 1930410263,
+    "expected": "312108276032743083256",
+    "overflow": false
+  },
+  {
+    "principal": "5639953710305014618",
+    "rate_bps": 3901,
+    "seconds": 1069366300,
+    "expected": "74605591256772980162",
+    "overflow": false
+  },
+  {
+    "principal": "13928282224601921083",
+    "rate_bps": 9316,
+    "seconds": 3892144101,
+    "expected": "1601435096496552307206",
+    "overflow": false
+  },
+  {
+    "principal": "6356603923293691792",
+    "rate_bps": 7036,
+    "seconds": 1246476098,
+    "expected": "176778046545676293161",
+    "overflow": false
+  },
+  {
+    "principal": "5203890097237947881",
+    "rate_bps": 7489,
+    "seconds": 4262802243,
+    "expected": "526793642640374324432",
+    "overflow": false
+  },
+  {
+    "principal": "16376384474294698262",
+    "rate_bps": 1308,
+    "seconds": 1735264312,
+    "expected": "117864983014610249918",
+    "overflow": false
+  },
+  {
+    "principal": "15874218024483076903",
+    "rate_bps": 9185,
+    "seconds": 2082545329,
+    "expected": "962851602696728501687",
+    "overflow": false
+  },
+  {
+    "principal": "8808064743726691692",
+    "rate_bps": 4843,
+    "seconds": 3901065342,
+    "expected": "527681155635565664338",
+    "overflow": false
+  },
+  {
+    "principal": "5018909030164005237",
+    "rate_bps": 6642,
+    "seconds": 1774703023,
+    "expected": "187597599733436501442",
+    "overflow": false
+  },
+  {
+    "principal": "16018045013995302418",
+    "rate_bps": 2893,
+    "seconds": 1606190484,
+    "expected": "236019771225253913705",
+    "overflow": false
+  },
+  {
+    "principal": "7570582120728586323",
+    "rate_bps": 1894,
+    "seconds": 2032236477,
+    "expected": "92401045418325801891",
+    "overflow": false
+  },
+  {
+    "principal": "11898811188193087624",
+    "rate_bps": 690,
+    "seconds": 1317052666,
+    "expected": "34288556216298294986",
+    "overflow": false
+  },
+  {
+    "principal": "15045909187527824193",
+    "rate_bps": 6673,
+    "seconds": 14000219,
+    "expected": "4457258105065050182",
+    "overflow": false
+  },
+  {
+    "principal": "5837364880800798286",
+    "rate_bps": 8396,
+    "seconds": 2400858160,
+    "expected": "373120548446548480022",
+    "overflow": false
+  },
+  {
+    "principal": "207747668650871231",
+    "rate_bps": 342,
+    "seconds": 2432311049,
+    "expected": "547992696769782839",
+    "overflow": false
+  },
+  {
+    "principal": "17958004241423494372",
+    "rate_bps": 2907,
+    "seconds": 16293046,
+    "expected": "2697110739243941668",
+    "overflow": false
+  },
+  {
+    "principal": "17550969299337172813",
+    "rate_bps": 4081,
+    "seconds": 2804607815,
+    "expected": "636990909022266208808",
+    "overflow": false
+  },
+  {
+    "principal": "11996472040048432586",
+    "rate_bps": 6305,
+    "seconds": 4270572556,
+    "expected": "1024278684292693830082",
+    "overflow": false
+  },
+  {
+    "principal": "10734560900116048747",
+    "rate_bps": 7126,
+    "seconds": 1318256789,
+    "expected": "319759541049296132961",
+    "overflow": false
+  },
+  {
+    "principal": "13076504288690275968",
+    "rate_bps": 3466,
+    "seconds": 1220695986,
+    "expected": "175436974259062891861",
+    "overflow": false
+  },
+  {
+    "principal": "8158122411400378777",
+    "rate_bps": 9696,
+    "seconds": 517881459,
+    "expected": "129899231065077402073",
+    "overflow": false
+  },
+  {
+    "principal": "1178491726124451974",
+    "rate_bps": 909,
+    "seconds": 797261096,
+    "expected": "2708222777536762378",
+    "overflow": false
+  },
+  {
+    "principal": "4104303088682277207",
+    "rate_bps": 9728,
+    "seconds": 558647393,
+    "expected": "70728452466215869910",
+    "overflow": false
+  },
+  {
+    "principal": "11784083003547670876",
+    "rate_bps": 838,
+    "seconds": 533196270,
+    "expected": "16696302600831964954",
+    "overflow": false
+  },
+  {
+    "principal": "973369047642760741",
+    "rate_bps": 8478,
+    "seconds": 895247839,
+    "expected": "23426511339539747737",
+    "overflow": false
+  },
+  {
+    "principal": "6138001331148425858",
+    "rate_bps": 9149,
+    "seconds": 923129732,
+    "expected": "164382937822172029690",
+    "overflow": false
+  },
+  {
+    "principal": "12650968033828593539",
+    "rate_bps": 6232,
+    "seconds": 2932499053,
+    "expected": "733132507245942413523",
+    "overflow": false
+  },
+  {
+    "principal": "5387717471606137208",
+    "rate_bps": 8639,
+    "seconds": 1497676650,
+    "expected": "221044513293037061767",
+    "overflow": false
+  },
+  {
+    "principal": "9528338828128422129",
+    "rate_bps": 7140,
+    "seconds": 2765385099,
+    "expected": "596574128502664728511",
+    "overflow": false
+  },
+  {
+    "principal": "3114081346721265598",
+    "rate_bps": 4040,
+    "seconds": 1509166880,
+    "expected": "60206305357667503025",
+    "overflow": false
+  },
+  {
+    "principal": "10158116333148899823",
+    "rate_bps": 7345,
+    "seconds": 3607231161,
+    "expected": "853438733098724033042",
+    "overflow": false
+  },
+  {
+    "principal": "16570320143634094804",
+    "rate_bps": 7212,
+    "seconds": 1631673382,
+    "expected": "618319921463519319362",
+    "overflow": false
+  },
+  {
+    "principal": "4305182688458411517",
+    "rate_bps": 1238,
+    "seconds": 3051594103,
+    "expected": "51574186926983352154",
+    "overflow": false
+  },
+  {
+    "principal": "14137278557990677562",
+    "rate_bps": 9426,
+    "seconds": 2797182972,
+    "expected": "1181972900947478036555",
+    "overflow": false
+  },
+  {
+    "principal": "7997130343621764251",
+    "rate_bps": 7366,
+    "seconds": 377748805,
+    "expected": "70560618876124333409",
+    "overflow": false
+  },
+  {
+    "principal": "18147069204428833136",
+    "rate_bps": 6735,
+    "seconds": 793750562,
+    "expected": "307624934573395041696",
+    "overflow": false
+  },
+  {
+    "principal": "5470021785369420105",
+    "rate_bps": 656,
+    "seconds": 3984690595,
+    "expected": "45339935000856017890",
+    "overflow": false
+  },
+  {
+    "principal": "183198015279875062",
+    "rate_bps": 9194,
+    "seconds": 1210025496,
+    "expected": "6462687823415891071",
+    "overflow": false
+  },
+  {
+    "principal": "15390466637982333831",
+    "rate_bps": 4619,
+    "seconds": 856266257,
+    "expected": "193019849731346124850",
+    "overflow": false
+  },
+  {
+    "principal": "3766078508064723276",
+    "rate_bps": 527,
+    "seconds": 1216792414,
+    "expected": "7657903174364597810",
+    "overflow": false
+  },
+  {
+    "principal": "4040050415016226517",
+    "rate_bps": 2392,
+    "seconds": 1395392015,
+    "expected": "42759989160426496565",
+    "overflow": false
+  },
+  {
+    "principal": "13080350425270950642",
+    "rate_bps": 4299,
+    "seconds": 2372533620,
+    "expected": "423050869970199656913",
+    "overflow": false
+  },
+  {
+    "principal": "3556965437898594995",
+    "rate_bps": 3324,
+    "seconds": 1581265181,
+    "expected": "59284172388148481834",
+    "overflow": false
+  },
+  {
+    "principal": "475822318039238248",
+    "rate_bps": 9466,
+    "seconds": 3971942874,
+    "expected": "56729335341589279658",
+    "overflow": false
+  },
+  {
+    "principal": "9530094531312181921",
+    "rate_bps": 8884,
+    "seconds": 458423995,
+    "expected": "123074050244306571614",
+    "overflow": false
+  },
+  {
+    "principal": "6569856109634653486",
+    "rate_bps": 5862,
+    "seconds": 3820257808,
+    "expected": "466538766856204687216",
+    "overflow": false
+  },
+  {
+    "principal": "13890084506229558815",
+    "rate_bps": 2680,
+    "seconds": 987069033,
+    "expected": "116514668047197315753",
+    "overflow": false
+  },
+  {
+    "principal": "11361481152646159556",
+    "rate_bps": 7195,
+    "seconds": 3406696342,
+    "expected": "883064788343555056625",
+    "overflow": false
+  },
+  {
+    "principal": "15538900887189170349",
+    "rate_bps": 2899,
+    "seconds": 3255098279,
+    "expected": "464971153612517692335",
+    "overflow": false
+  },
+  {
+    "principal": "8572910350543681194",
+    "rate_bps": 3139,
+    "seconds": 1015926764,
+    "expected": "86691275470154571775",
+    "overflow": false
+  },
+  {
+    "principal": "14129632076837102027",
+    "rate_bps": 3111,
+    "seconds": 1875074549,
+    "expected": "261362211694156003992",
+    "overflow": false
+  },
+  {
+    "principal": "461146004099731552",
+    "rate_bps": 2781,
+    "seconds": 3649221778,
+    "expected": "14839972279352484532",
+    "overflow": false
+  },
+  {
+    "principal": "14273897290018041081",
+    "rate_bps": 2662,
+    "seconds": 3789168851,
+    "expected": "456549603682315935750",
+    "overflow": false
+  },
+  {
+    "principal": "5101551831769084774",
+    "rate_bps": 7889,
+    "seconds": 2647909128,
+    "expected": "337925316558649861791",
+    "overflow": false
+  },
+  {
+    "principal": "17268136793525412279",
+    "rate_bps": 5111,
+    "seconds": 3051096001,
+    "expected": "853887443122292887875",
+    "overflow": false
+  },
+  {
+    "principal": "6418775404500393276",
+    "rate_bps": 9883,
+    "seconds": 740365518,
+    "expected": "148929438405138053607",
+    "overflow": false
+  },
+  {
+    "principal": "16720495959233026949",
+    "rate_bps": 1124,
+    "seconds": 1394711103,
+    "expected": "83117623575907047083",
+    "overflow": false
+  },
+  {
+    "principal": "8231078463956574050",
+    "rate_bps": 3378,
+    "seconds": 3603953508,
+    "expected": "317752488032765310879",
+    "overflow": false
+  },
+  {
+    "principal": "33077753224141283",
+    "rate_bps": 8783,
+    "seconds": 2341856205,
+    "expected": "2157409086706752068",
+    "overflow": false
+  },
+  {
+    "principal": "2124532825860620120",
+    "rate_bps": 2249,
+    "seconds": 3877538890,
+    "expected": "58749267554211017174",
+    "overflow": false
+  },
+  {
+    "principal": "15284994296796733521",
+    "rate_bps": 7479,
+    "seconds": 1598837739,
+    "expected": "579570935361882916882",
+    "overflow": false
+  },
+  {
+    "principal": "14118408065216337566",
+    "rate_bps": 8852,
+    "seconds": 2526185728,
+    "expected": "1001119234862743737812",
+    "overflow": false
+  },
+  {
+    "principal": "7082840127862511183",
+    "rate_bps": 637,
+    "seconds": 4212629017,
+    "expected": "60268929754957414558",
+    "overflow": false
+  },
+  {
+    "principal": "729046196823896756",
+    "rate_bps": 5515,
+    "seconds": 2824713990,
+    "expected": "36013757795088224100",
+    "overflow": false
+  },
+  {
+    "principal": "3610824117335009117",
+    "rate_bps": 3754,
+    "seconds": 345610711,
+    "expected": "14855291880049236182",
+    "overflow": false
+  },
+  {
+    "principal": "10431599741511677210",
+    "rate_bps": 1476,
+    "seconds": 1603228636,
+    "expected": "78275549819651880375",
+    "overflow": false
+  },
+  {
+    "principal": "17121478377715229435",
+    "rate_bps": 2728,
+    "seconds": 511976101,
+    "expected": "75827844252253955427",
+    "overflow": false
+  },
+  {
+    "principal": "8773986829962212176",
+    "rate_bps": 9042,
+    "seconds": 69890306,
+    "expected": "17582143320961675589",
+    "overflow": false
+  },
+  {
+    "principal": "14844969334276054185",
+    "rate_bps": 3903,
+    "seconds": 100857859,
+    "expected": "18530237851906728693",
+    "overflow": false
+  },
+  {
+    "principal": "17868636745780008662",
+    "rate_bps": 6100,
+    "seconds": 343495672,
+    "expected": "118723288492405958780",
+    "overflow": false
+  },
+  {
+    "principal": "883106738125622247",
+    "rate_bps": 3031,
+    "seconds": 1317444977,
+    "expected": "11182142280316522041",
+    "overflow": false
+  },
+  {
+    "principal": "13412510134948674860",
+    "rate_bps": 4868,
+    "seconds": 4046837310,
+    "expected": "837856746717767594879",
+    "overflow": false
+  },
+  {
+    "principal": "10501309388688256053",
+    "rate_bps": 9695,
+    "seconds": 57162351,
+    "expected": "18454179587522254555",
+    "overflow": false
+  },
+  {
+    "principal": "6173560037795026898",
+    "rate_bps": 6315,
+    "seconds": 442418516,
+    "expected": "54693500324428922132",
+    "overflow": false
+  },
+  {
+    "principal": "10232270533716139283",
+    "rate_bps": 5711,
+    "seconds": 656308861,
+    "expected": "121614633430835161390",
+    "overflow": false
+  },
+  {
+    "principal": "8103921467353730120",
+    "rate_bps": 9817,
+    "seconds": 1070744250,
+    "expected": "270117771872821943966",
+    "overflow": false
+  },
+  {
+    "principal": "15667847471885287937",
+    "rate_bps": 2514,
+    "seconds": 2516282651,
+    "expected": "314287728909361266454",
+    "overflow": false
+  },
+  {
+    "principal": "16517848764345553934",
+    "rate_bps": 4678,
+    "seconds": 1275405296,
+    "expected": "312503806715050261316",
+    "overflow": false
+  },
+  {
+    "principal": "6601464918557516415",
+    "rate_bps": 1010,
+    "seconds": 3467339209,
+    "expected": "73308007770300586857",
+    "overflow": false
+  },
+  {
+    "principal": "16989216192344628388",
+    "rate_bps": 6458,
+    "seconds": 2020561526,
+    "expected": "702970104298149133150",
+    "overflow": false
+  },
+  {
+    "principal": "8663038823993674253",
+    "rate_bps": 4268,
+    "seconds": 1290591239,
+    "expected": "151313186504191103680",
+    "overflow": false
+  },
+  {
+    "principal": "12789837331553363850",
+    "rate_bps": 1289,
+    "seconds": 981806028,
+    "expected": "51325953427049218675",
+    "overflow": false
+  },
+  {
+    "principal": "2808864460918646827",
+    "rate_bps": 9159,
+    "seconds": 725175125,
+    "expected": "59158224861126456061",
+    "overflow": false
+  },
+  {
+    "principal": "6024014270873856576",
+    "rate_bps": 8543,
+    "seconds": 3176522098,
+    "expected": "518372164025839066724",
+    "overflow": false
+  },
+  {
+    "principal": "16890927419155918937",
+    "rate_bps": 6785,
+    "seconds": 643240755,
+    "expected": "233760051260465980292",
+    "overflow": false
+  },
+  {
+    "principal": "13087999295954300486",
+    "rate_bps": 2912,
+    "seconds": 1999034600,
+    "expected": "241589657311246482883",
+    "overflow": false
+  },
+  {
+    "principal": "9398598904177408535",
+    "rate_bps": 7889,
+    "seconds": 4060895009,
+    "expected": "954773213968738374627",
+    "overflow": false
+  },
+  {
+    "principal": "1622378146693198108",
+    "rate_bps": 3675,
+    "seconds": 2342783918,
+    "expected": "44292996127850551979",
+    "overflow": false
+  },
+  {
+    "principal": "1456702215078994149",
+    "rate_bps": 6366,
+    "seconds": 2691358367,
+    "expected": "79141146578422409084",
+    "overflow": false
+  },
+  {
+    "principal": "11983132560099935298",
+    "rate_bps": 4850,
+    "seconds": 3799869252,
+    "expected": "700283911228926823320",
+    "overflow": false
+  },
+  {
+    "principal": "8623134308158235715",
+    "rate_bps": 8121,
+    "seconds": 3178034477,
+    "expected": "705710628624092662552",
+    "overflow": false
+  },
+  {
+    "principal": "14235942405862911288",
+    "rate_bps": 3262,
+    "seconds": 2005478698,
+    "expected": "295312360742827266235",
+    "overflow": false
+  },
+  {
+    "principal": "10965630140945418161",
+    "rate_bps": 6039,
+    "seconds": 1054558795,
+    "expected": "221443437384933644574",
+    "overflow": false
+  },
+  {
+    "principal": "13297514191959475582",
+    "rate_bps": 717,
+    "seconds": 1019433696,
+    "expected": "30820664342055619294",
+    "overflow": false
+  },
+  {
+    "principal": "6278864398345450159",
+    "rate_bps": 8266,
+    "seconds": 2494812537,
+    "expected": "410589478030207286101",
+    "overflow": false
+  },
+  {
+    "principal": "15695332499215047316",
+    "rate_bps": 9717,
+    "seconds": 1069670886,
+    "expected": "517304542182261709467",
+    "overflow": false
+  },
+  {
+    "principal": "10769091021568168125",
+    "rate_bps": 8770,
+    "seconds": 2424939063,
+    "expected": "726227789947527573440",
+    "overflow": false
+  },
+  {
+    "principal": "7931089037146017274",
+    "rate_bps": 4794,
+    "seconds": 1937135548,
+    "expected": "233552359437951015600",
+    "overflow": false
+  },
+  {
+    "principal": "13323259916163952987",
+    "rate_bps": 5024,
+    "seconds": 2459293701,
+    "expected": "521992089559758927780",
+    "overflow": false
+  },
+  {
+    "principal": "15145729608199042352",
+    "rate_bps": 6941,
+    "seconds": 3562276322,
+    "expected": "1187498968084452987325",
+    "overflow": false
+  },
+  {
+    "principal": "15399350709268883465",
+    "rate_bps": 7814,
+    "seconds": 24212067,
+    "expected": "9238491781977654409",
+    "overflow": false
+  },
+  {
+    "principal": "14334501232703879606",
+    "rate_bps": 4230,
+    "seconds": 1748201944,
+    "expected": "336130518635934925532",
+    "overflow": false
+  },
+  {
+    "principal": "11588736009342594119",
+    "rate_bps": 3289,
+    "seconds": 2511353041,
+    "expected": "303529639139860181667",
+    "overflow": false
+  },
+  {
+    "principal": "9256489655568267532",
+    "rate_bps": 1698,
+    "seconds": 747287838,
+    "expected": "37244771427637937812",
+    "overflow": false
+  },
+  {
+    "principal": "6105288834073311637",
+    "rate_bps": 808,
+    "seconds": 81037007,
+    "expected": "1267635406706390161",
+    "overflow": false
+  },
+  {
+    "principal": "17872352276578755762",
+    "rate_bps": 7622,
+    "seconds": 752016692,
+    "expected": "324841520048944828895",
+    "overflow": false
+  },
+  {
+    "principal": "13092297091143249779",
+    "rate_bps": 9377,
+    "seconds": 659837917,
+    "expected": "256868251287039384808",
+    "overflow": false
+  },
+  {
+    "principal": "10774315067667505704",
+    "rate_bps": 6768,
+    "seconds": 137513882,
+    "expected": "31797278935965486551",
+    "overflow": false
+  },
+  {
+    "principal": "14640683148852212065",
+    "rate_bps": 1047,
+    "seconds": 1671883643,
+    "expected": "81265734578959283713",
+    "overflow": false
+  },
+  {
+    "principal": "2633761008604670702",
+    "rate_bps": 6420,
+    "seconds": 4039382480,
+    "expected": "216580704716350353984",
+    "overflow": false
+  },
+  {
+    "principal": "1489028568448075487",
+    "rate_bps": 3565,
+    "seconds": 76800297,
+    "expected": "1292762831061101279",
+    "overflow": false
+  },
+  {
+    "principal": "7422994642082622596",
+    "rate_bps": 2681,
+    "seconds": 4162086230,
+    "expected": "262651828031635229896",
+    "overflow": false
+  },
+  {
+    "principal": "18283891516157000557",
+    "rate_bps": 5325,
+    "seconds": 3141200999,
+    "expected": "969789254905669622841",
+    "overflow": false
+  },
+  {
+    "principal": "12697158139871307882",
+    "rate_bps": 1113,
+    "seconds": 464115628,
+    "expected": "20797985857758035823",
+    "overflow": false
+  },
+  {
+    "principal": "16196503039708544651",
+    "rate_bps": 9921,
+    "seconds": 4119644341,
+    "expected": "2099084025177624298806",
+    "overflow": false
+  },
+  {
+    "principal": "4356077905412985888",
+    "rate_bps": 9355,
+    "seconds": 1236524626,
+    "expected": "159784847711691937937",
+    "overflow": false
+  },
+  {
+    "principal": "2635108687870051257",
+    "rate_bps": 7914,
+    "seconds": 2016220563,
+    "expected": "133329426655495760947",
+    "overflow": false
+  },
+  {
+    "principal": "13136357227966708006",
+    "rate_bps": 9821,
+    "seconds": 1362501320,
+    "expected": "557392326876165618402",
+    "overflow": false
+  },
+  {
+    "principal": "17958377375776907895",
+    "rate_bps": 6708,
+    "seconds": 3740612225,
+    "expected": "1428881552805324847203",
+    "overflow": false
+  },
+  {
+    "principal": "6959605524415452412",
+    "rate_bps": 9015,
+    "seconds": 2991116942,
+    "expected": "595082448165107898974",
+    "overflow": false
+  },
+  {
+    "principal": "1029467725452211781",
+    "rate_bps": 8136,
+    "seconds": 3650106111,
+    "expected": "96944362383514588130",
+    "overflow": false
+  },
+  {
+    "principal": "2276205613718960418",
+    "rate_bps": 8168,
+    "seconds": 1514546980,
+    "expected": "89290110736112560357",
+    "overflow": false
+  },
+  {
+    "principal": "7646409150302994083",
+    "rate_bps": 3111,
+    "seconds": 971478669,
+    "expected": "73279788329266621604",
+    "overflow": false
+  },
+  {
+    "principal": "10684323976775068440",
+    "rate_bps": 1393,
+    "seconds": 3573325322,
+    "expected": "168641367397971505876",
+    "overflow": false
+  },
+  {
+    "principal": "543495468182159121",
+    "rate_bps": 263,
+    "seconds": 3361296555,
+    "expected": "1523533117699978874",
+    "overflow": false
+  },
+  {
+    "principal": "13610423338091840606",
+    "rate_bps": 3091,
+    "seconds": 792620224,
+    "expected": "105737534859405463288",
+    "overflow": false
+  },
+  {
+    "principal": "16339735851914485519",
+    "rate_bps": 2534,
+    "seconds": 1575916761,
+    "expected": "206908489221015180514",
+    "overflow": false
+  },
+  {
+    "principal": "5726387059577082484",
+    "rate_bps": 7295,
+    "seconds": 6675654,
+    "expected": "884286933882683440",
+    "overflow": false
+  },
+  {
+    "principal": "2741729558575417885",
+    "rate_bps": 1938,
+    "seconds": 2399910551,
+    "expected": "40435874042679430848",
+    "overflow": false
+  },
+  {
+    "principal": "12414534191023863514",
+    "rate_bps": 883,
+    "seconds": 2678500252,
+    "expected": "93105688745887209908",
+    "overflow": false
+  },
+  {
+    "principal": "17033346503153946555",
+    "rate_bps": 2389,
+    "seconds": 1230052709,
+    "expected": "158720581458623514493",
+    "overflow": false
+  },
+  {
+    "principal": "16080926554297190160",
+    "rate_bps": 3147,
+    "seconds": 3208932034,
+    "expected": "514946040467592114343",
+    "overflow": false
+  },
+  {
+    "principal": "9624588220399256425",
+    "rate_bps": 754,
+    "seconds": 3181706435,
+    "expected": "73216169341078172175",
+    "overflow": false
+  },
+  {
+    "principal": "16034830955102055574",
+    "rate_bps": 9149,
+    "seconds": 1392893880,
+    "expected": "647961849966676518422",
+    "overflow": false
+  },
+  {
+    "principal": "8824185588581407911",
+    "rate_bps": 6752,
+    "seconds": 3550370865,
+    "expected": "670770850313753104635",
+    "overflow": false
+  },
+  {
+    "principal": "3661524993243546860",
+    "rate_bps": 3794,
+    "seconds": 410870782,
+    "expected": "18099141742342275404",
+    "overflow": false
+  },
+  {
+    "principal": "14237871532107044597",
+    "rate_bps": 8384,
+    "seconds": 3318276911,
+    "expected": "1256036782962460713533",
+    "overflow": false
+  },
+  {
+    "principal": "17020223370874503570",
+    "rate_bps": 771,
+    "seconds": 519980308,
+    "expected": "21637143403618184047",
+    "overflow": false
+  },
+  {
+    "principal": "7362828907726410195",
+    "rate_bps": 662,
+    "seconds": 1987689789,
+    "expected": "30721661379958388485",
+    "overflow": false
+  },
+  {
+    "principal": "12974708440565811208",
+    "rate_bps": 5362,
+    "seconds": 2589402234,
+    "expected": "571238313778798055433",
+    "overflow": false
+  },
+  {
+    "principal": "3307426525528420545",
+    "rate_bps": 9808,
+    "seconds": 455965147,
+    "expected": "46902468748214853766",
+    "overflow": false
+  },
+  {
+    "principal": "12250759841920881102",
+    "rate_bps": 9236,
+    "seconds": 4004075440,
+    "expected": "1436622271556301785419",
+    "overflow": false
+  },
+  {
+    "principal": "18176922473773939519",
+    "rate_bps": 229,
+    "seconds": 413592713,
+    "expected": "5459113310823862296",
+    "overflow": false
+  },
+  {
+    "principal": "6075614894383959140",
+    "rate_bps": 9454,
+    "seconds": 2364885046,
+    "expected": "430734109170883928234",
+    "overflow": false
+  },
+  {
+    "principal": "9272371791819832525",
+    "rate_bps": 2454,
+    "seconds": 3829861575,
+    "expected": "276338799044012793899",
+    "overflow": false
+  },
+  {
+    "principal": "13157571983565551946",
+    "rate_bps": 1890,
+    "seconds": 3073627020,
+    "expected": "242371816236279567480",
+    "overflow": false
+  },
+  {
+    "principal": "3590613544035558635",
+    "rate_bps": 1736,
+    "seconds": 2270549525,
+    "expected": "44878957262315205998",
+    "overflow": false
+  },
+  {
+    "principal": "94856831681924608",
+    "rate_bps": 7921,
+    "seconds": 3893668658,
+    "expected": "9276860208675418442",
+    "overflow": false
+  },
+  {
+    "principal": "3733010160777520921",
+    "rate_bps": 9970,
+    "seconds": 2268342259,
+    "expected": "267704891770203288221",
+    "overflow": false
+  },
+  {
+    "principal": "18407395357162148870",
+    "rate_bps": 7840,
+    "seconds": 901362856,
+    "expected": "412478630178583416269",
+    "overflow": false
+  },
+  {
+    "principal": "3473117811599186647",
+    "rate_bps": 6436,
+    "seconds": 2309924321,
+    "expected": "163729409412257898754",
+    "overflow": false
+  },
+  {
+    "principal": "13434320766658824412",
+    "rate_bps": 7599,
+    "seconds": 3892799854,
+    "expected": "1260165618540000708319",
+    "overflow": false
+  },
+  {
+    "principal": "10813424856533080997",
+    "rate_bps": 4644,
+    "seconds": 2666108767,
+    "expected": "424547935919807627493",
+    "overflow": false
+  },
+  {
+    "principal": "16300452541510598146",
+    "rate_bps": 2444,
+    "seconds": 1919039236,
+    "expected": "242425394253395690680",
+    "overflow": false
+  },
+  {
+    "principal": "15563701904256674051",
+    "rate_bps": 8644,
+    "seconds": 3130902509,
+    "expected": "1335643638390289322700",
+    "overflow": false
+  },
+  {
+    "principal": "13287321570805758200",
+    "rate_bps": 2644,
+    "seconds": 1576066794,
+    "expected": "175576710682570834456",
+    "overflow": false
+  },
+  {
+    "principal": "4065107995804485233",
+    "rate_bps": 5538,
+    "seconds": 614360843,
+    "expected": "43857306900665348974",
+    "overflow": false
+  },
+  {
+    "principal": "517718103313158974",
+    "rate_bps": 3397,
+    "seconds": 1153160864,
+    "expected": "6430906365230762715",
+    "overflow": false
+  },
+  {
+    "principal": "10518669352189139823",
+    "rate_bps": 6540,
+    "seconds": 2497701945,
+    "expected": "544844482130030973225",
+    "overflow": false
+  },
+  {
+    "principal": "3711788846755912276",
+    "rate_bps": 7456,
+    "seconds": 390178726,
+    "expected": "34240976470230121031",
+    "overflow": false
+  },
+  {
+    "principal": "16168319622393320317",
+    "rate_bps": 5753,
+    "seconds": 3648512759,
+    "expected": "1076139375495247340209",
+    "overflow": false
+  },
+  {
+    "principal": "5644426723531812794",
+    "rate_bps": 7717,
+    "seconds": 1431850876,
+    "expected": "197769594112122504839",
+    "overflow": false
+  },
+  {
+    "principal": "5139709091010575899",
+    "rate_bps": 7160,
+    "seconds": 1565389509,
+    "expected": "182670060575595995426",
+    "overflow": false
+  },
+  {
+    "principal": "12947964801844504816",
+    "rate_bps": 8159,
+    "seconds": 4168327074,
+    "expected": "1396347865612188064867",
+    "overflow": false
+  },
+  {
+    "principal": "16967319159576063689",
+    "rate_bps": 6489,
+    "seconds": 1014339363,
+    "expected": "354134041369019392987",
+    "overflow": false
+  },
+  {
+    "principal": "8323461164192001910",
+    "rate_bps": 5684,
+    "seconds": 1487445400,
+    "expected": "223147719476082317834",
+    "overflow": false
+  },
+  {
+    "principal": "14038210639956122887",
+    "rate_bps": 7791,
+    "seconds": 3613987729,
+    "expected": "1253386537393633690597",
+    "overflow": false
+  },
+  {
+    "principal": "516917041097728204",
+    "rate_bps": 4863,
+    "seconds": 2802180830,
+    "expected": "22336476719097733127",
+    "overflow": false
+  },
+  {
+    "principal": "13571102195179488341",
+    "rate_bps": 6542,
+    "seconds": 2560446351,
+    "expected": "720833122265022123550",
+    "overflow": false
+  },
+  {
+    "principal": "7030959889568591474",
+    "rate_bps": 1881,
+    "seconds": 2132344052,
+    "expected": "89423999131786017151",
+    "overflow": false
+  },
+  {
+    "principal": "4412837031433798707",
+    "rate_bps": 7873,
+    "seconds": 4029068957,
+    "expected": "443870450370535479192",
+    "overflow": false
+  },
+  {
+    "principal": "2463086307206659560",
+    "rate_bps": 7578,
+    "seconds": 3736653146,
+    "expected": "221161949922938001830",
+    "overflow": false
+  },
+  {
+    "principal": "11252750501049352225",
+    "rate_bps": 2945,
+    "seconds": 4150728763,
+    "expected": "436175970853907827405",
+    "overflow": false
+  },
+  {
+    "principal": "13055849825065699502",
+    "rate_bps": 3649,
+    "seconds": 1449978256,
+    "expected": "219045276241265194419",
+    "overflow": false
+  },
+  {
+    "principal": "9742929359642754975",
+    "rate_bps": 9288,
+    "seconds": 3405547497,
+    "expected": "977219434143633884814",
+    "overflow": false
+  },
+  {
+    "principal": "5682286766209694788",
+    "rate_bps": 7237,
+    "seconds": 3456760598,
+    "expected": "450759009654954928617",
+    "overflow": false
+  },
+  {
+    "principal": "12644298227269930541",
+    "rate_bps": 152,
+    "seconds": 57228583,
+    "expected": "348774483534889182",
+    "overflow": false
+  },
+  {
+    "principal": "10773252534894107178",
+    "rate_bps": 9726,
+    "seconds": 2556108652,
+    "expected": "849285694591040977223",
+    "overflow": false
+  },
+  {
+    "principal": "7577651217281489739",
+    "rate_bps": 5681,
+    "seconds": 3710677877,
+    "expected": "506531022761778661792",
+    "overflow": false
+  },
+  {
+    "principal": "5401790868645992416",
+    "rate_bps": 9673,
+    "seconds": 368068626,
+    "expected": "60984735869071015158",
+    "overflow": false
+  },
+  {
+    "principal": "3638659482363304569",
+    "rate_bps": 1714,
+    "seconds": 658786899,
+    "expected": "13028384866475951822",
+    "overflow": false
+  },
+  {
+    "principal": "8901357407781175014",
+    "rate_bps": 7284,
+    "seconds": 2724829832,
+    "expected": "560220445794517317577",
+    "overflow": false
+  },
+  {
+    "principal": "3228786818711888695",
+    "rate_bps": 2578,
+    "seconds": 55616833,
+    "expected": "1467986064214818626",
+    "overflow": false
+  },
+  {
+    "principal": "16688593520417885372",
+    "rate_bps": 7005,
+    "seconds": 1222103118,
+    "expected": "453032252489988416744",
+    "overflow": false
+  },
+  {
+    "principal": "4647353236025757957",
+    "rate_bps": 6094,
+    "seconds": 1959726015,
+    "expected": "175993603801157043061",
+    "overflow": false
+  },
+  {
+    "principal": "11674802208570561250",
+    "rate_bps": 4831,
+    "seconds": 2466879204,
+    "expected": "441192220541622141615",
+    "overflow": false
+  },
+  {
+    "principal": "8322872714132333411",
+    "rate_bps": 2881,
+    "seconds": 3173484877,
+    "expected": "241293896823302952698",
+    "overflow": false
+  },
+  {
+    "principal": "16522277150603663064",
+    "rate_bps": 7983,
+    "seconds": 81653706,
+    "expected": "34151149478411572025",
+    "overflow": false
+  },
+  {
+    "principal": "11239533535573433809",
+    "rate_bps": 3486,
+    "seconds": 545426795,
+    "expected": "67765014076165296812",
+    "overflow": false
+  },
+  {
+    "principal": "9621638931913732638",
+    "rate_bps": 9785,
+    "seconds": 1207144576,
+    "expected": "360381563928176008286",
+    "overflow": false
+  },
+  {
+    "principal": "16152947797281695695",
+    "rate_bps": 8122,
+    "seconds": 4221553561,
+    "expected": "1756226279610581905687",
+    "overflow": false
+  },
+  {
+    "principal": "7662172480375370292",
+    "rate_bps": 430,
+    "seconds": 88949382,
+    "expected": "929301648813807761",
+    "overflow": false
+  },
+  {
+    "principal": "15221524517172718813",
+    "rate_bps": 478,
+    "seconds": 2636520279,
+    "expected": "60828983244357890018",
+    "overflow": false
+  },
+  {
+    "principal": "15479347471948019866",
+    "rate_bps": 1063,
+    "seconds": 3116581724,
+    "expected": "162613960142825614789",
+    "overflow": false
+  },
+  {
+    "principal": "11080714731184520315",
+    "rate_bps": 4215,
+    "seconds": 757356581,
+    "expected": "112165462086224986226",
+    "overflow": false
+  },
+  {
+    "principal": "1984428947874405072",
+    "rate_bps": 8614,
+    "seconds": 3344540802,
+    "expected": "181288523845054100533",
+    "overflow": false
+  },
+  {
+    "principal": "4343526294268406313",
+    "rate_bps": 3802,
+    "seconds": 2746958211,
+    "expected": "143846736433379228968",
+    "overflow": false
+  },
+  {
+    "principal": "13851183048991769174",
+    "rate_bps": 6682,
+    "seconds": 1892920184,
+    "expected": "555544733824546034901",
+    "overflow": false
+  },
+  {
+    "principal": "10539201712127028583",
+    "rate_bps": 1766,
+    "seconds": 1948801777,
+    "expected": "115016322088142491433",
+    "overflow": false
+  },
+  {
+    "principal": "2432381416787545260",
+    "rate_bps": 8714,
+    "seconds": 2652647870,
+    "expected": "178288047192163322024",
+    "overflow": false
+  },
+  {
+    "principal": "15234143849969320373",
+    "rate_bps": 5099,
+    "seconds": 3014249455,
+    "expected": "742464423058495463754",
+    "overflow": false
+  },
+  {
+    "principal": "17297730454325488466",
+    "rate_bps": 9033,
+    "seconds": 257623252,
+    "expected": "127643759407142312434",
+    "overflow": false
+  },
+  {
+    "principal": "5728466986287007379",
+    "rate_bps": 341,
+    "seconds": 871579645,
+    "expected": "5398750605038898934",
+    "overflow": false
+  },
+  {
+    "principal": "9664815252887913416",
+    "rate_bps": 8322,
+    "seconds": 1372538426,
+    "expected": "350057327751127505630",
+    "overflow": false
+  },
+  {
+    "principal": "13110478334652817281",
+    "rate_bps": 3806,
+    "seconds": 3609970331,
+    "expected": "571194933781953120634",
+    "overflow": false
+  },
+  {
+    "principal": "12504436840559234958",
+    "rate_bps": 5861,
+    "seconds": 751225712,
+    "expected": "174582092976593159729",
+    "overflow": false
+  },
+  {
+    "principal": "1763150548711101439",
+    "rate_bps": 1657,
+    "seconds": 1605153609,
+    "expected": "14870374213430184738",
+    "overflow": false
+  },
+  {
+    "principal": "14028752329255238692",
+    "rate_bps": 1389,
+    "seconds": 2789899766,
+    "expected": "172386513938604550146",
+    "overflow": false
+  },
+  {
+    "principal": "14081155530243092365",
+    "rate_bps": 1250,
+    "seconds": 3086581127,
+    "expected": "172273865209601751236",
+    "overflow": false
+  },
+  {
+    "principal": "6938592115120900874",
+    "rate_bps": 9898,
+    "seconds": 4267162444,
+    "expected": "929290241979390940992",
+    "overflow": false
+  },
+  {
+    "principal": "18241814406901670315",
+    "rate_bps": 3374,
+    "seconds": 933798101,
+    "expected": "182246623394566247362",
+    "overflow": false
+  },
+  {
+    "principal": "14364658224375689664",
+    "rate_bps": 3174,
+    "seconds": 1690219762,
+    "expected": "244364879177303337022",
+    "overflow": false
+  },
+  {
+    "principal": "4160986518955711961",
+    "rate_bps": 190,
+    "seconds": 1345682611,
+    "expected": "3373540615807913046",
+    "overflow": false
+  },
+  {
+    "principal": "1434698929992776134",
+    "rate_bps": 3330,
+    "seconds": 2298335336,
+    "expected": "34818639312494332676",
+    "overflow": false
+  },
+  {
+    "principal": "13730548191453035415",
+    "rate_bps": 1937,
+    "seconds": 1626551457,
+    "expected": "137176177742775401038",
+    "overflow": false
+  },
+  {
+    "principal": "15346537225579438236",
+    "rate_bps": 3243,
+    "seconds": 3300001582,
+    "expected": "520792698721151008810",
+    "overflow": false
+  },
+  {
+    "principal": "13389382242699613797",
+    "rate_bps": 5036,
+    "seconds": 3281555487,
+    "expected": "701648185749413314758",
+    "overflow": false
+  },
+  {
+    "principal": "14813355458689185730",
+    "rate_bps": 6533,
+    "seconds": 1484015300,
+    "expected": "455405083287361587033",
+    "overflow": false
+  },
+  {
+    "principal": "5685941918119701955",
+    "rate_bps": 8893,
+    "seconds": 2199706285,
+    "expected": "352702712862564870405",
+    "overflow": false
+  },
+  {
+    "principal": "9682410796900336824",
+    "rate_bps": 6565,
+    "seconds": 1346097322,
+    "expected": "271323923320167533461",
+    "overflow": false
+  },
+  {
+    "principal": "7457361739045242161",
+    "rate_bps": 1269,
+    "seconds": 752731083,
+    "expected": "22588119432641400713",
+    "overflow": false
+  },
+  {
+    "principal": "10981090851998638334",
+    "rate_bps": 6666,
+    "seconds": 4154301024,
+    "expected": "964277758654614116776",
+    "overflow": false
+  },
+  {
+    "principal": "10433732634613990447",
+    "rate_bps": 7088,
+    "seconds": 3628482297,
+    "expected": "850906447044815776666",
+    "overflow": false
+  },
+  {
+    "principal": "17152653412507785748",
+    "rate_bps": 5904,
+    "seconds": 2676010342,
+    "expected": "859327760232470091097",
+    "overflow": false
+  },
+  {
+    "principal": "13117923835597395517",
+    "rate_bps": 5425,
+    "seconds": 1802396599,
+    "expected": "406732241221709033837",
+    "overflow": false
+  },
+  {
+    "principal": "10389521619739070842",
+    "rate_bps": 8612,
+    "seconds": 2787084092,
+    "expected": "790756986751636164535",
+    "overflow": false
+  },
+  {
+    "principal": "9278735949136988891",
+    "rate_bps": 7933,
+    "seconds": 1533824389,
+    "expected": "358010119332385946984",
+    "overflow": false
+  },
+  {
+    "principal": "3160734552889957552",
+    "rate_bps": 9656,
+    "seconds": 2272164194,
+    "expected": "219896534970139499025",
+    "overflow": false
+  },
+  {
+    "principal": "12348243775826720137",
+    "rate_bps": 2969,
+    "seconds": 1028520931,
+    "expected": "119569914735110301280",
+    "overflow": false
+  },
+  {
+    "principal": "2291606860906718518",
+    "rate_bps": 2846,
+    "seconds": 121571672,
+    "expected": "2514205617020706598",
+    "overflow": false
+  },
+  {
+    "principal": "9790637620984204743",
+    "rate_bps": 6574,
+    "seconds": 2163487313,
+    "expected": "441558675530594239479",
+    "overflow": false
+  },
+  {
+    "principal": "10692646732584421516",
+    "rate_bps": 906,
+    "seconds": 2545438878,
+    "expected": "78193289268984940021",
+    "overflow": false
+  },
+  {
+    "principal": "7058249314228899605",
+    "rate_bps": 7288,
+    "seconds": 826693711,
+    "expected": "134847650948121733673",
+    "overflow": false
+  },
+  {
+    "principal": "4266896950446471218",
+    "rate_bps": 3296,
+    "seconds": 3321650356,
+    "expected": "148131242696091431198",
+    "overflow": false
+  },
+  {
+    "principal": "9193106443237398771",
+    "rate_bps": 495,
+    "seconds": 2776062301,
+    "expected": "40058076268217313118",
+    "overflow": false
+  },
+  {
+    "principal": "18909387583674792",
+    "rate_bps": 6234,
+    "seconds": 68325146,
+    "expected": "25539842988104050",
+    "overflow": false
+  },
+  {
+    "principal": "9411224585863073505",
+    "rate_bps": 9340,
+    "seconds": 1028883707,
+    "expected": "286782533203885226323",
+    "overflow": false
+  },
+  {
+    "principal": "7354343127788119662",
+    "rate_bps": 7806,
+    "seconds": 1785658704,
+    "expected": "325060563368664566686",
+    "overflow": false
+  },
+  {
+    "principal": "9369602388616591455",
+    "rate_bps": 9142,
+    "seconds": 2664394409,
+    "expected": "723692855378345454881",
+    "overflow": false
+  },
+  {
+    "principal": "15349262924688444420",
+    "rate_bps": 5311,
+    "seconds": 1420742870,
+    "expected": "367259217949309611929",
+    "overflow": false
+  },
+  {
+    "principal": "2663712365883318509",
+    "rate_bps": 3,
+    "seconds": 89116135,
+    "expected": "2258178755700411",
+    "overflow": false
+  },
+  {
+    "principal": "3196751532486249450",
+    "rate_bps": 9697,
+    "seconds": 3697387308,
+    "expected": "363441584163811798782",
+    "overflow": false
+  },
+  {
+    "principal": "5820984687595403275",
+    "rate_bps": 9259,
+    "seconds": 459431477,
+    "expected": "78518985679967939272",
+    "overflow": false
+  },
+  {
+    "principal": "15367332263465802656",
+    "rate_bps": 4663,
+    "seconds": 2046292434,
+    "expected": "464970059368934864351",
+    "overflow": false
+  },
+  {
+    "principal": "7810750028266221881",
+    "rate_bps": 6519,
+    "seconds": 501202707,
+    "expected": "80924592491873730922",
+    "overflow": false
+  },
+  {
+    "principal": "8232370881206518950",
+    "rate_bps": 8653,
+    "seconds": 1328436808,
+    "expected": "300072312409026433543",
+    "overflow": false
+  },
+  {
+    "principal": "4337089339352835063",
+    "rate_bps": 3666,
+    "seconds": 3148764161,
+    "expected": "158753882631440781998",
+    "overflow": false
+  },
+  {
+    "principal": "16981620256601392252",
+    "rate_bps": 7980,
+    "seconds": 529403406,
+    "expected": "227489910812665210932",
+    "overflow": false
+  },
+  {
+    "principal": "16269036987044785093",
+    "rate_bps": 3462,
+    "seconds": 3617465471,
+    "expected": "646080595484237705506",
+    "overflow": false
+  },
+  {
+    "principal": "12681282231285181602",
+    "rate_bps": 3548,
+    "seconds": 2463778468,
+    "expected": "351513353448241441088",
+    "overflow": false
+  },
+  {
+    "principal": "6879539564600707107",
+    "rate_bps": 9691,
+    "seconds": 303414285,
+    "expected": "64144198543206130462",
+    "overflow": false
+  },
+  {
+    "principal": "9971669346454667928",
+    "rate_bps": 9696,
+    "seconds": 1518502282,
+    "expected": "465553201964087381333",
+    "overflow": false
+  },
+  {
+    "principal": "15906524376962284689",
+    "rate_bps": 4513,
+    "seconds": 1585973803,
+    "expected": "361018977093975840639",
+    "overflow": false
+  },
+  {
+    "principal": "11480473522760032222",
+    "rate_bps": 418,
+    "seconds": 108131392,
+    "expected": "1645437042190219856",
+    "overflow": false
+  },
+  {
+    "principal": "17121477075494711439",
+    "rate_bps": 2806,
+    "seconds": 4109058649,
+    "expected": "625986011576519712703",
+    "overflow": false
+  },
+  {
+    "principal": "17262414541715231220",
+    "rate_bps": 1174,
+    "seconds": 248768582,
+    "expected": "15986690318534398389",
+    "overflow": false
+  },
+  {
+    "principal": "14398855571839127453",
+    "rate_bps": 4893,
+    "seconds": 967359511,
+    "expected": "216114790547252944830",
+    "overflow": false
+  },
+  {
+    "principal": "12670053450944543322",
+    "rate_bps": 6962,
+    "seconds": 2812615452,
+    "expected": "786712802030136063638",
+    "overflow": false
+  },
+  {
+    "principal": "3304329015118801211",
+    "rate_bps": 1738,
+    "seconds": 3468546789,
+    "expected": "63164637252790334806",
+    "overflow": false
+  },
+  {
+    "principal": "16114955271040544400",
+    "rate_bps": 8651,
+    "seconds": 2821332546,
+    "expected": "1247220062706873557300",
+    "overflow": false
+  },
+  {
+    "principal": "15148233902016663785",
+    "rate_bps": 5895,
+    "seconds": 1996867139,
+    "expected": "565442405045632084516",
+    "overflow": false
+  },
+  {
+    "principal": "14622642151432230934",
+    "rate_bps": 2405,
+    "seconds": 4221744952,
+    "expected": "470789012490315875318",
+    "overflow": false
+  },
+  {
+    "principal": "5410285477963922983",
+    "rate_bps": 5265,
+    "seconds": 3638860209,
+    "expected": "328683060470310428739",
+    "overflow": false
+  },
+  {
+    "principal": "16988978024644498540",
+    "rate_bps": 1317,
+    "seconds": 30556030,
+    "expected": "2167920491263089403",
+    "overflow": false
+  },
+  {
+    "principal": "18363260608024030325",
+    "rate_bps": 344,
+    "seconds": 264959151,
+    "expected": "5307384561964307637",
+    "overflow": false
+  },
+  {
+    "principal": "6341488021607699730",
+    "rate_bps": 94,
+    "seconds": 3442803860,
+    "expected": "6507657747526213506",
+    "overflow": false
+  },
+  {
+    "principal": "459342955306728275",
+    "rate_bps": 7085,
+    "seconds": 1816855229,
+    "expected": "18749540595018176291",
+    "overflow": false
+  },
+  {
+    "principal": "10363018351247343496",
+    "rate_bps": 9738,
+    "seconds": 2583341050,
+    "expected": "826668093230376393022",
+    "overflow": false
+  },
+  {
+    "principal": "16283997668299902529",
+    "rate_bps": 829,
+    "seconds": 1354126171,
+    "expected": "57965299859974595543",
+    "overflow": false
+  },
+  {
+    "principal": "15640057378140147022",
+    "rate_bps": 8932,
+    "seconds": 4229791536,
+    "expected": "1873697223768716142120",
+    "overflow": false
+  },
+  {
+    "principal": "6521685841538952383",
+    "rate_bps": 670,
+    "seconds": 3564943881,
+    "expected": "49394747283045021648",
+    "overflow": false
+  },
+  {
+    "principal": "2402541299398585316",
+    "rate_bps": 4038,
+    "seconds": 1815016374,
+    "expected": "55835590939840887286",
+    "overflow": false
+  },
+  {
+    "principal": "14419718923018412621",
+    "rate_bps": 5248,
+    "seconds": 1388588615,
+    "expected": "333209683875450267777",
+    "overflow": false
+  },
+  {
+    "principal": "15689780191833087178",
+    "rate_bps": 530,
+    "seconds": 3652248332,
+    "expected": "96304464654954931868",
+    "overflow": false
+  },
+  {
+    "principal": "12722116681940229739",
+    "rate_bps": 1179,
+    "seconds": 1358015381,
+    "expected": "64590888910292486158",
+    "overflow": false
+  },
+  {
+    "principal": "8339915247896401280",
+    "rate_bps": 3402,
+    "seconds": 252968626,
+    "expected": "22759148078194953321",
+    "overflow": false
+  },
+  {
+    "principal": "9503860780070573209",
+    "rate_bps": 7381,
+    "seconds": 3491434867,
+    "expected": "776627221407128428540",
+    "overflow": false
+  },
+  {
+    "principal": "18088323736859090822",
+    "rate_bps": 6031,
+    "seconds": 3467848744,
+    "expected": "1199613074596978073932",
+    "overflow": false
+  },
+  {
+    "principal": "11548313652215290967",
+    "rate_bps": 7363,
+    "seconds": 815399777,
+    "expected": "219855509163985030620",
+    "overflow": false
+  },
+  {
+    "principal": "16686193491153008732",
+    "rate_bps": 8775,
+    "seconds": 4049855726,
+    "expected": "1880344159500790359204",
+    "overflow": false
+  },
+  {
+    "principal": "7751960384299258149",
+    "rate_bps": 7743,
+    "seconds": 3778529503,
+    "expected": "719179028138090100829",
+    "overflow": false
+  },
+  {
+    "principal": "5504827278026568066",
+    "rate_bps": 2469,
+    "seconds": 1181980292,
+    "expected": "50941111319667321837",
+    "overflow": false
+  },
+  {
+    "principal": "2398551714332963459",
+    "rate_bps": 9713,
+    "seconds": 866790765,
+    "expected": "64033928092210023009",
+    "overflow": false
+  },
+  {
+    "principal": "14206429082367529080",
+    "rate_bps": 3083,
+    "seconds": 3525968490,
+    "expected": "489700189838374907226",
+    "overflow": false
+  },
+  {
+    "principal": "3489401566193943537",
+    "rate_bps": 8474,
+    "seconds": 1851351179,
+    "expected": "173588764206356594153",
+    "overflow": false
+  },
+  {
+    "principal": "2158238122241519294",
+    "rate_bps": 3210,
+    "seconds": 455646752,
+    "expected": "10009815294642904601",
+    "overflow": false
+  },
+  {
+    "principal": "6335729241968946415",
+    "rate_bps": 4395,
+    "seconds": 2678511033,
+    "expected": "236506086295536674157",
+    "overflow": false
+  },
+  {
+    "principal": "7633716744576489940",
+    "rate_bps": 3146,
+    "seconds": 3493786406,
+    "expected": "266063011902677282776",
+    "overflow": false
+  },
+  {
+    "principal": "15537562826053130493",
+    "rate_bps": 8423,
+    "seconds": 1630348407,
+    "expected": "676586791210810147570",
+    "overflow": false
+  },
+  {
+    "principal": "2991620652092420922",
+    "rate_bps": 8611,
+    "seconds": 4287364860,
+    "expected": "350222423524321380855",
+    "overflow": false
+  },
+  {
+    "principal": "3200598851013466011",
+    "rate_bps": 7603,
+    "seconds": 2981161029,
+    "expected": "230035606255958517139",
+    "overflow": false
+  },
+  {
+    "principal": "11998320967532384368",
+    "rate_bps": 6505,
+    "seconds": 2902758178,
+    "expected": "718409434112067558765",
+    "overflow": false
+  },
+  {
+    "principal": "13887809790131649609",
+    "rate_bps": 6929,
+    "seconds": 3803881635,
+    "expected": "1160712626109842717024",
+    "overflow": false
+  },
+  {
+    "principal": "12519002282299595510",
+    "rate_bps": 587,
+    "seconds": 2713105688,
+    "expected": "63221955505494394955",
+    "overflow": false
+  },
+  {
+    "principal": "10869099959720099463",
+    "rate_bps": 9495,
+    "seconds": 1527877905,
+    "expected": "500000680589492868190",
+    "overflow": false
+  },
+  {
+    "principal": "9525421634217472076",
+    "rate_bps": 2919,
+    "seconds": 509738590,
+    "expected": "44942705176664851600",
+    "overflow": false
+  },
+  {
+    "principal": "8827605840975878613",
+    "rate_bps": 5791,
+    "seconds": 831496463,
+    "expected": "134787710829432452598",
+    "overflow": false
+  },
+  {
+    "principal": "14596168226800419314",
+    "rate_bps": 4588,
+    "seconds": 2201812084,
+    "expected": "467558453328263828505",
+    "overflow": false
+  },
+  {
+    "principal": "16964336625446383027",
+    "rate_bps": 9629,
+    "seconds": 1946565661,
+    "expected": "1008278529209967905451",
+    "overflow": false
+  },
+  {
+    "principal": "16037837298610697576",
+    "rate_bps": 2275,
+    "seconds": 1275039962,
+    "expected": "147517788784264947250",
+    "overflow": false
+  },
+  {
+    "principal": "8442448353401380257",
+    "rate_bps": 2680,
+    "seconds": 3693883835,
+    "expected": "265020722289480673321",
+    "overflow": false
+  },
+  {
+    "principal": "17493579715857810478",
+    "rate_bps": 38,
+    "seconds": 3263844624,
+    "expected": "6879947971158303419",
+    "overflow": false
+  },
+  {
+    "principal": "4528914829095645471",
+    "rate_bps": 5438,
+    "seconds": 3503068521,
+    "expected": "273574353786951055549",
+    "overflow": false
+  },
+  {
+    "principal": "8207199702355663812",
+    "rate_bps": 9251,
+    "seconds": 3552765590,
+    "expected": "855349545487622550493",
+    "overflow": false
+  },
+  {
+    "principal": "5881381669220152237",
+    "rate_bps": 7113,
+    "seconds": 1806605991,
+    "expected": "239656389080284884681",
+    "overflow": false
+  },
+  {
+    "principal": "14437321937908743594",
+    "rate_bps": 4948,
+    "seconds": 1367174892,
+    "expected": "309694718464498180013",
+    "overflow": false
+  },
+  {
+    "principal": "8709388997586523339",
+    "rate_bps": 7818,
+    "seconds": 3840837877,
+    "expected": "829282925135787037557",
+    "overflow": false
+  },
+  {
+    "principal": "9600915244278882144",
+    "rate_bps": 6425,
+    "seconds": 4052409234,
+    "expected": "792670064436449349282",
+    "overflow": false
+  },
+  {
+    "principal": "14818518517610416121",
+    "rate_bps": 1970,
+    "seconds": 3401544659,
+    "expected": "314876742326878829104",
+    "overflow": false
+  },
+  {
+    "principal": "7315613395675482726",
+    "rate_bps": 2669,
+    "seconds": 1430540808,
+    "expected": "88571288864586807371",
+    "overflow": false
+  },
+  {
+    "principal": "1873262535906682039",
+    "rate_bps": 477,
+    "seconds": 3771613889,
+    "expected": "10686553050883480846",
+    "overflow": false
+  },
+  {
+    "principal": "9436879405031619644",
+    "rate_bps": 3087,
+    "seconds": 2787871694,
+    "expected": "257532005643032827000",
+    "overflow": false
+  },
+  {
+    "principal": "10049504951695066757",
+    "rate_bps": 7980,
+    "seconds": 4106059071,
+    "expected": "1044157821246880474868",
+    "overflow": false
+  },
+  {
+    "principal": "3695048074817947234",
+    "rate_bps": 4565,
+    "seconds": 2876782180,
+    "expected": "153872584351503902171",
+    "overflow": false
+  },
+  {
+    "principal": "2742176541151112419",
+    "rate_bps": 3300,
+    "seconds": 1970417357,
+    "expected": "56540672354514976572",
+    "overflow": false
+  },
+  {
+    "principal": "13375333703862087256",
+    "rate_bps": 7389,
+    "seconds": 4188689226,
+    "expected": "1312688937882060427292",
+    "overflow": false
+  },
+  {
+    "principal": "17943043957763857233",
+    "rate_bps": 5601,
+    "seconds": 3106522859,
+    "expected": "989987339165690804653",
+    "overflow": false
+  },
+  {
+    "principal": "11021513382048370078",
+    "rate_bps": 580,
+    "seconds": 3497629696,
+    "expected": "70898401984874391318",
+    "overflow": false
+  },
+  {
+    "principal": "414227014492305743",
+    "rate_bps": 3421,
+    "seconds": 2861627673,
+    "expected": "12858728091689772261",
+    "overflow": false
+  },
+  {
+    "principal": "2434248427866141108",
+    "rate_bps": 6992,
+    "seconds": 3032075782,
+    "expected": "163643877894747167479",
+    "overflow": false
+  },
+  {
+    "principal": "1110902905843724893",
+    "rate_bps": 6111,
+    "seconds": 2673056983,
+    "expected": "57542668286600469903",
+    "overflow": false
+  },
+  {
+    "principal": "6728057119042157594",
+    "rate_bps": 7335,
+    "seconds": 2735485660,
+    "expected": "428072790284606137345",
+    "overflow": false
+  },
+  {
+    "principal": "12499135512932750843",
+    "rate_bps": 6781,
+    "seconds": 1927122341,
+    "expected": "517936359939654761453",
+    "overflow": false
+  },
+  {
+    "principal": "10929593873724818000",
+    "rate_bps": 5373,
+    "seconds": 762697730,
+    "expected": "142025625943925791208",
+    "overflow": false
+  },
+  {
+    "principal": "5970624364216940457",
+    "rate_bps": 6700,
+    "seconds": 910461699,
+    "expected": "115491394527934829298",
+    "overflow": false
+  },
+  {
+    "principal": "6895174029136195030",
+    "rate_bps": 1733,
+    "seconds": 3241345784,
+    "expected": "122818150005308840158",
+    "overflow": false
+  },
+  {
+    "principal": "8113022027267313383",
+    "rate_bps": 6329,
+    "seconds": 3935508593,
+    "expected": "640784515985880090596",
+    "overflow": false
+  },
+  {
+    "principal": "479084325823306796",
+    "rate_bps": 550,
+    "seconds": 56593726,
+    "expected": "47286408823555371",
+    "overflow": false
+  },
+  {
+    "principal": "14801089931696084789",
+    "rate_bps": 9675,
+    "seconds": 1558994287,
+    "expected": "707917401348572278447",
+    "overflow": false
+  },
+  {
+    "principal": "18364479339114331858",
+    "rate_bps": 6454,
+    "seconds": 2051818580,
+    "expected": "771151898794441060417",
+    "overflow": false
+  },
+  {
+    "principal": "15761286862487498771",
+    "rate_bps": 3281,
+    "seconds": 1816200573,
+    "expected": "297820854437706673261",
+    "overflow": false
+  },
+  {
+    "principal": "7138319640720014152",
+    "rate_bps": 5180,
+    "seconds": 3868805562,
+    "expected": "453624024537165208074",
+    "overflow": false
+  },
+  {
+    "principal": "4884342163169524993",
+    "rate_bps": 3544,
+    "seconds": 1317871643,
+    "expected": "72337967071964115261",
+    "overflow": false
+  },
+  {
+    "principal": "14654693664636963598",
+    "rate_bps": 3586,
+    "seconds": 2456646384,
+    "expected": "409376652450187612857",
+    "overflow": false
+  },
+  {
+    "principal": "12829267626775135615",
+    "rate_bps": 3643,
+    "seconds": 3889627337,
+    "expected": "576451034634935878270",
+    "overflow": false
+  },
+  {
+    "principal": "4106280335381322660",
+    "rate_bps": 3938,
+    "seconds": 3328354678,
+    "expected": "170666113956271229823",
+    "overflow": false
+  },
+  {
+    "principal": "9102871353987355917",
+    "rate_bps": 3350,
+    "seconds": 2137464583,
+    "expected": "206688128365117064602",
+    "overflow": false
+  },
+  {
+    "principal": "2540187697696173706",
+    "rate_bps": 3368,
+    "seconds": 1392462540,
+    "expected": "37775898679100268003",
+    "overflow": false
+  },
+  {
+    "principal": "2127096813929290539",
+    "rate_bps": 4048,
+    "seconds": 670103125,
+    "expected": "18296279970292489252",
+    "overflow": false
+  },
+  {
+    "principal": "3602428726613113152",
+    "rate_bps": 9963,
+    "seconds": 47482994,
+    "expected": "5404020847134597259",
+    "overflow": false
+  },
+  {
+    "principal": "13534869069228804953",
+    "rate_bps": 1684,
+    "seconds": 2510612019,
+    "expected": "181455084836321830374",
+    "overflow": false
+  },
+  {
+    "principal": "6244306210662008134",
+    "rate_bps": 9151,
+    "seconds": 2761541608,
+    "expected": "500377452270461588132",
+    "overflow": false
+  },
+  {
+    "principal": "6482764196024139031",
+    "rate_bps": 2171,
+    "seconds": 4049801761,
+    "expected": "180737057014189794095",
+    "overflow": false
+  },
+  {
+    "principal": "6891086485504987164",
+    "rate_bps": 6442,
+    "seconds": 2111636142,
+    "expected": "297249341135829083865",
+    "overflow": false
+  },
+  {
+    "principal": "8949273189513120741",
+    "rate_bps": 3182,
+    "seconds": 176636319,
+    "expected": "15950023961239791960",
+    "overflow": false
+  },
+  {
+    "principal": "1077795136307915586",
+    "rate_bps": 7833,
+    "seconds": 773858884,
+    "expected": "20716649184751410946",
+    "overflow": false
+  },
+  {
+    "principal": "3982915371146278723",
+    "rate_bps": 8699,
+    "seconds": 688242733,
+    "expected": "75614561334490249912",
+    "overflow": false
+  },
+  {
+    "principal": "5863943649409211448",
+    "rate_bps": 2347,
+    "seconds": 2809885738,
+    "expected": "122626668864323992522",
+    "overflow": false
+  },
+  {
+    "principal": "11333212777841803953",
+    "rate_bps": 8072,
+    "seconds": 1070677323,
+    "expected": "310589087854662046708",
+    "overflow": false
+  },
+  {
+    "principal": "9489606270261296254",
+    "rate_bps": 6893,
+    "seconds": 3038568928,
+    "expected": "630258857267726511061",
+    "overflow": false
+  },
+  {
+    "principal": "10199839573642139055",
+    "rate_bps": 9533,
+    "seconds": 1807854713,
+    "expected": "557416542216796153386",
+    "overflow": false
+  },
+  {
+    "principal": "11115955845323544980",
+    "rate_bps": 8750,
+    "seconds": 3778836710,
+    "expected": "1165484185158762427005",
+    "overflow": false
+  },
+  {
+    "principal": "3648481801516669885",
+    "rate_bps": 6864,
+    "seconds": 359933239,
+    "expected": "28582802394535824185",
+    "overflow": false
+  },
+  {
+    "principal": "20813086580233466",
+    "rate_bps": 9762,
+    "seconds": 995997372,
+    "expected": "641692376463011145",
+    "overflow": false
+  },
+  {
+    "principal": "15629137131416577115",
+    "rate_bps": 846,
+    "seconds": 3302736645,
+    "expected": "138475423794635066775",
+    "overflow": false
+  },
+  {
+    "principal": "11948487630006600752",
+    "rate_bps": 1280,
+    "seconds": 3572886754,
+    "expected": "173274858177913492681",
+    "overflow": false
+  },
+  {
+    "principal": "5536225962962731785",
+    "rate_bps": 8344,
+    "seconds": 1266386275,
+    "expected": "185501613381807009878",
+    "overflow": false
+  },
+  {
+    "principal": "13227891570481107126",
+    "rate_bps": 523,
+    "seconds": 2513412312,
+    "expected": "55137801607148099018",
+    "overflow": false
+  },
+  {
+    "principal": "10345417391129358151",
+    "rate_bps": 7589,
+    "seconds": 1853960145,
+    "expected": "461558078687659148333",
+    "overflow": false
+  },
+  {
+    "principal": "8529200689362671628",
+    "rate_bps": 6192,
+    "seconds": 2596465694,
+    "expected": "434825758195601409621",
+    "overflow": false
+  },
+  {
+    "principal": "7607432502902514837",
+    "rate_bps": 2330,
+    "seconds": 1010379215,
+    "expected": "56789994341210485219",
+    "overflow": false
+  },
+  {
+    "principal": "878519650540620722",
+    "rate_bps": 1279,
+    "seconds": 2023414836,
+    "expected": "7209420343165923488",
+    "overflow": false
+  },
+  {
+    "principal": "15236256043976753779",
+    "rate_bps": 2525,
+    "seconds": 3365101277,
+    "expected": "410517029085711517971",
+    "overflow": false
+  },
+  {
+    "principal": "7785968525050368296",
+    "rate_bps": 2987,
+    "seconds": 3393180314,
+    "expected": "250235083197784937370",
+    "overflow": false
+  },
+  {
+    "principal": "11458957715384822881",
+    "rate_bps": 6875,
+    "seconds": 3132169851,
+    "expected": "782449860239357385209",
+    "overflow": false
+  },
+  {
+    "principal": "6434131295596437998",
+    "rate_bps": 3640,
+    "seconds": 880731344,
+    "expected": "65407590108234805033",
+    "overflow": false
+  },
+  {
+    "principal": "5101331836874320351",
+    "rate_bps": 893,
+    "seconds": 4055104553,
+    "expected": "58577452830286366062",
+    "overflow": false
+  },
+  {
+    "principal": "1168515236697746308",
+    "rate_bps": 4023,
+    "seconds": 3540401238,
+    "expected": "52775248784534079198",
+    "overflow": false
+  },
+  {
+    "principal": "999985397750351469",
+    "rate_bps": 2440,
+    "seconds": 558215015,
+    "expected": "4318952142580491895",
+    "overflow": false
+  },
+  {
+    "principal": "1143991559157346154",
+    "rate_bps": 546,
+    "seconds": 2708371116,
+    "expected": "5364349054699963996",
+    "overflow": false
+  },
+  {
+    "principal": "17331754085066322315",
+    "rate_bps": 5897,
+    "seconds": 2928735157,
+    "expected": "949176855098196328130",
+    "overflow": false
+  },
+  {
+    "principal": "14990417688875115296",
+    "rate_bps": 9158,
+    "seconds": 946406738,
+    "expected": "411988970890568007031",
+    "overflow": false
+  },
+  {
+    "principal": "13889122899261595321",
+    "rate_bps": 641,
+    "seconds": 3701696659,
+    "expected": "104502593901320215815",
+    "overflow": false
+  },
+  {
+    "principal": "5001936502197899302",
+    "rate_bps": 892,
+    "seconds": 4067134920,
+    "expected": "57542006434598128607",
+    "overflow": false
+  },
+  {
+    "principal": "8372061246929610103",
+    "rate_bps": 214,
+    "seconds": 2339402113,
+    "expected": "13290595519545169179",
+    "overflow": false
+  },
+  {
+    "principal": "10172664733687051260",
+    "rate_bps": 4910,
+    "seconds": 2356169102,
+    "expected": "373178034636116754176",
+    "overflow": false
+  },
+  {
+    "principal": "5104099660919202117",
+    "rate_bps": 3497,
+    "seconds": 4276950527,
+    "expected": "242070795681117684827",
+    "overflow": false
+  },
+  {
+    "principal": "135303731526295586",
+    "rate_bps": 2942,
+    "seconds": 1856202276,
+    "expected": "2342993784105165836",
+    "overflow": false
+  },
+  {
+    "principal": "17468793839949992355",
+    "rate_bps": 976,
+    "seconds": 1677517197,
+    "expected": "90692862847244568519",
+    "overflow": false
+  },
+  {
+    "principal": "11101585790290958872",
+    "rate_bps": 9576,
+    "seconds": 1175807242,
+    "expected": "396368086985803096560",
+    "overflow": false
+  },
+  {
+    "principal": "2708166922450254353",
+    "rate_bps": 7702,
+    "seconds": 2804401067,
+    "expected": "185486565721088862970",
+    "overflow": false
+  },
+  {
+    "principal": "12724447431974828894",
+    "rate_bps": 5310,
+    "seconds": 1271561152,
+    "expected": "272435750306722588111",
+    "overflow": false
+  },
+  {
+    "principal": "1007410262176924175",
+    "rate_bps": 2496,
+    "seconds": 3176198105,
+    "expected": "25325144203282007069",
+    "overflow": false
+  },
+  {
+    "principal": "17879903259668992372",
+    "rate_bps": 8177,
+    "seconds": 3468620742,
+    "expected": "1608086375182823878577",
+    "overflow": false
+  },
+  {
+    "principal": "8789097515642623261",
+    "rate_bps": 5535,
+    "seconds": 1223081367,
+    "expected": "188673389370405747090",
+    "overflow": false
+  },
+  {
+    "principal": "12941268220281077210",
+    "rate_bps": 2591,
+    "seconds": 632851100,
+    "expected": "67288242300553012296",
+    "overflow": false
+  },
+  {
+    "principal": "17976533897989014203",
+    "rate_bps": 6814,
+    "seconds": 2655225957,
+    "expected": "1031342620202845039493",
+    "overflow": false
+  },
+  {
+    "principal": "13560915879066703376",
+    "rate_bps": 7151,
+    "seconds": 1660735938,
+    "expected": "510681090249756642362",
+    "overflow": false
+  },
+  {
+    "principal": "220206488559394409",
+    "rate_bps": 752,
+    "seconds": 540512195,
+    "expected": "283822513788462253",
+    "overflow": false
+  },
+  {
+    "principal": "14331132175703638934",
+    "rate_bps": 8024,
+    "seconds": 3477376696,
+    "expected": "1267992117966841051897",
+    "overflow": false
+  },
+  {
+    "principal": "13483224891865554855",
+    "rate_bps": 5557,
+    "seconds": 3522418481,
+    "expected": "836890271230190707399",
+    "overflow": false
+  },
+  {
+    "principal": "2173293715526427628",
+    "rate_bps": 5651,
+    "seconds": 2726566654,
+    "expected": "106182572659345123059",
+    "overflow": false
+  },
+  {
+    "principal": "12524028566110355957",
+    "rate_bps": 8052,
+    "seconds": 1573783087,
+    "expected": "503252664044882300556",
+    "overflow": false
+  },
+  {
+    "principal": "6972441650027751570",
+    "rate_bps": 8838,
+    "seconds": 2019607572,
+    "expected": "394638334035193638740",
+    "overflow": false
+  },
+  {
+    "principal": "11046526740767958227",
+    "rate_bps": 8206,
+    "seconds": 3231008829,
+    "expected": "928728554896192753779",
+    "overflow": false
+  },
+  {
+    "principal": "3114971138031908616",
+    "rate_bps": 1458,
+    "seconds": 3949669242,
+    "expected": "56880796871106828532",
+    "overflow": false
+  },
+  {
+    "principal": "6884713995900660673",
+    "rate_bps": 8410,
+    "seconds": 3614452955,
+    "expected": "663617559175854062654",
+    "overflow": false
+  },
+  {
+    "principal": "3377651787012442318",
+    "rate_bps": 2072,
+    "seconds": 1702274736,
+    "expected": "37777017953969106295",
+    "overflow": false
+  },
+  {
+    "principal": "1844867257120071231",
+    "rate_bps": 9979,
+    "seconds": 1249609609,
+    "expected": "72949092711119944704",
+    "overflow": false
+  },
+  {
+    "principal": "16267857780480166756",
+    "rate_bps": 3899,
+    "seconds": 3701841718,
+    "expected": "744551667564269280731",
+    "overflow": false
+  },
+  {
+    "principal": "11132304313285494733",
+    "rate_bps": 2672,
+    "seconds": 1218596807,
+    "expected": "114940995025397223272",
+    "overflow": false
+  },
+  {
+    "principal": "10747626508678217802",
+    "rate_bps": 796,
+    "seconds": 3020092044,
+    "expected": "81929292755425848876",
+    "overflow": false
+  },
+  {
+    "principal": "903463094472906731",
+    "rate_bps": 7161,
+    "seconds": 1365672213,
+    "expected": "28017150084243130664",
+    "overflow": false
+  },
+  {
+    "principal": "3657922630480993536",
+    "rate_bps": 6696,
+    "seconds": 2613072434,
+    "expected": "202952685297160427031",
+    "overflow": false
+  },
+  {
+    "principal": "2319726699036983833",
+    "rate_bps": 6523,
+    "seconds": 1871903475,
+    "expected": "89817516651258703544",
+    "overflow": false
+  },
+  {
+    "principal": "12745234021289241350",
+    "rate_bps": 3605,
+    "seconds": 3899761576,
+    "expected": "568178154989957688302",
+    "overflow": false
+  },
+  {
+    "principal": "2551825064800132567",
+    "rate_bps": 8792,
+    "seconds": 3691929825,
+    "expected": "262654840495815972343",
+    "overflow": false
+  },
+  {
+    "principal": "16395579585476110300",
+    "rate_bps": 3105,
+    "seconds": 3118293102,
+    "expected": "503383186073497433685",
+    "overflow": false
+  },
+  {
+    "principal": "4000100809872115365",
+    "rate_bps": 9486,
+    "seconds": 2454125151,
+    "expected": "295286883454935196661",
+    "overflow": false
+  },
+  {
+    "principal": "3357596970697991426",
+    "rate_bps": 8879,
+    "seconds": 1094317572,
+    "expected": "103449735925376863227",
+    "overflow": false
+  },
+  {
+    "principal": "7214317424898194435",
+    "rate_bps": 1073,
+    "seconds": 4293890797,
+    "expected": "105399695759823102916",
+    "overflow": false
+  },
+  {
+    "principal": "1458709856018556920",
+    "rate_bps": 772,
+    "seconds": 3555730922,
+    "expected": "12697215754253813733",
+    "overflow": false
+  },
+  {
+    "principal": "2260664913487675761",
+    "rate_bps": 4497,
+    "seconds": 939874827,
+    "expected": "30298595173699863342",
+    "overflow": false
+  },
+  {
+    "principal": "12643387936162368062",
+    "rate_bps": 2292,
+    "seconds": 188376480,
+    "expected": "17310043025325256330",
+    "overflow": false
+  },
+  {
+    "principal": "5250797400950685295",
+    "rate_bps": 9022,
+    "seconds": 4250321721,
+    "expected": "638474096061287661070",
+    "overflow": false
+  },
+  {
+    "principal": "1914020431739623764",
+    "rate_bps": 4508,
+    "seconds": 1245265574,
+    "expected": "34071076205331971669",
+    "overflow": false
+  },
+  {
+    "principal": "1018920428315991677",
+    "rate_bps": 7845,
+    "seconds": 587425271,
+    "expected": "14889469908975017332",
+    "overflow": false
+  },
+  {
+    "principal": "13127259004727785146",
+    "rate_bps": 5240,
+    "seconds": 1934929532,
+    "expected": "422049983135762836389",
+    "overflow": false
+  },
+  {
+    "principal": "1068239389429444891",
+    "rate_bps": 2388,
+    "seconds": 967630277,
+    "expected": "7827187765711149228",
+    "overflow": false
+  },
+  {
+    "principal": "1762152558550857712",
+    "rate_bps": 7336,
+    "seconds": 2869069474,
+    "expected": "117608113921484390267",
+    "overflow": false
+  },
+  {
+    "principal": "17823388943180990921",
+    "rate_bps": 7829,
+    "seconds": 3595610659,
+    "expected": "1590972341789568088796",
+    "overflow": false
+  },
+  {
+    "principal": "4125022969482954358",
+    "rate_bps": 9229,
+    "seconds": 2437532824,
+    "expected": "294255699061833413278",
+    "overflow": false
+  },
+  {
+    "principal": "649483109046673415",
+    "rate_bps": 8867,
+    "seconds": 67309201,
+    "expected": "1229171261547652782",
+    "overflow": false
+  },
+  {
+    "principal": "8373649783022157772",
+    "rate_bps": 1122,
+    "seconds": 2895845854,
+    "expected": "86273314579744629710",
+    "overflow": false
+  },
+  {
+    "principal": "16808890431243169621",
+    "rate_bps": 7238,
+    "seconds": 872608399,
+    "expected": "336643634486428053502",
+    "overflow": false
+  },
+  {
+    "principal": "11516756987484050802",
+    "rate_bps": 5264,
+    "seconds": 2815818740,
+    "expected": "541307658505691691785",
+    "overflow": false
+  },
+  {
+    "principal": "11582031245492016947",
+    "rate_bps": 6420,
+    "seconds": 1339998621,
+    "expected": "315949378047029875147",
+    "overflow": false
+  },
+  {
+    "principal": "4071073154019978472",
+    "rate_bps": 8734,
+    "seconds": 3532870746,
+    "expected": "398330201164674703452",
+    "overflow": false
+  },
+  {
+    "principal": "10955160965310053153",
+    "rate_bps": 3289,
+    "seconds": 4288826171,
+    "expected": "490020753715338082932",
+    "overflow": false
+  },
+  {
+    "principal": "4548930587898412974",
+    "rate_bps": 8765,
+    "seconds": 3591157904,
+    "expected": "454034783203232070231",
+    "overflow": false
+  },
+  {
+    "principal": "6603512303818334879",
+    "rate_bps": 1949,
+    "seconds": 3527779049,
+    "expected": "143973181000544338874",
+    "overflow": false
+  },
+  {
+    "principal": "11462338567566768964",
+    "rate_bps": 9216,
+    "seconds": 439931414,
+    "expected": "147364904146889737636",
+    "overflow": false
+  },
+  {
+    "principal": "5741849013480282413",
+    "rate_bps": 5295,
+    "seconds": 1356136487,
+    "expected": "130741820079862287855",
+    "overflow": false
+  },
+  {
+    "principal": "8290443372135375146",
+    "rate_bps": 653,
+    "seconds": 3052715628,
+    "expected": "52404753385000766343",
+    "overflow": false
+  },
+  {
+    "principal": "12499031229699493451",
+    "rate_bps": 4710,
+    "seconds": 755605109,
+    "expected": "141054043111653719220",
+    "overflow": false
+  },
+  {
+    "principal": "11467327108306265824",
+    "rate_bps": 4207,
+    "seconds": 1246916370,
+    "expected": "190750389172711172643",
+    "overflow": false
+  }
+]

--- a/docs/EXECUTION_QUALITY.md
+++ b/docs/EXECUTION_QUALITY.md
@@ -78,7 +78,19 @@ Companion: `COVERAGE_REPORT.md` (per-issue coverage snapshots),
 | `lib.rs` (inline) | Contract-level integration scaffolding tests |
 | `lifecycle.rs` (inline) | State-transition unit tests |
 
-### 1.3 Auction tests — `gateway-contract/contracts/auction_contract/src/test.rs`
+### 1.3 CosmWasm tests — `contracts/creditra-credit/tests/`
+
+| File | Concern |
+|---|---|
+| `proptest_monotonic.rs` | `accrued_interest` monotone-in-time/principal/rate; zero boundary; total / panic-free; overflow upward-closed |
+| `proptest_total.rs` | `net_outstanding` conservation across random draw/repay sequences |
+| `repay_inv.rs` | Repayment invariants |
+| `borrower_key.rs` | Borrower key encoding and collision resistance |
+| `borrower_id.rs` | Borrower ID stability |
+| `e2e_outage.rs` | End-to-end oracle-outage simulation |
+| `snap_prorate.rs` | **Snapshot-fuzz for `accrued_interest`**: 4 096-entry pinned JSON; floor/overflow; monotonicity; proptest suite (see §3) |
+
+### 1.4 Auction tests — `gateway-contract/contracts/auction_contract/src/test.rs`
 
 1 934 lines of tests covering:
 
@@ -91,7 +103,7 @@ Companion: `COVERAGE_REPORT.md` (per-issue coverage snapshots),
 - `claim_auction` (winner-only, post-settlement)
 - Reentrancy guard around refund + claim
 
-### 1.4 Total test surface
+### 1.5 Total test surface
 
 The workspace has **~817 `#[test]` annotations** across source and tests
 (reproduce with `grep -r '#\[test\]' contracts/ gateway-contract/ | wc -l`).
@@ -143,6 +155,10 @@ harness. Concrete property tests:
 - `tests/accrual_overflow_audit.rs` — sweeps `(u, r, Δt)` over wide ranges
   for overflow safety
 - `tests/borrower_key_encoding.rs` — property-style key isolation
+- `contracts/creditra-credit/tests/snap_prorate.rs` — 4 096-entry pinned
+  JSON snapshot + 8 proptest properties for `accrued_interest` (the CosmWasm
+  accrual primitive); mirrors the Soroban `snapshot_prorate_interest.rs`
+  suite. See `docs/contributing-tests.md` for the regeneration workflow.
 
 A `cargo fuzz` harness for `apply_accrual` and `compute_rate_from_score` is
 listed as a follow-up in `POST_AUDIT_CHECKLIST.md` — the targets are simple

--- a/docs/contributing-tests.md
+++ b/docs/contributing-tests.md
@@ -122,3 +122,46 @@ cargo test -p creditra-credit --test snap_deviation
 The test locks in expected outcomes for common oracle-feed moves, zero/negative
 price edge cases, and a deterministic proptest over positive prices so the
 oracle circuit-breaker math stays stable.
+
+## `accrued_interest` snapshot-fuzz test (`contracts/creditra-credit`)
+
+`contracts/creditra-credit/tests/snap_prorate.rs` pins the CosmWasm
+`accrued_interest` function — the 365-day simple-interest accrual primitive
+that mirrors the Soroban `prorate_interest`.
+
+### Run (verify mode — CI default)
+
+```bash
+cargo test -p creditra-credit --test snap_prorate
+```
+
+### Regenerate after an intentional change
+
+```bash
+cargo test -p creditra-credit --test snap_prorate \
+    -- --nocapture regenerate
+```
+
+Commit both the updated test and the regenerated
+`contracts/creditra-credit/tests/snapshots/accrued_interest.json`.
+
+### What is tested
+
+| Layer | Coverage |
+|---|---|
+| Snapshot (4 096 entries) | Exact bit-for-bit match against the pinned JSON; fails CI on any silent arithmetic drift |
+| Deterministic unit cases | Zero inputs, exact-year boundary, half-year, floor-to-zero, exact-division, overflow path, monotone time series |
+| `proptest` (512 cases each) | Monotone in time / principal / rate; zero boundary; total / panic-free; overflow upward-closed; interest ≤ principal within one year; additive consistency across split periods |
+
+### Key differences from the Soroban twin
+
+| Property | Soroban `prorate_interest` | CosmWasm `accrued_interest` |
+|---|---|---|
+| Year length | 31 557 600 s (Julian 365.25-day) | 31 536 000 s (365-day) |
+| Rounding | Caller-controlled `Floor`/`Ceil` | Always floor |
+| Overflow | Panics | Returns `Err(ContractError::Overflow)` |
+| Snapshot location | `contracts/credit/test_snapshots/prorate_interest.json` | `contracts/creditra-credit/tests/snapshots/accrued_interest.json` |
+
+The snapshot file is committed to the repository.  Any modification to
+`accrued_interest`'s arithmetic must be followed by a regeneration run and the
+new JSON committed in the same PR so CI never sees a stale snapshot.


### PR DESCRIPTION
Add snapshot-fuzz test suite for accrued_interest (the CosmWasm mirror of the Soroban prorate_interest) in contracts/creditra-credit.

Changes:
- contracts/creditra-credit/tests/snap_prorate.rs (new, 802 lines)
  - verify_accrued_interest_snapshot: loads 4 096-entry pinned JSON, re-runs accrued_interest, asserts exact match + secondary invariants (zero-input short-circuit, interest <= principal within one year); auto-bootstraps snapshot on first run
  - regenerate_accrued_interest_snapshot: rewrites + self-verifies JSON
  - mod deterministic: 16 hand-written cases (zero inputs, exact year / half / quarter / day / hour, floor-to-zero, exact division, overflow, monotone daily series, SECONDS_PER_YEAR constant guard)
  - mod fuzz: 8 proptest properties, 512 cases each (monotone in time / principal / rate; zero boundary; total/panic-free; overflow upward- closed; interest <= principal; additive split-period consistency)
- contracts/creditra-credit/tests/snapshots/accrued_interest.json (new) 4 096-entry pinned corpus: 21 anchors + LCG-seeded random inputs
- contracts/creditra-credit/Cargo.toml: add serde_json = "1.0" dev-dep
- docs/contributing-tests.md: document verify/regenerate workflow, comparison table vs Soroban twin
- docs/EXECUTION_QUALITY.md: add CosmWasm test catalog (ss 1.3), reference snap_prorate in Property & Fuzz Tests section

closes #760