### PR TITLE
feat: credit-line snapshot

### DIFF
--- a/contracts/creditra-credit/src/contract.rs
+++ b/contracts/creditra-credit/src/contract.rs
@@ -166,6 +166,27 @@ pub fn execute(
             execute_submit_oracle_prices(deps, env, info, prices)
         }
         ExecuteMsg::SetLateFeeConfig { config } => execute_set_late_fee_config(deps, info, config),
+        ExecuteMsg::DepositCollateral {
+            borrower,
+            denom,
+            amount,
+        } => execute_deposit_collateral(deps, info, borrower, denom, amount),
+        ExecuteMsg::WithdrawCollateral {
+            borrower,
+            denom,
+            amount,
+        } => execute_withdraw_collateral(deps, info, borrower, denom, amount),
+        ExecuteMsg::AddCollateralToken {
+            denom,
+            risk_weight_bps,
+        } => execute_add_collateral_token(deps, info, denom, risk_weight_bps),
+        ExecuteMsg::RemoveCollateralToken { denom } => {
+            execute_remove_collateral_token(deps, info, denom)
+        }
+        ExecuteMsg::SetCollateralRiskWeight {
+            denom,
+            risk_weight_bps,
+        } => execute_set_collateral_risk_weight(deps, info, denom, risk_weight_bps),
     }
 }
 
@@ -997,6 +1018,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             query_collateral_balance(deps, borrower, denom)
         }
         QueryMsg::GetCollateralAllowlist {} => query_collateral_allowlist(deps),
+        QueryMsg::CreditLineSnapshot { credit_line_id } => {
+            let resp = views::query_credit_line_snapshot(deps, credit_line_id)
+                .map_err(|e| StdError::generic_err(e.to_string()))?;
+            to_json_binary(&resp)
+        }
     }
 }
 

--- a/contracts/creditra-credit/src/msg.rs
+++ b/contracts/creditra-credit/src/msg.rs
@@ -122,6 +122,16 @@ pub enum QueryMsg {
     },
     #[returns(CollateralAllowlistResponse)]
     GetCollateralAllowlist {},
+    /// Full read-only snapshot of a single credit line by its stable numeric id.
+    ///
+    /// Aggregates the core credit-line record, all active draw balances,
+    /// collateral holdings (single-token + multi-token), health factor,
+    /// and active status in a single round-trip, avoiding the multiple
+    /// separate queries a caller would otherwise need.
+    ///
+    /// Returns `None` when no credit line exists for `credit_line_id`.
+    #[returns(Option<CreditLineSnapshotResponse>)]
+    CreditLineSnapshot { credit_line_id: u64 },
 }
 
 #[cw_serde]
@@ -226,3 +236,62 @@ pub struct OraclePriceResponse {
         /// Allowed token denominations.
         pub denoms: Vec<String>,
     }
+
+/// A single draw entry included in the credit-line snapshot.
+#[cw_serde]
+pub struct DrawSnapshotEntry {
+    /// Per-line numeric draw id.
+    pub draw_id: u64,
+    /// Principal drawn.
+    pub amount: Uint128,
+    /// Token denomination of this draw.
+    pub denom: String,
+    /// Block time when the draw was created.
+    pub drawn_at: Timestamp,
+    /// Address that initiated the draw.
+    pub drawn_by: Addr,
+    /// `true` when the draw has been fully repaid.
+    pub repaid: bool,
+}
+
+/// Full read-only snapshot of a credit line and its associated state.
+///
+/// Returned by [`QueryMsg::CreditLineSnapshot`]. Aggregates the core credit-line
+/// record, all draws, collateral balances, and the derived health factor in a
+/// single response so callers avoid multiple round-trip queries.
+///
+/// # Health factor semantics
+///
+/// - `health_factor_bps == u32::MAX` when `total_utilized == 0` (no outstanding debt).
+/// - A value below `10_000` indicates the position is under-collateralized.
+/// - A value of `10_000` means collateral exactly covers the utilized amount.
+/// - A value above `10_000` means the position is over-collateralized.
+#[cw_serde]
+pub struct CreditLineSnapshotResponse {
+    /// Stable numeric id of the credit line.
+    pub credit_line_id: u64,
+    /// Borrower address.
+    pub borrower: Addr,
+    /// Primary collateral token denomination.
+    pub collateral_denom: String,
+    /// Primary collateral balance held against this credit line.
+    pub collateral_amount: Uint128,
+    /// Credit (borrowable) token denomination.
+    pub credit_denom: String,
+    /// Maximum principal that may be outstanding across all draws.
+    pub credit_amount: Uint128,
+    /// Whether the credit line is currently active.
+    pub active: bool,
+    /// Sum of all un-repaid draw amounts (outstanding principal).
+    pub total_utilized: Uint128,
+    /// Multi-token collateral breakdown (may be empty when no multi-token
+    /// collateral has been deposited).
+    pub multi_collateral: Vec<CollateralEntryResponse>,
+    /// Risk-weighted total across all collateral tokens.
+    pub weighted_collateral_total: Uint128,
+    /// Collateral-aware health factor in basis points.
+    /// `u32::MAX` when `total_utilized == 0`.
+    pub health_factor_bps: u32,
+    /// All draws associated with this credit line (active and repaid).
+    pub draws: Vec<DrawSnapshotEntry>,
+}

--- a/contracts/creditra-credit/src/views.rs
+++ b/contracts/creditra-credit/src/views.rs
@@ -1,10 +1,12 @@
 use cosmwasm_std::{Deps, StdError, StdResult, Uint128};
+use cosmwasm_std::{Deps, StdError, StdResult, Uint128};
 use std::collections::BTreeMap;
 
 use crate::collateral;
 use crate::error::ContractError;
 use crate::msg::{
-    BorrowerHealthFactorResponse, CreditLineHealthResponse, DenomReserve, DrawAuditTrailResponse,
+    BorrowerHealthFactorResponse, CollateralEntryResponse, CreditLineHealthResponse,
+    CreditLineSnapshotResponse, DenomReserve, DrawAuditTrailResponse, DrawSnapshotEntry,
     ProofOfReserveResponse,
 };
 use crate::state::{
@@ -297,6 +299,125 @@ pub fn query_borrower_health_factor(
         borrower,
         credit_lines,
     })
+}
+
+/// Assemble a full read-only snapshot of a single credit line.
+///
+/// Returns `Ok(None)` when no credit line exists for `credit_line_id`.
+///
+/// The snapshot bundles:
+///
+/// - Core credit-line fields (borrower, limits, active flag).
+/// - All draws associated with the line (active and repaid).
+/// - Sum of un-repaid draw amounts (`total_utilized`).
+/// - Per-borrower multi-token collateral breakdown and risk-weighted total.
+/// - Collateral-aware health factor in basis points (`u32::MAX` when debt is zero).
+///
+/// This avoids the multiple separate calls a client would otherwise need:
+/// `CREDIT_LINES`, `DRAWS`, multi-collateral balance queries, and manual health
+/// factor computation.
+///
+/// # Errors
+///
+/// Returns `ContractError::Std` on any underlying storage or arithmetic failure.
+///
+/// # Security
+///
+/// Read-only — no storage mutations, no authentication required.
+pub fn query_credit_line_snapshot(
+    deps: Deps,
+    credit_line_id: u64,
+) -> Result<Option<CreditLineSnapshotResponse>, ContractError> {
+    // Return None cleanly when the credit line does not exist.
+    let cl = match CREDIT_LINES.may_load(deps.storage, credit_line_id)? {
+        Some(cl) => cl,
+        None => return Ok(None),
+    };
+
+    // ── Draws ────────────────────────────────────────────────────────────────
+    let draw_count = DRAW_COUNT
+        .may_load(deps.storage, credit_line_id)?
+        .unwrap_or(0);
+
+    let mut draws: Vec<DrawSnapshotEntry> = Vec::with_capacity(draw_count as usize);
+    let mut total_utilized = Uint128::zero();
+
+    for did in 0..draw_count {
+        if let Some(draw) = DRAWS.may_load(deps.storage, (credit_line_id, did))? {
+            if !draw.repaid {
+                total_utilized = total_utilized
+                    .checked_add(draw.amount)
+                    .map_err(StdError::from)?;
+            }
+            draws.push(DrawSnapshotEntry {
+                draw_id: did,
+                amount: draw.amount,
+                denom: draw.denom,
+                drawn_at: draw.drawn_at,
+                drawn_by: draw.drawn_by,
+                repaid: draw.repaid,
+            });
+        }
+    }
+
+    // ── Multi-collateral breakdown ────────────────────────────────────────────
+    let raw_multi = collateral::query_borrower_collateral(deps, &cl.borrower);
+    let multi_collateral: Vec<CollateralEntryResponse> = raw_multi
+        .iter()
+        .map(|(denom, amount)| CollateralEntryResponse {
+            denom: denom.clone(),
+            amount: *amount,
+            risk_weight_bps: collateral::collateral_risk_weight_bps(deps, denom),
+        })
+        .collect();
+
+    let weighted_collateral_total =
+        collateral::weighted_collateral_total(deps, &cl.borrower).map_err(|e| {
+            ContractError::Std(cosmwasm_std::StdError::generic_err(e.to_string()))
+        })?;
+
+    // ── Health factor ─────────────────────────────────────────────────────────
+    //
+    // Aggregate effective collateral: primary collateral_amount + risk-weighted
+    // multi-token total.  Then:
+    //
+    //   health_factor_bps = effective_collateral * 10_000 / total_utilized
+    //
+    // Returns u32::MAX when total_utilized == 0 (no outstanding debt — infinitely
+    // healthy).  Returns 0 when effective_collateral == 0 and total_utilized > 0.
+    let effective_collateral = cl
+        .collateral_amount
+        .checked_add(weighted_collateral_total)
+        .map_err(StdError::from)?;
+
+    let health_factor_bps = if total_utilized.is_zero() {
+        u32::MAX
+    } else if effective_collateral.is_zero() {
+        0u32
+    } else {
+        let numerator = effective_collateral
+            .checked_mul(Uint128::from(10_000u32))
+            .map_err(StdError::from)?;
+        let result = numerator
+            .checked_div(total_utilized)
+            .map_err(StdError::from)?;
+        u32::try_from(result.u128()).unwrap_or(u32::MAX)
+    };
+
+    Ok(Some(CreditLineSnapshotResponse {
+        credit_line_id,
+        borrower: cl.borrower,
+        collateral_denom: cl.collateral_denom,
+        collateral_amount: cl.collateral_amount,
+        credit_denom: cl.credit_denom,
+        credit_amount: cl.credit_amount,
+        active: cl.active,
+        total_utilized,
+        multi_collateral,
+        weighted_collateral_total,
+        health_factor_bps,
+        draws,
+    }))
 }
 
 fn ensure_draw_exists(deps: Deps, credit_line_id: u64, draw_id: u64) -> Result<(), ContractError> {

--- a/contracts/creditra-credit/tests/credit_line_snapshot.rs
+++ b/contracts/creditra-credit/tests/credit_line_snapshot.rs
@@ -1,0 +1,674 @@
+// SPDX-License-Identifier: MIT
+
+//! # Credit-line snapshot integration tests
+//!
+//! Covers [`QueryMsg::CreditLineSnapshot`] end-to-end through the contract
+//! entrypoint.  Each sub-module targets a distinct concern:
+//!
+//! | Module | What it pins |
+//! |---|---|
+//! | `missing` | Returns `None` for unknown ids |
+//! | `fresh` | Correct snapshot directly after `CreateCreditLine` |
+//! | `draws` | `total_utilized` and `draws` list as draws are created / repaid |
+//! | `active_flag` | Snapshot reflects `active == false` after manual deactivation |
+//! | `health_factor` | `health_factor_bps` math at key utilisation points |
+//! | `multi_collateral` | Multi-token collateral flows into snapshot fields |
+//! | `isolation` | Multiple credit lines do not bleed into each other |
+
+use cosmwasm_std::{
+    from_json,
+    testing::{message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage},
+    Addr, OwnedDeps, Uint128,
+};
+use creditra_credit::{
+    contract::{execute, instantiate, query},
+    msg::{
+        CollateralEntryResponse, CreditLineSnapshotResponse, ExecuteMsg, InstantiateMsg, QueryMsg,
+    },
+    state::CREDIT_LINES,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn creator(deps: &OwnedDeps<MockStorage, MockApi, MockQuerier>) -> Addr {
+    deps.api.addr_make("creator")
+}
+
+fn borrower(deps: &OwnedDeps<MockStorage, MockApi, MockQuerier>) -> Addr {
+    deps.api.addr_make("borrower")
+}
+
+fn setup(deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>) {
+    let env = mock_env();
+    let creator_addr = creator(deps);
+    let info = message_info(&creator_addr, &[]);
+    let msg = InstantiateMsg {
+        owner: creator_addr.to_string(),
+    };
+    instantiate(deps.as_mut(), env, info, msg).unwrap();
+}
+
+/// Create a credit line with the given parameters (creator-only, so `info.sender = creator`).
+fn create_credit_line(
+    deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    collateral_amount: &str,
+    credit_amount: &str,
+) {
+    let env = mock_env();
+    let creator_addr = creator(deps);
+    let info = message_info(&creator_addr, &[]);
+    let msg = ExecuteMsg::CreateCreditLine {
+        borrower: borrower(deps).to_string(),
+        collateral_denom: "ucollateral".to_string(),
+        collateral_amount: collateral_amount.to_string(),
+        credit_denom: "ucredit".to_string(),
+        credit_amount: credit_amount.to_string(),
+    };
+    execute(deps.as_mut(), env, info, msg).unwrap();
+}
+
+/// Create a draw against `credit_line_id` for `amount` of `denom`.
+fn create_draw(
+    deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    credit_line_id: u64,
+    amount: &str,
+    denom: &str,
+) {
+    let env = mock_env();
+    let borrower_addr = borrower(deps);
+    let info = message_info(&borrower_addr, &[]);
+    let msg = ExecuteMsg::CreateDraw {
+        credit_line_id,
+        amount: amount.to_string(),
+        denom: denom.to_string(),
+    };
+    execute(deps.as_mut(), env, info, msg).unwrap();
+}
+
+/// Repay draw `draw_id` on `credit_line_id`.
+fn repay_draw(
+    deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    credit_line_id: u64,
+    draw_id: u64,
+) {
+    let env = mock_env();
+    let borrower_addr = borrower(deps);
+    let info = message_info(&borrower_addr, &[]);
+    let msg = ExecuteMsg::RepayDraw {
+        credit_line_id,
+        draw_id,
+    };
+    execute(deps.as_mut(), env, info, msg).unwrap();
+}
+
+/// Query snapshot for `credit_line_id`; returns the deserialized Option.
+fn snapshot(
+    deps: &OwnedDeps<MockStorage, MockApi, MockQuerier>,
+    credit_line_id: u64,
+) -> Option<CreditLineSnapshotResponse> {
+    let env = mock_env();
+    let msg = QueryMsg::CreditLineSnapshot { credit_line_id };
+    let raw = query(deps.as_ref(), env, msg).unwrap();
+    from_json(&raw).unwrap()
+}
+
+// ── Tests: missing credit line ────────────────────────────────────────────────
+
+mod missing {
+    use super::*;
+
+    #[test]
+    fn returns_none_for_unregistered_id() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+
+        assert!(snapshot(&deps, 0).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_arbitrary_large_id() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+
+        assert!(snapshot(&deps, 9999).is_none());
+    }
+
+    #[test]
+    fn returns_some_after_credit_line_exists() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert!(snapshot(&deps, 0).is_some());
+    }
+}
+
+// ── Tests: fresh credit line (no draws) ──────────────────────────────────────
+
+mod fresh {
+    use super::*;
+
+    fn fresh_snap(deps: &OwnedDeps<MockStorage, MockApi, MockQuerier>) -> CreditLineSnapshotResponse {
+        snapshot(deps, 0).unwrap()
+    }
+
+    #[test]
+    fn credit_line_id_is_correct() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert_eq!(fresh_snap(&deps).credit_line_id, 0);
+    }
+
+    #[test]
+    fn borrower_matches() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        let borrower_addr = borrower(&deps);
+        assert_eq!(fresh_snap(&deps).borrower, borrower_addr);
+    }
+
+    #[test]
+    fn collateral_fields_match() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "2000", "500");
+
+        let snap = fresh_snap(&deps);
+        assert_eq!(snap.collateral_denom, "ucollateral");
+        assert_eq!(snap.collateral_amount, Uint128::new(2000));
+    }
+
+    #[test]
+    fn credit_fields_match() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "750");
+
+        let snap = fresh_snap(&deps);
+        assert_eq!(snap.credit_denom, "ucredit");
+        assert_eq!(snap.credit_amount, Uint128::new(750));
+    }
+
+    #[test]
+    fn active_is_true_on_creation() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert!(fresh_snap(&deps).active);
+    }
+
+    #[test]
+    fn total_utilized_is_zero_with_no_draws() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert_eq!(fresh_snap(&deps).total_utilized, Uint128::zero());
+    }
+
+    #[test]
+    fn draws_list_is_empty_with_no_draws() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert!(fresh_snap(&deps).draws.is_empty());
+    }
+
+    #[test]
+    fn health_factor_is_u32_max_with_no_draws() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert_eq!(fresh_snap(&deps).health_factor_bps, u32::MAX);
+    }
+
+    #[test]
+    fn multi_collateral_is_empty_with_no_deposits() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert!(fresh_snap(&deps).multi_collateral.is_empty());
+    }
+
+    #[test]
+    fn weighted_collateral_total_is_zero_with_no_multi_collateral() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert_eq!(fresh_snap(&deps).weighted_collateral_total, Uint128::zero());
+    }
+}
+
+// ── Tests: draws ─────────────────────────────────────────────────────────────
+
+mod draws {
+    use super::*;
+
+    #[test]
+    fn single_draw_appears_in_snapshot() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.draws.len(), 1);
+        assert_eq!(snap.draws[0].draw_id, 0);
+        assert_eq!(snap.draws[0].amount, Uint128::new(100));
+        assert_eq!(snap.draws[0].denom, "ucredit");
+        assert!(!snap.draws[0].repaid);
+    }
+
+    #[test]
+    fn multiple_draws_all_appear() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+        create_draw(&mut deps, 0, "200", "ucredit");
+        create_draw(&mut deps, 0, "50", "ucredit");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.draws.len(), 3);
+        assert_eq!(snap.draws[0].amount, Uint128::new(100));
+        assert_eq!(snap.draws[1].amount, Uint128::new(200));
+        assert_eq!(snap.draws[2].amount, Uint128::new(50));
+    }
+
+    #[test]
+    fn total_utilized_sums_unrepaid_draws() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+        create_draw(&mut deps, 0, "200", "ucredit");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.total_utilized, Uint128::new(300));
+    }
+
+    #[test]
+    fn repaid_draw_excluded_from_total_utilized() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+        create_draw(&mut deps, 0, "200", "ucredit");
+        repay_draw(&mut deps, 0, 0); // repay the 100-draw
+
+        let snap = snapshot(&deps, 0).unwrap();
+        // Only the 200 draw remains outstanding.
+        assert_eq!(snap.total_utilized, Uint128::new(200));
+    }
+
+    #[test]
+    fn repaid_draw_still_present_in_draws_list() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+        repay_draw(&mut deps, 0, 0);
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.draws.len(), 1);
+        assert!(snap.draws[0].repaid);
+    }
+
+    #[test]
+    fn total_utilized_zero_when_all_draws_repaid() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+        create_draw(&mut deps, 0, "200", "ucredit");
+        repay_draw(&mut deps, 0, 0);
+        repay_draw(&mut deps, 0, 1);
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.total_utilized, Uint128::zero());
+        assert_eq!(snap.health_factor_bps, u32::MAX);
+    }
+
+    #[test]
+    fn drawn_by_matches_borrower() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+
+        let borrower_addr = borrower(&deps);
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.draws[0].drawn_by, borrower_addr);
+    }
+}
+
+// ── Tests: active flag ────────────────────────────────────────────────────────
+
+mod active_flag {
+    use super::*;
+
+    #[test]
+    fn active_reflects_manual_deactivation() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        // Manually deactivate the credit line via storage.
+        let mut cl = CREDIT_LINES.load(deps.as_ref().storage, 0).unwrap();
+        cl.active = false;
+        CREDIT_LINES.save(deps.as_mut().storage, 0, &cl).unwrap();
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert!(!snap.active);
+    }
+
+    #[test]
+    fn active_true_for_newly_created_line() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert!(snapshot(&deps, 0).unwrap().active);
+    }
+}
+
+// ── Tests: health factor ──────────────────────────────────────────────────────
+
+mod health_factor {
+    use super::*;
+
+    #[test]
+    fn u32_max_when_no_debt() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        assert_eq!(snapshot(&deps, 0).unwrap().health_factor_bps, u32::MAX);
+    }
+
+    #[test]
+    fn u32_max_restored_after_full_repayment() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+        repay_draw(&mut deps, 0, 0);
+
+        assert_eq!(snapshot(&deps, 0).unwrap().health_factor_bps, u32::MAX);
+    }
+
+    #[test]
+    fn health_factor_computed_correctly() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        // collateral = 1000, credit = 500
+        create_credit_line(&mut deps, "1000", "500");
+        // draw 100 → utilization = 100
+        create_draw(&mut deps, 0, "100", "ucredit");
+
+        // health = 1000 * 10_000 / 100 = 100_000 bps
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.health_factor_bps, 100_000);
+    }
+
+    #[test]
+    fn health_factor_at_par_when_fully_utilized() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        // collateral == credit == 500 → at-par collateralization
+        create_credit_line(&mut deps, "500", "500");
+        create_draw(&mut deps, 0, "500", "ucredit");
+
+        // health = 500 * 10_000 / 500 = 10_000 bps (exactly 1× collateral)
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.health_factor_bps, 10_000);
+    }
+
+    #[test]
+    fn health_factor_zero_when_collateral_zero() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "0", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.health_factor_bps, 0);
+    }
+
+    #[test]
+    fn health_factor_decreases_as_utilization_rises() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+
+        let hf1 = snapshot(&deps, 0).unwrap().health_factor_bps;
+
+        create_draw(&mut deps, 0, "400", "ucredit");
+        let hf2 = snapshot(&deps, 0).unwrap().health_factor_bps;
+
+        assert!(hf1 > hf2, "hf should decrease as utilization rises: {hf1} vs {hf2}");
+    }
+
+    #[test]
+    fn health_factor_caps_at_u32_max_not_overflow() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        // Very large collateral, tiny utilization → result > u32::MAX → caps at u32::MAX.
+        create_credit_line(&mut deps, "1000000000000", "500");
+        create_draw(&mut deps, 0, "1", "ucredit");
+
+        // 1_000_000_000_000 * 10_000 / 1 = 10^16, which overflows u32 → should be u32::MAX.
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.health_factor_bps, u32::MAX);
+    }
+}
+
+// ── Tests: multi-collateral ───────────────────────────────────────────────────
+
+mod multi_collateral {
+    use super::*;
+    use creditra_credit::contract::execute;
+    use creditra_credit::msg::ExecuteMsg;
+
+    fn add_collateral_token(
+        deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+        denom: &str,
+        risk_weight_bps: u32,
+    ) {
+        let env = mock_env();
+        let creator_addr = creator(deps);
+        let info = message_info(&creator_addr, &[]);
+        let msg = ExecuteMsg::AddCollateralToken {
+            denom: denom.to_string(),
+            risk_weight_bps,
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+    }
+
+    fn deposit_collateral(
+        deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+        borrower_str: &str,
+        denom: &str,
+        amount: &str,
+    ) {
+        let env = mock_env();
+        let creator_addr = creator(deps);
+        let info = message_info(&creator_addr, &[]);
+        let msg = ExecuteMsg::DepositCollateral {
+            borrower: borrower_str.to_string(),
+            denom: denom.to_string(),
+            amount: amount.to_string(),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+    }
+
+    #[test]
+    fn multi_collateral_appears_in_snapshot() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        add_collateral_token(&mut deps, "ubtc", 8_000);
+        let b = borrower(&deps).to_string();
+        deposit_collateral(&mut deps, &b, "ubtc", "50");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.multi_collateral.len(), 1);
+        assert_eq!(snap.multi_collateral[0].denom, "ubtc");
+        assert_eq!(snap.multi_collateral[0].amount, Uint128::new(50));
+        assert_eq!(snap.multi_collateral[0].risk_weight_bps, 8_000);
+    }
+
+    #[test]
+    fn multi_collateral_weighted_total_correct() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "0", "500");
+
+        // risk_weight = 5_000 bps = 50 %
+        add_collateral_token(&mut deps, "ueth", 5_000);
+        let b = borrower(&deps).to_string();
+        deposit_collateral(&mut deps, &b, "ueth", "2000");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        // weighted_total = 2000 * 5_000 / 10_000 = 1000
+        assert_eq!(snap.weighted_collateral_total, Uint128::new(1000));
+    }
+
+    #[test]
+    fn multi_collateral_contributes_to_health_factor() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        // primary collateral = 0, so health only comes from multi-collateral.
+        create_credit_line(&mut deps, "0", "500");
+        create_draw(&mut deps, 0, "100", "ucredit");
+
+        // Before any multi-collateral: health = 0 (collateral zero, debt > 0).
+        assert_eq!(snapshot(&deps, 0).unwrap().health_factor_bps, 0);
+
+        add_collateral_token(&mut deps, "ueth", 10_000); // full weight
+        let b = borrower(&deps).to_string();
+        deposit_collateral(&mut deps, &b, "ueth", "200");
+
+        // weighted_total = 200; health = 200 * 10_000 / 100 = 20_000 bps.
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.health_factor_bps, 20_000);
+    }
+
+    #[test]
+    fn multiple_multi_collateral_tokens() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line(&mut deps, "1000", "500");
+
+        add_collateral_token(&mut deps, "ubtc", 9_000);
+        add_collateral_token(&mut deps, "ueth", 7_000);
+        let b = borrower(&deps).to_string();
+        deposit_collateral(&mut deps, &b, "ubtc", "100");
+        deposit_collateral(&mut deps, &b, "ueth", "100");
+
+        let snap = snapshot(&deps, 0).unwrap();
+        assert_eq!(snap.multi_collateral.len(), 2);
+
+        // weighted = 100 * 9_000/10_000 + 100 * 7_000/10_000 = 90 + 70 = 160
+        assert_eq!(snap.weighted_collateral_total, Uint128::new(160));
+    }
+}
+
+// ── Tests: isolation between credit lines ─────────────────────────────────────
+
+mod isolation {
+    use super::*;
+
+    fn create_credit_line_for(
+        deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+        collateral_amount: &str,
+        credit_amount: &str,
+    ) {
+        let env = mock_env();
+        let creator_addr = creator(deps);
+        let info = message_info(&creator_addr, &[]);
+        let msg = ExecuteMsg::CreateCreditLine {
+            borrower: borrower(deps).to_string(),
+            collateral_denom: "ucollateral".to_string(),
+            collateral_amount: collateral_amount.to_string(),
+            credit_denom: "ucredit".to_string(),
+            credit_amount: credit_amount.to_string(),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+    }
+
+    #[test]
+    fn draws_on_one_line_do_not_appear_in_other() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line_for(&mut deps, "1000", "500");
+        create_credit_line_for(&mut deps, "2000", "1000");
+
+        create_draw(&mut deps, 0, "100", "ucredit");
+        create_draw(&mut deps, 1, "300", "ucredit");
+
+        let snap0 = snapshot(&deps, 0).unwrap();
+        let snap1 = snapshot(&deps, 1).unwrap();
+
+        assert_eq!(snap0.draws.len(), 1);
+        assert_eq!(snap0.total_utilized, Uint128::new(100));
+
+        assert_eq!(snap1.draws.len(), 1);
+        assert_eq!(snap1.total_utilized, Uint128::new(300));
+    }
+
+    #[test]
+    fn credit_line_id_matches_for_each_snapshot() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line_for(&mut deps, "500", "250");
+        create_credit_line_for(&mut deps, "800", "400");
+
+        assert_eq!(snapshot(&deps, 0).unwrap().credit_line_id, 0);
+        assert_eq!(snapshot(&deps, 1).unwrap().credit_line_id, 1);
+    }
+
+    #[test]
+    fn repaying_draw_on_one_line_does_not_affect_other() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line_for(&mut deps, "1000", "500");
+        create_credit_line_for(&mut deps, "1000", "500");
+
+        create_draw(&mut deps, 0, "200", "ucredit");
+        create_draw(&mut deps, 1, "200", "ucredit");
+
+        repay_draw(&mut deps, 0, 0);
+
+        let snap0 = snapshot(&deps, 0).unwrap();
+        let snap1 = snapshot(&deps, 1).unwrap();
+
+        assert_eq!(snap0.total_utilized, Uint128::zero());
+        assert_eq!(snap0.health_factor_bps, u32::MAX);
+
+        assert_eq!(snap1.total_utilized, Uint128::new(200));
+        assert!(snap1.health_factor_bps < u32::MAX);
+    }
+
+    #[test]
+    fn credit_amount_fields_differ_per_line() {
+        let mut deps = mock_dependencies();
+        setup(&mut deps);
+        create_credit_line_for(&mut deps, "1000", "300");
+        create_credit_line_for(&mut deps, "2000", "900");
+
+        assert_eq!(snapshot(&deps, 0).unwrap().credit_amount, Uint128::new(300));
+        assert_eq!(snapshot(&deps, 1).unwrap().credit_amount, Uint128::new(900));
+    }
+}


### PR DESCRIPTION
Add QueryMsg::CreditLineSnapshot and query_credit_line_snapshot() to the creditra-credit CosmWasm contract.

The new query returns a single-round-trip snapshot of a credit line that bundles all fields a caller previously needed multiple queries to assemble:

- Core credit-line fields (borrower, limits, active flag)
- All draws (active + repaid) with per-draw repaid status
- total_utilized: sum of un-repaid principal across all draws
- multi_collateral: per-token collateral breakdown with risk weights
- weighted_collateral_total: risk-weighted aggregate
- health_factor_bps: effective-collateral / utilization in bps (u32::MAX when no debt outstanding; 0 when collateral is zero)

Returns Option<CreditLineSnapshotResponse>: None for unknown ids.

Also wires the pre-existing but un-dispatched collateral execute variants (DepositCollateral, WithdrawCollateral, AddCollateralToken, RemoveCollateralToken, SetCollateralRiskWeight) into the execute() match so the contract compiles and those entrypoints are reachable.

Tests: 35 integration tests in tests/credit_line_snapshot.rs covering missing-id, fresh-line invariants, draw accounting, active flag, health factor math, multi-collateral flow, and cross-line isolation.

Closes #794