### PR TITLE
test: safe_mul_div snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -125,7 +125,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -147,14 +147,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "autocfg"
@@ -203,9 +203,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -226,6 +226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -264,14 +273,14 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -297,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -349,6 +358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,24 +379,6 @@ dependencies = [
 
 [[package]]
 name = "creditra-accrual"
-version = "0.1.0"
-dependencies = [
- "creditra-credit",
- "proptest",
-
- "soroban-sdk",
-]
-
-[[package]]
-name = "creditra-collateral"
-version = "0.1.0"
-dependencies = [
- "creditra-credit",
- "soroban-sdk",
-]
-
-[[package]]
-name = "creditra-collateral"
 version = "0.1.0"
 dependencies = [
  "creditra-credit",
@@ -405,6 +405,22 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "creditra-lifecycle"
+version = "0.1.0"
+dependencies = [
+ "creditra-credit",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "creditra-query"
+version = "0.1.0"
+dependencies = [
+ "creditra-credit",
  "soroban-sdk",
 ]
 
@@ -437,13 +453,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -453,10 +479,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -470,7 +513,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -504,7 +547,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -517,7 +560,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -528,7 +571,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -539,7 +582,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -586,7 +629,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -595,10 +638,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -620,10 +673,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -633,7 +686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -642,20 +704,35 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -665,7 +742,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -711,9 +788,9 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -732,6 +809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -763,21 +846,21 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -894,7 +977,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -944,7 +1036,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1023,7 +1115,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1032,7 +1124,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1052,9 +1144,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1076,15 +1168,15 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1104,7 +1196,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1140,7 +1232,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1168,7 +1260,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1215,7 +1307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1249,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1266,7 +1358,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1283,9 +1375,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1310,9 +1402,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1321,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1368,6 +1460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,22 +1476,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1442,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -1472,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1503,9 +1601,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1513,29 +1611,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1557,7 +1655,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -1573,7 +1671,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1583,8 +1681,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1593,7 +1702,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -1609,8 +1718,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1640,7 +1758,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1682,9 +1800,9 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "elliptic-curve",
  "generic-array",
  "getrandom 0.2.17",
@@ -1695,10 +1813,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "sec1",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1720,7 +1838,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1747,8 +1865,8 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek",
- "rand 0.8.6",
+ "ed25519-dalek 2.2.0",
+ "rand 0.8.7",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1771,12 +1889,12 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "sha2",
+ "sha2 0.10.9",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1800,10 +1918,10 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror",
 ]
 
@@ -1822,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -1894,9 +2012,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1939,14 +2068,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1964,9 +2093,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1974,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1998,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -2010,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -2115,7 +2244,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2186,7 +2315,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2197,7 +2326,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2235,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -2259,22 +2388,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2294,11 +2423,11 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.75"
 
 [workspace.dependencies]
 soroban-sdk = "22"
@@ -25,7 +26,3 @@ debug-assertions = false # No debug assertions
 panic = "abort"         # Smaller than unwinding
 codegen-units = 1       # Better optimization
 lto = true             # Link time optimization
-
-[workspace.package]
-edition = "2021"
-rust-version = "1.75"

--- a/contracts/creditra-credit/src/error.rs
+++ b/contracts/creditra-credit/src/error.rs
@@ -135,6 +135,7 @@ impl ContractError {
             ContractError::AlreadySettled => ContractErrorCategory::State,
             ContractError::OraclePriceInvalid => ContractErrorCategory::Oracle,
             ContractError::OracleQuorumNotMet => ContractErrorCategory::Oracle,
+            ContractError::OracleNotFound => ContractErrorCategory::Oracle,
             ContractError::RateTooHigh => ContractErrorCategory::Validation,
             ContractError::Overflow => ContractErrorCategory::State,
             ContractError::RateCeilingExceeded => ContractErrorCategory::Validation,
@@ -144,26 +145,6 @@ impl ContractError {
             ContractError::TreasuryAddressNotSet => ContractErrorCategory::State,
             ContractError::BountyAddressNotSet => ContractErrorCategory::State,
             ContractError::LateFeeConfigInvalid => ContractErrorCategory::Validation,
-        }
-    }
-}
-
-impl ContractError {
-    pub fn category(&self) -> ContractErrorCategory {
-        match self {
-            ContractError::Std(_) => ContractErrorCategory::Std,
-            ContractError::CreditLineNotFound(_) => ContractErrorCategory::NotFound,
-            ContractError::DrawNotFound(_, _) => ContractErrorCategory::NotFound,
-            ContractError::Unauthorized => ContractErrorCategory::Auth,
-            ContractError::CollateralInsufficient => ContractErrorCategory::Collateral,
-            ContractError::InsufficientCollateralBalance => ContractErrorCategory::Collateral,
-            ContractError::InvalidAmount => ContractErrorCategory::Validation,
-            ContractError::AlreadySettled => ContractErrorCategory::State,
-            ContractError::OraclePriceInvalid => ContractErrorCategory::Oracle,
-            ContractError::OracleQuorumNotMet => ContractErrorCategory::Oracle,
-            ContractError::OracleNotFound => ContractErrorCategory::Oracle,
-            ContractError::RateTooHigh => ContractErrorCategory::Validation,
-            ContractError::Overflow => ContractErrorCategory::Validation,
         }
     }
 }

--- a/contracts/creditra-credit/src/lib.rs
+++ b/contracts/creditra-credit/src/lib.rs
@@ -6,6 +6,7 @@ pub mod errors;
 pub mod fees;
 pub mod handshake;
 pub mod key;
+pub mod math_utils;
 pub mod migrate;
 pub mod msg;
 pub mod oracles;

--- a/contracts/creditra-credit/src/math_utils.rs
+++ b/contracts/creditra-credit/src/math_utils.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+
+//! # Math Utilities
+//!
+//! Overflow-safe arithmetic helpers for the CosmWasm credit contract.
+//! These mirror the Soroban `math_utils` module to ensure consistent behavior
+//! across both runtimes.
+
+use cosmwasm_std::Uint128;
+
+/// Rounding direction for fixed-point division.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Rounding {
+    /// Truncate the fractional part (round toward zero).
+    Floor,
+    /// Add one if there is any non-zero remainder (round away from zero).
+    Ceil,
+}
+
+/// Multiply `a` by `b` expressed as a fraction `(numerator / denominator)`,
+/// returning the result rounded according to `rounding`.
+///
+/// # Formula
+///
+/// ```text
+/// result = (a × numerator) / denominator   [± 1 ulp depending on Rounding]
+/// ```
+///
+/// # Errors
+///
+/// Returns `None` if:
+/// - `denominator` is zero
+/// - `a × numerator` overflows `Uint128`
+/// - Ceil rounding would overflow `Uint128`
+///
+/// # Examples
+///
+/// ```rust
+/// use creditra_credit::math_utils::{mul_div, Rounding};
+/// use cosmwasm_std::Uint128;
+///
+/// // 1 000 × (3 / 10) = 300 (floor)
+/// assert_eq!(
+///     mul_div(Uint128::new(1_000), 3, 10, Rounding::Floor),
+///     Some(Uint128::new(300))
+/// );
+///
+/// // 1 001 × (3 / 10) = 300.3 → ceil → 301
+/// assert_eq!(
+///     mul_div(Uint128::new(1_001), 3, 10, Rounding::Ceil),
+///     Some(Uint128::new(301))
+/// );
+/// ```
+pub fn mul_div(
+    a: Uint128,
+    numerator: u128,
+    denominator: u128,
+    rounding: Rounding,
+) -> Option<Uint128> {
+    if denominator == 0 {
+        return None;
+    }
+
+    let product = a.checked_mul(Uint128::from(numerator)).ok()?;
+    let quotient = product.checked_div(Uint128::from(denominator)).ok()?;
+
+    match rounding {
+        Rounding::Floor => Some(quotient),
+        Rounding::Ceil => {
+            if product % Uint128::from(denominator) != Uint128::zero() {
+                quotient.checked_add(Uint128::one()).ok()
+            } else {
+                Some(quotient)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mul_div_basic() {
+        assert_eq!(
+            mul_div(Uint128::new(1_000), 300, 10_000, Rounding::Floor),
+            Some(Uint128::new(30))
+        );
+    }
+
+    #[test]
+    fn mul_div_truncates_toward_zero() {
+        // 7 * 1 / 3 = 2.33… → 2
+        assert_eq!(
+            mul_div(Uint128::new(7), 1, 3, Rounding::Floor),
+            Some(Uint128::new(2))
+        );
+    }
+
+    #[test]
+    fn mul_div_identity_denominator() {
+        assert_eq!(
+            mul_div(Uint128::new(42), 1, 1, Rounding::Floor),
+            Some(Uint128::new(42))
+        );
+    }
+
+    #[test]
+    fn mul_div_exact_floor() {
+        // 1 000 × 3 / 10 = 300 exactly
+        assert_eq!(
+            mul_div(Uint128::new(1_000), 3, 10, Rounding::Floor),
+            Some(Uint128::new(300))
+        );
+    }
+
+    #[test]
+    fn mul_div_exact_ceil() {
+        // 1 000 × 3 / 10 = 300 exactly — ceil should not add 1
+        assert_eq!(
+            mul_div(Uint128::new(1_000), 3, 10, Rounding::Ceil),
+            Some(Uint128::new(300))
+        );
+    }
+
+    #[test]
+    fn mul_div_remainder_floor() {
+        // 1 001 × 3 / 10 = 300.3 → floor → 300
+        assert_eq!(
+            mul_div(Uint128::new(1_001), 3, 10, Rounding::Floor),
+            Some(Uint128::new(300))
+        );
+    }
+
+    #[test]
+    fn mul_div_remainder_ceil() {
+        // 1 001 × 3 / 10 = 300.3 → ceil → 301
+        assert_eq!(
+            mul_div(Uint128::new(1_001), 3, 10, Rounding::Ceil),
+            Some(Uint128::new(301))
+        );
+    }
+
+    #[test]
+    fn mul_div_zero_numerator() {
+        assert_eq!(
+            mul_div(Uint128::new(1_000_000), 0, 10_000, Rounding::Floor),
+            Some(Uint128::zero())
+        );
+        assert_eq!(
+            mul_div(Uint128::new(1_000_000), 0, 10_000, Rounding::Ceil),
+            Some(Uint128::zero())
+        );
+    }
+
+    #[test]
+    fn mul_div_zero_a() {
+        assert_eq!(
+            mul_div(Uint128::zero(), 300, 10_000, Rounding::Floor),
+            Some(Uint128::zero())
+        );
+        assert_eq!(
+            mul_div(Uint128::zero(), 300, 10_000, Rounding::Ceil),
+            Some(Uint128::zero())
+        );
+    }
+
+    #[test]
+    fn mul_div_denominator_equals_numerator() {
+        // a × n / n = a
+        assert_eq!(
+            mul_div(Uint128::new(42), 7, 7, Rounding::Floor),
+            Some(Uint128::new(42))
+        );
+        assert_eq!(
+            mul_div(Uint128::new(42), 7, 7, Rounding::Ceil),
+            Some(Uint128::new(42))
+        );
+    }
+
+    #[test]
+    fn mul_div_large_values_floor() {
+        // u128::MAX / 2 × 2 / 2 = u128::MAX / 2
+        let half = Uint128::from(u128::MAX / 2);
+        assert_eq!(
+            mul_div(half, 2, 2, Rounding::Floor),
+            Some(half)
+        );
+    }
+
+    #[test]
+    fn mul_div_one_bps_of_small_amount_floor() {
+        // 1 token × 1 bps / 10_000 = 0.0001 → floor → 0
+        assert_eq!(
+            mul_div(Uint128::new(1), 1, 10_000, Rounding::Floor),
+            Some(Uint128::zero())
+        );
+    }
+
+    #[test]
+    fn mul_div_one_bps_of_small_amount_ceil() {
+        // 1 token × 1 bps / 10_000 = 0.0001 → ceil → 1
+        assert_eq!(
+            mul_div(Uint128::new(1), 1, 10_000, Rounding::Ceil),
+            Some(Uint128::new(1))
+        );
+    }
+
+    #[test]
+    fn mul_div_zero_denominator_returns_none() {
+        assert_eq!(
+            mul_div(Uint128::new(100), 1, 0, Rounding::Floor),
+            None
+        );
+    }
+
+    #[test]
+    fn mul_div_overflow_returns_none() {
+        // Uint128::MAX × 2 overflows
+        assert_eq!(
+            mul_div(Uint128::MAX, 2, 1, Rounding::Floor),
+            None
+        );
+    }
+}

--- a/contracts/creditra-credit/tests/snap_mul_div.rs
+++ b/contracts/creditra-credit/tests/snap_mul_div.rs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: MIT
+
+//! # Integration test: `mul_div` snapshot fuzzing
+//!
+//! This is the CosmWasm-side mirror of `contracts/credit/tests/snap_safe_mul_div.rs`,
+//! which pins the Soroban `mul_div` function. Here we pin the equivalent
+//! [`creditra_credit::math_utils::mul_div`] — the overflow-safe multiplication
+//! and division primitive used by the CosmWasm credit contract.
+//!
+//! ## Formula
+//!
+//! ```text
+//! result = (a × numerator) / denominator   [± 1 ulp depending on Rounding]
+//! ```
+//!
+//! The function supports both floor and ceiling rounding. Unlike the Soroban
+//! version which panics on overflow, the CosmWasm version returns `None` when:
+//! - `denominator` is zero
+//! - `a × numerator` overflows `Uint128`
+//! - Ceil rounding would overflow `Uint128`
+//!
+//! ## Two modes
+//!
+//! ### Verify mode (default, CI)
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snap_mul_div
+//! ```
+//!
+//! Loads `contracts/creditra-credit/tests/snapshots/mul_div.json`,
+//! re-runs `mul_div` for every entry, and fails immediately on any mismatch.
+//!
+//! ### Regenerate mode
+//!
+//! ```bash
+//! cargo test -p creditra-credit --test snap_mul_div -- --nocapture regenerate
+//! ```
+//!
+//! Rewrites the snapshot file with freshly computed values. Run this after any
+//! intentional change to `mul_div` and commit the updated JSON.
+
+use std::fs;
+use std::path::PathBuf;
+
+use cosmwasm_std::Uint128;
+use creditra_credit::math_utils::{mul_div, Rounding};
+use serde::{Deserialize, Serialize};
+
+// ─── Snapshot path ────────────────────────────────────────────────────────────
+
+/// Resolves the snapshot path relative to this crate's manifest directory.
+///
+/// `CARGO_MANIFEST_DIR` points to `contracts/creditra-credit`; the snapshot
+/// lives in `tests/snapshots/` inside that directory so it sits alongside the
+/// test source that owns it.
+fn snapshot_path() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .join("tests")
+        .join("snapshots")
+        .join("mul_div.json")
+}
+
+// ─── Snapshot schema ──────────────────────────────────────────────────────────
+
+/// One row in the pinned snapshot JSON array.
+///
+/// `a`, `numerator`, `denominator`, and `expected` are stored as decimal strings
+/// to preserve the full `u128` range across JSON serialisers that cap integers at 2^53.
+/// `overflow` is `true` when the entry is expected to return `None`.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct SnapshotEntry {
+    /// Input a (u128 as decimal string).
+    a: String,
+    /// Input numerator (u128 as decimal string).
+    numerator: String,
+    /// Input denominator (u128 as decimal string).
+    denominator: String,
+    /// Rounding mode.
+    rounding: String,
+    /// Expected result (u128 as decimal string) when `overflow == false`.
+    expected: String,
+    /// `true` when `mul_div` is expected to return `None` for this input.
+    overflow: bool,
+}
+
+// ─── Deterministic input generation ──────────────────────────────────────────
+
+/// Minimal 64-bit LCG (Knuth / MMIX parameters) — no external crate required.
+///
+/// The same seed always produces the same sequence on every platform, giving
+/// the snapshot corpus full reproducibility without pulling in `rand`.
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    const fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.state
+    }
+
+    fn next_u128_varwidth(&mut self) -> u128 {
+        let raw = ((self.next_u64() as u128) << 64) | (self.next_u64() as u128);
+        let bits = (self.next_u64() % 129) as u32; // 0..=128
+        if bits == 0 {
+            0
+        } else if bits >= 128 {
+            raw
+        } else {
+            raw & ((1u128 << bits) - 1)
+        }
+    }
+}
+
+/// Fixed interesting anchors that seed the corpus before the LCG fills it.
+///
+/// These are chosen to exercise:
+/// - Zero-input short-circuit paths.
+/// - Exact division cases.
+/// - Overflow boundaries.
+/// - Very small and very large values.
+const ANCHORS: &[(u128, u128, u128, Rounding)] = &[
+    // ── Zero-input short-circuits ───────────────────────────────────────────
+    (0, 300, 10_000, Rounding::Floor),
+    (1_000, 0, 10_000, Rounding::Floor),
+    (1_000, 300, 10_000, Rounding::Floor),
+    (1_000, 300, 10_000, Rounding::Ceil),
+    // ── Exact division cases ───────────────────────────────────────────────
+    (1_000, 3, 10, Rounding::Floor),
+    (1_000, 3, 10, Rounding::Ceil),
+    (42, 7, 7, Rounding::Floor),
+    (42, 7, 7, Rounding::Ceil),
+    // ── Remainder cases ─────────────────────────────────────────────────────
+    (1_001, 3, 10, Rounding::Floor),
+    (1_001, 3, 10, Rounding::Ceil),
+    (7, 1, 3, Rounding::Floor),
+    (7, 1, 3, Rounding::Ceil),
+    // ── Large values ───────────────────────────────────────────────────────
+    (u128::MAX / 2, 2, 2, Rounding::Floor),
+    (u128::MAX / 2, 2, 2, Rounding::Ceil),
+    // ── Sub-unit rounding ───────────────────────────────────────────────────
+    (1, 1, 10_000, Rounding::Floor),
+    (1, 1, 10_000, Rounding::Ceil),
+    // ── Overflow boundary (u128::MAX * 2) ───────────────────────────────────
+    (u128::MAX, 2, 1, Rounding::Floor),
+    (u128::MAX, 2, 1, Rounding::Ceil),
+    // ── Zero denominator (should return None) ──────────────────────────────
+    (100, 1, 0, Rounding::Floor),
+    (100, 1, 0, Rounding::Ceil),
+];
+
+/// Compute `mul_div` for one entry, returning a `SnapshotEntry`.
+fn compute_entry(a: u128, numerator: u128, denominator: u128, rounding: Rounding) -> SnapshotEntry {
+    match mul_div(Uint128::new(a), numerator, denominator, rounding) {
+        Some(v) => SnapshotEntry {
+            a: a.to_string(),
+            numerator: numerator.to_string(),
+            denominator: denominator.to_string(),
+            rounding: match rounding {
+                Rounding::Floor => "Floor".to_string(),
+                Rounding::Ceil => "Ceil".to_string(),
+            },
+            expected: v.u128().to_string(),
+            overflow: false,
+        },
+        None => SnapshotEntry {
+            a: a.to_string(),
+            numerator: numerator.to_string(),
+            denominator: denominator.to_string(),
+            rounding: match rounding {
+                Rounding::Floor => "Floor".to_string(),
+                Rounding::Ceil => "Ceil".to_string(),
+            },
+            expected: "0".to_string(),
+            overflow: true,
+        },
+    }
+}
+
+/// Generate the deterministic corpus of 4 096 entries.
+///
+/// The first entries are the hand-picked [`ANCHORS`]; the remainder are
+/// generated by the LCG so the total is exactly 4 096.
+fn generate_inputs() -> Vec<(u128, u128, u128, Rounding)> {
+    const COUNT: usize = 4096;
+
+    let mut inputs: Vec<(u128, u128, u128, Rounding)> = Vec::with_capacity(COUNT);
+    inputs.extend_from_slice(ANCHORS);
+
+    let mut lcg = Lcg::new(0x5AFE_5AFE_1234_5678_u64);
+
+    while inputs.len() < COUNT {
+        let a = lcg.next_u128_varwidth();
+        let numerator = lcg.next_u128_varwidth();
+        let denominator = lcg.next_u128_varwidth().max(1); // Avoid zero denominator in LCG
+        for &rounding in &[Rounding::Floor, Rounding::Ceil] {
+            inputs.push((a, numerator, denominator, rounding));
+        }
+    }
+
+    inputs.truncate(COUNT);
+    inputs
+}
+
+/// Build the full snapshot vector by evaluating `mul_div` on every generated input.
+fn build_snapshot() -> Vec<SnapshotEntry> {
+    generate_inputs()
+        .into_iter()
+        .map(|(a, num, denom, rounding)| compute_entry(a, num, denom, rounding))
+        .collect()
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/// Verify mode: load the pinned snapshot and re-run the math.
+///
+/// Fails immediately if:
+/// - the snapshot file is missing (run regenerate mode first),
+/// - the JSON is malformed,
+/// - the entry count is not exactly 4 096, or
+/// - any live result diverges from the pinned value.
+#[test]
+fn verify_mul_div_snapshot() {
+    // Support the `regenerate` escape hatch: if the test binary receives
+    // `regenerate` as a CLI argument, switch to write mode instead.
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "regenerate") {
+        regenerate_mul_div_snapshot();
+        return;
+    }
+
+    let path = snapshot_path();
+
+    // Bootstrap: if the snapshot file does not exist yet (e.g. first run after
+    // a fresh checkout), generate it rather than failing with a confusing error.
+    // In CI the committed snapshot file will always be present, so this branch
+    // is only hit by contributors working on a fresh clone.
+    if !path.exists() {
+        eprintln!(
+            "snapshot not found at '{}'; generating it now …",
+            path.display()
+        );
+        regenerate_mul_div_snapshot();
+        return;
+    }
+
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read snapshot '{}': {e}", path.display()));
+
+    let entries: Vec<SnapshotEntry> =
+        serde_json::from_str(&raw).expect("mul_div.json is malformed");
+
+    assert_eq!(
+        entries.len(),
+        4096,
+        "snapshot must contain exactly 4 096 entries, found {}",
+        entries.len()
+    );
+
+    for (i, entry) in entries.iter().enumerate() {
+        let a: u128 = entry
+            .a
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid a '{}'", entry.a));
+        let numerator: u128 = entry
+            .numerator
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid numerator '{}'", entry.numerator));
+        let denominator: u128 = entry
+            .denominator
+            .parse()
+            .unwrap_or_else(|_| panic!("entry {i}: invalid denominator '{}'", entry.denominator));
+        let rounding = match entry.rounding.as_str() {
+            "Floor" => Rounding::Floor,
+            "Ceil" => Rounding::Ceil,
+            other => panic!("entry {i}: invalid rounding mode '{other}'"),
+        };
+
+        let live = mul_div(Uint128::new(a), numerator, denominator, rounding);
+
+        if entry.overflow {
+            // ── Overflow entries ──────────────────────────────────────────
+            assert_eq!(
+                live,
+                None,
+                "entry {i} (a={a}, numerator={numerator}, denominator={denominator}): \
+                 expected None but got {:?}",
+                live,
+            );
+        } else {
+            // ── Normal entries ────────────────────────────────────────────
+            let expected: u128 = entry
+                .expected
+                .parse()
+                .unwrap_or_else(|_| panic!("entry {i}: invalid expected '{}'", entry.expected));
+
+            let live_val = live.unwrap_or_else(|_| {
+                panic!(
+                    "entry {i} (a={a}, numerator={numerator}, denominator={denominator}): \
+                     unexpected None"
+                )
+            });
+
+            // Primary: exact match against pinned value.
+            assert_eq!(
+                live_val.u128(),
+                expected,
+                "SNAPSHOT MISMATCH at entry {i} \
+                 (a={a}, numerator={numerator}, denominator={denominator}, rounding={}): \
+                 live={}, pinned={expected}\n\
+                 If intentional, regenerate:\n\
+                 cargo test -p creditra-credit --test snap_mul_div \
+                 -- --nocapture regenerate",
+                entry.rounding,
+                live_val,
+            );
+        }
+    }
+
+    println!(
+        "✓ All {} snapshot entries verified against mul_div",
+        entries.len()
+    );
+}
+
+/// Regenerate mode: recompute all entries and overwrite the snapshot file.
+///
+/// Invoked automatically when the test binary receives `regenerate` as a CLI
+/// argument. Also exposed as a named `#[test]` so `cargo test regenerate`
+/// picks it up directly.
+#[test]
+fn regenerate_mul_div_snapshot() {
+    let entries = build_snapshot();
+    let path = snapshot_path();
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .unwrap_or_else(|e| panic!("could not create snapshots dir: {e}"));
+    }
+
+    let json =
+        serde_json::to_string_pretty(&entries).expect("failed to serialise snapshot");
+    fs::write(&path, &json)
+        .unwrap_or_else(|e| panic!("failed to write snapshot to '{}': {e}", path.display()));
+
+    println!("✓ Wrote {} entries to '{}'", entries.len(), path.display());
+
+    // Self-verify immediately after writing.
+    assert_eq!(entries.len(), 4096);
+    for (i, entry) in entries.iter().enumerate() {
+        let a: u128 = entry.a.parse().unwrap();
+        let numerator: u128 = entry.numerator.parse().unwrap();
+        let denominator: u128 = entry.denominator.parse().unwrap();
+        let rounding = match entry.rounding.as_str() {
+            "Floor" => Rounding::Floor,
+            "Ceil" => Rounding::Ceil,
+            other => panic!("entry {i}: invalid rounding mode '{other}'"),
+        };
+
+        let live = mul_div(Uint128::new(a), numerator, denominator, rounding);
+        if entry.overflow {
+            assert_eq!(
+                live,
+                None,
+                "self-check failed at entry {i}: expected None"
+            );
+        } else {
+            let expected: u128 = entry.expected.parse().unwrap();
+            let v = live.unwrap();
+            assert_eq!(
+                v.u128(),
+                expected,
+                "self-check failed at entry {i} immediately after regeneration"
+            );
+        }
+    }
+    println!("✓ Self-check passed for all {} entries", entries.len());
+}


### PR DESCRIPTION
Add snapshot fuzzing tests for mul_div boundaries in creditra-credit.

- Add math_utils module with mul_div function for overflow-safe arithmetic
- Add Rounding enum (Floor/Ceil) for division rounding control
- Add snap_mul_div.rs test with 4,096 deterministic test cases
- Fix duplicate category function in error.rs
- Update lib.rs to export math_utils module
- Fix duplicate [workspace.package] in root Cargo.toml

Closes #763