### PR TITLE
fix: TTL bump gateway-auction storage reads (#918)

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -14,7 +14,7 @@ pub use types::{AuctionMode, AuctionState, AuctionStatus, DutchAuctionDecay};
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env, Symbol};
 
 use crate::storage::{
-    bump_auction_state_ttl, bump_settlement_marker_ttl, clear_reentrancy_guard,
+    bump_auction_state_ttl, bump_instance_ttl, bump_settlement_marker_ttl, clear_reentrancy_guard,
     get_factory_contract, set_liquidation_grace_window, set_reentrancy_guard,
 };
 use crate::types::*;
@@ -236,6 +236,7 @@ impl Auction {
         dutch_decay: DutchAuctionDecay,
         dutch_step_count: Option<u32>,
     ) {
+        bump_instance_ttl(&env);
         if start_time >= end_time {
             panic!("invalid times");
         }
@@ -291,11 +292,13 @@ impl Auction {
     /// # Authorization
     /// Requires `require_auth` from the factory itself.
     pub fn set_factory_contract(env: Env, factory: Address) {
+        bump_instance_ttl(&env);
         factory.require_auth();
         storage::set_factory_contract(&env, &factory);
     }
 
     pub fn place_bid(env: Env, auction_id: Symbol, bidder: Address, amount: i128) {
+        bump_instance_ttl(&env);
         bidder.require_auth();
 
         if amount <= 0 {
@@ -454,6 +457,7 @@ impl Auction {
         credit_contract: Address,
         borrower: Address,
     ) -> i128 {
+        bump_instance_ttl(&env);
         let factory = get_factory_contract(&env)
             .unwrap_or_else(|| env.panic_with_error(AuctionError::NoFactoryContract));
         factory.require_auth();
@@ -529,6 +533,7 @@ impl Auction {
     /// * [`AuctionError::AlreadyClaimed`] - Auction was already claimed.
     /// * [`AuctionError::InvalidState`] - Bid token not found in storage.
     pub fn claim_auction(env: Env, auction_id: Symbol) {
+        bump_instance_ttl(&env);
         let state: AuctionState = env
             .storage()
             .persistent()
@@ -577,6 +582,64 @@ impl Auction {
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&env.current_contract_address(), &winner, &recovered_amount);
         clear_reentrancy_guard(&env);
+    }
+
+    /// Closes the singleton auction once its end time has passed.
+    ///
+    /// Transitions the auction from [`AuctionStatus::Open`] to
+    /// [`AuctionStatus::Closed`] and emits an [`AuctionClosedEvent`].
+    /// No caller authorization is required — any account may trigger
+    /// close once the end time is reached (permissionless keeper pattern).
+    ///
+    /// # Parameters
+    /// - `auction_id`: The unique identifier of the auction to close.
+    ///
+    /// # Errors
+    /// - [`AuctionError::NotFound`]        — No auction exists for `auction_id`.
+    /// - [`AuctionError::AuctionNotOpen`]  — Auction is not in the `Open` state
+    ///                                       (already `Closed` or `Claimed`).
+    /// - [`AuctionError::AuctionNotClosed`] — Current ledger timestamp is before
+    ///                                        the auction's configured `end_time`.
+    ///
+    /// # State transitions
+    /// `Open` → `Closed` (terminal for further bidding; enables `claim_auction`
+    /// and `settle_default_liquidation`).
+    ///
+    /// # Events
+    /// Emits [`AuctionClosedEvent`] on `(AUC_CLOSE, auction)` with:
+    /// - `auction_id`
+    /// - `winner`: the current highest bidder, or `None` if no bids were placed
+    /// - `amount`: the highest bid amount, or `0` if no bids were placed
+    pub fn close_auction(env: Env, auction_id: Symbol) {
+        bump_instance_ttl(&env);
+
+        let state: AuctionState = env
+            .storage()
+            .persistent()
+            .get(&auction_id)
+            .unwrap_or_else(|| env.panic_with_error(AuctionError::NotFound));
+        bump_auction_state_ttl(&env, &auction_id);
+
+        if state.status != AuctionStatus::Open {
+            env.panic_with_error(AuctionError::AuctionNotOpen);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < state.config.end_time {
+            env.panic_with_error(AuctionError::AuctionNotClosed);
+        }
+
+        let mut updated = state;
+        updated.status = AuctionStatus::Closed;
+        env.storage().persistent().set(&auction_id, &updated);
+        bump_auction_state_ttl(&env, &auction_id);
+
+        publish_auction_closed_event(
+            &env,
+            auction_id,
+            updated.highest_bidder,
+            updated.highest_bid,
+        );
     }
 }
 

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -14,12 +14,18 @@
 //!
 //! # How
 //!
-//! Both instance and persistent reads/writes go through helpers that bump
+//! **Persistent storage** — both reads and writes go through helpers that bump
 //! TTL when remaining lifetime drops below
 //! [`PERSISTENT_LIFETIME_THRESHOLD`] (~7 days), extending the entry by
 //! [`PERSISTENT_BUMP_AMOUNT`] (~30 days). Auction state is short-lived by
 //! nature, so the cadence is more aggressive than the credit contract's
 //! ~3 / ~6 month cycle.
+//!
+//! **Instance storage** — every hot entrypoint calls [`bump_instance_ttl`]
+//! at the top of its body, extending the contract instance ledger entry by
+//! [`INSTANCE_BUMP_AMOUNT`] (~30 days) whenever the remaining TTL drops below
+//! [`INSTANCE_LIFETIME_THRESHOLD`] (~7 days). This prevents the instance from
+//! being archived mid-auction.
 //!
 //! # Why
 //!
@@ -39,10 +45,31 @@ use crate::types::{AuctionStatus, DataKey};
 use soroban_sdk::{Address, Env, Symbol};
 
 /// TTL constants for persistent storage entries.
-/// Bump amount: ~30 days (at ~5s per ledger close).
+/// Bump amount: ~30 days (at ~5 s per ledger close).
 pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
 /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+
+/// TTL constants for the contract instance storage entry.
+/// Bump amount: ~30 days (at ~5 s per ledger close).
+pub(crate) const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+/// Lifetime threshold: ~7 days — instance is extended when remaining TTL drops below this.
+pub(crate) const INSTANCE_LIFETIME_THRESHOLD: u32 = 120_960;
+
+/// Extend the contract instance TTL on every hot read path.
+///
+/// Called at the top of every [`#[contractimpl]`] entrypoint body so that the
+/// instance ledger entry is never archived while an auction is in flight.
+///
+/// # Storage
+/// - **Type**: Instance storage (the contract's own instance entry)
+/// - **TTL extended when**: remaining lifetime < [`INSTANCE_LIFETIME_THRESHOLD`]
+/// - **Extended to**: [`INSTANCE_BUMP_AMOUNT`] ledgers from the current ledger
+pub(crate) fn bump_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
 
 /// Extend TTL for an `AuctionState` entry stored under `auction_id`.
 ///
@@ -184,15 +211,53 @@ pub fn set_highest_bid(env: &Env, bid: u128) {
 // --- id-scoped auction storage ---
 use crate::types::AuctionKey;
 
+/// Check whether an auction with the given `id` exists in persistent storage.
+///
+/// Bumps the TTL of `AuctionKey::Status(id)` when the key is present, so
+/// a bare existence probe does not let live auctions drift toward expiry.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::Status(id)`
+/// - **TTL bumped when**: key exists and remaining lifetime < [`PERSISTENT_LIFETIME_THRESHOLD`]
 pub fn auction_exists(env: &Env, id: u32) -> bool {
-    env.storage().persistent().has(&AuctionKey::Status(id))
+    let key = AuctionKey::Status(id);
+    let exists = env.storage().persistent().has(&key);
+    if exists {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    exists
 }
 
+/// Get the [`AuctionStatus`] for the auction identified by `id`.
+///
+/// Returns [`AuctionStatus::Open`] when the key is absent (consistent with
+/// the write-path default). Bumps persistent TTL on every successful read so
+/// the entry is not archived between status transitions.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::Status(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_status(env: &Env, id: u32) -> crate::types::AuctionStatus {
-    env.storage()
+    let key = AuctionKey::Status(id);
+    let value = env
+        .storage()
         .persistent()
-        .get(&AuctionKey::Status(id))
-        .unwrap_or(crate::types::AuctionStatus::Open)
+        .get(&key)
+        .unwrap_or(crate::types::AuctionStatus::Open);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_status(env: &Env, id: u32, status: crate::types::AuctionStatus) {
@@ -205,8 +270,26 @@ pub fn auction_set_status(env: &Env, id: u32, status: crate::types::AuctionStatu
     );
 }
 
+/// Get the seller [`Address`] for the auction identified by `id`.
+///
+/// Returns `None` when no seller has been written. Bumps persistent TTL on
+/// every read where the key exists.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::Seller(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_seller(env: &Env, id: u32) -> Option<Address> {
-    env.storage().persistent().get(&AuctionKey::Seller(id))
+    let key = AuctionKey::Seller(id);
+    let value = env.storage().persistent().get(&key);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_seller(env: &Env, id: u32, seller: &Address) {
@@ -219,8 +302,26 @@ pub fn auction_set_seller(env: &Env, id: u32, seller: &Address) {
     );
 }
 
+/// Get the asset [`Address`] for the auction identified by `id`.
+///
+/// Returns `None` when no asset has been written. Bumps persistent TTL on
+/// every read where the key exists.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::Asset(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_asset(env: &Env, id: u32) -> Option<Address> {
-    env.storage().persistent().get(&AuctionKey::Asset(id))
+    let key = AuctionKey::Asset(id);
+    let value = env.storage().persistent().get(&key);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_asset(env: &Env, id: u32, asset: &Address) {
@@ -233,11 +334,26 @@ pub fn auction_set_asset(env: &Env, id: u32, asset: &Address) {
     );
 }
 
+/// Get the minimum bid amount for the auction identified by `id`.
+///
+/// Returns `0` when the key is absent. Bumps persistent TTL on every read
+/// where the key exists.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::MinBid(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_min_bid(env: &Env, id: u32) -> i128 {
-    env.storage()
-        .persistent()
-        .get(&AuctionKey::MinBid(id))
-        .unwrap_or(0)
+    let key = AuctionKey::MinBid(id);
+    let value = env.storage().persistent().get(&key).unwrap_or(0);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_min_bid(env: &Env, id: u32, min_bid: i128) {
@@ -250,11 +366,26 @@ pub fn auction_set_min_bid(env: &Env, id: u32, min_bid: i128) {
     );
 }
 
+/// Get the end timestamp for the auction identified by `id`.
+///
+/// Returns `0` when the key is absent. Bumps persistent TTL on every read
+/// where the key exists.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::EndTime(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_end_time(env: &Env, id: u32) -> u64 {
-    env.storage()
-        .persistent()
-        .get(&AuctionKey::EndTime(id))
-        .unwrap_or(0)
+    let key = AuctionKey::EndTime(id);
+    let value = env.storage().persistent().get(&key).unwrap_or(0);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_end_time(env: &Env, id: u32, end_time: u64) {
@@ -267,10 +398,26 @@ pub fn auction_set_end_time(env: &Env, id: u32, end_time: u64) {
     );
 }
 
+/// Get the current highest bidder [`Address`] for the auction identified by `id`.
+///
+/// Returns `None` when no bid has been placed. Bumps persistent TTL on every
+/// read where the key exists.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::HighestBidder(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_highest_bidder(env: &Env, id: u32) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&AuctionKey::HighestBidder(id))
+    let key = AuctionKey::HighestBidder(id);
+    let value = env.storage().persistent().get(&key);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_highest_bidder(env: &Env, id: u32, bidder: &Address) {
@@ -283,11 +430,26 @@ pub fn auction_set_highest_bidder(env: &Env, id: u32, bidder: &Address) {
     );
 }
 
+/// Get the current highest bid amount for the auction identified by `id`.
+///
+/// Returns `0` when no bid has been placed. Bumps persistent TTL on every
+/// read where the key exists.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::HighestBid(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_get_highest_bid(env: &Env, id: u32) -> i128 {
-    env.storage()
-        .persistent()
-        .get(&AuctionKey::HighestBid(id))
-        .unwrap_or(0)
+    let key = AuctionKey::HighestBid(id);
+    let value = env.storage().persistent().get(&key).unwrap_or(0);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_highest_bid(env: &Env, id: u32, bid: i128) {
@@ -300,11 +462,31 @@ pub fn auction_set_highest_bid(env: &Env, id: u32, bid: i128) {
     );
 }
 
+/// Check whether the auction identified by `id` has already been claimed.
+///
+/// Returns `false` when the key is absent (default: not claimed). Bumps
+/// persistent TTL on every read where the key exists so the claimed marker
+/// is not archived before settlement replay-protection is no longer needed.
+///
+/// # Storage
+/// - **Type**: Persistent
+/// - **Key**: `AuctionKey::Claimed(id)`
+/// - **TTL bumped when**: key exists
 pub fn auction_is_claimed(env: &Env, id: u32) -> bool {
-    env.storage()
+    let key = AuctionKey::Claimed(id);
+    let value = env
+        .storage()
         .persistent()
-        .get(&AuctionKey::Claimed(id))
-        .unwrap_or(false)
+        .get(&key)
+        .unwrap_or(false);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    value
 }
 
 pub fn auction_set_claimed(env: &Env, id: u32) {


### PR DESCRIPTION
 ### What this PR does
  
  Soroban persistent and instance storage entries expire after a fixed number
  of ledgers unless their TTL is explicitly extended. Before this PR, the
  gateway-auction contract had three silent gaps where live auction data could
  be archived mid-lifecycle, causing any subsequent read to return a default
  value or panic — potentially losing bid state, blocking settlement, or
  making replay-protection markers disappear.
  
  ---
  
  ### Gap 1 — Contract instance was never extended
  
  Every entrypoint reads from instance storage: the bid token address, the
  factory contract pointer, the reentrancy flag, the liquidation grace window,
  and the legacy singleton fields (`Status`, `HighestBidder`, `HighestBid`,
  `EndTime`). None of them called `extend_ttl` on the instance entry. If the
  instance TTL expired between an `init_auction` and a later `place_bid` or
  `settle_default_liquidation`, the contract would behave as if it had never
  been configured.
  
  **Fix:**
  - Added `INSTANCE_BUMP_AMOUNT = 518_400` (~30 days) and
    `INSTANCE_LIFETIME_THRESHOLD = 120_960` (~7 days) constants in `storage.rs`
  - Added `bump_instance_ttl(env)` — calls
    `env.storage().instance().extend_ttl(threshold, bump)`
  - Called `bump_instance_ttl(&env)` as the first statement in every
    `#[contractimpl]` entrypoint: `init_auction`, `set_factory_contract`,
    `place_bid`, `settle_default_liquidation`, `claim_auction`, and the new
    `close_auction`
  
  ---
  
  ### Gap 2 — Persistent read helpers had no TTL bump
  
  `storage.rs` contained two families of helpers for the id-scoped auction
  flow. Every `auction_set_*` write helper called `extend_ttl` after its
  `.set()`. But none of the corresponding `auction_get_*` read helpers did.
  This asymmetry meant that a key written at auction creation could expire
  before it was read at bid or settlement time, silently returning a default
  (`0`, `None`, `false`) instead of the real stored value.
  
  **Fix:** Added `extend_ttl(PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT)`
  on the read path of all nine helpers:
  
  `auction_get_status`, `auction_get_seller`, `auction_get_asset`,
  `auction_get_min_bid`, `auction_get_end_time`, `auction_get_highest_bidder`,
  `auction_get_highest_bid`, `auction_is_claimed`, `auction_exists`
  
  Each bump is guarded by a `.has()` check (matching the style of the existing
  `bump_auction_state_ttl` helper) so reads on absent keys do not panic.
  
  ---
  
  ### Gap 3 — `close_auction` was specified but not implemented
  
  `auction.md` defines `close_auction(auction_id)` as the transition from
  `Open → Closed` for the Symbol-keyed auction flow. The test suite references
  it via `AuctionClient::close_auction`. The function did not exist in
  `lib.rs`, meaning the transition could only happen through a Dutch-mode
  `place_bid` auto-close — English-mode auctions had no closing mechanism.
  
  **Fix:** Implemented `close_auction` per spec:
  
  1. `bump_instance_ttl` + `bump_auction_state_ttl` on entry
  2. Guard order: `NotFound` → `AuctionNotOpen` → `AuctionNotClosed`
  3. Flips `Open → Closed`, writes back, bumps persistent TTL again
  4. Emits `AuctionClosedEvent` on `(AUC_CLOSE, auction)` with the current
     highest bidder and highest bid (both `None`/`0` when no bids were placed)
  
  `close_auction` is permissionless by design (keeper pattern) — any account
  can trigger it once `ledger.timestamp() >= end_time`.
  
  ---
  
  ### Files changed
  
  | File | Changes |
  |---|---|
  | `src/storage.rs` | `INSTANCE_BUMP_AMOUNT`, `INSTANCE_LIFETIME_THRESHOLD` constants; `bump_instance_ttl()` helper; `extend_ttl` on read in all
  `auction_get_*` and `auction_exists`; updated module-level doc; `///` rustdoc on all new/changed functions |
  | `src/lib.rs` | Import `bump_instance_ttl`; call it at the top of 5 existing entrypoints; implement `close_auction` |
  
  ---
  
  ### Checklist
  
  - [x] All panics use `env.panic_with_error(AuctionError::...)` — no `unwrap()` in production paths
  - [x] `require_auth` on every state-changing entrypoint (`close_auction` is permissionless per spec)
  - [x] No discriminant or event topic changes — fully ABI-stable
  - [x] TTL constants and bump-guard pattern match the existing `storage.rs` style
  - [x] `///` rustdoc on every new and modified public function

closes #918 