### PR TITLE
fix: resolve creditra-credit compilation errors and add safe_mul_div …

### DIFF
--- a/contracts/creditra-credit/src/contract.rs
+++ b/contracts/creditra-credit/src/contract.rs
@@ -193,6 +193,9 @@ pub fn execute(
             denom,
             risk_weight_bps,
         } => execute_set_collateral_risk_weight(deps, info, denom, risk_weight_bps),
+        ExecuteMsg::SetProtocolFeeBps { bps } => {
+            execute_set_protocol_fee_bps(deps, info, bps)
+        }
     }
 }
 
@@ -976,6 +979,21 @@ pub fn execute_set_collateral_risk_weight(
     collateral::set_collateral_risk_weight(deps, &denom, risk_weight_bps)
 }
 
+/// Set the protocol fee basis points (admin only).
+///
+/// # Errors
+///
+/// - [`ContractError::Unauthorized`] if the caller is not the contract owner.
+/// - [`ContractError::ProtocolFeeBpsExceeded`] if `bps` exceeds the maximum.
+pub fn execute_set_protocol_fee_bps(
+    deps: DepsMut,
+    info: MessageInfo,
+    bps: u32,
+) -> Result<Response, ContractError> {
+    fees::set_protocol_fee_bps(deps, &info.sender, bps)?;
+    Ok(Response::new().add_attribute("action", "set_protocol_fee_bps"))
+}
+
 fn append_audit_entry(
     deps: DepsMut,
     env: Env,
@@ -1102,6 +1120,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             query_collateral_balance(deps, borrower, denom)
         }
         QueryMsg::GetCollateralAllowlist {} => query_collateral_allowlist(deps),
+        QueryMsg::GetProtocolFeeBps {} => {
+            let bps = PROTOCOL_FEE_BPS
+                .may_load(deps.storage)
+                .map_err(|e| StdError::generic_err(e.to_string()))?;
+            let resp = crate::msg::ProtocolFeeBpsResponse { bps };
+            to_json_binary(&resp)
+        }
     }
 }
 

--- a/contracts/creditra-credit/src/error.rs
+++ b/contracts/creditra-credit/src/error.rs
@@ -118,6 +118,10 @@ pub enum ContractError {
     /// Late-fee configuration is invalid.
     #[error("LateFeeConfigInvalid")]
     LateFeeConfigInvalid,
+
+    /// Protocol fee basis points exceeds maximum allowed value.
+    #[error("ProtocolFeeBpsExceeded")]
+    ProtocolFeeBpsExceeded,
 }
 
 impl ContractError {
@@ -145,6 +149,7 @@ impl ContractError {
             ContractError::TreasuryAddressNotSet => ContractErrorCategory::State,
             ContractError::BountyAddressNotSet => ContractErrorCategory::State,
             ContractError::LateFeeConfigInvalid => ContractErrorCategory::Validation,
+            ContractError::ProtocolFeeBpsExceeded => ContractErrorCategory::Validation,
         }
     }
 }

--- a/contracts/creditra-credit/src/fees.rs
+++ b/contracts/creditra-credit/src/fees.rs
@@ -12,8 +12,7 @@
 //! The treasury share is computed with floor rounding; the bounty pool receives
 //! the remainder so no tokens are lost to integer division.
 
-use cosmwasm_std::{Deps, DepsMut, Uint128};
-use cw_storage_plus::Item;
+use cosmwasm_std::{Addr, Deps, DepsMut, Uint128};
 
 use crate::error::ContractError;
 use crate::state::{
@@ -27,10 +26,8 @@ pub const MAX_FEE_SHARE_BPS: u32 = 10_000;
 /// Default treasury share when unset: 100% to treasury (backward compatible).
 pub const DEFAULT_TREASURY_FEE_SHARE_BPS: u32 = 10_000;
 
-/// Protocol fee in basis points charged on draw repayment.
-///
-/// When absent no fee is charged. Stored as an `Item<u32>` in instance storage.
-pub const PROTOCOL_FEE_BPS: Item<u32> = Item::new("pfb");
+/// Maximum protocol fee basis points (100%).
+pub const MAX_PROTOCOL_FEE_BPS: u32 = 10_000;
 
 /// Result of splitting a protocol fee between treasury and bounty accumulators.
 #[derive(Clone, Debug, PartialEq)]

--- a/contracts/creditra-credit/src/msg.rs
+++ b/contracts/creditra-credit/src/msg.rs
@@ -94,6 +94,10 @@ pub enum ExecuteMsg {
         denom: String,
         risk_weight_bps: u32,
     },
+    /// Set the protocol fee basis points (admin only).
+    SetProtocolFeeBps {
+        bps: u32,
+    },
 }
 
 #[cw_serde]
@@ -122,6 +126,8 @@ pub enum QueryMsg {
     },
     #[returns(CollateralAllowlistResponse)]
     GetCollateralAllowlist {},
+    #[returns(ProtocolFeeBpsResponse)]
+    GetProtocolFeeBps {},
 }
 
 #[cw_serde]
@@ -225,4 +231,11 @@ pub struct OraclePriceResponse {
     pub struct CollateralAllowlistResponse {
         /// Allowed token denominations.
         pub denoms: Vec<String>,
+    }
+
+    /// Response for the protocol fee basis points query.
+    #[cw_serde]
+    pub struct ProtocolFeeBpsResponse {
+        /// Current protocol fee in basis points, or None if unset.
+        pub bps: Option<u32>,
     }

--- a/contracts/creditra-credit/src/state.rs
+++ b/contracts/creditra-credit/src/state.rs
@@ -177,3 +177,18 @@ pub const COLLATERAL_RISK_WEIGHTS: Map<&str, u32> = Map::new("crw");
 ///
 /// 10_000 bps = 100 % (full notional value).
 pub const DEFAULT_COLLATERAL_RISK_WEIGHT_BPS: u32 = 10_000;
+
+/// Protocol fee rate in basis points (0 ..= 10_000).
+pub const PROTOCOL_FEE_BPS: Item<u32> = Item::new("pfb");
+
+/// Default fee share for treasury (basis points).
+pub const DEFAULT_FEE_SHARE_BPS: Item<u32> = Item::new("dfsb");
+
+/// Market-specific fee share override (basis points), keyed by market denomination.
+pub const MARKET_FEE_SHARE_BPS: Map<&str, u32> = Map::new("mfsb");
+
+/// Treasury balance accumulator, keyed by market denomination.
+pub const TREASURY_BALANCE: Map<&str, Uint128> = Map::new("tb");
+
+/// Bounty pool balance accumulator, keyed by market denomination.
+pub const BOUNTY_BALANCE: Map<&str, Uint128> = Map::new("bb");

--- a/contracts/creditra-credit/tests/snap_mul_div.rs
+++ b/contracts/creditra-credit/tests/snap_mul_div.rs
@@ -302,12 +302,10 @@ fn verify_mul_div_snapshot() {
                 .parse()
                 .unwrap_or_else(|_| panic!("entry {i}: invalid expected '{}'", entry.expected));
 
-            let live_val = live.unwrap_or_else(|_| {
-                panic!(
-                    "entry {i} (a={a}, numerator={numerator}, denominator={denominator}): \
-                     unexpected None"
-                )
-            });
+            let live_val = live.expect(
+                "entry {i} (a={a}, numerator={numerator}, denominator={denominator}): \
+                 unexpected None"
+            );
 
             // Primary: exact match against pinned value.
             assert_eq!(

--- a/contracts/creditra-credit/tests/snapshots/mul_div.json
+++ b/contracts/creditra-credit/tests/snapshots/mul_div.json
@@ -1,0 +1,32770 @@
+[
+  {
+    "a": "0",
+    "numerator": "300",
+    "denominator": "10000",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1000",
+    "numerator": "0",
+    "denominator": "10000",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1000",
+    "numerator": "300",
+    "denominator": "10000",
+    "rounding": "Floor",
+    "expected": "30",
+    "overflow": false
+  },
+  {
+    "a": "1000",
+    "numerator": "300",
+    "denominator": "10000",
+    "rounding": "Ceil",
+    "expected": "30",
+    "overflow": false
+  },
+  {
+    "a": "1000",
+    "numerator": "3",
+    "denominator": "10",
+    "rounding": "Floor",
+    "expected": "300",
+    "overflow": false
+  },
+  {
+    "a": "1000",
+    "numerator": "3",
+    "denominator": "10",
+    "rounding": "Ceil",
+    "expected": "300",
+    "overflow": false
+  },
+  {
+    "a": "42",
+    "numerator": "7",
+    "denominator": "7",
+    "rounding": "Floor",
+    "expected": "42",
+    "overflow": false
+  },
+  {
+    "a": "42",
+    "numerator": "7",
+    "denominator": "7",
+    "rounding": "Ceil",
+    "expected": "42",
+    "overflow": false
+  },
+  {
+    "a": "1001",
+    "numerator": "3",
+    "denominator": "10",
+    "rounding": "Floor",
+    "expected": "300",
+    "overflow": false
+  },
+  {
+    "a": "1001",
+    "numerator": "3",
+    "denominator": "10",
+    "rounding": "Ceil",
+    "expected": "301",
+    "overflow": false
+  },
+  {
+    "a": "7",
+    "numerator": "1",
+    "denominator": "3",
+    "rounding": "Floor",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "7",
+    "numerator": "1",
+    "denominator": "3",
+    "rounding": "Ceil",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "170141183460469231731687303715884105727",
+    "numerator": "2",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "170141183460469231731687303715884105727",
+    "overflow": false
+  },
+  {
+    "a": "170141183460469231731687303715884105727",
+    "numerator": "2",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "170141183460469231731687303715884105727",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "1",
+    "denominator": "10000",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "1",
+    "denominator": "10000",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "340282366920938463463374607431768211455",
+    "numerator": "2",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "340282366920938463463374607431768211455",
+    "numerator": "2",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100",
+    "numerator": "1",
+    "denominator": "0",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100",
+    "numerator": "1",
+    "denominator": "0",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "970209386",
+    "numerator": "6535771417907358969222455561867",
+    "denominator": "4661508117249795411199148599201506336",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "970209386",
+    "numerator": "6535771417907358969222455561867",
+    "denominator": "4661508117249795411199148599201506336",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "139559052057383865",
+    "numerator": "3198501865766",
+    "denominator": "1185519423289914104753018204791",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "139559052057383865",
+    "numerator": "3198501865766",
+    "denominator": "1185519423289914104753018204791",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6617736444",
+    "numerator": "7119685189",
+    "denominator": "3139567817949776162",
+    "rounding": "Floor",
+    "expected": "15",
+    "overflow": false
+  },
+  {
+    "a": "6617736444",
+    "numerator": "7119685189",
+    "denominator": "3139567817949776162",
+    "rounding": "Ceil",
+    "expected": "16",
+    "overflow": false
+  },
+  {
+    "a": "3903139",
+    "numerator": "34489826286290762520",
+    "denominator": "1809",
+    "rounding": "Floor",
+    "expected": "74416023262159558060558",
+    "overflow": false
+  },
+  {
+    "a": "3903139",
+    "numerator": "34489826286290762520",
+    "denominator": "1809",
+    "rounding": "Ceil",
+    "expected": "74416023262159558060559",
+    "overflow": false
+  },
+  {
+    "a": "104784404158761555872808604766",
+    "numerator": "11621388562223627304340500239",
+    "denominator": "10753232069236",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "104784404158761555872808604766",
+    "numerator": "11621388562223627304340500239",
+    "denominator": "10753232069236",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "467079813661",
+    "numerator": "2793638011861138818778",
+    "denominator": "281506914983684460273595",
+    "rounding": "Floor",
+    "expected": "4635239322",
+    "overflow": false
+  },
+  {
+    "a": "467079813661",
+    "numerator": "2793638011861138818778",
+    "denominator": "281506914983684460273595",
+    "rounding": "Ceil",
+    "expected": "4635239323",
+    "overflow": false
+  },
+  {
+    "a": "61124512470800",
+    "numerator": "441602921",
+    "denominator": "51748387990",
+    "rounding": "Floor",
+    "expected": "521615538188",
+    "overflow": false
+  },
+  {
+    "a": "61124512470800",
+    "numerator": "441602921",
+    "denominator": "51748387990",
+    "rounding": "Ceil",
+    "expected": "521615538189",
+    "overflow": false
+  },
+  {
+    "a": "483879243836583",
+    "numerator": "12",
+    "denominator": "42076570922116853",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "483879243836583",
+    "numerator": "12",
+    "denominator": "42076570922116853",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "47796332922244839720565592466",
+    "numerator": "7308962824679916336270205395",
+    "denominator": "8",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47796332922244839720565592466",
+    "numerator": "7308962824679916336270205395",
+    "denominator": "8",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8110973731009",
+    "numerator": "15886754254",
+    "denominator": "7720253492031",
+    "rounding": "Floor",
+    "expected": "16690779202",
+    "overflow": false
+  },
+  {
+    "a": "8110973731009",
+    "numerator": "15886754254",
+    "denominator": "7720253492031",
+    "rounding": "Ceil",
+    "expected": "16690779203",
+    "overflow": false
+  },
+  {
+    "a": "557173039934492533507910769764",
+    "numerator": "5117647441101",
+    "denominator": "438142833701198652868938",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "557173039934492533507910769764",
+    "numerator": "5117647441101",
+    "denominator": "438142833701198652868938",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "235",
+    "numerator": "28730186049363643080192",
+    "denominator": "128438881335377803687705",
+    "rounding": "Floor",
+    "expected": "52",
+    "overflow": false
+  },
+  {
+    "a": "235",
+    "numerator": "28730186049363643080192",
+    "denominator": "128438881335377803687705",
+    "rounding": "Ceil",
+    "expected": "53",
+    "overflow": false
+  },
+  {
+    "a": "255871755270",
+    "numerator": "189475426462423",
+    "denominator": "252124",
+    "rounding": "Floor",
+    "expected": "192291927581158397087",
+    "overflow": false
+  },
+  {
+    "a": "255871755270",
+    "numerator": "189475426462423",
+    "denominator": "252124",
+    "rounding": "Ceil",
+    "expected": "192291927581158397088",
+    "overflow": false
+  },
+  {
+    "a": "1704463877598293318325857381285",
+    "numerator": "488167551110297207918082",
+    "denominator": "33138879145161842129155",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1704463877598293318325857381285",
+    "numerator": "488167551110297207918082",
+    "denominator": "33138879145161842129155",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19669940547914098271165335800",
+    "numerator": "38513",
+    "denominator": "12928292264987624840114236891966",
+    "rounding": "Floor",
+    "expected": "58",
+    "overflow": false
+  },
+  {
+    "a": "19669940547914098271165335800",
+    "numerator": "38513",
+    "denominator": "12928292264987624840114236891966",
+    "rounding": "Ceil",
+    "expected": "59",
+    "overflow": false
+  },
+  {
+    "a": "1063398309423983",
+    "numerator": "259595868255185870088774166303525317204",
+    "denominator": "16204100021163005961132057469",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1063398309423983",
+    "numerator": "259595868255185870088774166303525317204",
+    "denominator": "16204100021163005961132057469",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1393273949612356133922721038266",
+    "numerator": "539",
+    "denominator": "1997040",
+    "rounding": "Floor",
+    "expected": "376043874354574748720279333",
+    "overflow": false
+  },
+  {
+    "a": "1393273949612356133922721038266",
+    "numerator": "539",
+    "denominator": "1997040",
+    "rounding": "Ceil",
+    "expected": "376043874354574748720279334",
+    "overflow": false
+  },
+  {
+    "a": "75311655817328629748887162473396944585",
+    "numerator": "1910",
+    "denominator": "3286167383303",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75311655817328629748887162473396944585",
+    "numerator": "1910",
+    "denominator": "3286167383303",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28876",
+    "numerator": "1112934629678311655856955282517",
+    "denominator": "15260620697200286296604274",
+    "rounding": "Floor",
+    "expected": "2105884223",
+    "overflow": false
+  },
+  {
+    "a": "28876",
+    "numerator": "1112934629678311655856955282517",
+    "denominator": "15260620697200286296604274",
+    "rounding": "Ceil",
+    "expected": "2105884224",
+    "overflow": false
+  },
+  {
+    "a": "4102116403",
+    "numerator": "11783896710829838490702168052403688",
+    "denominator": "4920177709803081208376922860359713",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4102116403",
+    "numerator": "11783896710829838490702168052403688",
+    "denominator": "4920177709803081208376922860359713",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "174",
+    "numerator": "2281817098998245438214000543",
+    "denominator": "3854428326726542305165244653145156",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "174",
+    "numerator": "2281817098998245438214000543",
+    "denominator": "3854428326726542305165244653145156",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "11514199629357",
+    "numerator": "607547348640539490412636714",
+    "denominator": "553221439622835935232705111368198987",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11514199629357",
+    "numerator": "607547348640539490412636714",
+    "denominator": "553221439622835935232705111368198987",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "110747346912",
+    "numerator": "4486620816988054067233651250240612985",
+    "denominator": "4247270",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "110747346912",
+    "numerator": "4486620816988054067233651250240612985",
+    "denominator": "4247270",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "823",
+    "numerator": "553726550998534022651068",
+    "denominator": "5688697093",
+    "rounding": "Floor",
+    "expected": "80109196187042174",
+    "overflow": false
+  },
+  {
+    "a": "823",
+    "numerator": "553726550998534022651068",
+    "denominator": "5688697093",
+    "rounding": "Ceil",
+    "expected": "80109196187042175",
+    "overflow": false
+  },
+  {
+    "a": "235817732170466",
+    "numerator": "65068836326896483",
+    "denominator": "216",
+    "rounding": "Floor",
+    "expected": "71038821377685016079339314217",
+    "overflow": false
+  },
+  {
+    "a": "235817732170466",
+    "numerator": "65068836326896483",
+    "denominator": "216",
+    "rounding": "Ceil",
+    "expected": "71038821377685016079339314218",
+    "overflow": false
+  },
+  {
+    "a": "397587895796890201961640996305",
+    "numerator": "17009419584030",
+    "denominator": "7685453775",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "397587895796890201961640996305",
+    "numerator": "17009419584030",
+    "denominator": "7685453775",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13016087955180105792696951751220",
+    "numerator": "17789247354691838765125246267258535133",
+    "denominator": "2107664603655997566608246938",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13016087955180105792696951751220",
+    "numerator": "17789247354691838765125246267258535133",
+    "denominator": "2107664603655997566608246938",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "91429014954785306004603",
+    "numerator": "450151214929842609137374179139578576",
+    "denominator": "198715882025",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "91429014954785306004603",
+    "numerator": "450151214929842609137374179139578576",
+    "denominator": "198715882025",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20781980751892294772914548838998",
+    "numerator": "47809309080935",
+    "denominator": "13902733083871514959020",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20781980751892294772914548838998",
+    "numerator": "47809309080935",
+    "denominator": "13902733083871514959020",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "568603606336612749749",
+    "numerator": "33516163413551747033405559817689365330",
+    "denominator": "83274124386858436165285422278469539475",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "568603606336612749749",
+    "numerator": "33516163413551747033405559817689365330",
+    "denominator": "83274124386858436165285422278469539475",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1143160162343091033032",
+    "numerator": "2825046098701826675273601",
+    "denominator": "2318222",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1143160162343091033032",
+    "numerator": "2825046098701826675273601",
+    "denominator": "2318222",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9215",
+    "numerator": "49914749229068053142879652900",
+    "denominator": "996360764229949816717",
+    "rounding": "Floor",
+    "expected": "461644447130",
+    "overflow": false
+  },
+  {
+    "a": "9215",
+    "numerator": "49914749229068053142879652900",
+    "denominator": "996360764229949816717",
+    "rounding": "Ceil",
+    "expected": "461644447131",
+    "overflow": false
+  },
+  {
+    "a": "210511764234",
+    "numerator": "106797726495638894116571343637626253739",
+    "denominator": "210463637700979475056848339392",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "210511764234",
+    "numerator": "106797726495638894116571343637626253739",
+    "denominator": "210463637700979475056848339392",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "924708535290306440665",
+    "numerator": "214794443822490197352471349702",
+    "denominator": "136693697699348881094671469463",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "924708535290306440665",
+    "numerator": "214794443822490197352471349702",
+    "denominator": "136693697699348881094671469463",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "131794782122322392127778972",
+    "numerator": "1",
+    "denominator": "144619597196542101442",
+    "rounding": "Floor",
+    "expected": "911320",
+    "overflow": false
+  },
+  {
+    "a": "131794782122322392127778972",
+    "numerator": "1",
+    "denominator": "144619597196542101442",
+    "rounding": "Ceil",
+    "expected": "911321",
+    "overflow": false
+  },
+  {
+    "a": "5209539",
+    "numerator": "306664243636170204659799224",
+    "denominator": "3478813696577659842024753",
+    "rounding": "Floor",
+    "expected": "459231070",
+    "overflow": false
+  },
+  {
+    "a": "5209539",
+    "numerator": "306664243636170204659799224",
+    "denominator": "3478813696577659842024753",
+    "rounding": "Ceil",
+    "expected": "459231071",
+    "overflow": false
+  },
+  {
+    "a": "93473229280103459172606",
+    "numerator": "5167",
+    "denominator": "2580",
+    "rounding": "Floor",
+    "expected": "187200068097013400598781",
+    "overflow": false
+  },
+  {
+    "a": "93473229280103459172606",
+    "numerator": "5167",
+    "denominator": "2580",
+    "rounding": "Ceil",
+    "expected": "187200068097013400598782",
+    "overflow": false
+  },
+  {
+    "a": "1888076523548450907709",
+    "numerator": "57722",
+    "denominator": "44946189188303417657977474557990886107",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1888076523548450907709",
+    "numerator": "57722",
+    "denominator": "44946189188303417657977474557990886107",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "650543475888",
+    "numerator": "4629374775084425",
+    "denominator": "237152998942274870",
+    "rounding": "Floor",
+    "expected": "12699015280",
+    "overflow": false
+  },
+  {
+    "a": "650543475888",
+    "numerator": "4629374775084425",
+    "denominator": "237152998942274870",
+    "rounding": "Ceil",
+    "expected": "12699015281",
+    "overflow": false
+  },
+  {
+    "a": "1627224454738951806407",
+    "numerator": "466950284",
+    "denominator": "48342818581",
+    "rounding": "Floor",
+    "expected": "15717596606390944432",
+    "overflow": false
+  },
+  {
+    "a": "1627224454738951806407",
+    "numerator": "466950284",
+    "denominator": "48342818581",
+    "rounding": "Ceil",
+    "expected": "15717596606390944433",
+    "overflow": false
+  },
+  {
+    "a": "140068149205799809363576113202",
+    "numerator": "12691496977505531233656060839346137331",
+    "denominator": "2436909341187163814496457779624",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "140068149205799809363576113202",
+    "numerator": "12691496977505531233656060839346137331",
+    "denominator": "2436909341187163814496457779624",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1335009",
+    "numerator": "474789176477207232482895049881198",
+    "denominator": "1512629204577546566361707710559",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1335009",
+    "numerator": "474789176477207232482895049881198",
+    "denominator": "1512629204577546566361707710559",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7172",
+    "numerator": "15177319020278526189",
+    "denominator": "26969278143466",
+    "rounding": "Floor",
+    "expected": "4036138135",
+    "overflow": false
+  },
+  {
+    "a": "7172",
+    "numerator": "15177319020278526189",
+    "denominator": "26969278143466",
+    "rounding": "Ceil",
+    "expected": "4036138136",
+    "overflow": false
+  },
+  {
+    "a": "67595",
+    "numerator": "32369568",
+    "denominator": "8613297026579142410553",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "67595",
+    "numerator": "32369568",
+    "denominator": "8613297026579142410553",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "103590",
+    "numerator": "503",
+    "denominator": "38855658658406482531275900",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "103590",
+    "numerator": "503",
+    "denominator": "38855658658406482531275900",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "40230490269742375090697140143867673541",
+    "numerator": "1639392427310242",
+    "denominator": "35",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "40230490269742375090697140143867673541",
+    "numerator": "1639392427310242",
+    "denominator": "35",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "122560335803203387385098551455473832600",
+    "numerator": "1193664226495633",
+    "denominator": "30546309086",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "122560335803203387385098551455473832600",
+    "numerator": "1193664226495633",
+    "denominator": "30546309086",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15603632603279",
+    "numerator": "2581020950771878382858137584591348",
+    "denominator": "13",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15603632603279",
+    "numerator": "2581020950771878382858137584591348",
+    "denominator": "13",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7832259409611354",
+    "numerator": "6656518038315994001868406290747",
+    "denominator": "16",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7832259409611354",
+    "numerator": "6656518038315994001868406290747",
+    "denominator": "16",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66506940649",
+    "numerator": "287829490618145833661212694",
+    "denominator": "497667526183",
+    "rounding": "Floor",
+    "expected": "38464753761196540968264688",
+    "overflow": false
+  },
+  {
+    "a": "66506940649",
+    "numerator": "287829490618145833661212694",
+    "denominator": "497667526183",
+    "rounding": "Ceil",
+    "expected": "38464753761196540968264689",
+    "overflow": false
+  },
+  {
+    "a": "3039738636196137552085247084",
+    "numerator": "12117750186835061",
+    "denominator": "274",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3039738636196137552085247084",
+    "numerator": "12117750186835061",
+    "denominator": "274",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "199507",
+    "numerator": "5001096",
+    "denominator": "5168776127498411585",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "199507",
+    "numerator": "5001096",
+    "denominator": "5168776127498411585",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "255477283904846",
+    "numerator": "15",
+    "denominator": "216904518118357988",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "255477283904846",
+    "numerator": "15",
+    "denominator": "216904518118357988",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1226453508295314704331341",
+    "numerator": "93385546422400206092753081920714",
+    "denominator": "27268559005068907",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1226453508295314704331341",
+    "numerator": "93385546422400206092753081920714",
+    "denominator": "27268559005068907",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11885625288064",
+    "numerator": "4433643529369",
+    "denominator": "1224582",
+    "rounding": "Floor",
+    "expected": "43032337279928588097",
+    "overflow": false
+  },
+  {
+    "a": "11885625288064",
+    "numerator": "4433643529369",
+    "denominator": "1224582",
+    "rounding": "Ceil",
+    "expected": "43032337279928588098",
+    "overflow": false
+  },
+  {
+    "a": "23",
+    "numerator": "95014481600639912367796818962401372",
+    "denominator": "32886544418403222573395006038309",
+    "rounding": "Floor",
+    "expected": "66450",
+    "overflow": false
+  },
+  {
+    "a": "23",
+    "numerator": "95014481600639912367796818962401372",
+    "denominator": "32886544418403222573395006038309",
+    "rounding": "Ceil",
+    "expected": "66451",
+    "overflow": false
+  },
+  {
+    "a": "33903923916734850",
+    "numerator": "30773924686908376531587",
+    "denominator": "13286038472881132750774392",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33903923916734850",
+    "numerator": "30773924686908376531587",
+    "denominator": "13286038472881132750774392",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2631918475445674598996923377",
+    "numerator": "833701138725312805306046",
+    "denominator": "20446307663008675782672218652230843631",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2631918475445674598996923377",
+    "numerator": "833701138725312805306046",
+    "denominator": "20446307663008675782672218652230843631",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17707570607431449736800724",
+    "numerator": "11026792340434643197",
+    "denominator": "29475763889322809448002135173332992826",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17707570607431449736800724",
+    "numerator": "11026792340434643197",
+    "denominator": "29475763889322809448002135173332992826",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1884163414516447667595163",
+    "numerator": "562277647282144837202470511882150000",
+    "denominator": "1097",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1884163414516447667595163",
+    "numerator": "562277647282144837202470511882150000",
+    "denominator": "1097",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "486620375138160585658440329974",
+    "numerator": "647",
+    "denominator": "401604684",
+    "rounding": "Floor",
+    "expected": "783963422882761743189755",
+    "overflow": false
+  },
+  {
+    "a": "486620375138160585658440329974",
+    "numerator": "647",
+    "denominator": "401604684",
+    "rounding": "Ceil",
+    "expected": "783963422882761743189756",
+    "overflow": false
+  },
+  {
+    "a": "9004404304138381781",
+    "numerator": "95434596909023431558255090",
+    "denominator": "114099",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9004404304138381781",
+    "numerator": "95434596909023431558255090",
+    "denominator": "114099",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "83318015336",
+    "numerator": "4976033",
+    "denominator": "8190219750884920988718",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "83318015336",
+    "numerator": "4976033",
+    "denominator": "8190219750884920988718",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1388066242847",
+    "numerator": "6995405764",
+    "denominator": "4898655628221165306745905300397",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1388066242847",
+    "numerator": "6995405764",
+    "denominator": "4898655628221165306745905300397",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "133304148787217321386",
+    "numerator": "15295290043061453302919533711418571",
+    "denominator": "169272650867855494888521293666627424",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "133304148787217321386",
+    "numerator": "15295290043061453302919533711418571",
+    "denominator": "169272650867855494888521293666627424",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "249",
+    "numerator": "1126119130747941054486877972387961446",
+    "denominator": "287852390722799937000948734702775",
+    "rounding": "Floor",
+    "expected": "974123",
+    "overflow": false
+  },
+  {
+    "a": "249",
+    "numerator": "1126119130747941054486877972387961446",
+    "denominator": "287852390722799937000948734702775",
+    "rounding": "Ceil",
+    "expected": "974124",
+    "overflow": false
+  },
+  {
+    "a": "886633761852",
+    "numerator": "13182489011623902927440649361757829",
+    "denominator": "54882",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "886633761852",
+    "numerator": "13182489011623902927440649361757829",
+    "denominator": "54882",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "308547856991059171",
+    "numerator": "24",
+    "denominator": "81",
+    "rounding": "Floor",
+    "expected": "91421587256610124",
+    "overflow": false
+  },
+  {
+    "a": "308547856991059171",
+    "numerator": "24",
+    "denominator": "81",
+    "rounding": "Ceil",
+    "expected": "91421587256610125",
+    "overflow": false
+  },
+  {
+    "a": "62972380967638967057194398",
+    "numerator": "2383",
+    "denominator": "4330285805091844846104098265317812",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "62972380967638967057194398",
+    "numerator": "2383",
+    "denominator": "4330285805091844846104098265317812",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1321727843380491628664265172146225757",
+    "numerator": "55935071275633690",
+    "denominator": "6964841301511157260084731",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1321727843380491628664265172146225757",
+    "numerator": "55935071275633690",
+    "denominator": "6964841301511157260084731",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4540955292427151875680303437173328",
+    "numerator": "47319095864803542953",
+    "denominator": "30250774437681501251028184663033085398",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4540955292427151875680303437173328",
+    "numerator": "47319095864803542953",
+    "denominator": "30250774437681501251028184663033085398",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7167719",
+    "numerator": "2095558303688133274668",
+    "denominator": "1159818168906609452853",
+    "rounding": "Floor",
+    "expected": "12950627",
+    "overflow": false
+  },
+  {
+    "a": "7167719",
+    "numerator": "2095558303688133274668",
+    "denominator": "1159818168906609452853",
+    "rounding": "Ceil",
+    "expected": "12950628",
+    "overflow": false
+  },
+  {
+    "a": "50769039058",
+    "numerator": "552110554209419283",
+    "denominator": "9081086063142243144",
+    "rounding": "Floor",
+    "expected": "3086648677",
+    "overflow": false
+  },
+  {
+    "a": "50769039058",
+    "numerator": "552110554209419283",
+    "denominator": "9081086063142243144",
+    "rounding": "Ceil",
+    "expected": "3086648678",
+    "overflow": false
+  },
+  {
+    "a": "1056295148956347371726874966265089",
+    "numerator": "8031423640694082716943424270",
+    "denominator": "63",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1056295148956347371726874966265089",
+    "numerator": "8031423640694082716943424270",
+    "denominator": "63",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1236706515387817926876744859450272676",
+    "numerator": "404332455181",
+    "denominator": "12427752013450",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1236706515387817926876744859450272676",
+    "numerator": "404332455181",
+    "denominator": "12427752013450",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24718123",
+    "numerator": "52925066134367700188528337375687772480",
+    "denominator": "6764549311946838685637465",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24718123",
+    "numerator": "52925066134367700188528337375687772480",
+    "denominator": "6764549311946838685637465",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "447239494",
+    "numerator": "35177738634045306794466413847",
+    "denominator": "983837510968713244",
+    "rounding": "Floor",
+    "expected": "15991333783628210473",
+    "overflow": false
+  },
+  {
+    "a": "447239494",
+    "numerator": "35177738634045306794466413847",
+    "denominator": "983837510968713244",
+    "rounding": "Ceil",
+    "expected": "15991333783628210474",
+    "overflow": false
+  },
+  {
+    "a": "1063525576481765",
+    "numerator": "36455199881645739684286558894914",
+    "denominator": "818300739",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1063525576481765",
+    "numerator": "36455199881645739684286558894914",
+    "denominator": "818300739",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1324835890203448736192410299448",
+    "numerator": "775758333265267364529",
+    "denominator": "2496711265406",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1324835890203448736192410299448",
+    "numerator": "775758333265267364529",
+    "denominator": "2496711265406",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1320286559258292759154379498927",
+    "numerator": "20",
+    "denominator": "646487264880523249822653",
+    "rounding": "Floor",
+    "expected": "40844936",
+    "overflow": false
+  },
+  {
+    "a": "1320286559258292759154379498927",
+    "numerator": "20",
+    "denominator": "646487264880523249822653",
+    "rounding": "Ceil",
+    "expected": "40844937",
+    "overflow": false
+  },
+  {
+    "a": "187309367635770501338397165380858",
+    "numerator": "977402642549781613454872015524213851",
+    "denominator": "222629219677464274473577075760",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "187309367635770501338397165380858",
+    "numerator": "977402642549781613454872015524213851",
+    "denominator": "222629219677464274473577075760",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "255068630746158120084181769",
+    "numerator": "307178178131868211862532726966",
+    "denominator": "2959581201075558917571197484871",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "255068630746158120084181769",
+    "numerator": "307178178131868211862532726966",
+    "denominator": "2959581201075558917571197484871",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "603596304700904333912076",
+    "numerator": "483832981",
+    "denominator": "14989226796982783468340965302688652210",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "603596304700904333912076",
+    "numerator": "483832981",
+    "denominator": "14989226796982783468340965302688652210",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7191548531",
+    "numerator": "4661839271146597412363067688",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "33525843362172423306528020670289966328",
+    "overflow": false
+  },
+  {
+    "a": "7191548531",
+    "numerator": "4661839271146597412363067688",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "33525843362172423306528020670289966328",
+    "overflow": false
+  },
+  {
+    "a": "16962959912961576560545231342",
+    "numerator": "813622376927",
+    "denominator": "1476936753462148",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16962959912961576560545231342",
+    "numerator": "813622376927",
+    "denominator": "1476936753462148",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "109",
+    "numerator": "8042",
+    "denominator": "325585885281867341931319285252491",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "109",
+    "numerator": "8042",
+    "denominator": "325585885281867341931319285252491",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "19444512",
+    "numerator": "12540245425974969",
+    "denominator": "43976291476080923279262529282086",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "19444512",
+    "numerator": "12540245425974969",
+    "denominator": "43976291476080923279262529282086",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1399",
+    "numerator": "3025705960444",
+    "denominator": "30113530924605640247648504669188421",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1399",
+    "numerator": "3025705960444",
+    "denominator": "30113530924605640247648504669188421",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1177813386396361205207363088418",
+    "numerator": "530671877075153735645176227",
+    "denominator": "259413349772923799831603685912",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1177813386396361205207363088418",
+    "numerator": "530671877075153735645176227",
+    "denominator": "259413349772923799831603685912",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17",
+    "numerator": "379742",
+    "denominator": "1813225579927726533077922664975",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "17",
+    "numerator": "379742",
+    "denominator": "1813225579927726533077922664975",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "233019739453207642508550516",
+    "numerator": "424164241597725",
+    "denominator": "708058",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "233019739453207642508550516",
+    "numerator": "424164241597725",
+    "denominator": "708058",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "69528487850550307997084669049148091",
+    "numerator": "1917593104",
+    "denominator": "6404746179121163659336052329",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "69528487850550307997084669049148091",
+    "numerator": "1917593104",
+    "denominator": "6404746179121163659336052329",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "37782",
+    "numerator": "520564647",
+    "denominator": "553913590280106988",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "37782",
+    "numerator": "520564647",
+    "denominator": "553913590280106988",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "0",
+    "denominator": "59782355",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "0",
+    "denominator": "59782355",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "13693683464",
+    "numerator": "9596210290899882055227016825093192641",
+    "denominator": "7451821938894",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13693683464",
+    "numerator": "9596210290899882055227016825093192641",
+    "denominator": "7451821938894",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1386860064807022143",
+    "numerator": "185858539641700",
+    "denominator": "464845",
+    "rounding": "Floor",
+    "expected": "554506956797269102658510226",
+    "overflow": false
+  },
+  {
+    "a": "1386860064807022143",
+    "numerator": "185858539641700",
+    "denominator": "464845",
+    "rounding": "Ceil",
+    "expected": "554506956797269102658510227",
+    "overflow": false
+  },
+  {
+    "a": "72950965267897321112052518986",
+    "numerator": "370115674023914370483754493931",
+    "denominator": "1959603456",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "72950965267897321112052518986",
+    "numerator": "370115674023914370483754493931",
+    "denominator": "1959603456",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25",
+    "numerator": "4012806",
+    "denominator": "3380345264751898357706253781430365655",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "25",
+    "numerator": "4012806",
+    "denominator": "3380345264751898357706253781430365655",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "47068",
+    "numerator": "1739871586597620304631461",
+    "denominator": "94811394",
+    "rounding": "Floor",
+    "expected": "863738759478389195484",
+    "overflow": false
+  },
+  {
+    "a": "47068",
+    "numerator": "1739871586597620304631461",
+    "denominator": "94811394",
+    "rounding": "Ceil",
+    "expected": "863738759478389195485",
+    "overflow": false
+  },
+  {
+    "a": "2213404782116338336657260416003",
+    "numerator": "3164436472",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2213404782116338336657260416003",
+    "numerator": "3164436472",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "574",
+    "numerator": "1290267529654582658396213051996835439",
+    "denominator": "8296999023457069071784515932629332",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "574",
+    "numerator": "1290267529654582658396213051996835439",
+    "denominator": "8296999023457069071784515932629332",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1572093332359071429215850046719700605",
+    "numerator": "72570894191451608886215041091258",
+    "denominator": "283",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1572093332359071429215850046719700605",
+    "numerator": "72570894191451608886215041091258",
+    "denominator": "283",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "342946627048766505931163632",
+    "numerator": "546810892924055699641480295106566601",
+    "denominator": "257268386637065621538194383479363190",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "342946627048766505931163632",
+    "numerator": "546810892924055699641480295106566601",
+    "denominator": "257268386637065621538194383479363190",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "181776146418593621406986247",
+    "numerator": "4575626346931114309216210892",
+    "denominator": "129552777368652939322261333",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "181776146418593621406986247",
+    "numerator": "4575626346931114309216210892",
+    "denominator": "129552777368652939322261333",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75122",
+    "numerator": "93748208731523115950745395",
+    "denominator": "5111016",
+    "rounding": "Floor",
+    "expected": "1377916433118088363732748",
+    "overflow": false
+  },
+  {
+    "a": "75122",
+    "numerator": "93748208731523115950745395",
+    "denominator": "5111016",
+    "rounding": "Ceil",
+    "expected": "1377916433118088363732749",
+    "overflow": false
+  },
+  {
+    "a": "1668082245234579327777",
+    "numerator": "645754860699619567538439045243473838",
+    "denominator": "13618315416482463",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1668082245234579327777",
+    "numerator": "645754860699619567538439045243473838",
+    "denominator": "13618315416482463",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89825260704245802373104881648324791108",
+    "numerator": "339612411611588909",
+    "denominator": "4107124108855394453944269499261120810",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89825260704245802373104881648324791108",
+    "numerator": "339612411611588909",
+    "denominator": "4107124108855394453944269499261120810",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "187979",
+    "numerator": "259808",
+    "denominator": "146743114388644129981817",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "187979",
+    "numerator": "259808",
+    "denominator": "146743114388644129981817",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "41379302",
+    "numerator": "56566793861600729863585678449767991",
+    "denominator": "41614607141944252",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "41379302",
+    "numerator": "56566793861600729863585678449767991",
+    "denominator": "41614607141944252",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1972629703685",
+    "numerator": "430461775467952853206243082479487458",
+    "denominator": "4083975779",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1972629703685",
+    "numerator": "430461775467952853206243082479487458",
+    "denominator": "4083975779",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3331281977866704011213349663222371800",
+    "numerator": "2257",
+    "denominator": "300507652274462",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3331281977866704011213349663222371800",
+    "numerator": "2257",
+    "denominator": "300507652274462",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "986317547859565263",
+    "numerator": "7848244",
+    "denominator": "2013",
+    "rounding": "Floor",
+    "expected": "3845435060647563794311",
+    "overflow": false
+  },
+  {
+    "a": "986317547859565263",
+    "numerator": "7848244",
+    "denominator": "2013",
+    "rounding": "Ceil",
+    "expected": "3845435060647563794312",
+    "overflow": false
+  },
+  {
+    "a": "214332188559481345614247759770",
+    "numerator": "360315",
+    "denominator": "2512",
+    "rounding": "Floor",
+    "expected": "30743273296500605511543663042009",
+    "overflow": false
+  },
+  {
+    "a": "214332188559481345614247759770",
+    "numerator": "360315",
+    "denominator": "2512",
+    "rounding": "Ceil",
+    "expected": "30743273296500605511543663042010",
+    "overflow": false
+  },
+  {
+    "a": "54359734433547834873129",
+    "numerator": "1757449272224086",
+    "denominator": "171716514821955169779688962343015",
+    "rounding": "Floor",
+    "expected": "556349",
+    "overflow": false
+  },
+  {
+    "a": "54359734433547834873129",
+    "numerator": "1757449272224086",
+    "denominator": "171716514821955169779688962343015",
+    "rounding": "Ceil",
+    "expected": "556350",
+    "overflow": false
+  },
+  {
+    "a": "18582416145324",
+    "numerator": "2784437",
+    "denominator": "19266069591091340721736529289810",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "18582416145324",
+    "numerator": "2784437",
+    "denominator": "19266069591091340721736529289810",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8911236513041320073741215934867",
+    "numerator": "1689802366488395033039261239821000",
+    "denominator": "207166574621945245043567233",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8911236513041320073741215934867",
+    "numerator": "1689802366488395033039261239821000",
+    "denominator": "207166574621945245043567233",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "45682311408158947636860558",
+    "numerator": "1988757247",
+    "denominator": "4437853651802055231553249646349092",
+    "rounding": "Floor",
+    "expected": "20",
+    "overflow": false
+  },
+  {
+    "a": "45682311408158947636860558",
+    "numerator": "1988757247",
+    "denominator": "4437853651802055231553249646349092",
+    "rounding": "Ceil",
+    "expected": "21",
+    "overflow": false
+  },
+  {
+    "a": "1264408719733865502378085005",
+    "numerator": "2504297424722364162570",
+    "denominator": "5771339464401666373427817429787819",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1264408719733865502378085005",
+    "numerator": "2504297424722364162570",
+    "denominator": "5771339464401666373427817429787819",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "131449248965990690394304",
+    "numerator": "509774454157296292956377",
+    "denominator": "24045744069842466158149098326136545478",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "131449248965990690394304",
+    "numerator": "509774454157296292956377",
+    "denominator": "24045744069842466158149098326136545478",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "101402887701182698944041549208555159",
+    "numerator": "1083930702778268",
+    "denominator": "188158490455184882179828994405",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "101402887701182698944041549208555159",
+    "numerator": "1083930702778268",
+    "denominator": "188158490455184882179828994405",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51091873146463290615705282",
+    "numerator": "8978823640955883715",
+    "denominator": "7863665592",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51091873146463290615705282",
+    "numerator": "8978823640955883715",
+    "denominator": "7863665592",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2190992696071475249",
+    "numerator": "7279634430",
+    "denominator": "1205937021476105071520540899119",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2190992696071475249",
+    "numerator": "7279634430",
+    "denominator": "1205937021476105071520540899119",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "13352888043721940296754579109512292628",
+    "numerator": "22364418365",
+    "denominator": "10807418",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13352888043721940296754579109512292628",
+    "numerator": "22364418365",
+    "denominator": "10807418",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1109516112438014643675",
+    "numerator": "2638835022768",
+    "denominator": "2154633",
+    "rounding": "Floor",
+    "expected": "1358853213436734339551485581",
+    "overflow": false
+  },
+  {
+    "a": "1109516112438014643675",
+    "numerator": "2638835022768",
+    "denominator": "2154633",
+    "rounding": "Ceil",
+    "expected": "1358853213436734339551485582",
+    "overflow": false
+  },
+  {
+    "a": "222184088779018113699235482678",
+    "numerator": "7871881415",
+    "denominator": "12",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "222184088779018113699235482678",
+    "numerator": "7871881415",
+    "denominator": "12",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100885",
+    "numerator": "0",
+    "denominator": "55277158087923560889331",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "100885",
+    "numerator": "0",
+    "denominator": "55277158087923560889331",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3432005260597416",
+    "numerator": "60318025340132411722427977964001",
+    "denominator": "3476892168467737966",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3432005260597416",
+    "numerator": "60318025340132411722427977964001",
+    "denominator": "3476892168467737966",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1476137179019985644383",
+    "numerator": "392941458635627268",
+    "denominator": "88617490394446829",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1476137179019985644383",
+    "numerator": "392941458635627268",
+    "denominator": "88617490394446829",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31285228092476329660359402",
+    "numerator": "6661836241675",
+    "denominator": "153157158599328",
+    "rounding": "Floor",
+    "expected": "1360805255474634422084048",
+    "overflow": false
+  },
+  {
+    "a": "31285228092476329660359402",
+    "numerator": "6661836241675",
+    "denominator": "153157158599328",
+    "rounding": "Ceil",
+    "expected": "1360805255474634422084049",
+    "overflow": false
+  },
+  {
+    "a": "3883518112599637548089",
+    "numerator": "9640815526",
+    "denominator": "224589801514990971194158560444102391",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3883518112599637548089",
+    "numerator": "9640815526",
+    "denominator": "224589801514990971194158560444102391",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "34391536939900",
+    "numerator": "1615557",
+    "denominator": "10084600866553321634259874",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "34391536939900",
+    "numerator": "1615557",
+    "denominator": "10084600866553321634259874",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "673150472540792859427",
+    "numerator": "161461521245545995521924972952",
+    "denominator": "8418597148171783170400733202321",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "673150472540792859427",
+    "numerator": "161461521245545995521924972952",
+    "denominator": "8418597148171783170400733202321",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "321246",
+    "numerator": "3268158351",
+    "denominator": "25266247123648551444724",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "321246",
+    "numerator": "3268158351",
+    "denominator": "25266247123648551444724",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "20968796838208213123699448347528063645",
+    "numerator": "823642",
+    "denominator": "235208397541888601147",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20968796838208213123699448347528063645",
+    "numerator": "823642",
+    "denominator": "235208397541888601147",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "4436478163945",
+    "denominator": "3543564054",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "4436478163945",
+    "denominator": "3543564054",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "154696328023638853244129575",
+    "numerator": "34986140485653726060",
+    "denominator": "517278837135234753384147199861",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "154696328023638853244129575",
+    "numerator": "34986140485653726060",
+    "denominator": "517278837135234753384147199861",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9527150982276940724342483864620050",
+    "numerator": "22469309355699740377165807640147",
+    "denominator": "3321934779014197759142833594482312",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9527150982276940724342483864620050",
+    "numerator": "22469309355699740377165807640147",
+    "denominator": "3321934779014197759142833594482312",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "199235905",
+    "numerator": "30041005510136491524973777998",
+    "denominator": "69770036530158188533633771077833646015",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "199235905",
+    "numerator": "30041005510136491524973777998",
+    "denominator": "69770036530158188533633771077833646015",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "302494087908",
+    "numerator": "8178941261",
+    "denominator": "308170",
+    "rounding": "Floor",
+    "expected": "8028300538012468",
+    "overflow": false
+  },
+  {
+    "a": "302494087908",
+    "numerator": "8178941261",
+    "denominator": "308170",
+    "rounding": "Ceil",
+    "expected": "8028300538012469",
+    "overflow": false
+  },
+  {
+    "a": "1275394793835",
+    "numerator": "17246484261184615552",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "21996076238672125044816774721920",
+    "overflow": false
+  },
+  {
+    "a": "1275394793835",
+    "numerator": "17246484261184615552",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "21996076238672125044816774721920",
+    "overflow": false
+  },
+  {
+    "a": "247692006925596241479302",
+    "numerator": "180938225692598512252317527",
+    "denominator": "3320358748",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "247692006925596241479302",
+    "numerator": "180938225692598512252317527",
+    "denominator": "3320358748",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9524062289637739557",
+    "numerator": "850258050",
+    "denominator": "855959249771237845895611438467",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "9524062289637739557",
+    "numerator": "850258050",
+    "denominator": "855959249771237845895611438467",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2533226434424",
+    "numerator": "52977",
+    "denominator": "144957077021618552650740584093398462",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2533226434424",
+    "numerator": "52977",
+    "denominator": "144957077021618552650740584093398462",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "22164223218660993887924893687791",
+    "numerator": "59604",
+    "denominator": "64028863586004622809628239688701",
+    "rounding": "Floor",
+    "expected": "20632",
+    "overflow": false
+  },
+  {
+    "a": "22164223218660993887924893687791",
+    "numerator": "59604",
+    "denominator": "64028863586004622809628239688701",
+    "rounding": "Ceil",
+    "expected": "20633",
+    "overflow": false
+  },
+  {
+    "a": "24987138034391124538",
+    "numerator": "9379879586697907034779",
+    "denominator": "19362926953374140562283458416",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24987138034391124538",
+    "numerator": "9379879586697907034779",
+    "denominator": "19362926953374140562283458416",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4260224798982055753",
+    "numerator": "0",
+    "denominator": "1963699860523745787831103115655",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4260224798982055753",
+    "numerator": "0",
+    "denominator": "1963699860523745787831103115655",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8012",
+    "numerator": "19173327015391394928529421077861589",
+    "denominator": "781580486277575759510690527328467186",
+    "rounding": "Floor",
+    "expected": "196",
+    "overflow": false
+  },
+  {
+    "a": "8012",
+    "numerator": "19173327015391394928529421077861589",
+    "denominator": "781580486277575759510690527328467186",
+    "rounding": "Ceil",
+    "expected": "197",
+    "overflow": false
+  },
+  {
+    "a": "16324796789929224016051",
+    "numerator": "6696942609901918087918061941864",
+    "denominator": "1397125683996079847155873",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16324796789929224016051",
+    "numerator": "6696942609901918087918061941864",
+    "denominator": "1397125683996079847155873",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2033208920878",
+    "numerator": "151346254791960080251549934623",
+    "denominator": "4233192697763104678619844",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2033208920878",
+    "numerator": "151346254791960080251549934623",
+    "denominator": "4233192697763104678619844",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2744389293",
+    "numerator": "11719278299637373643822250",
+    "denominator": "29539498281546348484374987225100539851",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2744389293",
+    "numerator": "11719278299637373643822250",
+    "denominator": "29539498281546348484374987225100539851",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "92855797519586218694344588896",
+    "numerator": "333904684946900595449",
+    "denominator": "16640373567846",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "92855797519586218694344588896",
+    "numerator": "333904684946900595449",
+    "denominator": "16640373567846",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "295287815336288621382912105884006327",
+    "numerator": "0",
+    "denominator": "16679895429",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "295287815336288621382912105884006327",
+    "numerator": "0",
+    "denominator": "16679895429",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "97175578117814590590588440651808098",
+    "numerator": "70581817315",
+    "denominator": "13646715148342934800248152",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "97175578117814590590588440651808098",
+    "numerator": "70581817315",
+    "denominator": "13646715148342934800248152",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10598848679808888658977921055443691089",
+    "numerator": "577185792936596638",
+    "denominator": "3886515317724157555321935",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10598848679808888658977921055443691089",
+    "numerator": "577185792936596638",
+    "denominator": "3886515317724157555321935",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "157506279810221147763980714164",
+    "numerator": "3421",
+    "denominator": "3550478521345121485738778",
+    "rounding": "Floor",
+    "expected": "151762355",
+    "overflow": false
+  },
+  {
+    "a": "157506279810221147763980714164",
+    "numerator": "3421",
+    "denominator": "3550478521345121485738778",
+    "rounding": "Ceil",
+    "expected": "151762356",
+    "overflow": false
+  },
+  {
+    "a": "32585370179835",
+    "numerator": "8890198639552143696",
+    "denominator": "20949382985203521596915387176542889",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "32585370179835",
+    "numerator": "8890198639552143696",
+    "denominator": "20949382985203521596915387176542889",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "560997946460793437670945696915084502",
+    "numerator": "254157287",
+    "denominator": "117735420445803047888620332",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "560997946460793437670945696915084502",
+    "numerator": "254157287",
+    "denominator": "117735420445803047888620332",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20041851136311228371509",
+    "numerator": "2050941328440807994834",
+    "denominator": "306251754239201358492848915",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20041851136311228371509",
+    "numerator": "2050941328440807994834",
+    "denominator": "306251754239201358492848915",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12620672667974216",
+    "numerator": "37341185",
+    "denominator": "131955167758",
+    "rounding": "Floor",
+    "expected": "3571446885532",
+    "overflow": false
+  },
+  {
+    "a": "12620672667974216",
+    "numerator": "37341185",
+    "denominator": "131955167758",
+    "rounding": "Ceil",
+    "expected": "3571446885533",
+    "overflow": false
+  },
+  {
+    "a": "416282751",
+    "numerator": "615131812",
+    "denominator": "18390566528236728143860731306211733517",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "416282751",
+    "numerator": "615131812",
+    "denominator": "18390566528236728143860731306211733517",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "935926017018381706",
+    "numerator": "106027",
+    "denominator": "18887994519860582464",
+    "rounding": "Floor",
+    "expected": "5253",
+    "overflow": false
+  },
+  {
+    "a": "935926017018381706",
+    "numerator": "106027",
+    "denominator": "18887994519860582464",
+    "rounding": "Ceil",
+    "expected": "5254",
+    "overflow": false
+  },
+  {
+    "a": "67999473446938319611901529",
+    "numerator": "5665689789451505986630",
+    "denominator": "131317876203264682161772664590359",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "67999473446938319611901529",
+    "numerator": "5665689789451505986630",
+    "denominator": "131317876203264682161772664590359",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "311488188228468508",
+    "numerator": "45723276312163295332069",
+    "denominator": "71669747524643628715132898482217538",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "311488188228468508",
+    "numerator": "45723276312163295332069",
+    "denominator": "71669747524643628715132898482217538",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "188997884483",
+    "numerator": "22342655371381787635017583352632",
+    "denominator": "40031423921",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "188997884483",
+    "numerator": "22342655371381787635017583352632",
+    "denominator": "40031423921",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "362347185022",
+    "numerator": "597468602730025306287",
+    "denominator": "1622017269469211610572948",
+    "rounding": "Floor",
+    "expected": "133470259",
+    "overflow": false
+  },
+  {
+    "a": "362347185022",
+    "numerator": "597468602730025306287",
+    "denominator": "1622017269469211610572948",
+    "rounding": "Ceil",
+    "expected": "133470260",
+    "overflow": false
+  },
+  {
+    "a": "2037190652883488384090060477",
+    "numerator": "27642",
+    "denominator": "4242992797509467",
+    "rounding": "Floor",
+    "expected": "13271769883762038",
+    "overflow": false
+  },
+  {
+    "a": "2037190652883488384090060477",
+    "numerator": "27642",
+    "denominator": "4242992797509467",
+    "rounding": "Ceil",
+    "expected": "13271769883762039",
+    "overflow": false
+  },
+  {
+    "a": "14599204053808",
+    "numerator": "160865065083036614087771206227625684489",
+    "denominator": "63643168878710776079448144290346934",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14599204053808",
+    "numerator": "160865065083036614087771206227625684489",
+    "denominator": "63643168878710776079448144290346934",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "111673797348324677199102535",
+    "numerator": "5191564965267212",
+    "denominator": "4508495085377892201457926677845073813",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "111673797348324677199102535",
+    "numerator": "5191564965267212",
+    "denominator": "4508495085377892201457926677845073813",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "278596120357061298",
+    "numerator": "52913557277472894166387",
+    "denominator": "3900035283577162015068200",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "278596120357061298",
+    "numerator": "52913557277472894166387",
+    "denominator": "3900035283577162015068200",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "45549322827172811471282883819932448609",
+    "numerator": "62629164664059118729890359534",
+    "denominator": "942043379835997453435389338426252511",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "45549322827172811471282883819932448609",
+    "numerator": "62629164664059118729890359534",
+    "denominator": "942043379835997453435389338426252511",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21092425944969869956",
+    "numerator": "2584732057708197127741805",
+    "denominator": "1188339710032486398698820944383362666",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21092425944969869956",
+    "numerator": "2584732057708197127741805",
+    "denominator": "1188339710032486398698820944383362666",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2041599816843",
+    "numerator": "2148398875168",
+    "denominator": "2431579276772312391191688104377",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2041599816843",
+    "numerator": "2148398875168",
+    "denominator": "2431579276772312391191688104377",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "165595457336079054967",
+    "denominator": "14586277973028473915385799420",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "165595457336079054967",
+    "denominator": "14586277973028473915385799420",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "493017685950335411333340229",
+    "numerator": "76424481437217604663765270655588130",
+    "denominator": "6560064058531",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "493017685950335411333340229",
+    "numerator": "76424481437217604663765270655588130",
+    "denominator": "6560064058531",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25666687802273813371854051608",
+    "numerator": "10026412122058236965826356951901668625",
+    "denominator": "19019456955118965484416467550",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25666687802273813371854051608",
+    "numerator": "10026412122058236965826356951901668625",
+    "denominator": "19019456955118965484416467550",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5391",
+    "numerator": "24692",
+    "denominator": "4275869085725",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5391",
+    "numerator": "24692",
+    "denominator": "4275869085725",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "66551174645740688602",
+    "numerator": "182848505275",
+    "denominator": "16036500153782940857616",
+    "rounding": "Floor",
+    "expected": "758817864",
+    "overflow": false
+  },
+  {
+    "a": "66551174645740688602",
+    "numerator": "182848505275",
+    "denominator": "16036500153782940857616",
+    "rounding": "Ceil",
+    "expected": "758817865",
+    "overflow": false
+  },
+  {
+    "a": "455002719816041",
+    "numerator": "85599743537422546303850080918",
+    "denominator": "4147971354587815",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "455002719816041",
+    "numerator": "85599743537422546303850080918",
+    "denominator": "4147971354587815",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "435816784947268329358283174826732",
+    "numerator": "27663602489639380679933173",
+    "denominator": "918502067679647589743477891029278610",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "435816784947268329358283174826732",
+    "numerator": "27663602489639380679933173",
+    "denominator": "918502067679647589743477891029278610",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14553856849096720353235",
+    "numerator": "4835627070984",
+    "denominator": "104920135871912124911607002543809",
+    "rounding": "Floor",
+    "expected": "670",
+    "overflow": false
+  },
+  {
+    "a": "14553856849096720353235",
+    "numerator": "4835627070984",
+    "denominator": "104920135871912124911607002543809",
+    "rounding": "Ceil",
+    "expected": "671",
+    "overflow": false
+  },
+  {
+    "a": "509065529071078576078",
+    "numerator": "34192707903",
+    "denominator": "18628805259434596",
+    "rounding": "Floor",
+    "expected": "934377094859482",
+    "overflow": false
+  },
+  {
+    "a": "509065529071078576078",
+    "numerator": "34192707903",
+    "denominator": "18628805259434596",
+    "rounding": "Ceil",
+    "expected": "934377094859483",
+    "overflow": false
+  },
+  {
+    "a": "295178128963185359339152157295469261",
+    "numerator": "7885363018",
+    "denominator": "37646054598030545971225764532086594283",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "295178128963185359339152157295469261",
+    "numerator": "7885363018",
+    "denominator": "37646054598030545971225764532086594283",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "214231375474342912",
+    "numerator": "1",
+    "denominator": "9219880647082168111622",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "214231375474342912",
+    "numerator": "1",
+    "denominator": "9219880647082168111622",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "215",
+    "numerator": "8882597219538651682524",
+    "denominator": "51651905540997541",
+    "rounding": "Floor",
+    "expected": "36973629",
+    "overflow": false
+  },
+  {
+    "a": "215",
+    "numerator": "8882597219538651682524",
+    "denominator": "51651905540997541",
+    "rounding": "Ceil",
+    "expected": "36973630",
+    "overflow": false
+  },
+  {
+    "a": "1767925329375910829058",
+    "numerator": "7939",
+    "denominator": "429086156536",
+    "rounding": "Floor",
+    "expected": "32710351933103",
+    "overflow": false
+  },
+  {
+    "a": "1767925329375910829058",
+    "numerator": "7939",
+    "denominator": "429086156536",
+    "rounding": "Ceil",
+    "expected": "32710351933104",
+    "overflow": false
+  },
+  {
+    "a": "35953",
+    "numerator": "4414",
+    "denominator": "21845427978045508104559",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "35953",
+    "numerator": "4414",
+    "denominator": "21845427978045508104559",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "242065549396",
+    "numerator": "2269914130003605885",
+    "denominator": "6843974105548131770",
+    "rounding": "Floor",
+    "expected": "80284934233",
+    "overflow": false
+  },
+  {
+    "a": "242065549396",
+    "numerator": "2269914130003605885",
+    "denominator": "6843974105548131770",
+    "rounding": "Ceil",
+    "expected": "80284934234",
+    "overflow": false
+  },
+  {
+    "a": "5492717079758579063670996330198043",
+    "numerator": "759358460815677688464650475248",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5492717079758579063670996330198043",
+    "numerator": "759358460815677688464650475248",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "490548598",
+    "numerator": "264113283398900498337629823529735",
+    "denominator": "254783180",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "490548598",
+    "numerator": "264113283398900498337629823529735",
+    "denominator": "254783180",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "411059414627962060275307293269",
+    "numerator": "107637794425826449222216174706",
+    "denominator": "178300289621838394587063319091",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "411059414627962060275307293269",
+    "numerator": "107637794425826449222216174706",
+    "denominator": "178300289621838394587063319091",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4824286579076409659488734809222120",
+    "numerator": "54940403860639088543918870529569",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4824286579076409659488734809222120",
+    "numerator": "54940403860639088543918870529569",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "159",
+    "numerator": "27396676",
+    "denominator": "66384941",
+    "rounding": "Floor",
+    "expected": "65",
+    "overflow": false
+  },
+  {
+    "a": "159",
+    "numerator": "27396676",
+    "denominator": "66384941",
+    "rounding": "Ceil",
+    "expected": "66",
+    "overflow": false
+  },
+  {
+    "a": "429273379541776250104693088271743018",
+    "numerator": "141405596495341967968303065911627",
+    "denominator": "361952",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "429273379541776250104693088271743018",
+    "numerator": "141405596495341967968303065911627",
+    "denominator": "361952",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "621280141433",
+    "numerator": "182348629768552115851499797734",
+    "denominator": "44859833581150598672180954991253223735",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "621280141433",
+    "numerator": "182348629768552115851499797734",
+    "denominator": "44859833581150598672180954991253223735",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "43448581298876",
+    "numerator": "191368239674717957",
+    "denominator": "1585378",
+    "rounding": "Floor",
+    "expected": "5244603192128168050704640",
+    "overflow": false
+  },
+  {
+    "a": "43448581298876",
+    "numerator": "191368239674717957",
+    "denominator": "1585378",
+    "rounding": "Ceil",
+    "expected": "5244603192128168050704641",
+    "overflow": false
+  },
+  {
+    "a": "99",
+    "numerator": "3256917894971901144",
+    "denominator": "144522698283232371103885455809046750161",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "99",
+    "numerator": "3256917894971901144",
+    "denominator": "144522698283232371103885455809046750161",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21468387848509136412442518344991895582",
+    "numerator": "488483992627714126669756382313935",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21468387848509136412442518344991895582",
+    "numerator": "488483992627714126669756382313935",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1151709",
+    "numerator": "1690",
+    "denominator": "27",
+    "rounding": "Floor",
+    "expected": "72088452",
+    "overflow": false
+  },
+  {
+    "a": "1151709",
+    "numerator": "1690",
+    "denominator": "27",
+    "rounding": "Ceil",
+    "expected": "72088453",
+    "overflow": false
+  },
+  {
+    "a": "595704972737356105943248",
+    "numerator": "0",
+    "denominator": "9739081118120712745709836349124034646",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "595704972737356105943248",
+    "numerator": "0",
+    "denominator": "9739081118120712745709836349124034646",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "29016208290376034693581069022921575",
+    "numerator": "71955573967605596079291935773481644",
+    "denominator": "523106658848059085444349863861",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29016208290376034693581069022921575",
+    "numerator": "71955573967605596079291935773481644",
+    "denominator": "523106658848059085444349863861",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6703442",
+    "numerator": "12434495437643846198264954003",
+    "denominator": "126398920",
+    "rounding": "Floor",
+    "expected": "659451195987356060059608260",
+    "overflow": false
+  },
+  {
+    "a": "6703442",
+    "numerator": "12434495437643846198264954003",
+    "denominator": "126398920",
+    "rounding": "Ceil",
+    "expected": "659451195987356060059608261",
+    "overflow": false
+  },
+  {
+    "a": "255361",
+    "numerator": "19753148512888181514258565975438",
+    "denominator": "878111231",
+    "rounding": "Floor",
+    "expected": "5744356272103800161579509129",
+    "overflow": false
+  },
+  {
+    "a": "255361",
+    "numerator": "19753148512888181514258565975438",
+    "denominator": "878111231",
+    "rounding": "Ceil",
+    "expected": "5744356272103800161579509130",
+    "overflow": false
+  },
+  {
+    "a": "1991691160100",
+    "numerator": "489629460075917",
+    "denominator": "14166282",
+    "rounding": "Floor",
+    "expected": "68838857461523056212",
+    "overflow": false
+  },
+  {
+    "a": "1991691160100",
+    "numerator": "489629460075917",
+    "denominator": "14166282",
+    "rounding": "Ceil",
+    "expected": "68838857461523056213",
+    "overflow": false
+  },
+  {
+    "a": "440963456391083",
+    "numerator": "55225868050489630776479262177304512",
+    "denominator": "2103866633281209099225",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "440963456391083",
+    "numerator": "55225868050489630776479262177304512",
+    "denominator": "2103866633281209099225",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22492606538401300430582347718",
+    "numerator": "1826955464544663",
+    "denominator": "126620",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22492606538401300430582347718",
+    "numerator": "1826955464544663",
+    "denominator": "126620",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "608228132793389571874076322324036709",
+    "numerator": "943746640807781802798552514",
+    "denominator": "5593267962946499",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "608228132793389571874076322324036709",
+    "numerator": "943746640807781802798552514",
+    "denominator": "5593267962946499",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3194819147838184010424",
+    "numerator": "1139191204657",
+    "denominator": "172667939514370407749241647472382",
+    "rounding": "Floor",
+    "expected": "21",
+    "overflow": false
+  },
+  {
+    "a": "3194819147838184010424",
+    "numerator": "1139191204657",
+    "denominator": "172667939514370407749241647472382",
+    "rounding": "Ceil",
+    "expected": "22",
+    "overflow": false
+  },
+  {
+    "a": "18475684673964106986740271",
+    "numerator": "2068",
+    "denominator": "1199553888064473422089769398139965",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "18475684673964106986740271",
+    "numerator": "2068",
+    "denominator": "1199553888064473422089769398139965",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3962",
+    "numerator": "439528243419",
+    "denominator": "14012395840827575970542229105167024",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3962",
+    "numerator": "439528243419",
+    "denominator": "14012395840827575970542229105167024",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4039440416578701629946761",
+    "numerator": "271158",
+    "denominator": "7",
+    "rounding": "Floor",
+    "expected": "156475226354092510939014831319",
+    "overflow": false
+  },
+  {
+    "a": "4039440416578701629946761",
+    "numerator": "271158",
+    "denominator": "7",
+    "rounding": "Ceil",
+    "expected": "156475226354092510939014831320",
+    "overflow": false
+  },
+  {
+    "a": "46077007234029196",
+    "numerator": "2245418449876966696112896647247125",
+    "denominator": "120706241678868767034274571589170",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "46077007234029196",
+    "numerator": "2245418449876966696112896647247125",
+    "denominator": "120706241678868767034274571589170",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4366539493233842741997407987",
+    "numerator": "235205347240",
+    "denominator": "980906133875540521011806735422689",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4366539493233842741997407987",
+    "numerator": "235205347240",
+    "denominator": "980906133875540521011806735422689",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "127421411531586069947502",
+    "numerator": "75113152105241565100503415574111",
+    "denominator": "514564",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "127421411531586069947502",
+    "numerator": "75113152105241565100503415574111",
+    "denominator": "514564",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13",
+    "numerator": "2101990823022881258",
+    "denominator": "2038853032732061195",
+    "rounding": "Floor",
+    "expected": "13",
+    "overflow": false
+  },
+  {
+    "a": "13",
+    "numerator": "2101990823022881258",
+    "denominator": "2038853032732061195",
+    "rounding": "Ceil",
+    "expected": "14",
+    "overflow": false
+  },
+  {
+    "a": "4786293984135584",
+    "numerator": "112441",
+    "denominator": "115849640638406863956140515574438",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4786293984135584",
+    "numerator": "112441",
+    "denominator": "115849640638406863956140515574438",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7229862840809975",
+    "numerator": "847516284",
+    "denominator": "6620314358747589",
+    "rounding": "Floor",
+    "expected": "925549174",
+    "overflow": false
+  },
+  {
+    "a": "7229862840809975",
+    "numerator": "847516284",
+    "denominator": "6620314358747589",
+    "rounding": "Ceil",
+    "expected": "925549175",
+    "overflow": false
+  },
+  {
+    "a": "13574434699780102170921634",
+    "numerator": "557518302099485327530835557923",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13574434699780102170921634",
+    "numerator": "557518302099485327530835557923",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11065578797337130885020483675018723985",
+    "numerator": "663006",
+    "denominator": "260194943138656143223020249375950479",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11065578797337130885020483675018723985",
+    "numerator": "663006",
+    "denominator": "260194943138656143223020249375950479",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "52",
+    "numerator": "1",
+    "denominator": "34366432901222885757633982645150357594",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "52",
+    "numerator": "1",
+    "denominator": "34366432901222885757633982645150357594",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "779489268489961922219121368891",
+    "numerator": "117577544746030779358352",
+    "denominator": "38633",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "779489268489961922219121368891",
+    "numerator": "117577544746030779358352",
+    "denominator": "38633",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "253428641888005056470281767704086",
+    "numerator": "8344615",
+    "denominator": "1516140",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "253428641888005056470281767704086",
+    "numerator": "8344615",
+    "denominator": "1516140",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1300197256539053338486354841785553525",
+    "numerator": "50464656291014687568658",
+    "denominator": "466694923989331",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1300197256539053338486354841785553525",
+    "numerator": "50464656291014687568658",
+    "denominator": "466694923989331",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11656",
+    "numerator": "1",
+    "denominator": "4187317397764220667998351668955982",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11656",
+    "numerator": "1",
+    "denominator": "4187317397764220667998351668955982",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5434735760425663",
+    "numerator": "4233083364",
+    "denominator": "29296717",
+    "rounding": "Floor",
+    "expected": "785265104455006463",
+    "overflow": false
+  },
+  {
+    "a": "5434735760425663",
+    "numerator": "4233083364",
+    "denominator": "29296717",
+    "rounding": "Ceil",
+    "expected": "785265104455006464",
+    "overflow": false
+  },
+  {
+    "a": "1080155027176138",
+    "numerator": "305485391304345025260000363",
+    "denominator": "10457685902208",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1080155027176138",
+    "numerator": "305485391304345025260000363",
+    "denominator": "10457685902208",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "997982607199272821155235773432339097",
+    "numerator": "390",
+    "denominator": "2790486615",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "997982607199272821155235773432339097",
+    "numerator": "390",
+    "denominator": "2790486615",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13644713940723790923138652",
+    "numerator": "1",
+    "denominator": "12546732150658",
+    "rounding": "Floor",
+    "expected": "1087511375622",
+    "overflow": false
+  },
+  {
+    "a": "13644713940723790923138652",
+    "numerator": "1",
+    "denominator": "12546732150658",
+    "rounding": "Ceil",
+    "expected": "1087511375623",
+    "overflow": false
+  },
+  {
+    "a": "118939183235",
+    "numerator": "1968848770280160888",
+    "denominator": "6638065",
+    "rounding": "Floor",
+    "expected": "35277338298187269655104",
+    "overflow": false
+  },
+  {
+    "a": "118939183235",
+    "numerator": "1968848770280160888",
+    "denominator": "6638065",
+    "rounding": "Ceil",
+    "expected": "35277338298187269655105",
+    "overflow": false
+  },
+  {
+    "a": "3012089907033468094",
+    "numerator": "5777886331631",
+    "denominator": "10196",
+    "rounding": "Floor",
+    "expected": "1706896145889796468339088022",
+    "overflow": false
+  },
+  {
+    "a": "3012089907033468094",
+    "numerator": "5777886331631",
+    "denominator": "10196",
+    "rounding": "Ceil",
+    "expected": "1706896145889796468339088023",
+    "overflow": false
+  },
+  {
+    "a": "47040360009503669406991099884491243261",
+    "numerator": "4368427320087684629535527226",
+    "denominator": "29243406007354922281311979892641179",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47040360009503669406991099884491243261",
+    "numerator": "4368427320087684629535527226",
+    "denominator": "29243406007354922281311979892641179",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3109994096",
+    "numerator": "1065545",
+    "denominator": "36977918273530916412571991562486",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3109994096",
+    "numerator": "1065545",
+    "denominator": "36977918273530916412571991562486",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "70128775",
+    "numerator": "18505239270654233112160338169839180",
+    "denominator": "7876509653",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70128775",
+    "numerator": "18505239270654233112160338169839180",
+    "denominator": "7876509653",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6079551439806450",
+    "numerator": "9453053447060649229798524150707",
+    "denominator": "161112472344832540009320",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6079551439806450",
+    "numerator": "9453053447060649229798524150707",
+    "denominator": "161112472344832540009320",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "155705794295833191999661269245846433",
+    "numerator": "161361599572485839828391820101222958",
+    "denominator": "1823",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "155705794295833191999661269245846433",
+    "numerator": "161361599572485839828391820101222958",
+    "denominator": "1823",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53889364595709262358980",
+    "numerator": "3195099295550690091260333",
+    "denominator": "3089855502314856307626",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53889364595709262358980",
+    "numerator": "3195099295550690091260333",
+    "denominator": "3089855502314856307626",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19485754074285001951829904075",
+    "numerator": "4536609787687199165792",
+    "denominator": "18294092483080449008168069041020931577",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19485754074285001951829904075",
+    "numerator": "4536609787687199165792",
+    "denominator": "18294092483080449008168069041020931577",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2847154334462117468201906468997222",
+    "numerator": "15031",
+    "denominator": "1857555875531277143053716028",
+    "rounding": "Floor",
+    "expected": "23038648454",
+    "overflow": false
+  },
+  {
+    "a": "2847154334462117468201906468997222",
+    "numerator": "15031",
+    "denominator": "1857555875531277143053716028",
+    "rounding": "Ceil",
+    "expected": "23038648455",
+    "overflow": false
+  },
+  {
+    "a": "10322176460075014052048005",
+    "numerator": "253838595163054203912975359200765026",
+    "denominator": "153845820774718578775065179792099",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10322176460075014052048005",
+    "numerator": "253838595163054203912975359200765026",
+    "denominator": "153845820774718578775065179792099",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18575808560305479449791575201635416",
+    "numerator": "10127478499165024752370338276872266065",
+    "denominator": "14988194712478",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18575808560305479449791575201635416",
+    "numerator": "10127478499165024752370338276872266065",
+    "denominator": "14988194712478",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "79",
+    "numerator": "737204",
+    "denominator": "81897527515011448012365797469",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "79",
+    "numerator": "737204",
+    "denominator": "81897527515011448012365797469",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "62836562458",
+    "numerator": "2676517231407811579",
+    "denominator": "1011792",
+    "rounding": "Floor",
+    "expected": "166223040092499438177934",
+    "overflow": false
+  },
+  {
+    "a": "62836562458",
+    "numerator": "2676517231407811579",
+    "denominator": "1011792",
+    "rounding": "Ceil",
+    "expected": "166223040092499438177935",
+    "overflow": false
+  },
+  {
+    "a": "828973704722301737415048617",
+    "numerator": "733315160697287219099473007717067734",
+    "denominator": "455350160797917802229449965476963559",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "828973704722301737415048617",
+    "numerator": "733315160697287219099473007717067734",
+    "denominator": "455350160797917802229449965476963559",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2088444247713402235436",
+    "numerator": "1046363445",
+    "denominator": "91781110951371471609042",
+    "rounding": "Floor",
+    "expected": "23809601",
+    "overflow": false
+  },
+  {
+    "a": "2088444247713402235436",
+    "numerator": "1046363445",
+    "denominator": "91781110951371471609042",
+    "rounding": "Ceil",
+    "expected": "23809602",
+    "overflow": false
+  },
+  {
+    "a": "26050060550035225675134858282804755",
+    "numerator": "2287944",
+    "denominator": "769",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "26050060550035225675134858282804755",
+    "numerator": "2287944",
+    "denominator": "769",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "203432657727364892942",
+    "numerator": "40545013390207",
+    "denominator": "279013796",
+    "rounding": "Floor",
+    "expected": "29561906793889887487494958",
+    "overflow": false
+  },
+  {
+    "a": "203432657727364892942",
+    "numerator": "40545013390207",
+    "denominator": "279013796",
+    "rounding": "Ceil",
+    "expected": "29561906793889887487494959",
+    "overflow": false
+  },
+  {
+    "a": "146189",
+    "numerator": "145639085062199708810",
+    "denominator": "629672876028277051685041599019356459",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "146189",
+    "numerator": "145639085062199708810",
+    "denominator": "629672876028277051685041599019356459",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "113667048606181184",
+    "numerator": "1078104409",
+    "denominator": "1039869184036193827455814",
+    "rounding": "Floor",
+    "expected": "117",
+    "overflow": false
+  },
+  {
+    "a": "113667048606181184",
+    "numerator": "1078104409",
+    "denominator": "1039869184036193827455814",
+    "rounding": "Ceil",
+    "expected": "118",
+    "overflow": false
+  },
+  {
+    "a": "3361219680281098125356927145739490071",
+    "numerator": "2201542563723471676047775411661331996",
+    "denominator": "3214977784879921951205",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3361219680281098125356927145739490071",
+    "numerator": "2201542563723471676047775411661331996",
+    "denominator": "3214977784879921951205",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "574048361750603811138",
+    "numerator": "35305666687596528650644803",
+    "denominator": "621986304250019740201880784177720",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "574048361750603811138",
+    "numerator": "35305666687596528650644803",
+    "denominator": "621986304250019740201880784177720",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "176478736003532977",
+    "numerator": "15552910376435972307582",
+    "denominator": "911583407023",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "176478736003532977",
+    "numerator": "15552910376435972307582",
+    "denominator": "911583407023",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "41704552355849210961358776212",
+    "numerator": "259263031387831950688701",
+    "denominator": "6213858381165306",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "41704552355849210961358776212",
+    "numerator": "259263031387831950688701",
+    "denominator": "6213858381165306",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2651",
+    "numerator": "560",
+    "denominator": "11613331655419423150992527804681",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2651",
+    "numerator": "560",
+    "denominator": "11613331655419423150992527804681",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "16197633953462",
+    "numerator": "110063652531171452552345871803860295",
+    "denominator": "4300101060217286573713942028",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16197633953462",
+    "numerator": "110063652531171452552345871803860295",
+    "denominator": "4300101060217286573713942028",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "198893862645226072967829",
+    "numerator": "16621829470386310514796978",
+    "denominator": "20405549171",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "198893862645226072967829",
+    "numerator": "16621829470386310514796978",
+    "denominator": "20405549171",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28813434177994536",
+    "numerator": "2843676981382231700065",
+    "denominator": "33895210990",
+    "rounding": "Floor",
+    "expected": "2417335580259656224005751300",
+    "overflow": false
+  },
+  {
+    "a": "28813434177994536",
+    "numerator": "2843676981382231700065",
+    "denominator": "33895210990",
+    "rounding": "Ceil",
+    "expected": "2417335580259656224005751301",
+    "overflow": false
+  },
+  {
+    "a": "1487044539297087029215",
+    "numerator": "2996517252",
+    "denominator": "1826654373963606579355603184987245",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1487044539297087029215",
+    "numerator": "2996517252",
+    "denominator": "1826654373963606579355603184987245",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "392321946197847548557004138",
+    "numerator": "16536946176765378893113830795147",
+    "denominator": "155761635917943072",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "392321946197847548557004138",
+    "numerator": "16536946176765378893113830795147",
+    "denominator": "155761635917943072",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "469038011148360557307065",
+    "numerator": "8365149734",
+    "denominator": "1154504252451327088744856439",
+    "rounding": "Floor",
+    "expected": "3398491",
+    "overflow": false
+  },
+  {
+    "a": "469038011148360557307065",
+    "numerator": "8365149734",
+    "denominator": "1154504252451327088744856439",
+    "rounding": "Ceil",
+    "expected": "3398492",
+    "overflow": false
+  },
+  {
+    "a": "35442902717047584178684",
+    "numerator": "537878194325317",
+    "denominator": "35588566045252137936022126114",
+    "rounding": "Floor",
+    "expected": "535676669",
+    "overflow": false
+  },
+  {
+    "a": "35442902717047584178684",
+    "numerator": "537878194325317",
+    "denominator": "35588566045252137936022126114",
+    "rounding": "Ceil",
+    "expected": "535676670",
+    "overflow": false
+  },
+  {
+    "a": "10783684906370979",
+    "numerator": "4045138665871033453363798738968",
+    "denominator": "3937141574094684177",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10783684906370979",
+    "numerator": "4045138665871033453363798738968",
+    "denominator": "3937141574094684177",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121216879779619974691166",
+    "numerator": "12210785661338319113206702675983",
+    "denominator": "2271598909530642681519277862608756",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121216879779619974691166",
+    "numerator": "12210785661338319113206702675983",
+    "denominator": "2271598909530642681519277862608756",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "162589",
+    "numerator": "2288722667244608474",
+    "denominator": "127335970576397635524928207035",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "162589",
+    "numerator": "2288722667244608474",
+    "denominator": "127335970576397635524928207035",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "108750782755142091792",
+    "numerator": "5335655529",
+    "denominator": "10502550",
+    "rounding": "Floor",
+    "expected": "55249126668337856544421",
+    "overflow": false
+  },
+  {
+    "a": "108750782755142091792",
+    "numerator": "5335655529",
+    "denominator": "10502550",
+    "rounding": "Ceil",
+    "expected": "55249126668337856544422",
+    "overflow": false
+  },
+  {
+    "a": "30914146907559",
+    "numerator": "3887827169704671486101266500622709228",
+    "denominator": "49987905652746229",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30914146907559",
+    "numerator": "3887827169704671486101266500622709228",
+    "denominator": "49987905652746229",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4256022613477010",
+    "numerator": "234281817618701011",
+    "denominator": "120883893629960331515085441328392",
+    "rounding": "Floor",
+    "expected": "8",
+    "overflow": false
+  },
+  {
+    "a": "4256022613477010",
+    "numerator": "234281817618701011",
+    "denominator": "120883893629960331515085441328392",
+    "rounding": "Ceil",
+    "expected": "9",
+    "overflow": false
+  },
+  {
+    "a": "203656896215790883701987657631540179393",
+    "numerator": "28876593785074337432995534",
+    "denominator": "9466875245480773070566463",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "203656896215790883701987657631540179393",
+    "numerator": "28876593785074337432995534",
+    "denominator": "9466875245480773070566463",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89093874669924",
+    "numerator": "359950849428136580822598921677",
+    "denominator": "344294998275746371049368903242",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89093874669924",
+    "numerator": "359950849428136580822598921677",
+    "denominator": "344294998275746371049368903242",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2583403048550334254571",
+    "numerator": "325511101238016",
+    "denominator": "2073",
+    "rounding": "Floor",
+    "expected": "405656715521112888146250289728399",
+    "overflow": false
+  },
+  {
+    "a": "2583403048550334254571",
+    "numerator": "325511101238016",
+    "denominator": "2073",
+    "rounding": "Ceil",
+    "expected": "405656715521112888146250289728400",
+    "overflow": false
+  },
+  {
+    "a": "26886",
+    "numerator": "7834452398931298677719",
+    "denominator": "13788",
+    "rounding": "Floor",
+    "expected": "15276841253094494941191",
+    "overflow": false
+  },
+  {
+    "a": "26886",
+    "numerator": "7834452398931298677719",
+    "denominator": "13788",
+    "rounding": "Ceil",
+    "expected": "15276841253094494941192",
+    "overflow": false
+  },
+  {
+    "a": "138196383166775504712147643557",
+    "numerator": "175371572466770857470034690",
+    "denominator": "20570705422818987673596419",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "138196383166775504712147643557",
+    "numerator": "175371572466770857470034690",
+    "denominator": "20570705422818987673596419",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "107595598945711347192",
+    "numerator": "2383948719106238620463807090788209",
+    "denominator": "62",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "107595598945711347192",
+    "numerator": "2383948719106238620463807090788209",
+    "denominator": "62",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15834631546131272815",
+    "numerator": "1198867658727794516",
+    "denominator": "718796008070609093757",
+    "rounding": "Floor",
+    "expected": "26410313128315075",
+    "overflow": false
+  },
+  {
+    "a": "15834631546131272815",
+    "numerator": "1198867658727794516",
+    "denominator": "718796008070609093757",
+    "rounding": "Ceil",
+    "expected": "26410313128315076",
+    "overflow": false
+  },
+  {
+    "a": "8134202554",
+    "numerator": "48944893499520853176327098033947",
+    "denominator": "3539235988976",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8134202554",
+    "numerator": "48944893499520853176327098033947",
+    "denominator": "3539235988976",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4571182321888453179298086686665",
+    "numerator": "100492614673389899742479478",
+    "denominator": "7",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4571182321888453179298086686665",
+    "numerator": "100492614673389899742479478",
+    "denominator": "7",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1003828099885424941321676",
+    "numerator": "27731449173",
+    "denominator": "51057209023695787570279379826",
+    "rounding": "Floor",
+    "expected": "545223",
+    "overflow": false
+  },
+  {
+    "a": "1003828099885424941321676",
+    "numerator": "27731449173",
+    "denominator": "51057209023695787570279379826",
+    "rounding": "Ceil",
+    "expected": "545224",
+    "overflow": false
+  },
+  {
+    "a": "4077723636884753715",
+    "numerator": "514792",
+    "denominator": "494717185057673658657",
+    "rounding": "Floor",
+    "expected": "4243",
+    "overflow": false
+  },
+  {
+    "a": "4077723636884753715",
+    "numerator": "514792",
+    "denominator": "494717185057673658657",
+    "rounding": "Ceil",
+    "expected": "4244",
+    "overflow": false
+  },
+  {
+    "a": "130478",
+    "numerator": "1644742709573791",
+    "denominator": "500765485773146436",
+    "rounding": "Floor",
+    "expected": "428",
+    "overflow": false
+  },
+  {
+    "a": "130478",
+    "numerator": "1644742709573791",
+    "denominator": "500765485773146436",
+    "rounding": "Ceil",
+    "expected": "429",
+    "overflow": false
+  },
+  {
+    "a": "393690472509456173",
+    "numerator": "46143536938",
+    "denominator": "181323",
+    "rounding": "Floor",
+    "expected": "100187349979753062066685",
+    "overflow": false
+  },
+  {
+    "a": "393690472509456173",
+    "numerator": "46143536938",
+    "denominator": "181323",
+    "rounding": "Ceil",
+    "expected": "100187349979753062066686",
+    "overflow": false
+  },
+  {
+    "a": "3467318496",
+    "numerator": "4595201176545133623016313",
+    "denominator": "323163786141520279454440409306086",
+    "rounding": "Floor",
+    "expected": "49",
+    "overflow": false
+  },
+  {
+    "a": "3467318496",
+    "numerator": "4595201176545133623016313",
+    "denominator": "323163786141520279454440409306086",
+    "rounding": "Ceil",
+    "expected": "50",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "1101047869507527383696283739650492",
+    "denominator": "649355781",
+    "rounding": "Floor",
+    "expected": "5086800957459377960152250",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "1101047869507527383696283739650492",
+    "denominator": "649355781",
+    "rounding": "Ceil",
+    "expected": "5086800957459377960152251",
+    "overflow": false
+  },
+  {
+    "a": "220076002",
+    "numerator": "8356387385254390883",
+    "denominator": "4246228542986528822007449426457560",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "220076002",
+    "numerator": "8356387385254390883",
+    "denominator": "4246228542986528822007449426457560",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "47499095868909337821848444625",
+    "numerator": "1020486731353484834102786247832512286",
+    "denominator": "834682646411630096151664173263",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47499095868909337821848444625",
+    "numerator": "1020486731353484834102786247832512286",
+    "denominator": "834682646411630096151664173263",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "210616873154858299670324",
+    "numerator": "35774399010295467127119325",
+    "denominator": "4176182008799451583946138",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "210616873154858299670324",
+    "numerator": "35774399010295467127119325",
+    "denominator": "4176182008799451583946138",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1710744573738405979515",
+    "numerator": "31689103312",
+    "denominator": "2857",
+    "rounding": "Floor",
+    "expected": "18975135294938659134424007929",
+    "overflow": false
+  },
+  {
+    "a": "1710744573738405979515",
+    "numerator": "31689103312",
+    "denominator": "2857",
+    "rounding": "Ceil",
+    "expected": "18975135294938659134424007930",
+    "overflow": false
+  },
+  {
+    "a": "86",
+    "numerator": "1623929609629195692871435879",
+    "denominator": "1151142906666252716",
+    "rounding": "Floor",
+    "expected": "121321119749",
+    "overflow": false
+  },
+  {
+    "a": "86",
+    "numerator": "1623929609629195692871435879",
+    "denominator": "1151142906666252716",
+    "rounding": "Ceil",
+    "expected": "121321119750",
+    "overflow": false
+  },
+  {
+    "a": "44110343075518265252833924896607621813",
+    "numerator": "293391528018",
+    "denominator": "751816595",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "44110343075518265252833924896607621813",
+    "numerator": "293391528018",
+    "denominator": "751816595",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100656275219898573000",
+    "numerator": "310583425",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "31262170705538726954952525000",
+    "overflow": false
+  },
+  {
+    "a": "100656275219898573000",
+    "numerator": "310583425",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "31262170705538726954952525000",
+    "overflow": false
+  },
+  {
+    "a": "511231",
+    "numerator": "1207975539370215971836467946678159652",
+    "denominator": "150768590278799793711994557936394381",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "511231",
+    "numerator": "1207975539370215971836467946678159652",
+    "denominator": "150768590278799793711994557936394381",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "133896095618288644106",
+    "numerator": "51883",
+    "denominator": "77504",
+    "rounding": "Floor",
+    "expected": "89633194789477571765",
+    "overflow": false
+  },
+  {
+    "a": "133896095618288644106",
+    "numerator": "51883",
+    "denominator": "77504",
+    "rounding": "Ceil",
+    "expected": "89633194789477571766",
+    "overflow": false
+  },
+  {
+    "a": "2103262983064608980697",
+    "numerator": "6014237580789952605174532726012219078",
+    "denominator": "39437166384279",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2103262983064608980697",
+    "numerator": "6014237580789952605174532726012219078",
+    "denominator": "39437166384279",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3504929223794572882014096796",
+    "numerator": "3330786416043877",
+    "denominator": "589474306734645411010",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3504929223794572882014096796",
+    "numerator": "3330786416043877",
+    "denominator": "589474306734645411010",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "40823968215697605094508787936943093443",
+    "numerator": "145160614012890345177379987896",
+    "denominator": "247345",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "40823968215697605094508787936943093443",
+    "numerator": "145160614012890345177379987896",
+    "denominator": "247345",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4434249205974634941974566398",
+    "numerator": "613528109848328126624495272690449711",
+    "denominator": "213857528686075847648954969961408276",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4434249205974634941974566398",
+    "numerator": "613528109848328126624495272690449711",
+    "denominator": "213857528686075847648954969961408276",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "706583620315318077",
+    "numerator": "276418588355783898991005727258234",
+    "denominator": "226267",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "706583620315318077",
+    "numerator": "276418588355783898991005727258234",
+    "denominator": "226267",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31246388526135754783677872774236445104",
+    "numerator": "88823699081",
+    "denominator": "23080495101816680249910",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31246388526135754783677872774236445104",
+    "numerator": "88823699081",
+    "denominator": "23080495101816680249910",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5105351",
+    "numerator": "5516",
+    "denominator": "18838909595482049102825838375002133",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5105351",
+    "numerator": "5516",
+    "denominator": "18838909595482049102825838375002133",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "70000392754380082",
+    "numerator": "6609651929993001904291524123955683827",
+    "denominator": "680",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70000392754380082",
+    "numerator": "6609651929993001904291524123955683827",
+    "denominator": "680",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "246044886504425446936545",
+    "numerator": "1948946100960341333524837260142",
+    "denominator": "351",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "246044886504425446936545",
+    "numerator": "1948946100960341333524837260142",
+    "denominator": "351",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3707042181880715524",
+    "numerator": "37357",
+    "denominator": "6363888234730",
+    "rounding": "Floor",
+    "expected": "21760906175",
+    "overflow": false
+  },
+  {
+    "a": "3707042181880715524",
+    "numerator": "37357",
+    "denominator": "6363888234730",
+    "rounding": "Ceil",
+    "expected": "21760906176",
+    "overflow": false
+  },
+  {
+    "a": "123147",
+    "numerator": "3774624",
+    "denominator": "4665",
+    "rounding": "Floor",
+    "expected": "99642791",
+    "overflow": false
+  },
+  {
+    "a": "123147",
+    "numerator": "3774624",
+    "denominator": "4665",
+    "rounding": "Ceil",
+    "expected": "99642792",
+    "overflow": false
+  },
+  {
+    "a": "365161196181950716326",
+    "numerator": "17252943984719183095",
+    "denominator": "42434163537899900",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "365161196181950716326",
+    "numerator": "17252943984719183095",
+    "denominator": "42434163537899900",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1010540564085957",
+    "numerator": "1237682061524054434",
+    "denominator": "100514240571822371",
+    "rounding": "Floor",
+    "expected": "12443290836166457",
+    "overflow": false
+  },
+  {
+    "a": "1010540564085957",
+    "numerator": "1237682061524054434",
+    "denominator": "100514240571822371",
+    "rounding": "Ceil",
+    "expected": "12443290836166458",
+    "overflow": false
+  },
+  {
+    "a": "12930467604275096",
+    "numerator": "34185884097426573126829964689",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12930467604275096",
+    "numerator": "34185884097426573126829964689",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14991886342143306127",
+    "numerator": "166937115874594639044340",
+    "denominator": "1308662313724984754333",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14991886342143306127",
+    "numerator": "166937115874594639044340",
+    "denominator": "1308662313724984754333",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1300423469875556678133736644442",
+    "numerator": "8760217021433490106010571323",
+    "denominator": "210220377175484854644517776",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1300423469875556678133736644442",
+    "numerator": "8760217021433490106010571323",
+    "denominator": "210220377175484854644517776",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "63615465",
+    "numerator": "22",
+    "denominator": "300776175387481895",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "63615465",
+    "numerator": "22",
+    "denominator": "300776175387481895",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1360236",
+    "numerator": "87677926971309429",
+    "denominator": "11238501353904658",
+    "rounding": "Floor",
+    "expected": "10611972",
+    "overflow": false
+  },
+  {
+    "a": "1360236",
+    "numerator": "87677926971309429",
+    "denominator": "11238501353904658",
+    "rounding": "Ceil",
+    "expected": "10611973",
+    "overflow": false
+  },
+  {
+    "a": "7336565519409148797977683",
+    "numerator": "1688207004526285439273507976",
+    "denominator": "4306743627585",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7336565519409148797977683",
+    "numerator": "1688207004526285439273507976",
+    "denominator": "4306743627585",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "211072186572522062",
+    "numerator": "42431",
+    "denominator": "559642256274404700587620707989732",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "211072186572522062",
+    "numerator": "42431",
+    "denominator": "559642256274404700587620707989732",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "458",
+    "denominator": "875",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "458",
+    "denominator": "875",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21120",
+    "numerator": "3195106713",
+    "denominator": "13446",
+    "rounding": "Floor",
+    "expected": "5018641512",
+    "overflow": false
+  },
+  {
+    "a": "21120",
+    "numerator": "3195106713",
+    "denominator": "13446",
+    "rounding": "Ceil",
+    "expected": "5018641513",
+    "overflow": false
+  },
+  {
+    "a": "13755492824407",
+    "numerator": "74234011895133192641375853253348713820",
+    "denominator": "9129230211977247711781",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13755492824407",
+    "numerator": "74234011895133192641375853253348713820",
+    "denominator": "9129230211977247711781",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6355699599782451633501826",
+    "numerator": "32209795",
+    "denominator": "7868391126412664",
+    "rounding": "Floor",
+    "expected": "26017489204798629",
+    "overflow": false
+  },
+  {
+    "a": "6355699599782451633501826",
+    "numerator": "32209795",
+    "denominator": "7868391126412664",
+    "rounding": "Ceil",
+    "expected": "26017489204798630",
+    "overflow": false
+  },
+  {
+    "a": "204192366921450075285079281",
+    "numerator": "0",
+    "denominator": "83241747565347066447586799",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "204192366921450075285079281",
+    "numerator": "0",
+    "denominator": "83241747565347066447586799",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1795975929160855072324373710169812",
+    "numerator": "945174793700344802609661",
+    "denominator": "3930205882846003952346929210",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1795975929160855072324373710169812",
+    "numerator": "945174793700344802609661",
+    "denominator": "3930205882846003952346929210",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5647878293227491274244251",
+    "numerator": "404074739862896",
+    "denominator": "645040495915515895113",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5647878293227491274244251",
+    "numerator": "404074739862896",
+    "denominator": "645040495915515895113",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2432413686",
+    "numerator": "159273863479797110663",
+    "denominator": "736910668",
+    "rounding": "Floor",
+    "expected": "525735265038060320874",
+    "overflow": false
+  },
+  {
+    "a": "2432413686",
+    "numerator": "159273863479797110663",
+    "denominator": "736910668",
+    "rounding": "Ceil",
+    "expected": "525735265038060320875",
+    "overflow": false
+  },
+  {
+    "a": "15912249381709137029845",
+    "numerator": "2738046706",
+    "denominator": "6672130958538065772331250890510251699",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "15912249381709137029845",
+    "numerator": "2738046706",
+    "denominator": "6672130958538065772331250890510251699",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2806376",
+    "numerator": "1663445778281514016417",
+    "denominator": "10284423706926",
+    "rounding": "Floor",
+    "expected": "453915011915227",
+    "overflow": false
+  },
+  {
+    "a": "2806376",
+    "numerator": "1663445778281514016417",
+    "denominator": "10284423706926",
+    "rounding": "Ceil",
+    "expected": "453915011915228",
+    "overflow": false
+  },
+  {
+    "a": "543",
+    "numerator": "33515350212",
+    "denominator": "70731096201822836321400111604909",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "543",
+    "numerator": "33515350212",
+    "denominator": "70731096201822836321400111604909",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "682",
+    "numerator": "5324235",
+    "denominator": "6444603909111878937998351456",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "682",
+    "numerator": "5324235",
+    "denominator": "6444603909111878937998351456",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "57",
+    "numerator": "81889741426596559522062182",
+    "denominator": "2330974803608054286399170349406797239",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "57",
+    "numerator": "81889741426596559522062182",
+    "denominator": "2330974803608054286399170349406797239",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "77533425019196",
+    "numerator": "627496837",
+    "denominator": "240178727778",
+    "rounding": "Floor",
+    "expected": "202565728494",
+    "overflow": false
+  },
+  {
+    "a": "77533425019196",
+    "numerator": "627496837",
+    "denominator": "240178727778",
+    "rounding": "Ceil",
+    "expected": "202565728495",
+    "overflow": false
+  },
+  {
+    "a": "114820001423459227357106820381652366819",
+    "numerator": "0",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "114820001423459227357106820381652366819",
+    "numerator": "0",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "102482590",
+    "numerator": "2922433503943619151",
+    "denominator": "52",
+    "rounding": "Floor",
+    "expected": "5759587588209948164770790",
+    "overflow": false
+  },
+  {
+    "a": "102482590",
+    "numerator": "2922433503943619151",
+    "denominator": "52",
+    "rounding": "Ceil",
+    "expected": "5759587588209948164770791",
+    "overflow": false
+  },
+  {
+    "a": "21746926802412381",
+    "numerator": "15032602",
+    "denominator": "12696357863163",
+    "rounding": "Floor",
+    "expected": "25748557095",
+    "overflow": false
+  },
+  {
+    "a": "21746926802412381",
+    "numerator": "15032602",
+    "denominator": "12696357863163",
+    "rounding": "Ceil",
+    "expected": "25748557096",
+    "overflow": false
+  },
+  {
+    "a": "145444502438689257856315295285072",
+    "numerator": "42513142992501184681",
+    "denominator": "40787179989384396821916260332115002070",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "145444502438689257856315295285072",
+    "numerator": "42513142992501184681",
+    "denominator": "40787179989384396821916260332115002070",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29622178234476519",
+    "numerator": "422386964909285784504620",
+    "denominator": "4831784865319694677861492789",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29622178234476519",
+    "numerator": "422386964909285784504620",
+    "denominator": "4831784865319694677861492789",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "105945737609330048336850",
+    "numerator": "1322727012351920733098637000603923",
+    "denominator": "106201445151142505240648",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "105945737609330048336850",
+    "numerator": "1322727012351920733098637000603923",
+    "denominator": "106201445151142505240648",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15873",
+    "numerator": "14",
+    "denominator": "428151812037656191",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "15873",
+    "numerator": "14",
+    "denominator": "428151812037656191",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "272074256722084",
+    "numerator": "8353980305964925743042549998519821",
+    "denominator": "1444021719946",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "272074256722084",
+    "numerator": "8353980305964925743042549998519821",
+    "denominator": "1444021719946",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36830627812941745521707",
+    "numerator": "138758878422915053561886272",
+    "denominator": "3538301953812902355568391038364761",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36830627812941745521707",
+    "numerator": "138758878422915053561886272",
+    "denominator": "3538301953812902355568391038364761",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4570868012748536256079189958040134",
+    "numerator": "32815285116706373624927767",
+    "denominator": "146716",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4570868012748536256079189958040134",
+    "numerator": "32815285116706373624927767",
+    "denominator": "146716",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1169638987938543992528101",
+    "numerator": "10694722",
+    "denominator": "1256444686102852534339",
+    "rounding": "Floor",
+    "expected": "9955841235",
+    "overflow": false
+  },
+  {
+    "a": "1169638987938543992528101",
+    "numerator": "10694722",
+    "denominator": "1256444686102852534339",
+    "rounding": "Ceil",
+    "expected": "9955841236",
+    "overflow": false
+  },
+  {
+    "a": "5558535787833996622136",
+    "numerator": "5738105168666232327969353892785",
+    "denominator": "250568906299525784274374507409790",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5558535787833996622136",
+    "numerator": "5738105168666232327969353892785",
+    "denominator": "250568906299525784274374507409790",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1445551",
+    "numerator": "257988353123988",
+    "denominator": "17292843043627435767516349",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1445551",
+    "numerator": "257988353123988",
+    "denominator": "17292843043627435767516349",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "93078869330556454972717562",
+    "numerator": "5960594654631578971",
+    "denominator": "78834425443005748619134780948784",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "93078869330556454972717562",
+    "numerator": "5960594654631578971",
+    "denominator": "78834425443005748619134780948784",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1041417",
+    "numerator": "9654",
+    "denominator": "896528479373742381140039",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1041417",
+    "numerator": "9654",
+    "denominator": "896528479373742381140039",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3867845535569964401932",
+    "numerator": "1197563055664732942340065439125517717",
+    "denominator": "139122269081238476417896175507509426",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3867845535569964401932",
+    "numerator": "1197563055664732942340065439125517717",
+    "denominator": "139122269081238476417896175507509426",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2931",
+    "numerator": "10158327866325130380320424989189090856",
+    "denominator": "6758317124387269985",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2931",
+    "numerator": "10158327866325130380320424989189090856",
+    "denominator": "6758317124387269985",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2304935643993715886879778014467708654",
+    "numerator": "109221469548647579952952795871",
+    "denominator": "137720527615595806521476",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2304935643993715886879778014467708654",
+    "numerator": "109221469548647579952952795871",
+    "denominator": "137720527615595806521476",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "63341",
+    "numerator": "659573725519717936672865271841641578",
+    "denominator": "57748191722527371",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "63341",
+    "numerator": "659573725519717936672865271841641578",
+    "denominator": "57748191722527371",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "94218775954516500512",
+    "numerator": "10971145909480224292793",
+    "denominator": "6512682278",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "94218775954516500512",
+    "numerator": "10971145909480224292793",
+    "denominator": "6512682278",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16850058871",
+    "numerator": "2935235664945404",
+    "denominator": "49717642675175667332907743355433541",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "16850058871",
+    "numerator": "2935235664945404",
+    "denominator": "49717642675175667332907743355433541",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7352558442030370",
+    "numerator": "8099527159261070885378723",
+    "denominator": "325893113315209873409914648",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7352558442030370",
+    "numerator": "8099527159261070885378723",
+    "denominator": "325893113315209873409914648",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "129809",
+    "numerator": "41985787502079154608846790160478",
+    "denominator": "2802829605647",
+    "rounding": "Floor",
+    "expected": "1944511032307043989110831",
+    "overflow": false
+  },
+  {
+    "a": "129809",
+    "numerator": "41985787502079154608846790160478",
+    "denominator": "2802829605647",
+    "rounding": "Ceil",
+    "expected": "1944511032307043989110832",
+    "overflow": false
+  },
+  {
+    "a": "85089808377610034641094702521972",
+    "numerator": "367750742286341458826304194077",
+    "denominator": "10",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "85089808377610034641094702521972",
+    "numerator": "367750742286341458826304194077",
+    "denominator": "10",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4845064858157911136453066042299",
+    "numerator": "784",
+    "denominator": "3395499411452725787360511590317929",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4845064858157911136453066042299",
+    "numerator": "784",
+    "denominator": "3395499411452725787360511590317929",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "2199232902404246",
+    "numerator": "9452577891856350713668882692263",
+    "denominator": "200940",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2199232902404246",
+    "numerator": "9452577891856350713668882692263",
+    "denominator": "200940",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35605924917782345950990468140060807925",
+    "numerator": "0",
+    "denominator": "611271358454492518512305384915",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "35605924917782345950990468140060807925",
+    "numerator": "0",
+    "denominator": "611271358454492518512305384915",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2972950810596627464",
+    "numerator": "9148712536379930459091355128975207617",
+    "denominator": "16774985262960473048732984573390",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2972950810596627464",
+    "numerator": "9148712536379930459091355128975207617",
+    "denominator": "16774985262960473048732984573390",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13843213161700726591",
+    "numerator": "151307158646804284782450788",
+    "denominator": "70626115582157",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13843213161700726591",
+    "numerator": "151307158646804284782450788",
+    "denominator": "70626115582157",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1703723225125116672517450",
+    "numerator": "65647637352467675404722161957093611",
+    "denominator": "239995155993483776",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1703723225125116672517450",
+    "numerator": "65647637352467675404722161957093611",
+    "denominator": "239995155993483776",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "411768515946100056564505",
+    "numerator": "8102241730566",
+    "denominator": "3114051709907749369559",
+    "rounding": "Floor",
+    "expected": "1071352811071514",
+    "overflow": false
+  },
+  {
+    "a": "411768515946100056564505",
+    "numerator": "8102241730566",
+    "denominator": "3114051709907749369559",
+    "rounding": "Ceil",
+    "expected": "1071352811071515",
+    "overflow": false
+  },
+  {
+    "a": "2053340",
+    "numerator": "24975269",
+    "denominator": "91485960190603065354754",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2053340",
+    "numerator": "24975269",
+    "denominator": "91485960190603065354754",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1566183068321027",
+    "numerator": "109885294502112298232",
+    "denominator": "43894830780023409",
+    "rounding": "Floor",
+    "expected": "3920746125418509642",
+    "overflow": false
+  },
+  {
+    "a": "1566183068321027",
+    "numerator": "109885294502112298232",
+    "denominator": "43894830780023409",
+    "rounding": "Ceil",
+    "expected": "3920746125418509643",
+    "overflow": false
+  },
+  {
+    "a": "97292371971970877774573777320673086",
+    "numerator": "358255",
+    "denominator": "9812",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "97292371971970877774573777320673086",
+    "numerator": "358255",
+    "denominator": "9812",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "92793069130346545696637",
+    "numerator": "395454060074179514",
+    "denominator": "9574130809232020624720572724669127195",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "92793069130346545696637",
+    "numerator": "395454060074179514",
+    "denominator": "9574130809232020624720572724669127195",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "77967911643115605302075529185703152",
+    "numerator": "9",
+    "denominator": "9183293368971215780726999831534454",
+    "rounding": "Floor",
+    "expected": "76",
+    "overflow": false
+  },
+  {
+    "a": "77967911643115605302075529185703152",
+    "numerator": "9",
+    "denominator": "9183293368971215780726999831534454",
+    "rounding": "Ceil",
+    "expected": "77",
+    "overflow": false
+  },
+  {
+    "a": "60340487687363973465241863",
+    "numerator": "32001468880291622092",
+    "denominator": "765392353755221",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "60340487687363973465241863",
+    "numerator": "32001468880291622092",
+    "denominator": "765392353755221",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3832489567091970134055538",
+    "numerator": "1555054999912882227",
+    "denominator": "561170920",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3832489567091970134055538",
+    "numerator": "1555054999912882227",
+    "denominator": "561170920",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28731992009121767299240906935368737",
+    "numerator": "1263414736046",
+    "denominator": "25680799",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28731992009121767299240906935368737",
+    "numerator": "1263414736046",
+    "denominator": "25680799",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21276629244963948612",
+    "numerator": "1935682996781",
+    "denominator": "22834519727811846856960667316684113450",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "21276629244963948612",
+    "numerator": "1935682996781",
+    "denominator": "22834519727811846856960667316684113450",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "77966016948337686347",
+    "numerator": "301190652896",
+    "denominator": "760706306881771129",
+    "rounding": "Floor",
+    "expected": "30869516048353",
+    "overflow": false
+  },
+  {
+    "a": "77966016948337686347",
+    "numerator": "301190652896",
+    "denominator": "760706306881771129",
+    "rounding": "Ceil",
+    "expected": "30869516048354",
+    "overflow": false
+  },
+  {
+    "a": "1539820314305049602790",
+    "numerator": "3453967171383",
+    "denominator": "10375387324",
+    "rounding": "Floor",
+    "expected": "512606291153655844756209",
+    "overflow": false
+  },
+  {
+    "a": "1539820314305049602790",
+    "numerator": "3453967171383",
+    "denominator": "10375387324",
+    "rounding": "Ceil",
+    "expected": "512606291153655844756210",
+    "overflow": false
+  },
+  {
+    "a": "133670212960997715627269",
+    "numerator": "3305322757750498",
+    "denominator": "1891",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "133670212960997715627269",
+    "numerator": "3305322757750498",
+    "denominator": "1891",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1436959110361629205208",
+    "numerator": "459523050900402928922892753",
+    "denominator": "6963861231132190",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1436959110361629205208",
+    "numerator": "459523050900402928922892753",
+    "denominator": "6963861231132190",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7",
+    "numerator": "36460607282331188",
+    "denominator": "18958068182525936832063709",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7",
+    "numerator": "36460607282331188",
+    "denominator": "18958068182525936832063709",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6344071666749748978842",
+    "numerator": "123",
+    "denominator": "95139484860461934192336",
+    "rounding": "Floor",
+    "expected": "8",
+    "overflow": false
+  },
+  {
+    "a": "6344071666749748978842",
+    "numerator": "123",
+    "denominator": "95139484860461934192336",
+    "rounding": "Ceil",
+    "expected": "9",
+    "overflow": false
+  },
+  {
+    "a": "2398081799583464957481",
+    "numerator": "626421334",
+    "denominator": "3793356516168236049640740718951",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2398081799583464957481",
+    "numerator": "626421334",
+    "denominator": "3793356516168236049640740718951",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2420790958709420559940049220047345836",
+    "numerator": "32837843034479578255568504290741",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2420790958709420559940049220047345836",
+    "numerator": "32837843034479578255568504290741",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1027482259",
+    "numerator": "0",
+    "denominator": "2944011056325781745105294614030867329",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1027482259",
+    "numerator": "0",
+    "denominator": "2944011056325781745105294614030867329",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "6833170283051918",
+    "numerator": "37067351587136412440143056383999",
+    "denominator": "27379748",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6833170283051918",
+    "numerator": "37067351587136412440143056383999",
+    "denominator": "27379748",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2995843162070070799408828577262477",
+    "numerator": "9418489422366315012187658499850",
+    "denominator": "469122475",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2995843162070070799408828577262477",
+    "numerator": "9418489422366315012187658499850",
+    "denominator": "469122475",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15808",
+    "numerator": "9860455603770355488295372228172249",
+    "denominator": "1938035353030",
+    "rounding": "Floor",
+    "expected": "80428915778394942460898129",
+    "overflow": false
+  },
+  {
+    "a": "15808",
+    "numerator": "9860455603770355488295372228172249",
+    "denominator": "1938035353030",
+    "rounding": "Ceil",
+    "expected": "80428915778394942460898130",
+    "overflow": false
+  },
+  {
+    "a": "3227885046616461125427021563697047",
+    "numerator": "22609725455618649244",
+    "denominator": "61949250024575589",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3227885046616461125427021563697047",
+    "numerator": "22609725455618649244",
+    "denominator": "61949250024575589",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "136658944499987199104054479414210",
+    "numerator": "1",
+    "denominator": "301284670852229704030084796600",
+    "rounding": "Floor",
+    "expected": "453",
+    "overflow": false
+  },
+  {
+    "a": "136658944499987199104054479414210",
+    "numerator": "1",
+    "denominator": "301284670852229704030084796600",
+    "rounding": "Ceil",
+    "expected": "454",
+    "overflow": false
+  },
+  {
+    "a": "588724537136032961610033",
+    "numerator": "67547758770803947755441406",
+    "denominator": "117217421853179793857423895575207983",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "588724537136032961610033",
+    "numerator": "67547758770803947755441406",
+    "denominator": "117217421853179793857423895575207983",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3736905236",
+    "numerator": "4669",
+    "denominator": "4652785124310394",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3736905236",
+    "numerator": "4669",
+    "denominator": "4652785124310394",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "127805147",
+    "numerator": "3369507227888832137849008",
+    "denominator": "6545152411548159488393",
+    "rounding": "Floor",
+    "expected": "65795315295",
+    "overflow": false
+  },
+  {
+    "a": "127805147",
+    "numerator": "3369507227888832137849008",
+    "denominator": "6545152411548159488393",
+    "rounding": "Ceil",
+    "expected": "65795315296",
+    "overflow": false
+  },
+  {
+    "a": "3953904697927718730409234742",
+    "numerator": "102836679",
+    "denominator": "2201412444968555660",
+    "rounding": "Floor",
+    "expected": "184702520941364363",
+    "overflow": false
+  },
+  {
+    "a": "3953904697927718730409234742",
+    "numerator": "102836679",
+    "denominator": "2201412444968555660",
+    "rounding": "Ceil",
+    "expected": "184702520941364364",
+    "overflow": false
+  },
+  {
+    "a": "277",
+    "numerator": "290001903478563890",
+    "denominator": "1267",
+    "rounding": "Floor",
+    "expected": "63402152536355325",
+    "overflow": false
+  },
+  {
+    "a": "277",
+    "numerator": "290001903478563890",
+    "denominator": "1267",
+    "rounding": "Ceil",
+    "expected": "63402152536355326",
+    "overflow": false
+  },
+  {
+    "a": "893351131686594716037121962976680",
+    "numerator": "68897505",
+    "denominator": "1232943100173376972364576281198",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "893351131686594716037121962976680",
+    "numerator": "68897505",
+    "denominator": "1232943100173376972364576281198",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "635802719",
+    "numerator": "22532",
+    "denominator": "91544994345289759131986741235106340077",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "635802719",
+    "numerator": "22532",
+    "denominator": "91544994345289759131986741235106340077",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "722439737885463902186",
+    "numerator": "14982427539003241845771",
+    "denominator": "1061258407406991410870626208",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "722439737885463902186",
+    "numerator": "14982427539003241845771",
+    "denominator": "1061258407406991410870626208",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1447122439859513",
+    "numerator": "70845900853064626342",
+    "denominator": "10774456410882538323959",
+    "rounding": "Floor",
+    "expected": "9515347130921",
+    "overflow": false
+  },
+  {
+    "a": "1447122439859513",
+    "numerator": "70845900853064626342",
+    "denominator": "10774456410882538323959",
+    "rounding": "Ceil",
+    "expected": "9515347130922",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "27139334290169719125686400098807932869",
+    "denominator": "2355999628492230269090",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "27139334290169719125686400098807932869",
+    "denominator": "2355999628492230269090",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3368631687607702095795272148003",
+    "numerator": "4495948545245774521192088",
+    "denominator": "215064356290548149221521",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3368631687607702095795272148003",
+    "numerator": "4495948545245774521192088",
+    "denominator": "215064356290548149221521",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "136307580430164164764830863",
+    "denominator": "32512990809206611444",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "136307580430164164764830863",
+    "denominator": "32512990809206611444",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7767133085",
+    "numerator": "9818",
+    "denominator": "529761824214671639867",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7767133085",
+    "numerator": "9818",
+    "denominator": "529761824214671639867",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21494416",
+    "numerator": "955150271660594368859369",
+    "denominator": "573878465035437078",
+    "rounding": "Floor",
+    "expected": "35774817374124",
+    "overflow": false
+  },
+  {
+    "a": "21494416",
+    "numerator": "955150271660594368859369",
+    "denominator": "573878465035437078",
+    "rounding": "Ceil",
+    "expected": "35774817374125",
+    "overflow": false
+  },
+  {
+    "a": "131106537516471204781820330826279",
+    "numerator": "404676772752287320137836",
+    "denominator": "1146863532985619687541",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "131106537516471204781820330826279",
+    "numerator": "404676772752287320137836",
+    "denominator": "1146863532985619687541",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18",
+    "numerator": "8840360872823248723",
+    "denominator": "16657509459110751588940231819004808",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "18",
+    "numerator": "8840360872823248723",
+    "denominator": "16657509459110751588940231819004808",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7045671866763294062201409",
+    "numerator": "72516434755694167275854",
+    "denominator": "549700134170514183431072155839",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7045671866763294062201409",
+    "numerator": "72516434755694167275854",
+    "denominator": "549700134170514183431072155839",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30914827532260",
+    "numerator": "334966704921406591062516244860031704653",
+    "denominator": "1152994310654352957980574091466",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30914827532260",
+    "numerator": "334966704921406591062516244860031704653",
+    "denominator": "1152994310654352957980574091466",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21920363",
+    "numerator": "47335033184931066033824128",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "1037601110030735097438395163918464",
+    "overflow": false
+  },
+  {
+    "a": "21920363",
+    "numerator": "47335033184931066033824128",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "1037601110030735097438395163918464",
+    "overflow": false
+  },
+  {
+    "a": "41094022",
+    "numerator": "31238483572823",
+    "denominator": "6507036830312188379167775391742510172",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "41094022",
+    "numerator": "31238483572823",
+    "denominator": "6507036830312188379167775391742510172",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "70601045596515133291640868133",
+    "numerator": "68930069208450",
+    "denominator": "17677715594666967382304997314596483",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70601045596515133291640868133",
+    "numerator": "68930069208450",
+    "denominator": "17677715594666967382304997314596483",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24212069496",
+    "numerator": "16369",
+    "denominator": "23230",
+    "rounding": "Floor",
+    "expected": "17061014445",
+    "overflow": false
+  },
+  {
+    "a": "24212069496",
+    "numerator": "16369",
+    "denominator": "23230",
+    "rounding": "Ceil",
+    "expected": "17061014446",
+    "overflow": false
+  },
+  {
+    "a": "275322361410900274684994279911524591",
+    "numerator": "274254577280967442353789101524",
+    "denominator": "13",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "275322361410900274684994279911524591",
+    "numerator": "274254577280967442353789101524",
+    "denominator": "13",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "805558469806512231843214680137530",
+    "numerator": "907957566288941562197443495129215899",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "805558469806512231843214680137530",
+    "numerator": "907957566288941562197443495129215899",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "146751617971272073283429020956745",
+    "numerator": "8748837715734256169322230",
+    "denominator": "135436935",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "146751617971272073283429020956745",
+    "numerator": "8748837715734256169322230",
+    "denominator": "135436935",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2629777600989110177823751244",
+    "numerator": "87509",
+    "denominator": "288345503060647443951090",
+    "rounding": "Floor",
+    "expected": "798102296",
+    "overflow": false
+  },
+  {
+    "a": "2629777600989110177823751244",
+    "numerator": "87509",
+    "denominator": "288345503060647443951090",
+    "rounding": "Ceil",
+    "expected": "798102297",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "4178280",
+    "denominator": "1279033551659662415132927999793569",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "4178280",
+    "denominator": "1279033551659662415132927999793569",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3511981701719840561454613999841326",
+    "numerator": "946103674703135",
+    "denominator": "10180",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3511981701719840561454613999841326",
+    "numerator": "946103674703135",
+    "denominator": "10180",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4940616567458939574858332990975537069",
+    "numerator": "4027404540704886687007127136987562",
+    "denominator": "72370323934249426279020014135029084363",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4940616567458939574858332990975537069",
+    "numerator": "4027404540704886687007127136987562",
+    "denominator": "72370323934249426279020014135029084363",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3979944455008",
+    "numerator": "369200907257",
+    "denominator": "5764710",
+    "rounding": "Floor",
+    "expected": "254895580804831468",
+    "overflow": false
+  },
+  {
+    "a": "3979944455008",
+    "numerator": "369200907257",
+    "denominator": "5764710",
+    "rounding": "Ceil",
+    "expected": "254895580804831469",
+    "overflow": false
+  },
+  {
+    "a": "183",
+    "numerator": "69682106330295759996988",
+    "denominator": "160567837317",
+    "rounding": "Floor",
+    "expected": "79417059303532",
+    "overflow": false
+  },
+  {
+    "a": "183",
+    "numerator": "69682106330295759996988",
+    "denominator": "160567837317",
+    "rounding": "Ceil",
+    "expected": "79417059303533",
+    "overflow": false
+  },
+  {
+    "a": "46948446818",
+    "numerator": "1575786039560419",
+    "denominator": "24380651862018397598366296",
+    "rounding": "Floor",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "46948446818",
+    "numerator": "1575786039560419",
+    "denominator": "24380651862018397598366296",
+    "rounding": "Ceil",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "833153590371511999940186707793",
+    "numerator": "13794022068014067087774",
+    "denominator": "1701365287137238370928586502772047",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "833153590371511999940186707793",
+    "numerator": "13794022068014067087774",
+    "denominator": "1701365287137238370928586502772047",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16632493131906484",
+    "numerator": "27798580829",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "462359704715089754343195236",
+    "overflow": false
+  },
+  {
+    "a": "16632493131906484",
+    "numerator": "27798580829",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "462359704715089754343195236",
+    "overflow": false
+  },
+  {
+    "a": "21672443",
+    "numerator": "33885776",
+    "denominator": "18940097474140891886505",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "21672443",
+    "numerator": "33885776",
+    "denominator": "18940097474140891886505",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "90853667299734304572496342",
+    "numerator": "46312115114950549228251879",
+    "denominator": "7858220",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "90853667299734304572496342",
+    "numerator": "46312115114950549228251879",
+    "denominator": "7858220",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "430901",
+    "numerator": "109703804522539147361232161778386",
+    "denominator": "1043",
+    "rounding": "Floor",
+    "expected": "45322606972738869738353115764590897",
+    "overflow": false
+  },
+  {
+    "a": "430901",
+    "numerator": "109703804522539147361232161778386",
+    "denominator": "1043",
+    "rounding": "Ceil",
+    "expected": "45322606972738869738353115764590898",
+    "overflow": false
+  },
+  {
+    "a": "859895656657728504097716788119368",
+    "numerator": "246758540229682763818301780752641",
+    "denominator": "226197558258508912298470700814",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "859895656657728504097716788119368",
+    "numerator": "246758540229682763818301780752641",
+    "denominator": "226197558258508912298470700814",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3221161496846719",
+    "numerator": "1123867294937890751685331773348",
+    "denominator": "415772904810183144897578595569933",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3221161496846719",
+    "numerator": "1123867294937890751685331773348",
+    "denominator": "415772904810183144897578595569933",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18356170963434053556831004399204670090",
+    "numerator": "335315704478697573376491824280172331",
+    "denominator": "11028047939352404084032",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18356170963434053556831004399204670090",
+    "numerator": "335315704478697573376491824280172331",
+    "denominator": "11028047939352404084032",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "247676812078166247425881",
+    "numerator": "5950600661217606",
+    "denominator": "802569677882900323486915959063",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "247676812078166247425881",
+    "numerator": "5950600661217606",
+    "denominator": "802569677882900323486915959063",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11613430114439453207726290281663175708",
+    "numerator": "8611678181",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11613430114439453207726290281663175708",
+    "numerator": "8611678181",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1062278711672073911393096515",
+    "numerator": "2097577288368797160368184",
+    "denominator": "98831155713310240632867353486543650481",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1062278711672073911393096515",
+    "numerator": "2097577288368797160368184",
+    "denominator": "98831155713310240632867353486543650481",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2195071755708542",
+    "numerator": "258563453359",
+    "denominator": "84991701089346964",
+    "rounding": "Floor",
+    "expected": "6677891208",
+    "overflow": false
+  },
+  {
+    "a": "2195071755708542",
+    "numerator": "258563453359",
+    "denominator": "84991701089346964",
+    "rounding": "Ceil",
+    "expected": "6677891209",
+    "overflow": false
+  },
+  {
+    "a": "27089485118596961097616255604669",
+    "numerator": "4631484139444706720205615319670489338",
+    "denominator": "19288298861233219537983446109733060699",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "27089485118596961097616255604669",
+    "numerator": "4631484139444706720205615319670489338",
+    "denominator": "19288298861233219537983446109733060699",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12404829261872",
+    "numerator": "1374387540229897",
+    "denominator": "3825198960943539862823795894",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "12404829261872",
+    "numerator": "1374387540229897",
+    "denominator": "3825198960943539862823795894",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "327",
+    "numerator": "163083438941840467631743454454796",
+    "denominator": "554480400147134636181",
+    "rounding": "Floor",
+    "expected": "96177041640842",
+    "overflow": false
+  },
+  {
+    "a": "327",
+    "numerator": "163083438941840467631743454454796",
+    "denominator": "554480400147134636181",
+    "rounding": "Ceil",
+    "expected": "96177041640843",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "51",
+    "denominator": "604892003463661597104282920",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "51",
+    "denominator": "604892003463661597104282920",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1202339087967754917292129",
+    "numerator": "19647982",
+    "denominator": "6956989751937371095231596462288782815",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1202339087967754917292129",
+    "numerator": "19647982",
+    "denominator": "6956989751937371095231596462288782815",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "23936925891571660676",
+    "numerator": "33993048685",
+    "denominator": "170858",
+    "rounding": "Floor",
+    "expected": "4762370431594847724575776",
+    "overflow": false
+  },
+  {
+    "a": "23936925891571660676",
+    "numerator": "33993048685",
+    "denominator": "170858",
+    "rounding": "Ceil",
+    "expected": "4762370431594847724575777",
+    "overflow": false
+  },
+  {
+    "a": "24388109376131280769312915231173496203",
+    "numerator": "8745819627020880962803408760608",
+    "denominator": "6243440898586771872441",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24388109376131280769312915231173496203",
+    "numerator": "8745819627020880962803408760608",
+    "denominator": "6243440898586771872441",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2725640076748884884518",
+    "numerator": "182554828719747578234161559227577729399",
+    "denominator": "72138027476908834709802483708",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2725640076748884884518",
+    "numerator": "182554828719747578234161559227577729399",
+    "denominator": "72138027476908834709802483708",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1",
+    "numerator": "10587170",
+    "denominator": "198639938979",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "10587170",
+    "denominator": "198639938979",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "122829168531715526700513302308376",
+    "numerator": "66713105",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "122829168531715526700513302308376",
+    "numerator": "66713105",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1371345083919",
+    "numerator": "37593996660",
+    "denominator": "285",
+    "rounding": "Floor",
+    "expected": "180892429840555458633",
+    "overflow": false
+  },
+  {
+    "a": "1371345083919",
+    "numerator": "37593996660",
+    "denominator": "285",
+    "rounding": "Ceil",
+    "expected": "180892429840555458634",
+    "overflow": false
+  },
+  {
+    "a": "120857337525115390585306",
+    "numerator": "140694937275",
+    "denominator": "479615774319120",
+    "rounding": "Floor",
+    "expected": "35453411736632583861",
+    "overflow": false
+  },
+  {
+    "a": "120857337525115390585306",
+    "numerator": "140694937275",
+    "denominator": "479615774319120",
+    "rounding": "Ceil",
+    "expected": "35453411736632583862",
+    "overflow": false
+  },
+  {
+    "a": "632089284132330089",
+    "numerator": "913302",
+    "denominator": "72359505230801338817199015",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "632089284132330089",
+    "numerator": "913302",
+    "denominator": "72359505230801338817199015",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "773198700442666575173955564",
+    "numerator": "7929377470773305167208627701",
+    "denominator": "86131055826066",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "773198700442666575173955564",
+    "numerator": "7929377470773305167208627701",
+    "denominator": "86131055826066",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19",
+    "numerator": "813240151264117512",
+    "denominator": "288705",
+    "rounding": "Floor",
+    "expected": "53520246874900",
+    "overflow": false
+  },
+  {
+    "a": "19",
+    "numerator": "813240151264117512",
+    "denominator": "288705",
+    "rounding": "Ceil",
+    "expected": "53520246874901",
+    "overflow": false
+  },
+  {
+    "a": "1552987596880729855030478",
+    "numerator": "310752246335",
+    "denominator": "1365860",
+    "rounding": "Floor",
+    "expected": "353326390890047473038979059631",
+    "overflow": false
+  },
+  {
+    "a": "1552987596880729855030478",
+    "numerator": "310752246335",
+    "denominator": "1365860",
+    "rounding": "Ceil",
+    "expected": "353326390890047473038979059632",
+    "overflow": false
+  },
+  {
+    "a": "17357",
+    "numerator": "436771798936650",
+    "denominator": "107610236076007138581992648717291",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "17357",
+    "numerator": "436771798936650",
+    "denominator": "107610236076007138581992648717291",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "14657656226670848",
+    "numerator": "2409337865008286222515737",
+    "denominator": "6",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14657656226670848",
+    "numerator": "2409337865008286222515737",
+    "denominator": "6",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1344511608821412082143325256151",
+    "numerator": "26491000516637902526282418236112253916",
+    "denominator": "2626562162594026491101333062309",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1344511608821412082143325256151",
+    "numerator": "26491000516637902526282418236112253916",
+    "denominator": "2626562162594026491101333062309",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4272260425423461391268730998352531714",
+    "numerator": "2866709525321731",
+    "denominator": "534112564547091253204478604280",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4272260425423461391268730998352531714",
+    "numerator": "2866709525321731",
+    "denominator": "534112564547091253204478604280",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "458097",
+    "numerator": "57910020777222070928925450677892670",
+    "denominator": "3861134872916662970325615",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "458097",
+    "numerator": "57910020777222070928925450677892670",
+    "denominator": "3861134872916662970325615",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9151828",
+    "numerator": "12511144689075749968509",
+    "denominator": "40496538298",
+    "rounding": "Floor",
+    "expected": "2827398318220931474",
+    "overflow": false
+  },
+  {
+    "a": "9151828",
+    "numerator": "12511144689075749968509",
+    "denominator": "40496538298",
+    "rounding": "Ceil",
+    "expected": "2827398318220931475",
+    "overflow": false
+  },
+  {
+    "a": "491441435",
+    "numerator": "1375470576",
+    "denominator": "1155917149397529183755103340594185673",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "491441435",
+    "numerator": "1375470576",
+    "denominator": "1155917149397529183755103340594185673",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "12918",
+    "numerator": "274542307126928179134872583",
+    "denominator": "956596239060291954281420",
+    "rounding": "Floor",
+    "expected": "3707455",
+    "overflow": false
+  },
+  {
+    "a": "12918",
+    "numerator": "274542307126928179134872583",
+    "denominator": "956596239060291954281420",
+    "rounding": "Ceil",
+    "expected": "3707456",
+    "overflow": false
+  },
+  {
+    "a": "11093",
+    "numerator": "11561491705918975293493645323668537714",
+    "denominator": "25850675",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11093",
+    "numerator": "11561491705918975293493645323668537714",
+    "denominator": "25850675",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2626344302824",
+    "numerator": "7292335732513",
+    "denominator": "1089268660514119478190",
+    "rounding": "Floor",
+    "expected": "17582",
+    "overflow": false
+  },
+  {
+    "a": "2626344302824",
+    "numerator": "7292335732513",
+    "denominator": "1089268660514119478190",
+    "rounding": "Ceil",
+    "expected": "17583",
+    "overflow": false
+  },
+  {
+    "a": "13645441988395550896730368259407519",
+    "numerator": "12589605840256037950752354879300",
+    "denominator": "48715053",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13645441988395550896730368259407519",
+    "numerator": "12589605840256037950752354879300",
+    "denominator": "48715053",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42",
+    "numerator": "9086829014904889319378990049867",
+    "denominator": "13024",
+    "rounding": "Floor",
+    "expected": "29303349095977069365319224669",
+    "overflow": false
+  },
+  {
+    "a": "42",
+    "numerator": "9086829014904889319378990049867",
+    "denominator": "13024",
+    "rounding": "Ceil",
+    "expected": "29303349095977069365319224670",
+    "overflow": false
+  },
+  {
+    "a": "35856867646216662370566025593",
+    "numerator": "596271136985486810695713254",
+    "denominator": "3982688823",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35856867646216662370566025593",
+    "numerator": "596271136985486810695713254",
+    "denominator": "3982688823",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "473020",
+    "numerator": "6149",
+    "denominator": "485548924247840082565197986485626338",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "473020",
+    "numerator": "6149",
+    "denominator": "485548924247840082565197986485626338",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2937443",
+    "numerator": "215370871230936",
+    "denominator": "3903515146371874453985592589980881",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2937443",
+    "numerator": "215370871230936",
+    "denominator": "3903515146371874453985592589980881",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "34921664445060382",
+    "numerator": "75424881184496198875809464837839",
+    "denominator": "17143151924",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "34921664445060382",
+    "numerator": "75424881184496198875809464837839",
+    "denominator": "17143151924",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8796943325",
+    "numerator": "154",
+    "denominator": "1712810207316371983227",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8796943325",
+    "numerator": "154",
+    "denominator": "1712810207316371983227",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5133900861944360753362384",
+    "numerator": "5903162418961807259458614447325481",
+    "denominator": "60980890192781264214",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5133900861944360753362384",
+    "numerator": "5903162418961807259458614447325481",
+    "denominator": "60980890192781264214",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1616723949226433111925795038448743",
+    "numerator": "10007791021688797100",
+    "denominator": "5052769875341939779020636924924864693",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1616723949226433111925795038448743",
+    "numerator": "10007791021688797100",
+    "denominator": "5052769875341939779020636924924864693",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "148949081790954140691315146322",
+    "numerator": "79086777747",
+    "denominator": "46878879300042733992869576",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "148949081790954140691315146322",
+    "numerator": "79086777747",
+    "denominator": "46878879300042733992869576",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "57345037000611457",
+    "numerator": "570338058264398389545206067854",
+    "denominator": "659744461567",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "57345037000611457",
+    "numerator": "570338058264398389545206067854",
+    "denominator": "659744461567",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1254383814379300",
+    "numerator": "2781788161296207542432750105654925",
+    "denominator": "25324712804104366803137494538",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1254383814379300",
+    "numerator": "2781788161296207542432750105654925",
+    "denominator": "25324712804104366803137494538",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1409402287994743861419",
+    "numerator": "2152622864355009665780928",
+    "denominator": "4471251418082571908313",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1409402287994743861419",
+    "numerator": "2152622864355009665780928",
+    "denominator": "4471251418082571908313",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1113063647941831800241350",
+    "numerator": "805534748920203265077822168046231",
+    "denominator": "810495992283463642221468",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1113063647941831800241350",
+    "numerator": "805534748920203265077822168046231",
+    "denominator": "810495992283463642221468",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "110407232707065088805165231262104933",
+    "numerator": "41061860342385346",
+    "denominator": "87103737377488993086781108524178627",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "110407232707065088805165231262104933",
+    "numerator": "41061860342385346",
+    "denominator": "87103737377488993086781108524178627",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "110775752456549035252694968",
+    "numerator": "49",
+    "denominator": "995457420947194881065982",
+    "rounding": "Floor",
+    "expected": "5452",
+    "overflow": false
+  },
+  {
+    "a": "110775752456549035252694968",
+    "numerator": "49",
+    "denominator": "995457420947194881065982",
+    "rounding": "Ceil",
+    "expected": "5453",
+    "overflow": false
+  },
+  {
+    "a": "6495484171418259047215",
+    "numerator": "500064066401412372",
+    "denominator": "5415954958762384701",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6495484171418259047215",
+    "numerator": "500064066401412372",
+    "denominator": "5415954958762384701",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15533178",
+    "numerator": "96294722011",
+    "denominator": "852496966110050701555632",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "15533178",
+    "numerator": "96294722011",
+    "denominator": "852496966110050701555632",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "9",
+    "numerator": "59320548882458678",
+    "denominator": "20521503699945190354119",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "9",
+    "numerator": "59320548882458678",
+    "denominator": "20521503699945190354119",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21974537512609891082881512332",
+    "numerator": "5291535542572989250170525246567957",
+    "denominator": "7719334543534774504189312951304227634",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21974537512609891082881512332",
+    "numerator": "5291535542572989250170525246567957",
+    "denominator": "7719334543534774504189312951304227634",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16514844412732365983663110853279320051",
+    "numerator": "7269707830640559045670389191848",
+    "denominator": "51352372705",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16514844412732365983663110853279320051",
+    "numerator": "7269707830640559045670389191848",
+    "denominator": "51352372705",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51722709863811508541242896763246",
+    "numerator": "46069599",
+    "denominator": "6618220033495796305033573595975456516",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51722709863811508541242896763246",
+    "numerator": "46069599",
+    "denominator": "6618220033495796305033573595975456516",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1513629677",
+    "numerator": "164736251001276735019237022792335082",
+    "denominator": "503996726550604701710874429195",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1513629677",
+    "numerator": "164736251001276735019237022792335082",
+    "denominator": "503996726550604701710874429195",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1696",
+    "numerator": "4999225",
+    "denominator": "5516333000787878",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1696",
+    "numerator": "4999225",
+    "denominator": "5516333000787878",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5500468019959",
+    "numerator": "2367518866585438757312685838249852",
+    "denominator": "69",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5500468019959",
+    "numerator": "2367518866585438757312685838249852",
+    "denominator": "69",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6126049589398244903022547534446498",
+    "numerator": "152106787",
+    "denominator": "825622604737309789721783401880",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6126049589398244903022547534446498",
+    "numerator": "152106787",
+    "denominator": "825622604737309789721783401880",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "402497566314634733665638063633297",
+    "numerator": "416702489838035897976812656152134366",
+    "denominator": "909815695",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "402497566314634733665638063633297",
+    "numerator": "416702489838035897976812656152134366",
+    "denominator": "909815695",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24926084340",
+    "numerator": "13",
+    "denominator": "130770708567796133210",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "24926084340",
+    "numerator": "13",
+    "denominator": "130770708567796133210",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8517447107374465279298501807415130171",
+    "numerator": "701745552",
+    "denominator": "68438732194036270737059276777",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8517447107374465279298501807415130171",
+    "numerator": "701745552",
+    "denominator": "68438732194036270737059276777",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121622",
+    "numerator": "2792743",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "339658989146",
+    "overflow": false
+  },
+  {
+    "a": "121622",
+    "numerator": "2792743",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "339658989146",
+    "overflow": false
+  },
+  {
+    "a": "2331935323799527019381",
+    "numerator": "34196258099439634",
+    "denominator": "918777651860088164582813051475",
+    "rounding": "Floor",
+    "expected": "86792992",
+    "overflow": false
+  },
+  {
+    "a": "2331935323799527019381",
+    "numerator": "34196258099439634",
+    "denominator": "918777651860088164582813051475",
+    "rounding": "Ceil",
+    "expected": "86792993",
+    "overflow": false
+  },
+  {
+    "a": "8",
+    "numerator": "70933213386746817660308148939488036161",
+    "denominator": "3437420889644970062",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8",
+    "numerator": "70933213386746817660308148939488036161",
+    "denominator": "3437420889644970062",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9564749304487719610633005517007807",
+    "numerator": "949921511266295409016271172171492",
+    "denominator": "298969421",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9564749304487719610633005517007807",
+    "numerator": "949921511266295409016271172171492",
+    "denominator": "298969421",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9658490933194",
+    "numerator": "2298284151253616083481835850034539",
+    "denominator": "241899558563968",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9658490933194",
+    "numerator": "2298284151253616083481835850034539",
+    "denominator": "241899558563968",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "605662506188024729",
+    "numerator": "646",
+    "denominator": "43833727201964082945299609912572759",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "605662506188024729",
+    "numerator": "646",
+    "denominator": "43833727201964082945299609912572759",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "15030812753340492191787488183591772",
+    "numerator": "132620924965",
+    "denominator": "37171151499971476030594",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15030812753340492191787488183591772",
+    "numerator": "132620924965",
+    "denominator": "37171151499971476030594",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3",
+    "numerator": "4636183416",
+    "denominator": "574116492036392592139653791923878641",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "4636183416",
+    "denominator": "574116492036392592139653791923878641",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "11259902618735000730258058223",
+    "denominator": "17457199053341219388655807341468837076",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "11259902618735000730258058223",
+    "denominator": "17457199053341219388655807341468837076",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "368637",
+    "numerator": "722043075372602",
+    "denominator": "45230765749225500570232475",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "368637",
+    "numerator": "722043075372602",
+    "denominator": "45230765749225500570232475",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "45264776048",
+    "numerator": "10078926494856727565129",
+    "denominator": "523918532086",
+    "rounding": "Floor",
+    "expected": "870784907679226538643",
+    "overflow": false
+  },
+  {
+    "a": "45264776048",
+    "numerator": "10078926494856727565129",
+    "denominator": "523918532086",
+    "rounding": "Ceil",
+    "expected": "870784907679226538644",
+    "overflow": false
+  },
+  {
+    "a": "23962770823",
+    "numerator": "613265717140526075628526412",
+    "denominator": "4757294925227103442083973628117",
+    "rounding": "Floor",
+    "expected": "3089055",
+    "overflow": false
+  },
+  {
+    "a": "23962770823",
+    "numerator": "613265717140526075628526412",
+    "denominator": "4757294925227103442083973628117",
+    "rounding": "Ceil",
+    "expected": "3089056",
+    "overflow": false
+  },
+  {
+    "a": "73895871245503497274692850",
+    "numerator": "15484214520052243635",
+    "denominator": "16032982006880221421678696",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "73895871245503497274692850",
+    "numerator": "15484214520052243635",
+    "denominator": "16032982006880221421678696",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1",
+    "numerator": "15876932899844271944736473717732140846",
+    "denominator": "2043399052563705275567362051865964575",
+    "rounding": "Floor",
+    "expected": "7",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "15876932899844271944736473717732140846",
+    "denominator": "2043399052563705275567362051865964575",
+    "rounding": "Ceil",
+    "expected": "8",
+    "overflow": false
+  },
+  {
+    "a": "23869596969281220",
+    "numerator": "411861203629",
+    "denominator": "12458",
+    "rounding": "Floor",
+    "expected": "789128346276071103562814",
+    "overflow": false
+  },
+  {
+    "a": "23869596969281220",
+    "numerator": "411861203629",
+    "denominator": "12458",
+    "rounding": "Ceil",
+    "expected": "789128346276071103562815",
+    "overflow": false
+  },
+  {
+    "a": "122423365060018715304907",
+    "numerator": "31328",
+    "denominator": "43282243321",
+    "rounding": "Floor",
+    "expected": "88610914923151339",
+    "overflow": false
+  },
+  {
+    "a": "122423365060018715304907",
+    "numerator": "31328",
+    "denominator": "43282243321",
+    "rounding": "Ceil",
+    "expected": "88610914923151340",
+    "overflow": false
+  },
+  {
+    "a": "27579157862",
+    "numerator": "32702548307055205625086903",
+    "denominator": "1927323200218752828",
+    "rounding": "Floor",
+    "expected": "467959261917040666",
+    "overflow": false
+  },
+  {
+    "a": "27579157862",
+    "numerator": "32702548307055205625086903",
+    "denominator": "1927323200218752828",
+    "rounding": "Ceil",
+    "expected": "467959261917040667",
+    "overflow": false
+  },
+  {
+    "a": "87543415348352725048196680297861",
+    "numerator": "49033533794",
+    "denominator": "4059458060894029775567709625315",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "87543415348352725048196680297861",
+    "numerator": "49033533794",
+    "denominator": "4059458060894029775567709625315",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "125272",
+    "numerator": "4668559953",
+    "denominator": "212086942",
+    "rounding": "Floor",
+    "expected": "2757547",
+    "overflow": false
+  },
+  {
+    "a": "125272",
+    "numerator": "4668559953",
+    "denominator": "212086942",
+    "rounding": "Ceil",
+    "expected": "2757548",
+    "overflow": false
+  },
+  {
+    "a": "100608340585068623",
+    "numerator": "793808411752479924",
+    "denominator": "4834065974754539059549",
+    "rounding": "Floor",
+    "expected": "16521029598265",
+    "overflow": false
+  },
+  {
+    "a": "100608340585068623",
+    "numerator": "793808411752479924",
+    "denominator": "4834065974754539059549",
+    "rounding": "Ceil",
+    "expected": "16521029598266",
+    "overflow": false
+  },
+  {
+    "a": "28442",
+    "numerator": "1328018291632403217250852246534677755",
+    "denominator": "248613804712562129231184",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28442",
+    "numerator": "1328018291632403217250852246534677755",
+    "denominator": "248613804712562129231184",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70903524478633",
+    "numerator": "140299343405378687658203805719957778646",
+    "denominator": "77287",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70903524478633",
+    "numerator": "140299343405378687658203805719957778646",
+    "denominator": "77287",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66390364161836",
+    "numerator": "78167605",
+    "denominator": "2205172133726894235307252718358994",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "66390364161836",
+    "numerator": "78167605",
+    "denominator": "2205172133726894235307252718358994",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3671664477065125651",
+    "numerator": "3081289083062753994290760",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3671664477065125651",
+    "numerator": "3081289083062753994290760",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89960740274237901250806589888145780238",
+    "numerator": "1366607234175",
+    "denominator": "6700174091940",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89960740274237901250806589888145780238",
+    "numerator": "1366607234175",
+    "denominator": "6700174091940",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58858932198821565832205",
+    "numerator": "3170698",
+    "denominator": "79603946950860442146097359759671781931",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "58858932198821565832205",
+    "numerator": "3170698",
+    "denominator": "79603946950860442146097359759671781931",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "25041326625856",
+    "numerator": "1457018561955865177",
+    "denominator": "75625848828356177045249441235147147334",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "25041326625856",
+    "numerator": "1457018561955865177",
+    "denominator": "75625848828356177045249441235147147334",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5381143",
+    "numerator": "2565988164452824336859790108",
+    "denominator": "170518862573642590806157832933",
+    "rounding": "Floor",
+    "expected": "80976",
+    "overflow": false
+  },
+  {
+    "a": "5381143",
+    "numerator": "2565988164452824336859790108",
+    "denominator": "170518862573642590806157832933",
+    "rounding": "Ceil",
+    "expected": "80977",
+    "overflow": false
+  },
+  {
+    "a": "2631130939735843616367284321858",
+    "numerator": "534884956838357734860355",
+    "denominator": "125717969135623941341700466239969080",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2631130939735843616367284321858",
+    "numerator": "534884956838357734860355",
+    "denominator": "125717969135623941341700466239969080",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "82253124532657",
+    "numerator": "78722486017071098462224825602416510",
+    "denominator": "1594543",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "82253124532657",
+    "numerator": "78722486017071098462224825602416510",
+    "denominator": "1594543",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4414964193409754260",
+    "numerator": "1925821",
+    "denominator": "46903181662259194",
+    "rounding": "Floor",
+    "expected": "181276204",
+    "overflow": false
+  },
+  {
+    "a": "4414964193409754260",
+    "numerator": "1925821",
+    "denominator": "46903181662259194",
+    "rounding": "Ceil",
+    "expected": "181276205",
+    "overflow": false
+  },
+  {
+    "a": "212781788721165147",
+    "numerator": "3493233712944",
+    "denominator": "269620013505033",
+    "rounding": "Floor",
+    "expected": "2756829911097925",
+    "overflow": false
+  },
+  {
+    "a": "212781788721165147",
+    "numerator": "3493233712944",
+    "denominator": "269620013505033",
+    "rounding": "Ceil",
+    "expected": "2756829911097926",
+    "overflow": false
+  },
+  {
+    "a": "330058756825999181726544221110",
+    "numerator": "55933132317737184759367",
+    "denominator": "127040340748",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "330058756825999181726544221110",
+    "numerator": "55933132317737184759367",
+    "denominator": "127040340748",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11783136766069653",
+    "numerator": "4054706",
+    "denominator": "89951342275164205128021160391027",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11783136766069653",
+    "numerator": "4054706",
+    "denominator": "89951342275164205128021160391027",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "720962980904",
+    "numerator": "25441",
+    "denominator": "509166",
+    "rounding": "Floor",
+    "expected": "36023652791",
+    "overflow": false
+  },
+  {
+    "a": "720962980904",
+    "numerator": "25441",
+    "denominator": "509166",
+    "rounding": "Ceil",
+    "expected": "36023652792",
+    "overflow": false
+  },
+  {
+    "a": "2025662727399647",
+    "numerator": "65566340",
+    "denominator": "4034390414101869",
+    "rounding": "Floor",
+    "expected": "32920782",
+    "overflow": false
+  },
+  {
+    "a": "2025662727399647",
+    "numerator": "65566340",
+    "denominator": "4034390414101869",
+    "rounding": "Ceil",
+    "expected": "32920783",
+    "overflow": false
+  },
+  {
+    "a": "942541806438046170644347865260650",
+    "numerator": "5292171",
+    "denominator": "91729460428320",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "942541806438046170644347865260650",
+    "numerator": "5292171",
+    "denominator": "91729460428320",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "123958230467559426515497334201",
+    "numerator": "53924646",
+    "denominator": "2025294451935170631945323639",
+    "rounding": "Floor",
+    "expected": "3300460182",
+    "overflow": false
+  },
+  {
+    "a": "123958230467559426515497334201",
+    "numerator": "53924646",
+    "denominator": "2025294451935170631945323639",
+    "rounding": "Ceil",
+    "expected": "3300460183",
+    "overflow": false
+  },
+  {
+    "a": "7747077686103145494929148",
+    "numerator": "1033560635951173",
+    "denominator": "160546",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7747077686103145494929148",
+    "numerator": "1033560635951173",
+    "denominator": "160546",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "163",
+    "numerator": "147673502775754884990376031464760907032",
+    "denominator": "75624721",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "163",
+    "numerator": "147673502775754884990376031464760907032",
+    "denominator": "75624721",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "338736168930501779003871596026746756702",
+    "numerator": "1188405719722623828239",
+    "denominator": "319793216529009566870527092",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "338736168930501779003871596026746756702",
+    "numerator": "1188405719722623828239",
+    "denominator": "319793216529009566870527092",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12082057961794626227942598183752342557",
+    "numerator": "129339076444711907546",
+    "denominator": "34476363846075",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12082057961794626227942598183752342557",
+    "numerator": "129339076444711907546",
+    "denominator": "34476363846075",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "93385826072255344912",
+    "numerator": "475815533599762822526313",
+    "denominator": "56805014",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "93385826072255344912",
+    "numerator": "475815533599762822526313",
+    "denominator": "56805014",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9166725929806159623914258087",
+    "numerator": "156574429714106323021242872567320300",
+    "denominator": "897214426030611134474485",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9166725929806159623914258087",
+    "numerator": "156574429714106323021242872567320300",
+    "denominator": "897214426030611134474485",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2962",
+    "numerator": "5075",
+    "denominator": "275728094409224",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2962",
+    "numerator": "5075",
+    "denominator": "275728094409224",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "89692604851815221313465707470",
+    "denominator": "2123603160821917873790271",
+    "rounding": "Floor",
+    "expected": "42236",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "89692604851815221313465707470",
+    "denominator": "2123603160821917873790271",
+    "rounding": "Ceil",
+    "expected": "42237",
+    "overflow": false
+  },
+  {
+    "a": "498576456109635435770145807341156",
+    "numerator": "1314688717",
+    "denominator": "13130",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "498576456109635435770145807341156",
+    "numerator": "1314688717",
+    "denominator": "13130",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28387051",
+    "numerator": "17332224",
+    "denominator": "6637379505728021199055913572633",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "28387051",
+    "numerator": "17332224",
+    "denominator": "6637379505728021199055913572633",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "72060599855472553478",
+    "numerator": "7587078405335",
+    "denominator": "152835062781090993081374951732482780",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "72060599855472553478",
+    "numerator": "7587078405335",
+    "denominator": "152835062781090993081374951732482780",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7563111845",
+    "numerator": "0",
+    "denominator": "37709341346753283",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7563111845",
+    "numerator": "0",
+    "denominator": "37709341346753283",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "58104",
+    "numerator": "23036803621308971935157418097",
+    "denominator": "5358952083024355897350089668105563454",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "58104",
+    "numerator": "23036803621308971935157418097",
+    "denominator": "5358952083024355897350089668105563454",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "15",
+    "numerator": "751200000867378260",
+    "denominator": "713054111930762093949",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "15",
+    "numerator": "751200000867378260",
+    "denominator": "713054111930762093949",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4572009735555262654906",
+    "numerator": "979140635",
+    "denominator": "12913136044888816",
+    "rounding": "Floor",
+    "expected": "346673379737966",
+    "overflow": false
+  },
+  {
+    "a": "4572009735555262654906",
+    "numerator": "979140635",
+    "denominator": "12913136044888816",
+    "rounding": "Ceil",
+    "expected": "346673379737967",
+    "overflow": false
+  },
+  {
+    "a": "53454253446840148169",
+    "numerator": "38323369425240482760809941366",
+    "denominator": "32519",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53454253446840148169",
+    "numerator": "38323369425240482760809941366",
+    "denominator": "32519",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "112807123680766668",
+    "numerator": "21087536676422702069545808486159957",
+    "denominator": "234039124832522812156018",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "112807123680766668",
+    "numerator": "21087536676422702069545808486159957",
+    "denominator": "234039124832522812156018",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8545388083",
+    "numerator": "0",
+    "denominator": "1432976649888223497107075538580001",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8545388083",
+    "numerator": "0",
+    "denominator": "1432976649888223497107075538580001",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4112616459862984311779390186158",
+    "numerator": "7617388519839",
+    "denominator": "67140",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4112616459862984311779390186158",
+    "numerator": "7617388519839",
+    "denominator": "67140",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "568495544737837",
+    "numerator": "1595495466",
+    "denominator": "1059094469237990482943916154187",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "568495544737837",
+    "numerator": "1595495466",
+    "denominator": "1059094469237990482943916154187",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3682320864",
+    "numerator": "121",
+    "denominator": "1248274110571153436630604006",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3682320864",
+    "numerator": "121",
+    "denominator": "1248274110571153436630604006",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2518340706205459907895",
+    "numerator": "412058839285546474706620",
+    "denominator": "457778208305311939361907461",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2518340706205459907895",
+    "numerator": "412058839285546474706620",
+    "denominator": "457778208305311939361907461",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2",
+    "numerator": "7716668562598930884348991694179",
+    "denominator": "33501875911604207832",
+    "rounding": "Floor",
+    "expected": "460670834251",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "7716668562598930884348991694179",
+    "denominator": "33501875911604207832",
+    "rounding": "Ceil",
+    "expected": "460670834252",
+    "overflow": false
+  },
+  {
+    "a": "4049",
+    "numerator": "947808255733227170521699683585054",
+    "denominator": "1921044886576823600899537926524144079",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4049",
+    "numerator": "947808255733227170521699683585054",
+    "denominator": "1921044886576823600899537926524144079",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "6943997259672960052",
+    "numerator": "114397",
+    "denominator": "12954",
+    "rounding": "Floor",
+    "expected": "61322560947568906211",
+    "overflow": false
+  },
+  {
+    "a": "6943997259672960052",
+    "numerator": "114397",
+    "denominator": "12954",
+    "rounding": "Ceil",
+    "expected": "61322560947568906212",
+    "overflow": false
+  },
+  {
+    "a": "75642176209876925108376580973803896443",
+    "numerator": "50384",
+    "denominator": "7209",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75642176209876925108376580973803896443",
+    "numerator": "50384",
+    "denominator": "7209",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13124452636564566",
+    "numerator": "2701143896111987830246805351",
+    "denominator": "45543526989561167130543672625419948",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13124452636564566",
+    "numerator": "2701143896111987830246805351",
+    "denominator": "45543526989561167130543672625419948",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7913477053811251979178933",
+    "numerator": "194901108050",
+    "denominator": "19",
+    "rounding": "Floor",
+    "expected": "81176076121898025594722608995616350",
+    "overflow": false
+  },
+  {
+    "a": "7913477053811251979178933",
+    "numerator": "194901108050",
+    "denominator": "19",
+    "rounding": "Ceil",
+    "expected": "81176076121898025594722608995616350",
+    "overflow": false
+  },
+  {
+    "a": "444062957703897356966456776",
+    "numerator": "3848765241348481",
+    "denominator": "408319248507873678",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "444062957703897356966456776",
+    "numerator": "3848765241348481",
+    "denominator": "408319248507873678",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11695615",
+    "numerator": "178761739240961754660",
+    "denominator": "49937853084249487727302719072895451533",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11695615",
+    "numerator": "178761739240961754660",
+    "denominator": "49937853084249487727302719072895451533",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "521197526602734866049044739382265098",
+    "numerator": "992171",
+    "denominator": "18570410193686453184",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "521197526602734866049044739382265098",
+    "numerator": "992171",
+    "denominator": "18570410193686453184",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "872409",
+    "numerator": "198",
+    "denominator": "5250455",
+    "rounding": "Floor",
+    "expected": "32",
+    "overflow": false
+  },
+  {
+    "a": "872409",
+    "numerator": "198",
+    "denominator": "5250455",
+    "rounding": "Ceil",
+    "expected": "33",
+    "overflow": false
+  },
+  {
+    "a": "870667211575553127544679602154140",
+    "numerator": "216028801125",
+    "denominator": "194",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "870667211575553127544679602154140",
+    "numerator": "216028801125",
+    "denominator": "194",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3624833864560093097923",
+    "numerator": "3517411000",
+    "denominator": "276273",
+    "rounding": "Floor",
+    "expected": "46150114228955350771369034",
+    "overflow": false
+  },
+  {
+    "a": "3624833864560093097923",
+    "numerator": "3517411000",
+    "denominator": "276273",
+    "rounding": "Ceil",
+    "expected": "46150114228955350771369035",
+    "overflow": false
+  },
+  {
+    "a": "74058520843362873502060247806",
+    "numerator": "10200033324615929471369570676336175",
+    "denominator": "1440196723730410619380756",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74058520843362873502060247806",
+    "numerator": "10200033324615929471369570676336175",
+    "denominator": "1440196723730410619380756",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19376189",
+    "numerator": "2938",
+    "denominator": "19213841684345073242967346395",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "19376189",
+    "numerator": "2938",
+    "denominator": "19213841684345073242967346395",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "39684400389682472798572363220656",
+    "numerator": "33468081739130761",
+    "denominator": "37060406",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39684400389682472798572363220656",
+    "numerator": "33468081739130761",
+    "denominator": "37060406",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "71",
+    "numerator": "260997258590961800554205836",
+    "denominator": "234676501",
+    "rounding": "Floor",
+    "expected": "78963190950074237894",
+    "overflow": false
+  },
+  {
+    "a": "71",
+    "numerator": "260997258590961800554205836",
+    "denominator": "234676501",
+    "rounding": "Ceil",
+    "expected": "78963190950074237895",
+    "overflow": false
+  },
+  {
+    "a": "136039561553272763787285507574912922162",
+    "numerator": "149787348367800559573818099",
+    "denominator": "96240552",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "136039561553272763787285507574912922162",
+    "numerator": "149787348367800559573818099",
+    "denominator": "96240552",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "496738485183693897953",
+    "numerator": "1547815698542",
+    "denominator": "3270661397087",
+    "rounding": "Floor",
+    "expected": "235077720402997230890",
+    "overflow": false
+  },
+  {
+    "a": "496738485183693897953",
+    "numerator": "1547815698542",
+    "denominator": "3270661397087",
+    "rounding": "Ceil",
+    "expected": "235077720402997230891",
+    "overflow": false
+  },
+  {
+    "a": "532088964850318501567996003014148",
+    "numerator": "53120404223029997",
+    "denominator": "4096656874",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "532088964850318501567996003014148",
+    "numerator": "53120404223029997",
+    "denominator": "4096656874",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10364263381515",
+    "numerator": "23093589919136",
+    "denominator": "9576116258736730083107641",
+    "rounding": "Floor",
+    "expected": "24",
+    "overflow": false
+  },
+  {
+    "a": "10364263381515",
+    "numerator": "23093589919136",
+    "denominator": "9576116258736730083107641",
+    "rounding": "Ceil",
+    "expected": "25",
+    "overflow": false
+  },
+  {
+    "a": "59318412354035719846",
+    "numerator": "38082502667761213410952695",
+    "denominator": "78793645264921163929202579243634300",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "59318412354035719846",
+    "numerator": "38082502667761213410952695",
+    "denominator": "78793645264921163929202579243634300",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "212421",
+    "numerator": "26274",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "5581149354",
+    "overflow": false
+  },
+  {
+    "a": "212421",
+    "numerator": "26274",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "5581149354",
+    "overflow": false
+  },
+  {
+    "a": "44184",
+    "numerator": "448578256268603633748504932135431825",
+    "denominator": "335096160786329102761811442142",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "44184",
+    "numerator": "448578256268603633748504932135431825",
+    "denominator": "335096160786329102761811442142",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4078576882319",
+    "numerator": "252912709622632434550103028",
+    "denominator": "5010061470998536279287542826738077",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4078576882319",
+    "numerator": "252912709622632434550103028",
+    "denominator": "5010061470998536279287542826738077",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "432411549730522870874",
+    "numerator": "128496598386198022233117535035",
+    "denominator": "24369010114185894032",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "432411549730522870874",
+    "numerator": "128496598386198022233117535035",
+    "denominator": "24369010114185894032",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3968616105852404457",
+    "numerator": "109103854102",
+    "denominator": "879348189771577969301938215",
+    "rounding": "Floor",
+    "expected": "492",
+    "overflow": false
+  },
+  {
+    "a": "3968616105852404457",
+    "numerator": "109103854102",
+    "denominator": "879348189771577969301938215",
+    "rounding": "Ceil",
+    "expected": "493",
+    "overflow": false
+  },
+  {
+    "a": "15925744747597023798628324843116",
+    "numerator": "5",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "39814361868992559496570812107790",
+    "overflow": false
+  },
+  {
+    "a": "15925744747597023798628324843116",
+    "numerator": "5",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "39814361868992559496570812107790",
+    "overflow": false
+  },
+  {
+    "a": "1261815545138937005611053814316371",
+    "numerator": "4956263503768057487664040831368",
+    "denominator": "118951329857",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1261815545138937005611053814316371",
+    "numerator": "4956263503768057487664040831368",
+    "denominator": "118951329857",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2",
+    "numerator": "656440432938687",
+    "denominator": "1508",
+    "rounding": "Floor",
+    "expected": "870610653764",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "656440432938687",
+    "denominator": "1508",
+    "rounding": "Ceil",
+    "expected": "870610653765",
+    "overflow": false
+  },
+  {
+    "a": "1143394546765",
+    "numerator": "4057872832202",
+    "denominator": "40709423129785022379647643553456235",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1143394546765",
+    "numerator": "4057872832202",
+    "denominator": "40709423129785022379647643553456235",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "134994085767089475988596424576",
+    "numerator": "7780766224212652609614362674841",
+    "denominator": "8544773159302",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "134994085767089475988596424576",
+    "numerator": "7780766224212652609614362674841",
+    "denominator": "8544773159302",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2850391",
+    "numerator": "25912537665438417500",
+    "denominator": "10199711651492514649781247326167845",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2850391",
+    "numerator": "25912537665438417500",
+    "denominator": "10199711651492514649781247326167845",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1783416023938",
+    "numerator": "85173208788797181516499793027",
+    "denominator": "542602050168",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1783416023938",
+    "numerator": "85173208788797181516499793027",
+    "denominator": "542602050168",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9841388302864903836951813667894769",
+    "numerator": "29098157224812773728712507696859326",
+    "denominator": "35065805229807",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9841388302864903836951813667894769",
+    "numerator": "29098157224812773728712507696859326",
+    "denominator": "35065805229807",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "91092",
+    "numerator": "515517181",
+    "denominator": "172031880506",
+    "rounding": "Floor",
+    "expected": "272",
+    "overflow": false
+  },
+  {
+    "a": "91092",
+    "numerator": "515517181",
+    "denominator": "172031880506",
+    "rounding": "Ceil",
+    "expected": "273",
+    "overflow": false
+  },
+  {
+    "a": "14100570104060315",
+    "numerator": "241736499244038768",
+    "denominator": "687387158768617154751319983959625",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "14100570104060315",
+    "numerator": "241736499244038768",
+    "denominator": "687387158768617154751319983959625",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "474083147603490038",
+    "numerator": "55660383320964170020406608305528967",
+    "denominator": "3384083616676428",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "474083147603490038",
+    "numerator": "55660383320964170020406608305528967",
+    "denominator": "3384083616676428",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "469",
+    "numerator": "278572617876595882994",
+    "denominator": "966637044552657579955",
+    "rounding": "Floor",
+    "expected": "135",
+    "overflow": false
+  },
+  {
+    "a": "469",
+    "numerator": "278572617876595882994",
+    "denominator": "966637044552657579955",
+    "rounding": "Ceil",
+    "expected": "136",
+    "overflow": false
+  },
+  {
+    "a": "11271184297993831513887973224",
+    "numerator": "235705487265",
+    "denominator": "504748299986387131950",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11271184297993831513887973224",
+    "numerator": "235705487265",
+    "denominator": "504748299986387131950",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "357331250754843183031751368277512991",
+    "numerator": "53115042624038340",
+    "denominator": "3117318451219123464239341962921389",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "357331250754843183031751368277512991",
+    "numerator": "53115042624038340",
+    "denominator": "3117318451219123464239341962921389",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "607551627687144509011882",
+    "numerator": "1739",
+    "denominator": "16848004123823616367854908895246944608",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "607551627687144509011882",
+    "numerator": "1739",
+    "denominator": "16848004123823616367854908895246944608",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "101870314433068578011641",
+    "numerator": "0",
+    "denominator": "313697511774804180563412663",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "101870314433068578011641",
+    "numerator": "0",
+    "denominator": "313697511774804180563412663",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2125050388997064252",
+    "numerator": "12570031714725003115272325",
+    "denominator": "687331709449683042",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2125050388997064252",
+    "numerator": "12570031714725003115272325",
+    "denominator": "687331709449683042",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65360878528155880879891508963",
+    "numerator": "65950231801687703432273074264",
+    "denominator": "48575867434847617089060499240750417",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65360878528155880879891508963",
+    "numerator": "65950231801687703432273074264",
+    "denominator": "48575867434847617089060499240750417",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "131524029999006",
+    "numerator": "7521298496422042447",
+    "denominator": "342248009761771229478487014324",
+    "rounding": "Floor",
+    "expected": "2890",
+    "overflow": false
+  },
+  {
+    "a": "131524029999006",
+    "numerator": "7521298496422042447",
+    "denominator": "342248009761771229478487014324",
+    "rounding": "Ceil",
+    "expected": "2891",
+    "overflow": false
+  },
+  {
+    "a": "52061672743952542189725860957",
+    "numerator": "422093780506",
+    "denominator": "4041921416631621627",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "52061672743952542189725860957",
+    "numerator": "422093780506",
+    "denominator": "4041921416631621627",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17223423014778676358224",
+    "numerator": "43543259012457163177",
+    "denominator": "245829896150",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17223423014778676358224",
+    "numerator": "43543259012457163177",
+    "denominator": "245829896150",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "529117408568083539019296999",
+    "numerator": "0",
+    "denominator": "583327488149481781",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "529117408568083539019296999",
+    "numerator": "0",
+    "denominator": "583327488149481781",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "189037914362636456887616338130",
+    "numerator": "75320276926796086993668242371091",
+    "denominator": "2144693408949262159757661212812813640",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "189037914362636456887616338130",
+    "numerator": "75320276926796086993668242371091",
+    "denominator": "2144693408949262159757661212812813640",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1082085279316948807425",
+    "numerator": "504441739461485880590",
+    "denominator": "16759385007409720809645951",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1082085279316948807425",
+    "numerator": "504441739461485880590",
+    "denominator": "16759385007409720809645951",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "92420421067096338244986276",
+    "numerator": "1805",
+    "denominator": "2190821325744266",
+    "rounding": "Floor",
+    "expected": "76144438647655",
+    "overflow": false
+  },
+  {
+    "a": "92420421067096338244986276",
+    "numerator": "1805",
+    "denominator": "2190821325744266",
+    "rounding": "Ceil",
+    "expected": "76144438647656",
+    "overflow": false
+  },
+  {
+    "a": "702687477599433253707051",
+    "numerator": "801919053367591619073065589596992",
+    "denominator": "444752474144089",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "702687477599433253707051",
+    "numerator": "801919053367591619073065589596992",
+    "denominator": "444752474144089",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "796073006362832365702557392710",
+    "numerator": "109172539315484249057488706412311",
+    "denominator": "50087975452",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "796073006362832365702557392710",
+    "numerator": "109172539315484249057488706412311",
+    "denominator": "50087975452",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1830933421399525",
+    "numerator": "86269509625764443970582937809610050",
+    "denominator": "328715456592195",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1830933421399525",
+    "numerator": "86269509625764443970582937809610050",
+    "denominator": "328715456592195",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "834293697549708445240",
+    "numerator": "49",
+    "denominator": "368453368884669099889242251996354174",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "834293697549708445240",
+    "numerator": "49",
+    "denominator": "368453368884669099889242251996354174",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "19566400655816623",
+    "numerator": "30579777811634593883028",
+    "denominator": "65236144326084499082777914813",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19566400655816623",
+    "numerator": "30579777811634593883028",
+    "denominator": "65236144326084499082777914813",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1873013589388038906852730113786",
+    "numerator": "3475817403603388884571",
+    "denominator": "765488",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1873013589388038906852730113786",
+    "numerator": "3475817403603388884571",
+    "denominator": "765488",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "223102910159152149896809133321",
+    "numerator": "17906946366851434252014791350",
+    "denominator": "51210494898778594791751",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "223102910159152149896809133321",
+    "numerator": "17906946366851434252014791350",
+    "denominator": "51210494898778594791751",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "46741",
+    "denominator": "4425138",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "46741",
+    "denominator": "4425138",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "650678582372958207320848099575809139",
+    "numerator": "4789893928",
+    "denominator": "24226932943041942677278170721",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "650678582372958207320848099575809139",
+    "numerator": "4789893928",
+    "denominator": "24226932943041942677278170721",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1394184010734",
+    "numerator": "3039",
+    "denominator": "66873628431821992244612",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1394184010734",
+    "numerator": "3039",
+    "denominator": "66873628431821992244612",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "109",
+    "numerator": "39318458814507370",
+    "denominator": "375479428587117455042491109825164171",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "109",
+    "numerator": "39318458814507370",
+    "denominator": "375479428587117455042491109825164171",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1764039827128760075147927970909472",
+    "numerator": "55316456598453096633",
+    "denominator": "1291738519016335910",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1764039827128760075147927970909472",
+    "numerator": "55316456598453096633",
+    "denominator": "1291738519016335910",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1312631",
+    "numerator": "53170035965436",
+    "denominator": "6212543281254583836357445",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1312631",
+    "numerator": "53170035965436",
+    "denominator": "6212543281254583836357445",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "202579368642304546",
+    "numerator": "32600019375011",
+    "denominator": "312344",
+    "rounding": "Floor",
+    "expected": "21143647205378121613687613",
+    "overflow": false
+  },
+  {
+    "a": "202579368642304546",
+    "numerator": "32600019375011",
+    "denominator": "312344",
+    "rounding": "Ceil",
+    "expected": "21143647205378121613687614",
+    "overflow": false
+  },
+  {
+    "a": "3528528901643824145",
+    "numerator": "1374",
+    "denominator": "3921589701191181327",
+    "rounding": "Floor",
+    "expected": "1236",
+    "overflow": false
+  },
+  {
+    "a": "3528528901643824145",
+    "numerator": "1374",
+    "denominator": "3921589701191181327",
+    "rounding": "Ceil",
+    "expected": "1237",
+    "overflow": false
+  },
+  {
+    "a": "7028",
+    "numerator": "33885160179596359029265580336925",
+    "denominator": "7738146924979805982487975335797848026",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7028",
+    "numerator": "33885160179596359029265580336925",
+    "denominator": "7738146924979805982487975335797848026",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1608497780494540328191163",
+    "numerator": "97219528246592611696961975907757260816",
+    "denominator": "14750452453514907549760971608169",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1608497780494540328191163",
+    "numerator": "97219528246592611696961975907757260816",
+    "denominator": "14750452453514907549760971608169",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4012891469887332145667478",
+    "numerator": "1506413412991399",
+    "denominator": "177334058610156",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4012891469887332145667478",
+    "numerator": "1506413412991399",
+    "denominator": "177334058610156",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4691184676379098118652957685",
+    "numerator": "13154089919233131798253357032082",
+    "denominator": "1896119805651",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4691184676379098118652957685",
+    "numerator": "13154089919233131798253357032082",
+    "denominator": "1896119805651",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1130318549235789963528",
+    "numerator": "1304021614821451301972245701367487937",
+    "denominator": "1134082047854751191404765897422",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1130318549235789963528",
+    "numerator": "1304021614821451301972245701367487937",
+    "denominator": "1134082047854751191404765897422",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1117711236415834953014373957695",
+    "numerator": "221530761522024566982206163829726467428",
+    "denominator": "1890765",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1117711236415834953014373957695",
+    "numerator": "221530761522024566982206163829726467428",
+    "denominator": "1890765",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "235067257898380505381450",
+    "numerator": "40747772282143664090011942427115",
+    "denominator": "231168",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "235067257898380505381450",
+    "numerator": "40747772282143664090011942427115",
+    "denominator": "231168",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "292515677928529326431458210841",
+    "numerator": "5123531169512491611964678",
+    "denominator": "7015815502132964400758743",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "292515677928529326431458210841",
+    "numerator": "5123531169512491611964678",
+    "denominator": "7015815502132964400758743",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12782884610221414406287836",
+    "numerator": "42509775315580227894907483190358268069",
+    "denominator": "3580936656579003284184222089178717954",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12782884610221414406287836",
+    "numerator": "42509775315580227894907483190358268069",
+    "denominator": "3580936656579003284184222089178717954",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3",
+    "numerator": "6730264415094067732645384696",
+    "denominator": "124367843862358964704637809",
+    "rounding": "Floor",
+    "expected": "162",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "6730264415094067732645384696",
+    "denominator": "124367843862358964704637809",
+    "rounding": "Ceil",
+    "expected": "163",
+    "overflow": false
+  },
+  {
+    "a": "219250240220980335324243006",
+    "numerator": "3361857647",
+    "denominator": "5229868350088020",
+    "rounding": "Floor",
+    "expected": "140938174224038418108",
+    "overflow": false
+  },
+  {
+    "a": "219250240220980335324243006",
+    "numerator": "3361857647",
+    "denominator": "5229868350088020",
+    "rounding": "Ceil",
+    "expected": "140938174224038418109",
+    "overflow": false
+  },
+  {
+    "a": "4741732945901514877",
+    "numerator": "1133129914",
+    "denominator": "13155365779813147",
+    "rounding": "Floor",
+    "expected": "408426457700",
+    "overflow": false
+  },
+  {
+    "a": "4741732945901514877",
+    "numerator": "1133129914",
+    "denominator": "13155365779813147",
+    "rounding": "Ceil",
+    "expected": "408426457701",
+    "overflow": false
+  },
+  {
+    "a": "6332912",
+    "numerator": "2666200009",
+    "denominator": "8973158352013783958413430",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "6332912",
+    "numerator": "2666200009",
+    "denominator": "8973158352013783958413430",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6346211680816176378473267719",
+    "numerator": "127769861402179851596023613900",
+    "denominator": "65877",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6346211680816176378473267719",
+    "numerator": "127769861402179851596023613900",
+    "denominator": "65877",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75451778164480764577057569050482",
+    "numerator": "22672972083",
+    "denominator": "88839912",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75451778164480764577057569050482",
+    "numerator": "22672972083",
+    "denominator": "88839912",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "404769",
+    "numerator": "951384683345467822",
+    "denominator": "9190391645275295",
+    "rounding": "Floor",
+    "expected": "41901481",
+    "overflow": false
+  },
+  {
+    "a": "404769",
+    "numerator": "951384683345467822",
+    "denominator": "9190391645275295",
+    "rounding": "Ceil",
+    "expected": "41901482",
+    "overflow": false
+  },
+  {
+    "a": "27547218624547374404",
+    "numerator": "417928035404933933",
+    "denominator": "12557098",
+    "rounding": "Floor",
+    "expected": "916832452898535197377756771686",
+    "overflow": false
+  },
+  {
+    "a": "27547218624547374404",
+    "numerator": "417928035404933933",
+    "denominator": "12557098",
+    "rounding": "Ceil",
+    "expected": "916832452898535197377756771687",
+    "overflow": false
+  },
+  {
+    "a": "11",
+    "numerator": "20704",
+    "denominator": "348056354419885729657",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11",
+    "numerator": "20704",
+    "denominator": "348056354419885729657",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "355377429561693846955267759206374",
+    "numerator": "41050013365878131667679292688439",
+    "denominator": "353092546117321257935566268",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "355377429561693846955267759206374",
+    "numerator": "41050013365878131667679292688439",
+    "denominator": "353092546117321257935566268",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12434417126917",
+    "numerator": "4043746",
+    "denominator": "2538313414755",
+    "rounding": "Floor",
+    "expected": "19809068",
+    "overflow": false
+  },
+  {
+    "a": "12434417126917",
+    "numerator": "4043746",
+    "denominator": "2538313414755",
+    "rounding": "Ceil",
+    "expected": "19809069",
+    "overflow": false
+  },
+  {
+    "a": "29772466492923926720472",
+    "numerator": "13222554335034472875833068241",
+    "denominator": "67795229277727425310",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29772466492923926720472",
+    "numerator": "13222554335034472875833068241",
+    "denominator": "67795229277727425310",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "364535999028599803185409231",
+    "numerator": "24162581300",
+    "denominator": "7712852445",
+    "rounding": "Floor",
+    "expected": "1142006900315498486063861100",
+    "overflow": false
+  },
+  {
+    "a": "364535999028599803185409231",
+    "numerator": "24162581300",
+    "denominator": "7712852445",
+    "rounding": "Ceil",
+    "expected": "1142006900315498486063861101",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "14606585722483067",
+    "denominator": "227845772921836496",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "14606585722483067",
+    "denominator": "227845772921836496",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "13038081991833605598487368497395497",
+    "numerator": "783190",
+    "denominator": "21118763230268138836583",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13038081991833605598487368497395497",
+    "numerator": "783190",
+    "denominator": "21118763230268138836583",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1452",
+    "numerator": "102506853048483509",
+    "denominator": "15469650",
+    "rounding": "Floor",
+    "expected": "9621416814627",
+    "overflow": false
+  },
+  {
+    "a": "1452",
+    "numerator": "102506853048483509",
+    "denominator": "15469650",
+    "rounding": "Ceil",
+    "expected": "9621416814628",
+    "overflow": false
+  },
+  {
+    "a": "187072000367507",
+    "numerator": "78634184",
+    "denominator": "563482172053673268857354587265",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "187072000367507",
+    "numerator": "78634184",
+    "denominator": "563482172053673268857354587265",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2465204114833214606227943538949070990",
+    "numerator": "1420407465441427337854250604799",
+    "denominator": "1966322333877540",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2465204114833214606227943538949070990",
+    "numerator": "1420407465441427337854250604799",
+    "denominator": "1966322333877540",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "979149454072492238269615245",
+    "numerator": "342355182397426698",
+    "denominator": "10150985438891",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "979149454072492238269615245",
+    "numerator": "342355182397426698",
+    "denominator": "10150985438891",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "342181374656",
+    "numerator": "23511499230743673015219734686425",
+    "denominator": "688055743852928526707398",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "342181374656",
+    "numerator": "23511499230743673015219734686425",
+    "denominator": "688055743852928526707398",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6219047063",
+    "numerator": "22642005670054300",
+    "denominator": "19766203237",
+    "rounding": "Floor",
+    "expected": "7123861733810247",
+    "overflow": false
+  },
+  {
+    "a": "6219047063",
+    "numerator": "22642005670054300",
+    "denominator": "19766203237",
+    "rounding": "Ceil",
+    "expected": "7123861733810248",
+    "overflow": false
+  },
+  {
+    "a": "93422176901314",
+    "numerator": "480018012151531978878452419",
+    "denominator": "184",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "93422176901314",
+    "numerator": "480018012151531978878452419",
+    "denominator": "184",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "111153",
+    "numerator": "510",
+    "denominator": "115640623",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "111153",
+    "numerator": "510",
+    "denominator": "115640623",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7321175375633966367400316487803872020",
+    "numerator": "143554855618606671541053",
+    "denominator": "343397056742842333467258",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7321175375633966367400316487803872020",
+    "numerator": "143554855618606671541053",
+    "denominator": "343397056742842333467258",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "984122060000400724233160114139",
+    "numerator": "7263664",
+    "denominator": "1606281",
+    "rounding": "Floor",
+    "expected": "4450237523092628703313014800839",
+    "overflow": false
+  },
+  {
+    "a": "984122060000400724233160114139",
+    "numerator": "7263664",
+    "denominator": "1606281",
+    "rounding": "Ceil",
+    "expected": "4450237523092628703313014800840",
+    "overflow": false
+  },
+  {
+    "a": "8428426221110",
+    "numerator": "62151",
+    "denominator": "4112907694476",
+    "rounding": "Floor",
+    "expected": "127363",
+    "overflow": false
+  },
+  {
+    "a": "8428426221110",
+    "numerator": "62151",
+    "denominator": "4112907694476",
+    "rounding": "Ceil",
+    "expected": "127364",
+    "overflow": false
+  },
+  {
+    "a": "72066342483910102157892881429",
+    "numerator": "67838261323370540944709938",
+    "denominator": "411186672250355",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "72066342483910102157892881429",
+    "numerator": "67838261323370540944709938",
+    "denominator": "411186672250355",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11402893660287656",
+    "numerator": "52972848122094839669646113279474657",
+    "denominator": "3669363676672208221671995246",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11402893660287656",
+    "numerator": "52972848122094839669646113279474657",
+    "denominator": "3669363676672208221671995246",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4825079436034963652424351071",
+    "numerator": "599547197718697220",
+    "denominator": "180338157",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4825079436034963652424351071",
+    "numerator": "599547197718697220",
+    "denominator": "180338157",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "302774071171730165777648874",
+    "numerator": "11",
+    "denominator": "13358240",
+    "rounding": "Floor",
+    "expected": "249322873588813483179",
+    "overflow": false
+  },
+  {
+    "a": "302774071171730165777648874",
+    "numerator": "11",
+    "denominator": "13358240",
+    "rounding": "Ceil",
+    "expected": "249322873588813483180",
+    "overflow": false
+  },
+  {
+    "a": "31325753",
+    "numerator": "8592092609426854",
+    "denominator": "1344876703893966047479",
+    "rounding": "Floor",
+    "expected": "200",
+    "overflow": false
+  },
+  {
+    "a": "31325753",
+    "numerator": "8592092609426854",
+    "denominator": "1344876703893966047479",
+    "rounding": "Ceil",
+    "expected": "201",
+    "overflow": false
+  },
+  {
+    "a": "11644",
+    "numerator": "12755253361327876293",
+    "denominator": "188221016722850",
+    "rounding": "Floor",
+    "expected": "789083879",
+    "overflow": false
+  },
+  {
+    "a": "11644",
+    "numerator": "12755253361327876293",
+    "denominator": "188221016722850",
+    "rounding": "Ceil",
+    "expected": "789083880",
+    "overflow": false
+  },
+  {
+    "a": "3373955273887234762576165170341158179",
+    "numerator": "229663987492292011367037262744",
+    "denominator": "401",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3373955273887234762576165170341158179",
+    "numerator": "229663987492292011367037262744",
+    "denominator": "401",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "217067742",
+    "numerator": "1191870974026763072911",
+    "denominator": "169482251129007102708",
+    "rounding": "Floor",
+    "expected": "1526512300",
+    "overflow": false
+  },
+  {
+    "a": "217067742",
+    "numerator": "1191870974026763072911",
+    "denominator": "169482251129007102708",
+    "rounding": "Ceil",
+    "expected": "1526512301",
+    "overflow": false
+  },
+  {
+    "a": "1911965",
+    "numerator": "329310887759312271721075011261807450",
+    "denominator": "59",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1911965",
+    "numerator": "329310887759312271721075011261807450",
+    "denominator": "59",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9142017259801760393291664",
+    "numerator": "4421433239739881",
+    "denominator": "1240257708835783543062",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9142017259801760393291664",
+    "numerator": "4421433239739881",
+    "denominator": "1240257708835783543062",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33613554471",
+    "numerator": "294305086828",
+    "denominator": "1166303267008883061",
+    "rounding": "Floor",
+    "expected": "8482",
+    "overflow": false
+  },
+  {
+    "a": "33613554471",
+    "numerator": "294305086828",
+    "denominator": "1166303267008883061",
+    "rounding": "Ceil",
+    "expected": "8483",
+    "overflow": false
+  },
+  {
+    "a": "2258450",
+    "numerator": "49214340804005971",
+    "denominator": "3310793250563482838465599624",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2258450",
+    "numerator": "49214340804005971",
+    "denominator": "3310793250563482838465599624",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "97089",
+    "numerator": "1852852616102200170028622",
+    "denominator": "280210783113139918620566767284671",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "97089",
+    "numerator": "1852852616102200170028622",
+    "denominator": "280210783113139918620566767284671",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3357783414120571073918180",
+    "numerator": "41142641594825452683694562398635720525",
+    "denominator": "1807877145808295623986896229720874442",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3357783414120571073918180",
+    "numerator": "41142641594825452683694562398635720525",
+    "denominator": "1807877145808295623986896229720874442",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "312823630498800778998901180781419",
+    "numerator": "33151835703768288896",
+    "denominator": "576788760983243778053291397013913",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "312823630498800778998901180781419",
+    "numerator": "33151835703768288896",
+    "denominator": "576788760983243778053291397013913",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "102367323574406",
+    "numerator": "98921316695",
+    "denominator": "1795417818735159664988",
+    "rounding": "Floor",
+    "expected": "5640",
+    "overflow": false
+  },
+  {
+    "a": "102367323574406",
+    "numerator": "98921316695",
+    "denominator": "1795417818735159664988",
+    "rounding": "Ceil",
+    "expected": "5641",
+    "overflow": false
+  },
+  {
+    "a": "43743284773",
+    "numerator": "426507822060162",
+    "denominator": "451073024368924620343171",
+    "rounding": "Floor",
+    "expected": "41",
+    "overflow": false
+  },
+  {
+    "a": "43743284773",
+    "numerator": "426507822060162",
+    "denominator": "451073024368924620343171",
+    "rounding": "Ceil",
+    "expected": "42",
+    "overflow": false
+  },
+  {
+    "a": "169921253571946872",
+    "numerator": "278447064460312552575697793265",
+    "denominator": "533883748286",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "169921253571946872",
+    "numerator": "278447064460312552575697793265",
+    "denominator": "533883748286",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14775670309687457706479",
+    "numerator": "21684948",
+    "denominator": "657634813",
+    "rounding": "Floor",
+    "expected": "487215147368903684569",
+    "overflow": false
+  },
+  {
+    "a": "14775670309687457706479",
+    "numerator": "21684948",
+    "denominator": "657634813",
+    "rounding": "Ceil",
+    "expected": "487215147368903684570",
+    "overflow": false
+  },
+  {
+    "a": "44701275286855302722618",
+    "numerator": "3",
+    "denominator": "49695088",
+    "rounding": "Floor",
+    "expected": "2698532817983256",
+    "overflow": false
+  },
+  {
+    "a": "44701275286855302722618",
+    "numerator": "3",
+    "denominator": "49695088",
+    "rounding": "Ceil",
+    "expected": "2698532817983257",
+    "overflow": false
+  },
+  {
+    "a": "15914347151771977",
+    "numerator": "72347316805874289654",
+    "denominator": "1488971366706668423",
+    "rounding": "Floor",
+    "expected": "773258869104050158",
+    "overflow": false
+  },
+  {
+    "a": "15914347151771977",
+    "numerator": "72347316805874289654",
+    "denominator": "1488971366706668423",
+    "rounding": "Ceil",
+    "expected": "773258869104050159",
+    "overflow": false
+  },
+  {
+    "a": "332",
+    "numerator": "15916901447864614803157",
+    "denominator": "698475798992904946",
+    "rounding": "Floor",
+    "expected": "7565632",
+    "overflow": false
+  },
+  {
+    "a": "332",
+    "numerator": "15916901447864614803157",
+    "denominator": "698475798992904946",
+    "rounding": "Ceil",
+    "expected": "7565633",
+    "overflow": false
+  },
+  {
+    "a": "380956576053363245747",
+    "numerator": "3369305483050640636696780397252200",
+    "denominator": "1673841699532389288609",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "380956576053363245747",
+    "numerator": "3369305483050640636696780397252200",
+    "denominator": "1673841699532389288609",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1296313603374",
+    "numerator": "31",
+    "denominator": "505105418030273113955849542449931460",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1296313603374",
+    "numerator": "31",
+    "denominator": "505105418030273113955849542449931460",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "47239341",
+    "numerator": "5369177194154",
+    "denominator": "68043",
+    "rounding": "Floor",
+    "expected": "3727589794160516",
+    "overflow": false
+  },
+  {
+    "a": "47239341",
+    "numerator": "5369177194154",
+    "denominator": "68043",
+    "rounding": "Ceil",
+    "expected": "3727589794160517",
+    "overflow": false
+  },
+  {
+    "a": "91386928533010849176319451175008",
+    "numerator": "339817134079069279481",
+    "denominator": "952941001574",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "91386928533010849176319451175008",
+    "numerator": "339817134079069279481",
+    "denominator": "952941001574",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "945671162295",
+    "numerator": "19224536380",
+    "denominator": "100295255026205573",
+    "rounding": "Floor",
+    "expected": "181265",
+    "overflow": false
+  },
+  {
+    "a": "945671162295",
+    "numerator": "19224536380",
+    "denominator": "100295255026205573",
+    "rounding": "Ceil",
+    "expected": "181266",
+    "overflow": false
+  },
+  {
+    "a": "1239371491170",
+    "numerator": "181091562379950841878115804086755",
+    "denominator": "344",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1239371491170",
+    "numerator": "181091562379950841878115804086755",
+    "denominator": "344",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1116841044718334309879941201",
+    "numerator": "743885116377304928607666419048094",
+    "denominator": "1893675704810609950654031",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1116841044718334309879941201",
+    "numerator": "743885116377304928607666419048094",
+    "denominator": "1893675704810609950654031",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22091707010911418310539956",
+    "numerator": "43318759261",
+    "denominator": "549622528670982355744324694138649882",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "22091707010911418310539956",
+    "numerator": "43318759261",
+    "denominator": "549622528670982355744324694138649882",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "224699213218795440891",
+    "numerator": "1018875879707048820598910433327952",
+    "denominator": "237557026599345741088982233965659305",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "224699213218795440891",
+    "numerator": "1018875879707048820598910433327952",
+    "denominator": "237557026599345741088982233965659305",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9038538575004828474349736058582",
+    "numerator": "5011746992783390427050308054851433447",
+    "denominator": "300141540281656331104142636",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9038538575004828474349736058582",
+    "numerator": "5011746992783390427050308054851433447",
+    "denominator": "300141540281656331104142636",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36481602613",
+    "numerator": "101803914836218356555707253530578",
+    "denominator": "5752083",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36481602613",
+    "numerator": "101803914836218356555707253530578",
+    "denominator": "5752083",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28485212705864",
+    "numerator": "480849296364310702593",
+    "denominator": "4411769507863566",
+    "rounding": "Floor",
+    "expected": "3104671370974535068",
+    "overflow": false
+  },
+  {
+    "a": "28485212705864",
+    "numerator": "480849296364310702593",
+    "denominator": "4411769507863566",
+    "rounding": "Ceil",
+    "expected": "3104671370974535069",
+    "overflow": false
+  },
+  {
+    "a": "645015232670202334555790043443972735",
+    "numerator": "270530618532",
+    "denominator": "176653",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "645015232670202334555790043443972735",
+    "numerator": "270530618532",
+    "denominator": "176653",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7170369085367689751363321785347978",
+    "numerator": "220038730284755869676395455336491",
+    "denominator": "1990259264",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7170369085367689751363321785347978",
+    "numerator": "220038730284755869676395455336491",
+    "denominator": "1990259264",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6233",
+    "numerator": "353173148436678871435284182598",
+    "denominator": "33536749871639",
+    "rounding": "Floor",
+    "expected": "65639283551069900379",
+    "overflow": false
+  },
+  {
+    "a": "6233",
+    "numerator": "353173148436678871435284182598",
+    "denominator": "33536749871639",
+    "rounding": "Ceil",
+    "expected": "65639283551069900380",
+    "overflow": false
+  },
+  {
+    "a": "19570212268434715641042483802650908",
+    "numerator": "3219902434816690817253",
+    "denominator": "153338856533880135589059092597826",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19570212268434715641042483802650908",
+    "numerator": "3219902434816690817253",
+    "denominator": "153338856533880135589059092597826",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8383455165471263473683523",
+    "numerator": "7009592",
+    "denominator": "67201572579040760971671636423471025",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8383455165471263473683523",
+    "numerator": "7009592",
+    "denominator": "67201572579040760971671636423471025",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "16844557694",
+    "numerator": "126920738860539728009903",
+    "denominator": "14790572118955262410214007444",
+    "rounding": "Floor",
+    "expected": "144546",
+    "overflow": false
+  },
+  {
+    "a": "16844557694",
+    "numerator": "126920738860539728009903",
+    "denominator": "14790572118955262410214007444",
+    "rounding": "Ceil",
+    "expected": "144547",
+    "overflow": false
+  },
+  {
+    "a": "46756878102757474334909",
+    "numerator": "34979948273446879218376017745402",
+    "denominator": "6491",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "46756878102757474334909",
+    "numerator": "34979948273446879218376017745402",
+    "denominator": "6491",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "87339413470512",
+    "numerator": "14548112396297",
+    "denominator": "3252437303655073751172088246",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "87339413470512",
+    "numerator": "14548112396297",
+    "denominator": "3252437303655073751172088246",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21520587166791",
+    "numerator": "95709242529541589469030960857356",
+    "denominator": "288625001232132333461909",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21520587166791",
+    "numerator": "95709242529541589469030960857356",
+    "denominator": "288625001232132333461909",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12816292337346476032480179005954010290",
+    "numerator": "30811955357284740799777054909536115",
+    "denominator": "4425782627002920",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12816292337346476032480179005954010290",
+    "numerator": "30811955357284740799777054909536115",
+    "denominator": "4425782627002920",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6879304033",
+    "numerator": "9368097854829294",
+    "denominator": "65229686408161983983327",
+    "rounding": "Floor",
+    "expected": "987",
+    "overflow": false
+  },
+  {
+    "a": "6879304033",
+    "numerator": "9368097854829294",
+    "denominator": "65229686408161983983327",
+    "rounding": "Ceil",
+    "expected": "988",
+    "overflow": false
+  },
+  {
+    "a": "5483523764257552331908",
+    "numerator": "31621309801325",
+    "denominator": "112310297444543619260133674860728447082",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5483523764257552331908",
+    "numerator": "31621309801325",
+    "denominator": "112310297444543619260133674860728447082",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "73650725038563689669434848643032715",
+    "numerator": "13508486231080055267199469495912274976",
+    "denominator": "181519849989346717805898681",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "73650725038563689669434848643032715",
+    "numerator": "13508486231080055267199469495912274976",
+    "denominator": "181519849989346717805898681",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "294",
+    "numerator": "147672096476361993784494711",
+    "denominator": "14067474893414409753289033038033165564",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "294",
+    "numerator": "147672096476361993784494711",
+    "denominator": "14067474893414409753289033038033165564",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "387586138832129268227841605",
+    "numerator": "399838439686039998568282734882",
+    "denominator": "3436455587",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "387586138832129268227841605",
+    "numerator": "399838439686039998568282734882",
+    "denominator": "3436455587",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3317703445979795308147480",
+    "numerator": "481873668904472069138193",
+    "denominator": "71176088390224990",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3317703445979795308147480",
+    "numerator": "481873668904472069138193",
+    "denominator": "71176088390224990",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "222316303",
+    "numerator": "1094062955124",
+    "denominator": "124456186570812599229203274052125",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "222316303",
+    "numerator": "1094062955124",
+    "denominator": "124456186570812599229203274052125",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1145574643249809411373072023258",
+    "numerator": "66617399179195",
+    "denominator": "257606565435592464",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1145574643249809411373072023258",
+    "numerator": "66617399179195",
+    "denominator": "257606565435592464",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10440501046121",
+    "numerator": "2289228575696227068834966",
+    "denominator": "167",
+    "rounding": "Floor",
+    "expected": "143117924187823626036432455088044711",
+    "overflow": false
+  },
+  {
+    "a": "10440501046121",
+    "numerator": "2289228575696227068834966",
+    "denominator": "167",
+    "rounding": "Ceil",
+    "expected": "143117924187823626036432455088044712",
+    "overflow": false
+  },
+  {
+    "a": "443785252076",
+    "numerator": "869744373",
+    "denominator": "1044225526162",
+    "rounding": "Floor",
+    "expected": "369632532",
+    "overflow": false
+  },
+  {
+    "a": "443785252076",
+    "numerator": "869744373",
+    "denominator": "1044225526162",
+    "rounding": "Ceil",
+    "expected": "369632533",
+    "overflow": false
+  },
+  {
+    "a": "467",
+    "numerator": "8",
+    "denominator": "2930125587741626554849473",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "467",
+    "numerator": "8",
+    "denominator": "2930125587741626554849473",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "22990",
+    "numerator": "435007",
+    "denominator": "38932157540",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "22990",
+    "numerator": "435007",
+    "denominator": "38932157540",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1118467521581030284564527092877829325",
+    "numerator": "16714",
+    "denominator": "9864526913554877675",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1118467521581030284564527092877829325",
+    "numerator": "16714",
+    "denominator": "9864526913554877675",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17580529797044460942381875118489114112",
+    "numerator": "724307737",
+    "denominator": "308351411799330693089451014",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17580529797044460942381875118489114112",
+    "numerator": "724307737",
+    "denominator": "308351411799330693089451014",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23727646092797557002473830287952118487",
+    "numerator": "55003414668169436",
+    "denominator": "3860205356840131943383973",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23727646092797557002473830287952118487",
+    "numerator": "55003414668169436",
+    "denominator": "3860205356840131943383973",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "555394552941938178",
+    "numerator": "85873056110470792331503507607113371907",
+    "denominator": "15640127468354465230569720",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "555394552941938178",
+    "numerator": "85873056110470792331503507607113371907",
+    "denominator": "15640127468354465230569720",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28273",
+    "numerator": "373270870283253642353470",
+    "denominator": "5690134233967",
+    "rounding": "Floor",
+    "expected": "1854699183108873",
+    "overflow": false
+  },
+  {
+    "a": "28273",
+    "numerator": "373270870283253642353470",
+    "denominator": "5690134233967",
+    "rounding": "Ceil",
+    "expected": "1854699183108874",
+    "overflow": false
+  },
+  {
+    "a": "40666606351519279352320354692396753492",
+    "numerator": "82421456599933",
+    "denominator": "19407240197853556907552880570",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "40666606351519279352320354692396753492",
+    "numerator": "82421456599933",
+    "denominator": "19407240197853556907552880570",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "217707032912596207753287124641307",
+    "numerator": "2205217008",
+    "denominator": "9556344603803932371621577",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "217707032912596207753287124641307",
+    "numerator": "2205217008",
+    "denominator": "9556344603803932371621577",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "790761912182",
+    "numerator": "1371703891152047617785529607",
+    "denominator": "305329629388",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "790761912182",
+    "numerator": "1371703891152047617785529607",
+    "denominator": "305329629388",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10690675691934454412014656859221",
+    "numerator": "3964141024882",
+    "denominator": "19",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10690675691934454412014656859221",
+    "numerator": "3964141024882",
+    "denominator": "19",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5459474993803342557896436516328",
+    "numerator": "1050035939361",
+    "denominator": "6995144439544108222773198568511426734",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5459474993803342557896436516328",
+    "numerator": "1050035939361",
+    "denominator": "6995144439544108222773198568511426734",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16856785470565631572141983",
+    "numerator": "0",
+    "denominator": "46637",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "16856785470565631572141983",
+    "numerator": "0",
+    "denominator": "46637",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5615630834783286413877802",
+    "numerator": "45149619019",
+    "denominator": "2299713764731529553456038345891808",
+    "rounding": "Floor",
+    "expected": "110",
+    "overflow": false
+  },
+  {
+    "a": "5615630834783286413877802",
+    "numerator": "45149619019",
+    "denominator": "2299713764731529553456038345891808",
+    "rounding": "Ceil",
+    "expected": "111",
+    "overflow": false
+  },
+  {
+    "a": "593054008139510677583020665",
+    "numerator": "222364064637450911017388483118822",
+    "denominator": "767536940825835163519799",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "593054008139510677583020665",
+    "numerator": "222364064637450911017388483118822",
+    "denominator": "767536940825835163519799",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "43886158609266044031816892",
+    "numerator": "210893061",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "4627643162319809494615322872693206",
+    "overflow": false
+  },
+  {
+    "a": "43886158609266044031816892",
+    "numerator": "210893061",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "4627643162319809494615322872693206",
+    "overflow": false
+  },
+  {
+    "a": "811010915",
+    "numerator": "8642662296606198867424607395544",
+    "denominator": "1489",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "811010915",
+    "numerator": "8642662296606198867424607395544",
+    "denominator": "1489",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "493796239801105439816104478",
+    "numerator": "18571008994389419112856103407567",
+    "denominator": "8837874151677974688165244942137908",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "493796239801105439816104478",
+    "numerator": "18571008994389419112856103407567",
+    "denominator": "8837874151677974688165244942137908",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "967190360867380535354184925",
+    "numerator": "38096952998415325888037018",
+    "denominator": "9078393857147",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "967190360867380535354184925",
+    "numerator": "38096952998415325888037018",
+    "denominator": "9078393857147",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "682741325436802261712",
+    "numerator": "3183854457732764201",
+    "denominator": "151374422",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "682741325436802261712",
+    "numerator": "3183854457732764201",
+    "denominator": "151374422",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1399630102702429013524504117810535",
+    "numerator": "13896256226827964814508",
+    "denominator": "12682637734423800245",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1399630102702429013524504117810535",
+    "numerator": "13896256226827964814508",
+    "denominator": "12682637734423800245",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3012429274529763898587406187367052114",
+    "numerator": "10859236754289759197385944723",
+    "denominator": "1854753736",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3012429274529763898587406187367052114",
+    "numerator": "10859236754289759197385944723",
+    "denominator": "1854753736",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39653611358081",
+    "numerator": "1749375981454",
+    "denominator": "604390308863",
+    "rounding": "Floor",
+    "expected": "114775293829972",
+    "overflow": false
+  },
+  {
+    "a": "39653611358081",
+    "numerator": "1749375981454",
+    "denominator": "604390308863",
+    "rounding": "Ceil",
+    "expected": "114775293829973",
+    "overflow": false
+  },
+  {
+    "a": "45161354055952632574297124",
+    "numerator": "9260587936504071706509",
+    "denominator": "11237643018",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "45161354055952632574297124",
+    "numerator": "9260587936504071706509",
+    "denominator": "11237643018",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5869128964062895785965772683733371307",
+    "numerator": "41720195875331308878272",
+    "denominator": "18150720985",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5869128964062895785965772683733371307",
+    "numerator": "41720195875331308878272",
+    "denominator": "18150720985",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29327030026694",
+    "numerator": "1743633117515051214878907852920071063",
+    "denominator": "824066517148",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29327030026694",
+    "numerator": "1743633117515051214878907852920071063",
+    "denominator": "824066517148",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11163908564974754147044274835067944549",
+    "numerator": "14238897484232216089356645403602943938",
+    "denominator": "398352914323760357703045879235",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11163908564974754147044274835067944549",
+    "numerator": "14238897484232216089356645403602943938",
+    "denominator": "398352914323760357703045879235",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "52408",
+    "numerator": "48297009082203653397286540553170225",
+    "denominator": "19787245822",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "52408",
+    "numerator": "48297009082203653397286540553170225",
+    "denominator": "19787245822",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66694786423122407110309162031",
+    "numerator": "82218344905770768194240366158356",
+    "denominator": "2024364137136176701",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66694786423122407110309162031",
+    "numerator": "82218344905770768194240366158356",
+    "denominator": "2024364137136176701",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "57552817092026505594",
+    "numerator": "1412494043",
+    "denominator": "24806461795094242480",
+    "rounding": "Floor",
+    "expected": "3277090137",
+    "overflow": false
+  },
+  {
+    "a": "57552817092026505594",
+    "numerator": "1412494043",
+    "denominator": "24806461795094242480",
+    "rounding": "Ceil",
+    "expected": "3277090138",
+    "overflow": false
+  },
+  {
+    "a": "3331081719024258477530505",
+    "numerator": "25473143195739921270264966454",
+    "denominator": "9844167",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3331081719024258477530505",
+    "numerator": "25473143195739921270264966454",
+    "denominator": "9844167",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "140",
+    "numerator": "4863765",
+    "denominator": "1471964341042348392498",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "140",
+    "numerator": "4863765",
+    "denominator": "1471964341042348392498",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1827668211",
+    "numerator": "157835688",
+    "denominator": "65156833",
+    "rounding": "Floor",
+    "expected": "4427337183",
+    "overflow": false
+  },
+  {
+    "a": "1827668211",
+    "numerator": "157835688",
+    "denominator": "65156833",
+    "rounding": "Ceil",
+    "expected": "4427337184",
+    "overflow": false
+  },
+  {
+    "a": "2168062692106025928544980905582",
+    "numerator": "2095548805400436831",
+    "denominator": "4",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2168062692106025928544980905582",
+    "numerator": "2095548805400436831",
+    "denominator": "4",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39422189",
+    "numerator": "8992742748657627468778",
+    "denominator": "2461595740714702765831921675",
+    "rounding": "Floor",
+    "expected": "144",
+    "overflow": false
+  },
+  {
+    "a": "39422189",
+    "numerator": "8992742748657627468778",
+    "denominator": "2461595740714702765831921675",
+    "rounding": "Ceil",
+    "expected": "145",
+    "overflow": false
+  },
+  {
+    "a": "20530026043659957860492443206706080",
+    "numerator": "273064867721762546964793",
+    "denominator": "1120254297654285325421005990",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20530026043659957860492443206706080",
+    "numerator": "273064867721762546964793",
+    "denominator": "1120254297654285325421005990",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2863091339038664878443511",
+    "numerator": "147470086773534948087450748",
+    "denominator": "5",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2863091339038664878443511",
+    "numerator": "147470086773534948087450748",
+    "denominator": "5",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1789733132474130570241261843618",
+    "numerator": "1630666612267313974488341557283",
+    "denominator": "172926888950041240",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1789733132474130570241261843618",
+    "numerator": "1630666612267313974488341557283",
+    "denominator": "172926888950041240",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17",
+    "numerator": "30",
+    "denominator": "159315892367",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "17",
+    "numerator": "30",
+    "denominator": "159315892367",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "149477876",
+    "numerator": "14621581306901502681853802397",
+    "denominator": "672346",
+    "rounding": "Floor",
+    "expected": "3250711564457795185948618902807",
+    "overflow": false
+  },
+  {
+    "a": "149477876",
+    "numerator": "14621581306901502681853802397",
+    "denominator": "672346",
+    "rounding": "Ceil",
+    "expected": "3250711564457795185948618902808",
+    "overflow": false
+  },
+  {
+    "a": "16486304601240821205045563",
+    "numerator": "189304833314173143988471862343312",
+    "denominator": "716716265",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16486304601240821205045563",
+    "numerator": "189304833314173143988471862343312",
+    "denominator": "716716265",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8214",
+    "numerator": "100469958183",
+    "denominator": "2617861528684",
+    "rounding": "Floor",
+    "expected": "315",
+    "overflow": false
+  },
+  {
+    "a": "8214",
+    "numerator": "100469958183",
+    "denominator": "2617861528684",
+    "rounding": "Ceil",
+    "expected": "316",
+    "overflow": false
+  },
+  {
+    "a": "32150088373236848369633874939760497781",
+    "numerator": "26002924918263991216857756245266",
+    "denominator": "181831041814339813702161117324115",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32150088373236848369633874939760497781",
+    "numerator": "26002924918263991216857756245266",
+    "denominator": "181831041814339813702161117324115",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1403999171826927496",
+    "numerator": "1077936425083785557569",
+    "denominator": "1008524435643471224559179086",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1403999171826927496",
+    "numerator": "1077936425083785557569",
+    "denominator": "1008524435643471224559179086",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70558312664498698439938626394133695",
+    "numerator": "4",
+    "denominator": "189611406932243641868158088301133",
+    "rounding": "Floor",
+    "expected": "1488",
+    "overflow": false
+  },
+  {
+    "a": "70558312664498698439938626394133695",
+    "numerator": "4",
+    "denominator": "189611406932243641868158088301133",
+    "rounding": "Ceil",
+    "expected": "1489",
+    "overflow": false
+  },
+  {
+    "a": "20527061159949686285255910602",
+    "numerator": "1532898609513931403633202841636849259",
+    "denominator": "268684880553457231813879727175872126336",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20527061159949686285255910602",
+    "numerator": "1532898609513931403633202841636849259",
+    "denominator": "268684880553457231813879727175872126336",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5442805940563140087417362372557946009",
+    "numerator": "7222621022274931616081798",
+    "denominator": "68425883872887895",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5442805940563140087417362372557946009",
+    "numerator": "7222621022274931616081798",
+    "denominator": "68425883872887895",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53748031513124429152348",
+    "numerator": "67438241168554277",
+    "denominator": "506242",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53748031513124429152348",
+    "numerator": "67438241168554277",
+    "denominator": "506242",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15860144069944551080286851",
+    "numerator": "101181993484887640610936",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15860144069944551080286851",
+    "numerator": "101181993484887640610936",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "304611276478",
+    "numerator": "45924249629898428667638682863",
+    "denominator": "4874708",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "304611276478",
+    "numerator": "45924249629898428667638682863",
+    "denominator": "4874708",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17009261149015991208098349309",
+    "numerator": "663329202948005930744634",
+    "denominator": "1947",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17009261149015991208098349309",
+    "numerator": "663329202948005930744634",
+    "denominator": "1947",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1066230107641968",
+    "numerator": "19503669235020621927312863004058697",
+    "denominator": "1273570942411510",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1066230107641968",
+    "numerator": "19503669235020621927312863004058697",
+    "denominator": "1273570942411510",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1793720034951",
+    "numerator": "63564",
+    "denominator": "32584060254028245",
+    "rounding": "Floor",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "1793720034951",
+    "numerator": "63564",
+    "denominator": "32584060254028245",
+    "rounding": "Ceil",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "2620371961285106",
+    "numerator": "666459393944241655148655062288717235",
+    "denominator": "19430679612963820371304",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2620371961285106",
+    "numerator": "666459393944241655148655062288717235",
+    "denominator": "19430679612963820371304",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33297258976798163559990281633",
+    "numerator": "90123123525457523454203579438",
+    "denominator": "4304650768816415",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33297258976798163559990281633",
+    "numerator": "90123123525457523454203579438",
+    "denominator": "4304650768816415",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7037892",
+    "numerator": "2778230527843857832877",
+    "denominator": "2030093834290602",
+    "rounding": "Floor",
+    "expected": "9631518541555",
+    "overflow": false
+  },
+  {
+    "a": "7037892",
+    "numerator": "2778230527843857832877",
+    "denominator": "2030093834290602",
+    "rounding": "Ceil",
+    "expected": "9631518541556",
+    "overflow": false
+  },
+  {
+    "a": "280427924431884108666830027",
+    "numerator": "825919608661856",
+    "denominator": "9273750262346821625",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "280427924431884108666830027",
+    "numerator": "825919608661856",
+    "denominator": "9273750262346821625",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1032999526",
+    "numerator": "3255",
+    "denominator": "253774094080077177720177724",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1032999526",
+    "numerator": "3255",
+    "denominator": "253774094080077177720177724",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "34",
+    "denominator": "240751843",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "34",
+    "denominator": "240751843",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "196297651800",
+    "numerator": "1967318991697",
+    "denominator": "1090403640988938669402181370041758",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "196297651800",
+    "numerator": "1967318991697",
+    "denominator": "1090403640988938669402181370041758",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "12820815",
+    "numerator": "1720429172855880116",
+    "denominator": "55901",
+    "rounding": "Floor",
+    "expected": "394577988690511093351",
+    "overflow": false
+  },
+  {
+    "a": "12820815",
+    "numerator": "1720429172855880116",
+    "denominator": "55901",
+    "rounding": "Ceil",
+    "expected": "394577988690511093352",
+    "overflow": false
+  },
+  {
+    "a": "3004539819721754",
+    "numerator": "3706797309221371387",
+    "denominator": "22323828428539152730705233492364511824",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3004539819721754",
+    "numerator": "3706797309221371387",
+    "denominator": "22323828428539152730705233492364511824",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "126138344567929789615989074604466089",
+    "numerator": "1062090198",
+    "denominator": "202523298218989045227970293475276519",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "126138344567929789615989074604466089",
+    "numerator": "1062090198",
+    "denominator": "202523298218989045227970293475276519",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1025909866422830078799130551340",
+    "numerator": "98770076755771189",
+    "denominator": "176370786977490",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1025909866422830078799130551340",
+    "numerator": "98770076755771189",
+    "denominator": "176370786977490",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "62444279827",
+    "numerator": "15233488882403395549551964347007468360",
+    "denominator": "73223738902232063467480321",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "62444279827",
+    "numerator": "15233488882403395549551964347007468360",
+    "denominator": "73223738902232063467480321",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "137007059849998",
+    "numerator": "11647",
+    "denominator": "4423854234222917432959908",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "137007059849998",
+    "numerator": "11647",
+    "denominator": "4423854234222917432959908",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "35192438029",
+    "numerator": "3672422026",
+    "denominator": "241554998059",
+    "rounding": "Floor",
+    "expected": "535039579",
+    "overflow": false
+  },
+  {
+    "a": "35192438029",
+    "numerator": "3672422026",
+    "denominator": "241554998059",
+    "rounding": "Ceil",
+    "expected": "535039580",
+    "overflow": false
+  },
+  {
+    "a": "143256629092000649380160",
+    "numerator": "117772119854419106926477488985",
+    "denominator": "30477638",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "143256629092000649380160",
+    "numerator": "117772119854419106926477488985",
+    "denominator": "30477638",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121675291084867540157965857531159",
+    "numerator": "242862497016420380",
+    "denominator": "95205",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121675291084867540157965857531159",
+    "numerator": "242862497016420380",
+    "denominator": "95205",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "283161770891409306434",
+    "numerator": "188227",
+    "denominator": "1080",
+    "rounding": "Floor",
+    "expected": "49350639490349351409400",
+    "overflow": false
+  },
+  {
+    "a": "283161770891409306434",
+    "numerator": "188227",
+    "denominator": "1080",
+    "rounding": "Ceil",
+    "expected": "49350639490349351409401",
+    "overflow": false
+  },
+  {
+    "a": "873762960309574639709982959299249",
+    "numerator": "2016167038",
+    "denominator": "977403081798845582814448702832047",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "873762960309574639709982959299249",
+    "numerator": "2016167038",
+    "denominator": "977403081798845582814448702832047",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "221588",
+    "numerator": "61",
+    "denominator": "433402",
+    "rounding": "Floor",
+    "expected": "31",
+    "overflow": false
+  },
+  {
+    "a": "221588",
+    "numerator": "61",
+    "denominator": "433402",
+    "rounding": "Ceil",
+    "expected": "32",
+    "overflow": false
+  },
+  {
+    "a": "50830983197819582232064430767590491",
+    "numerator": "1250474677743660041951065142610992",
+    "denominator": "2479542275388008903571729071270665",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "50830983197819582232064430767590491",
+    "numerator": "1250474677743660041951065142610992",
+    "denominator": "2479542275388008903571729071270665",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "182",
+    "numerator": "190598707632347898200020807",
+    "denominator": "134001014917493501640384524",
+    "rounding": "Floor",
+    "expected": "258",
+    "overflow": false
+  },
+  {
+    "a": "182",
+    "numerator": "190598707632347898200020807",
+    "denominator": "134001014917493501640384524",
+    "rounding": "Ceil",
+    "expected": "259",
+    "overflow": false
+  },
+  {
+    "a": "2336175958148254869",
+    "numerator": "7001010",
+    "denominator": "60019",
+    "rounding": "Floor",
+    "expected": "272506893562963625192",
+    "overflow": false
+  },
+  {
+    "a": "2336175958148254869",
+    "numerator": "7001010",
+    "denominator": "60019",
+    "rounding": "Ceil",
+    "expected": "272506893562963625193",
+    "overflow": false
+  },
+  {
+    "a": "4082116305353481115944",
+    "numerator": "5217",
+    "denominator": "74500273082977327481981839006617545198",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4082116305353481115944",
+    "numerator": "5217",
+    "denominator": "74500273082977327481981839006617545198",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2327256577731846836015583",
+    "numerator": "6017364868",
+    "denominator": "13198257567136920624060413912018541",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2327256577731846836015583",
+    "numerator": "6017364868",
+    "denominator": "13198257567136920624060413912018541",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "1693302005938026",
+    "numerator": "3927793734447134893632100747",
+    "denominator": "338720",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1693302005938026",
+    "numerator": "3927793734447134893632100747",
+    "denominator": "338720",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2565321144015579152238455849338553",
+    "numerator": "174488367019720550855503107299366",
+    "denominator": "1116319270991604969863872734312467831",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2565321144015579152238455849338553",
+    "numerator": "174488367019720550855503107299366",
+    "denominator": "1116319270991604969863872734312467831",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3517505192308081946709496953852",
+    "numerator": "5",
+    "denominator": "34",
+    "rounding": "Floor",
+    "expected": "517280175339423815692573081448",
+    "overflow": false
+  },
+  {
+    "a": "3517505192308081946709496953852",
+    "numerator": "5",
+    "denominator": "34",
+    "rounding": "Ceil",
+    "expected": "517280175339423815692573081449",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "205336",
+    "denominator": "17916522327564817",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "205336",
+    "denominator": "17916522327564817",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3156250728763424736094",
+    "numerator": "22194770103291953422025042626079247",
+    "denominator": "3137220224861526388",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3156250728763424736094",
+    "numerator": "22194770103291953422025042626079247",
+    "denominator": "3137220224861526388",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "108481145658906336163970333",
+    "numerator": "473463457242",
+    "denominator": "88839555843566267",
+    "rounding": "Floor",
+    "expected": "578141772339335528186",
+    "overflow": false
+  },
+  {
+    "a": "108481145658906336163970333",
+    "numerator": "473463457242",
+    "denominator": "88839555843566267",
+    "rounding": "Ceil",
+    "expected": "578141772339335528187",
+    "overflow": false
+  },
+  {
+    "a": "6343614731558416",
+    "numerator": "1325278316137",
+    "denominator": "16621587350",
+    "rounding": "Floor",
+    "expected": "505791346676742328",
+    "overflow": false
+  },
+  {
+    "a": "6343614731558416",
+    "numerator": "1325278316137",
+    "denominator": "16621587350",
+    "rounding": "Ceil",
+    "expected": "505791346676742329",
+    "overflow": false
+  },
+  {
+    "a": "6596439164492245607472769091495",
+    "numerator": "1809579163617267279014892",
+    "denominator": "1647483709941",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6596439164492245607472769091495",
+    "numerator": "1809579163617267279014892",
+    "denominator": "1647483709941",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58190789423250",
+    "numerator": "198623113295904332013292755",
+    "denominator": "459833096",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58190789423250",
+    "numerator": "198623113295904332013292755",
+    "denominator": "459833096",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13482597897153",
+    "numerator": "22942834298323518017742",
+    "denominator": "5472700935003080255",
+    "rounding": "Floor",
+    "expected": "56522184043870521",
+    "overflow": false
+  },
+  {
+    "a": "13482597897153",
+    "numerator": "22942834298323518017742",
+    "denominator": "5472700935003080255",
+    "rounding": "Ceil",
+    "expected": "56522184043870522",
+    "overflow": false
+  },
+  {
+    "a": "145644419832751474714651148013130596",
+    "numerator": "113864653",
+    "denominator": "22251594",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "145644419832751474714651148013130596",
+    "numerator": "113864653",
+    "denominator": "22251594",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2226792222235983668160082214649954283",
+    "numerator": "31933365085049100989720012032",
+    "denominator": "791365659077908359424338457",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2226792222235983668160082214649954283",
+    "numerator": "31933365085049100989720012032",
+    "denominator": "791365659077908359424338457",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4228925341005422144712706145609708294",
+    "numerator": "188990790639486423",
+    "denominator": "112909746296827868",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4228925341005422144712706145609708294",
+    "numerator": "188990790639486423",
+    "denominator": "112909746296827868",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1795549639981674149",
+    "numerator": "1423995083420724482",
+    "denominator": "828419",
+    "rounding": "Floor",
+    "expected": "3086425902075828645251721306284",
+    "overflow": false
+  },
+  {
+    "a": "1795549639981674149",
+    "numerator": "1423995083420724482",
+    "denominator": "828419",
+    "rounding": "Ceil",
+    "expected": "3086425902075828645251721306285",
+    "overflow": false
+  },
+  {
+    "a": "682861274070926858117560859470000120",
+    "numerator": "291870182228182158990698865",
+    "denominator": "8729843881793851966",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "682861274070926858117560859470000120",
+    "numerator": "291870182228182158990698865",
+    "denominator": "8729843881793851966",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "242673919599",
+    "numerator": "106836",
+    "denominator": "494709970006388332742791478314621",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "242673919599",
+    "numerator": "106836",
+    "denominator": "494709970006388332742791478314621",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "12820999623311331850681839060518715066",
+    "numerator": "4732758265610175961974457907124507",
+    "denominator": "69789715889069829203724769837793264",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12820999623311331850681839060518715066",
+    "numerator": "4732758265610175961974457907124507",
+    "denominator": "69789715889069829203724769837793264",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "276378825161",
+    "numerator": "11570460701380550777409142",
+    "denominator": "21708654864212267321351",
+    "rounding": "Floor",
+    "expected": "147306701185380",
+    "overflow": false
+  },
+  {
+    "a": "276378825161",
+    "numerator": "11570460701380550777409142",
+    "denominator": "21708654864212267321351",
+    "rounding": "Ceil",
+    "expected": "147306701185381",
+    "overflow": false
+  },
+  {
+    "a": "140604221291923404",
+    "numerator": "42053944283125589",
+    "denominator": "7616541367315762259642148871538",
+    "rounding": "Floor",
+    "expected": "776",
+    "overflow": false
+  },
+  {
+    "a": "140604221291923404",
+    "numerator": "42053944283125589",
+    "denominator": "7616541367315762259642148871538",
+    "rounding": "Ceil",
+    "expected": "777",
+    "overflow": false
+  },
+  {
+    "a": "6146342707",
+    "numerator": "4729991452911393207317736",
+    "denominator": "6120685413153",
+    "rounding": "Floor",
+    "expected": "4749819098413374579842",
+    "overflow": false
+  },
+  {
+    "a": "6146342707",
+    "numerator": "4729991452911393207317736",
+    "denominator": "6120685413153",
+    "rounding": "Ceil",
+    "expected": "4749819098413374579843",
+    "overflow": false
+  },
+  {
+    "a": "69156041214444947374",
+    "numerator": "69934474626452127",
+    "denominator": "13745161807027569509188",
+    "rounding": "Floor",
+    "expected": "351861366019332",
+    "overflow": false
+  },
+  {
+    "a": "69156041214444947374",
+    "numerator": "69934474626452127",
+    "denominator": "13745161807027569509188",
+    "rounding": "Ceil",
+    "expected": "351861366019333",
+    "overflow": false
+  },
+  {
+    "a": "160997203731459262552759997727021",
+    "numerator": "1219832064298",
+    "denominator": "467826251",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "160997203731459262552759997727021",
+    "numerator": "1219832064298",
+    "denominator": "467826251",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6981824609185667548737248",
+    "numerator": "112242373339189081513831406969",
+    "denominator": "705781481348582",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6981824609185667548737248",
+    "numerator": "112242373339189081513831406969",
+    "denominator": "705781481348582",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "82794777628096357273143",
+    "numerator": "1214325472792983942076",
+    "denominator": "89613259760645",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "82794777628096357273143",
+    "numerator": "1214325472792983942076",
+    "denominator": "89613259760645",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "42390835240547",
+    "denominator": "472",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "42390835240547",
+    "denominator": "472",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "175288539690137418506993873",
+    "numerator": "3898269537478029017564430451306782",
+    "denominator": "3997993562831",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "175288539690137418506993873",
+    "numerator": "3898269537478029017564430451306782",
+    "denominator": "3997993562831",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "26519410390015675462266703765469",
+    "denominator": "1619777113319759300506",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "26519410390015675462266703765469",
+    "denominator": "1619777113319759300506",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "200054896970282629011323",
+    "numerator": "188893508048",
+    "denominator": "524332329",
+    "rounding": "Floor",
+    "expected": "72070839810638288145656071",
+    "overflow": false
+  },
+  {
+    "a": "200054896970282629011323",
+    "numerator": "188893508048",
+    "denominator": "524332329",
+    "rounding": "Ceil",
+    "expected": "72070839810638288145656072",
+    "overflow": false
+  },
+  {
+    "a": "8534",
+    "numerator": "8041739236973434983",
+    "denominator": "186987436",
+    "rounding": "Floor",
+    "expected": "367020395147464",
+    "overflow": false
+  },
+  {
+    "a": "8534",
+    "numerator": "8041739236973434983",
+    "denominator": "186987436",
+    "rounding": "Ceil",
+    "expected": "367020395147465",
+    "overflow": false
+  },
+  {
+    "a": "41188618654901",
+    "numerator": "148527698",
+    "denominator": "2155607879694761743754779655680410003",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "41188618654901",
+    "numerator": "148527698",
+    "denominator": "2155607879694761743754779655680410003",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "100948613377489287880",
+    "numerator": "72818279521416538941354700713394817",
+    "denominator": "6020058206867086",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100948613377489287880",
+    "numerator": "72818279521416538941354700713394817",
+    "denominator": "6020058206867086",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3",
+    "numerator": "525092",
+    "denominator": "741230132444080304497293",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "525092",
+    "denominator": "741230132444080304497293",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "66803962963401226",
+    "numerator": "1211563",
+    "denominator": "18097397383454019389632",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "66803962963401226",
+    "numerator": "1211563",
+    "denominator": "18097397383454019389632",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "1655464153",
+    "numerator": "2917800134",
+    "denominator": "6504645422464918701033809874196702871",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1655464153",
+    "numerator": "2917800134",
+    "denominator": "6504645422464918701033809874196702871",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "984988",
+    "numerator": "883793209946985592494825731598693",
+    "denominator": "916448962",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "984988",
+    "numerator": "883793209946985592494825731598693",
+    "denominator": "916448962",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2243",
+    "numerator": "39549880",
+    "denominator": "14115749403338801",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2243",
+    "numerator": "39549880",
+    "denominator": "14115749403338801",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "885534035664445438",
+    "numerator": "389097377583",
+    "denominator": "63232543629588",
+    "rounding": "Floor",
+    "expected": "5449076555514354",
+    "overflow": false
+  },
+  {
+    "a": "885534035664445438",
+    "numerator": "389097377583",
+    "denominator": "63232543629588",
+    "rounding": "Ceil",
+    "expected": "5449076555514355",
+    "overflow": false
+  },
+  {
+    "a": "38947133",
+    "numerator": "194327970749685882",
+    "denominator": "1729510555850116048070107",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "38947133",
+    "numerator": "194327970749685882",
+    "denominator": "1729510555850116048070107",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "34523202968017282866109269448422320",
+    "numerator": "3520649",
+    "denominator": "1757520597485454909502658610230",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "34523202968017282866109269448422320",
+    "numerator": "3520649",
+    "denominator": "1757520597485454909502658610230",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "197486523369340937243449381108794095815",
+    "numerator": "319007301796624936844",
+    "denominator": "7174249002031436360803307008612033045",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "197486523369340937243449381108794095815",
+    "numerator": "319007301796624936844",
+    "denominator": "7174249002031436360803307008612033045",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1099130978001299250",
+    "numerator": "9108683406414916635375951130612388851",
+    "denominator": "2139361136808",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1099130978001299250",
+    "numerator": "9108683406414916635375951130612388851",
+    "denominator": "2139361136808",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "185410033145186040528368097",
+    "numerator": "1863631676484439948986441900687566190",
+    "denominator": "244105498630608939498756317104603999",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "185410033145186040528368097",
+    "numerator": "1863631676484439948986441900687566190",
+    "denominator": "244105498630608939498756317104603999",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2566609788673594116",
+    "numerator": "74795493613124546155501",
+    "denominator": "296372183836646122",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2566609788673594116",
+    "numerator": "74795493613124546155501",
+    "denominator": "296372183836646122",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "235505234782444604950680331",
+    "numerator": "18717930144",
+    "denominator": "3860557371116888439956419641",
+    "rounding": "Floor",
+    "expected": "1141848212",
+    "overflow": false
+  },
+  {
+    "a": "235505234782444604950680331",
+    "numerator": "18717930144",
+    "denominator": "3860557371116888439956419641",
+    "rounding": "Ceil",
+    "expected": "1141848213",
+    "overflow": false
+  },
+  {
+    "a": "934",
+    "numerator": "154711170716552339683371042579489967863",
+    "denominator": "6743042940",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "934",
+    "numerator": "154711170716552339683371042579489967863",
+    "denominator": "6743042940",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14690021520670417059980508869",
+    "numerator": "54863095578810217475886949890333602",
+    "denominator": "26642752256924506735395",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14690021520670417059980508869",
+    "numerator": "54863095578810217475886949890333602",
+    "denominator": "26642752256924506735395",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "454618003864",
+    "numerator": "22671555342344710413987704409775759249",
+    "denominator": "36491423924982760270682780507870",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "454618003864",
+    "numerator": "22671555342344710413987704409775759249",
+    "denominator": "36491423924982760270682780507870",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53140725564037686442895",
+    "numerator": "141935747150234916584394611349748",
+    "denominator": "34356139983096260936349",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "53140725564037686442895",
+    "numerator": "141935747150234916584394611349748",
+    "denominator": "34356139983096260936349",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "346",
+    "numerator": "1083",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "374718",
+    "overflow": false
+  },
+  {
+    "a": "346",
+    "numerator": "1083",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "374718",
+    "overflow": false
+  },
+  {
+    "a": "83375020070228969",
+    "numerator": "624761459521302",
+    "denominator": "129747128742903816980309017209127",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "83375020070228969",
+    "numerator": "624761459521302",
+    "denominator": "129747128742903816980309017209127",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "31596",
+    "numerator": "32629",
+    "denominator": "30671120334767122",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "31596",
+    "numerator": "32629",
+    "denominator": "30671120334767122",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2735720631662085469779",
+    "numerator": "50424196794925374966740616",
+    "denominator": "11736778905872899757618140148033",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2735720631662085469779",
+    "numerator": "50424196794925374966740616",
+    "denominator": "11736778905872899757618140148033",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3662113769303174871992656312241230",
+    "numerator": "2487710429199413330262175774655",
+    "denominator": "5301107518048020108585071782359780",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3662113769303174871992656312241230",
+    "numerator": "2487710429199413330262175774655",
+    "denominator": "5301107518048020108585071782359780",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "115022092196026455373",
+    "numerator": "319316224970",
+    "denominator": "139097203139393899",
+    "rounding": "Floor",
+    "expected": "264048589326269",
+    "overflow": false
+  },
+  {
+    "a": "115022092196026455373",
+    "numerator": "319316224970",
+    "denominator": "139097203139393899",
+    "rounding": "Ceil",
+    "expected": "264048589326270",
+    "overflow": false
+  },
+  {
+    "a": "36501629391972772992",
+    "numerator": "104345",
+    "denominator": "23428742",
+    "rounding": "Floor",
+    "expected": "162567948330533453",
+    "overflow": false
+  },
+  {
+    "a": "36501629391972772992",
+    "numerator": "104345",
+    "denominator": "23428742",
+    "rounding": "Ceil",
+    "expected": "162567948330533454",
+    "overflow": false
+  },
+  {
+    "a": "2737848228013148221812963040942327639",
+    "numerator": "589607265932705138001546069385052",
+    "denominator": "38484392836653835668981275976741",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2737848228013148221812963040942327639",
+    "numerator": "589607265932705138001546069385052",
+    "denominator": "38484392836653835668981275976741",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2",
+    "numerator": "37339867976316048701609455971715",
+    "denominator": "251356382779855234613039155064",
+    "rounding": "Floor",
+    "expected": "297",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "37339867976316048701609455971715",
+    "denominator": "251356382779855234613039155064",
+    "rounding": "Ceil",
+    "expected": "298",
+    "overflow": false
+  },
+  {
+    "a": "1048676135372793829923311232753",
+    "numerator": "30",
+    "denominator": "62892556587744204996440126773095020527",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1048676135372793829923311232753",
+    "numerator": "30",
+    "denominator": "62892556587744204996440126773095020527",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4675443398449354601677968799065563348",
+    "numerator": "86221675602374663758400509",
+    "denominator": "13320974811113617091575631205974586",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4675443398449354601677968799065563348",
+    "numerator": "86221675602374663758400509",
+    "denominator": "13320974811113617091575631205974586",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "775731407935894171",
+    "numerator": "34401170790179732276717217648",
+    "denominator": "201293641",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "775731407935894171",
+    "numerator": "34401170790179732276717217648",
+    "denominator": "201293641",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "953893414777633270",
+    "numerator": "4636010887",
+    "denominator": "113542254630732",
+    "rounding": "Floor",
+    "expected": "38948145519296",
+    "overflow": false
+  },
+  {
+    "a": "953893414777633270",
+    "numerator": "4636010887",
+    "denominator": "113542254630732",
+    "rounding": "Ceil",
+    "expected": "38948145519297",
+    "overflow": false
+  },
+  {
+    "a": "165522645",
+    "numerator": "2",
+    "denominator": "16316316823119619696819",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "165522645",
+    "numerator": "2",
+    "denominator": "16316316823119619696819",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "17335606294962999330378374999144",
+    "numerator": "4079440143634416507715745",
+    "denominator": "46",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17335606294962999330378374999144",
+    "numerator": "4079440143634416507715745",
+    "denominator": "46",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "197747225361439",
+    "numerator": "121714753486077151503781016642244",
+    "denominator": "173",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "197747225361439",
+    "numerator": "121714753486077151503781016642244",
+    "denominator": "173",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "736777772327126617258",
+    "numerator": "1745417014948574849821056359526347",
+    "denominator": "7927525551668847551145133037762144",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "736777772327126617258",
+    "numerator": "1745417014948574849821056359526347",
+    "denominator": "7927525551668847551145133037762144",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7680657885727996462244694777",
+    "numerator": "493709617510",
+    "denominator": "2279287604391752442454870481555383",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7680657885727996462244694777",
+    "numerator": "493709617510",
+    "denominator": "2279287604391752442454870481555383",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28953796337046250300",
+    "numerator": "2166644162590210873514373",
+    "denominator": "142965437624743266",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28953796337046250300",
+    "numerator": "2166644162590210873514373",
+    "denominator": "142965437624743266",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12076951271725466905585635",
+    "numerator": "1529342306470625323413945326959240536",
+    "denominator": "6701539976012732021579742801",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12076951271725466905585635",
+    "numerator": "1529342306470625323413945326959240536",
+    "denominator": "6701539976012732021579742801",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1369105592672866395294878",
+    "numerator": "3065881133967623247",
+    "denominator": "27313571718064692755626894899380",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1369105592672866395294878",
+    "numerator": "3065881133967623247",
+    "denominator": "27313571718064692755626894899380",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "292142839192079999277487692834141",
+    "numerator": "112131171382707524592360785611546",
+    "denominator": "3911931",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "292142839192079999277487692834141",
+    "numerator": "112131171382707524592360785611546",
+    "denominator": "3911931",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5217786192",
+    "numerator": "29364400536435369",
+    "denominator": "28398754328844766153942",
+    "rounding": "Floor",
+    "expected": "5395",
+    "overflow": false
+  },
+  {
+    "a": "5217786192",
+    "numerator": "29364400536435369",
+    "denominator": "28398754328844766153942",
+    "rounding": "Ceil",
+    "expected": "5396",
+    "overflow": false
+  },
+  {
+    "a": "117633202663",
+    "numerator": "25668163524067946588865324",
+    "denominator": "20049020462853856520757",
+    "rounding": "Floor",
+    "expected": "150602284406263",
+    "overflow": false
+  },
+  {
+    "a": "117633202663",
+    "numerator": "25668163524067946588865324",
+    "denominator": "20049020462853856520757",
+    "rounding": "Ceil",
+    "expected": "150602284406264",
+    "overflow": false
+  },
+  {
+    "a": "466",
+    "numerator": "1504492932266927783522533293976339",
+    "denominator": "1026040325282398746731016776",
+    "rounding": "Floor",
+    "expected": "683300343",
+    "overflow": false
+  },
+  {
+    "a": "466",
+    "numerator": "1504492932266927783522533293976339",
+    "denominator": "1026040325282398746731016776",
+    "rounding": "Ceil",
+    "expected": "683300344",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "6683609614",
+    "denominator": "16504000639",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "6683609614",
+    "denominator": "16504000639",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7173579428",
+    "numerator": "2179950147039573395469",
+    "denominator": "32138",
+    "rounding": "Floor",
+    "expected": "486590501240545734383985525",
+    "overflow": false
+  },
+  {
+    "a": "7173579428",
+    "numerator": "2179950147039573395469",
+    "denominator": "32138",
+    "rounding": "Ceil",
+    "expected": "486590501240545734383985526",
+    "overflow": false
+  },
+  {
+    "a": "13846001195",
+    "numerator": "1076913437365360129642749781676096",
+    "denominator": "314781877905287262593679953497",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13846001195",
+    "numerator": "1076913437365360129642749781676096",
+    "denominator": "314781877905287262593679953497",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5671133997087028421702",
+    "numerator": "4196384271902743",
+    "denominator": "12610533148",
+    "rounding": "Floor",
+    "expected": "1887172987051962063871699768",
+    "overflow": false
+  },
+  {
+    "a": "5671133997087028421702",
+    "numerator": "4196384271902743",
+    "denominator": "12610533148",
+    "rounding": "Ceil",
+    "expected": "1887172987051962063871699769",
+    "overflow": false
+  },
+  {
+    "a": "944492322462009278784772774026403557",
+    "numerator": "59609679387579760089666",
+    "denominator": "106901482521670643915387459",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "944492322462009278784772774026403557",
+    "numerator": "59609679387579760089666",
+    "denominator": "106901482521670643915387459",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1010048572609336",
+    "numerator": "18234243090074717008053331377",
+    "denominator": "3640820038526",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1010048572609336",
+    "numerator": "18234243090074717008053331377",
+    "denominator": "3640820038526",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6615446100275610637885615",
+    "numerator": "224186567915184316997780",
+    "denominator": "20160581123737618591624198852285",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6615446100275610637885615",
+    "numerator": "224186567915184316997780",
+    "denominator": "20160581123737618591624198852285",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "88019547660744486136747959290",
+    "numerator": "881885019",
+    "denominator": "4637467170169209890642736",
+    "rounding": "Floor",
+    "expected": "16738257676621",
+    "overflow": false
+  },
+  {
+    "a": "88019547660744486136747959290",
+    "numerator": "881885019",
+    "denominator": "4637467170169209890642736",
+    "rounding": "Ceil",
+    "expected": "16738257676622",
+    "overflow": false
+  },
+  {
+    "a": "137667324727756297",
+    "numerator": "67794425607287657718155441090486",
+    "denominator": "2228224316855712384981575",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "137667324727756297",
+    "numerator": "67794425607287657718155441090486",
+    "denominator": "2228224316855712384981575",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12",
+    "numerator": "11245007320981",
+    "denominator": "93462364715698",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "12",
+    "numerator": "11245007320981",
+    "denominator": "93462364715698",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "114035",
+    "numerator": "39242563512551464",
+    "denominator": "10571617",
+    "rounding": "Floor",
+    "expected": "423305699606200",
+    "overflow": false
+  },
+  {
+    "a": "114035",
+    "numerator": "39242563512551464",
+    "denominator": "10571617",
+    "rounding": "Ceil",
+    "expected": "423305699606201",
+    "overflow": false
+  },
+  {
+    "a": "1268787763273718429991316997775598",
+    "numerator": "46358792930724013998272214643935",
+    "denominator": "902740656878144021033604",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1268787763273718429991316997775598",
+    "numerator": "46358792930724013998272214643935",
+    "denominator": "902740656878144021033604",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32961189333760998168224053613",
+    "numerator": "618",
+    "denominator": "2245461565225340043",
+    "rounding": "Floor",
+    "expected": "9071638242990",
+    "overflow": false
+  },
+  {
+    "a": "32961189333760998168224053613",
+    "numerator": "618",
+    "denominator": "2245461565225340043",
+    "rounding": "Ceil",
+    "expected": "9071638242991",
+    "overflow": false
+  },
+  {
+    "a": "56077957664",
+    "numerator": "76583832149996614964168816480358408633",
+    "denominator": "6",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "56077957664",
+    "numerator": "76583832149996614964168816480358408633",
+    "denominator": "6",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "60322683999785079",
+    "numerator": "18854447291866438396",
+    "denominator": "14741239215638115397",
+    "rounding": "Floor",
+    "expected": "77154359232656230",
+    "overflow": false
+  },
+  {
+    "a": "60322683999785079",
+    "numerator": "18854447291866438396",
+    "denominator": "14741239215638115397",
+    "rounding": "Ceil",
+    "expected": "77154359232656231",
+    "overflow": false
+  },
+  {
+    "a": "5431027340680498978",
+    "numerator": "19025059",
+    "denominator": "2605618457567596269848",
+    "rounding": "Floor",
+    "expected": "39654",
+    "overflow": false
+  },
+  {
+    "a": "5431027340680498978",
+    "numerator": "19025059",
+    "denominator": "2605618457567596269848",
+    "rounding": "Ceil",
+    "expected": "39655",
+    "overflow": false
+  },
+  {
+    "a": "39655570765158148057129292173509516561",
+    "numerator": "545226159544253022",
+    "denominator": "488869135",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39655570765158148057129292173509516561",
+    "numerator": "545226159544253022",
+    "denominator": "488869135",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5095623747361147867550226465298438260",
+    "numerator": "124307485",
+    "denominator": "6710883986550263002",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5095623747361147867550226465298438260",
+    "numerator": "124307485",
+    "denominator": "6710883986550263002",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29516661455092545583556454285598139",
+    "numerator": "374908697483799497028663473849003280",
+    "denominator": "21159796795988457061441897",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29516661455092545583556454285598139",
+    "numerator": "374908697483799497028663473849003280",
+    "denominator": "21159796795988457061441897",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "662",
+    "numerator": "1050875956711814793895",
+    "denominator": "35515477145530190572",
+    "rounding": "Floor",
+    "expected": "19588",
+    "overflow": false
+  },
+  {
+    "a": "662",
+    "numerator": "1050875956711814793895",
+    "denominator": "35515477145530190572",
+    "rounding": "Ceil",
+    "expected": "19589",
+    "overflow": false
+  },
+  {
+    "a": "698290426824201461",
+    "numerator": "8447507388306",
+    "denominator": "3366187027939188081314620133441806291",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "698290426824201461",
+    "numerator": "8447507388306",
+    "denominator": "3366187027939188081314620133441806291",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3096968136551944",
+    "numerator": "11703141243740596178625",
+    "denominator": "54709553948630124899308969567083120590",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3096968136551944",
+    "numerator": "11703141243740596178625",
+    "denominator": "54709553948630124899308969567083120590",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "184183103",
+    "numerator": "295934349115254302755394148",
+    "denominator": "1005525658649979370189",
+    "rounding": "Floor",
+    "expected": "54206579648611",
+    "overflow": false
+  },
+  {
+    "a": "184183103",
+    "numerator": "295934349115254302755394148",
+    "denominator": "1005525658649979370189",
+    "rounding": "Ceil",
+    "expected": "54206579648612",
+    "overflow": false
+  },
+  {
+    "a": "10",
+    "numerator": "24903631158423429491651307",
+    "denominator": "10207671296",
+    "rounding": "Floor",
+    "expected": "24396975996065057",
+    "overflow": false
+  },
+  {
+    "a": "10",
+    "numerator": "24903631158423429491651307",
+    "denominator": "10207671296",
+    "rounding": "Ceil",
+    "expected": "24396975996065058",
+    "overflow": false
+  },
+  {
+    "a": "1305",
+    "numerator": "518",
+    "denominator": "854231",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1305",
+    "numerator": "518",
+    "denominator": "854231",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8796537862882629559899921336798940",
+    "numerator": "104869",
+    "denominator": "8535170438146",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8796537862882629559899921336798940",
+    "numerator": "104869",
+    "denominator": "8535170438146",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3666622733084939775577079822083",
+    "numerator": "40696",
+    "denominator": "61695089",
+    "rounding": "Floor",
+    "expected": "2418618421080885532183685486",
+    "overflow": false
+  },
+  {
+    "a": "3666622733084939775577079822083",
+    "numerator": "40696",
+    "denominator": "61695089",
+    "rounding": "Ceil",
+    "expected": "2418618421080885532183685487",
+    "overflow": false
+  },
+  {
+    "a": "318",
+    "numerator": "36001230497986020357282831728265583",
+    "denominator": "8276",
+    "rounding": "Floor",
+    "expected": "1383324226481338143259538483517213",
+    "overflow": false
+  },
+  {
+    "a": "318",
+    "numerator": "36001230497986020357282831728265583",
+    "denominator": "8276",
+    "rounding": "Ceil",
+    "expected": "1383324226481338143259538483517214",
+    "overflow": false
+  },
+  {
+    "a": "100670435099538192684936318129901949",
+    "numerator": "17429987280314",
+    "denominator": "45310794862447532182920414947396635",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100670435099538192684936318129901949",
+    "numerator": "17429987280314",
+    "denominator": "45310794862447532182920414947396635",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3824",
+    "numerator": "26906309664130026121306330746057",
+    "denominator": "68479688546057878025790838",
+    "rounding": "Floor",
+    "expected": "1502485340",
+    "overflow": false
+  },
+  {
+    "a": "3824",
+    "numerator": "26906309664130026121306330746057",
+    "denominator": "68479688546057878025790838",
+    "rounding": "Ceil",
+    "expected": "1502485341",
+    "overflow": false
+  },
+  {
+    "a": "779774139464731479759227655",
+    "numerator": "1579849980909601960114156141829727948",
+    "denominator": "85",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "779774139464731479759227655",
+    "numerator": "1579849980909601960114156141829727948",
+    "denominator": "85",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7375491359784201946226",
+    "numerator": "10613188276635800115",
+    "denominator": "204987799078868649864446779038655464",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7375491359784201946226",
+    "numerator": "10613188276635800115",
+    "denominator": "204987799078868649864446779038655464",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33",
+    "numerator": "12414616160573374126",
+    "denominator": "304388051360506326431",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "33",
+    "numerator": "12414616160573374126",
+    "denominator": "304388051360506326431",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "4",
+    "numerator": "287096654893",
+    "denominator": "203798364033586142277674",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4",
+    "numerator": "287096654893",
+    "denominator": "203798364033586142277674",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "907050248523",
+    "numerator": "8332639712",
+    "denominator": "89173835020366008964698962041",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "907050248523",
+    "numerator": "8332639712",
+    "denominator": "89173835020366008964698962041",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4593073226456151270",
+    "numerator": "559130710075976927353475383",
+    "denominator": "15381528177074542219964",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4593073226456151270",
+    "numerator": "559130710075976927353475383",
+    "denominator": "15381528177074542219964",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4495088170066104069",
+    "numerator": "4367038069749322545474244667618",
+    "denominator": "9293753683194122673098010979",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4495088170066104069",
+    "numerator": "4367038069749322545474244667618",
+    "denominator": "9293753683194122673098010979",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7384",
+    "numerator": "297041261478068266005061008337",
+    "denominator": "1425755261021347149627500574",
+    "rounding": "Floor",
+    "expected": "1538379",
+    "overflow": false
+  },
+  {
+    "a": "7384",
+    "numerator": "297041261478068266005061008337",
+    "denominator": "1425755261021347149627500574",
+    "rounding": "Ceil",
+    "expected": "1538380",
+    "overflow": false
+  },
+  {
+    "a": "71119",
+    "numerator": "52",
+    "denominator": "84087007965",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "71119",
+    "numerator": "52",
+    "denominator": "84087007965",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "11561606199706045859032714906",
+    "numerator": "6668691313871483",
+    "denominator": "58261712",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11561606199706045859032714906",
+    "numerator": "6668691313871483",
+    "denominator": "58261712",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29894982499928621844580393",
+    "numerator": "8214895574480982",
+    "denominator": "86515522407",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29894982499928621844580393",
+    "numerator": "8214895574480982",
+    "denominator": "86515522407",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17962093269078700",
+    "numerator": "17115252752738410711709908917",
+    "denominator": "4426963523119756575058",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17962093269078700",
+    "numerator": "17115252752738410711709908917",
+    "denominator": "4426963523119756575058",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "303421509071279251",
+    "numerator": "16552695179720",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "5022443750627532311921751989720",
+    "overflow": false
+  },
+  {
+    "a": "303421509071279251",
+    "numerator": "16552695179720",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "5022443750627532311921751989720",
+    "overflow": false
+  },
+  {
+    "a": "1075589516459389552785535183488398",
+    "numerator": "684075854602856788043649680015871",
+    "denominator": "4493054444185517465656443428",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1075589516459389552785535183488398",
+    "numerator": "684075854602856788043649680015871",
+    "denominator": "4493054444185517465656443428",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "239365517",
+    "numerator": "507792925758287229378826",
+    "denominator": "418898929568625352978263979",
+    "rounding": "Floor",
+    "expected": "290160",
+    "overflow": false
+  },
+  {
+    "a": "239365517",
+    "numerator": "507792925758287229378826",
+    "denominator": "418898929568625352978263979",
+    "rounding": "Ceil",
+    "expected": "290161",
+    "overflow": false
+  },
+  {
+    "a": "17924327709185984",
+    "numerator": "3672527827890807813111803757378521",
+    "denominator": "436632884807715640617608505099235270",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17924327709185984",
+    "numerator": "3672527827890807813111803757378521",
+    "denominator": "436632884807715640617608505099235270",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1928243739482820716951",
+    "numerator": "27322012",
+    "denominator": "851565165608746325093",
+    "rounding": "Floor",
+    "expected": "61866667",
+    "overflow": false
+  },
+  {
+    "a": "1928243739482820716951",
+    "numerator": "27322012",
+    "denominator": "851565165608746325093",
+    "rounding": "Ceil",
+    "expected": "61866668",
+    "overflow": false
+  },
+  {
+    "a": "4181866271099182913633716179324354",
+    "numerator": "6456056356778884035",
+    "denominator": "906809420950200",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4181866271099182913633716179324354",
+    "numerator": "6456056356778884035",
+    "denominator": "906809420950200",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47518458673",
+    "numerator": "136990117751512072356544829182",
+    "denominator": "117521395298955089876178836124207",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47518458673",
+    "numerator": "136990117751512072356544829182",
+    "denominator": "117521395298955089876178836124207",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4604377787877486993428",
+    "numerator": "757383126216360057145332192317",
+    "denominator": "47785850",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4604377787877486993428",
+    "numerator": "757383126216360057145332192317",
+    "denominator": "47785850",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "364741781090180581710043",
+    "numerator": "436730241966516377715459990819095216",
+    "denominator": "677109028882519858762633",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "364741781090180581710043",
+    "numerator": "436730241966516377715459990819095216",
+    "denominator": "677109028882519858762633",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "206773005007077149339736886",
+    "numerator": "485014471",
+    "denominator": "24978548264029836",
+    "rounding": "Floor",
+    "expected": "4014961101042316542",
+    "overflow": false
+  },
+  {
+    "a": "206773005007077149339736886",
+    "numerator": "485014471",
+    "denominator": "24978548264029836",
+    "rounding": "Ceil",
+    "expected": "4014961101042316543",
+    "overflow": false
+  },
+  {
+    "a": "254510138548544580723641621",
+    "numerator": "2",
+    "denominator": "33711576292999919183701747",
+    "rounding": "Floor",
+    "expected": "15",
+    "overflow": false
+  },
+  {
+    "a": "254510138548544580723641621",
+    "numerator": "2",
+    "denominator": "33711576292999919183701747",
+    "rounding": "Ceil",
+    "expected": "16",
+    "overflow": false
+  },
+  {
+    "a": "278440",
+    "numerator": "225",
+    "denominator": "72814",
+    "rounding": "Floor",
+    "expected": "860",
+    "overflow": false
+  },
+  {
+    "a": "278440",
+    "numerator": "225",
+    "denominator": "72814",
+    "rounding": "Ceil",
+    "expected": "861",
+    "overflow": false
+  },
+  {
+    "a": "6815868371952283372086879",
+    "numerator": "6550943532845529668743473030091268",
+    "denominator": "1882791661",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6815868371952283372086879",
+    "numerator": "6550943532845529668743473030091268",
+    "denominator": "1882791661",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16713077886399335868583322090",
+    "numerator": "196811700602379",
+    "denominator": "40367073016642088689200759200",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16713077886399335868583322090",
+    "numerator": "196811700602379",
+    "denominator": "40367073016642088689200759200",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36948553462433154764601",
+    "numerator": "27970594383119525970370958678522534",
+    "denominator": "719439516586487",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36948553462433154764601",
+    "numerator": "27970594383119525970370958678522534",
+    "denominator": "719439516586487",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "636",
+    "numerator": "16772336935209984524076924435918940613",
+    "denominator": "607559755022716218615182390723234",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "636",
+    "numerator": "16772336935209984524076924435918940613",
+    "denominator": "607559755022716218615182390723234",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "566557592499493157716850007932425763",
+    "numerator": "47476059120973688432792",
+    "denominator": "20157458567879313",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "566557592499493157716850007932425763",
+    "numerator": "47476059120973688432792",
+    "denominator": "20157458567879313",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4445662",
+    "numerator": "450191",
+    "denominator": "2138496235912466134598532650996",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4445662",
+    "numerator": "450191",
+    "denominator": "2138496235912466134598532650996",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1195986333",
+    "numerator": "741466",
+    "denominator": "707165243554165975189143582523",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1195986333",
+    "numerator": "741466",
+    "denominator": "707165243554165975189143582523",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "986477064649957351019664",
+    "numerator": "478820462174158177940519942254313",
+    "denominator": "3896728989509766431093335000908303894",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "986477064649957351019664",
+    "numerator": "478820462174158177940519942254313",
+    "denominator": "3896728989509766431093335000908303894",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "295577912531454918142113317847244303399",
+    "numerator": "6764",
+    "denominator": "4819462227426666328843279621991029",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "295577912531454918142113317847244303399",
+    "numerator": "6764",
+    "denominator": "4819462227426666328843279621991029",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24936511033895698",
+    "numerator": "1505180234200402259",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "37533943518140041790004455449581782",
+    "overflow": false
+  },
+  {
+    "a": "24936511033895698",
+    "numerator": "1505180234200402259",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "37533943518140041790004455449581782",
+    "overflow": false
+  },
+  {
+    "a": "8075651061851198766955119389761",
+    "numerator": "14",
+    "denominator": "121535",
+    "rounding": "Floor",
+    "expected": "930259718319140846154372579",
+    "overflow": false
+  },
+  {
+    "a": "8075651061851198766955119389761",
+    "numerator": "14",
+    "denominator": "121535",
+    "rounding": "Ceil",
+    "expected": "930259718319140846154372580",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "175023943675385065349306212429",
+    "denominator": "133549655173202881589962",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "175023943675385065349306212429",
+    "denominator": "133549655173202881589962",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4133839193451627",
+    "numerator": "1163648117274384997452007586688",
+    "denominator": "628945561",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4133839193451627",
+    "numerator": "1163648117274384997452007586688",
+    "denominator": "628945561",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "599385352934790",
+    "numerator": "12954766641751",
+    "denominator": "28",
+    "rounding": "Floor",
+    "expected": "277317763419777405014086331",
+    "overflow": false
+  },
+  {
+    "a": "599385352934790",
+    "numerator": "12954766641751",
+    "denominator": "28",
+    "rounding": "Ceil",
+    "expected": "277317763419777405014086332",
+    "overflow": false
+  },
+  {
+    "a": "17207757323607144797101118350151461",
+    "numerator": "13575314468278342944642",
+    "denominator": "127263604867",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17207757323607144797101118350151461",
+    "numerator": "13575314468278342944642",
+    "denominator": "127263604867",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "632",
+    "numerator": "812334437785552422431378108916209",
+    "denominator": "69128582430054456518419646",
+    "rounding": "Floor",
+    "expected": "7426672826",
+    "overflow": false
+  },
+  {
+    "a": "632",
+    "numerator": "812334437785552422431378108916209",
+    "denominator": "69128582430054456518419646",
+    "rounding": "Ceil",
+    "expected": "7426672827",
+    "overflow": false
+  },
+  {
+    "a": "6819930336778991",
+    "numerator": "12935124",
+    "denominator": "1101015613877257801848573",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "6819930336778991",
+    "numerator": "12935124",
+    "denominator": "1101015613877257801848573",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "7220480241967324457244819826075",
+    "denominator": "4352171650922096",
+    "rounding": "Floor",
+    "expected": "3318104533141526",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "7220480241967324457244819826075",
+    "denominator": "4352171650922096",
+    "rounding": "Ceil",
+    "expected": "3318104533141527",
+    "overflow": false
+  },
+  {
+    "a": "54248310076190038601",
+    "numerator": "58364083393052086518",
+    "denominator": "1832745184391",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "54248310076190038601",
+    "numerator": "58364083393052086518",
+    "denominator": "1832745184391",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1612",
+    "numerator": "569536400104615270357",
+    "denominator": "30564239913693992946",
+    "rounding": "Floor",
+    "expected": "30038",
+    "overflow": false
+  },
+  {
+    "a": "1612",
+    "numerator": "569536400104615270357",
+    "denominator": "30564239913693992946",
+    "rounding": "Ceil",
+    "expected": "30039",
+    "overflow": false
+  },
+  {
+    "a": "36883840031777504893074355",
+    "numerator": "2102898675805273923443055464",
+    "denominator": "1102525721635041707390973983649",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36883840031777504893074355",
+    "numerator": "2102898675805273923443055464",
+    "denominator": "1102525721635041707390973983649",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "196723313785390",
+    "numerator": "120619560579489567",
+    "denominator": "2064121940891564303837709886087620",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "196723313785390",
+    "numerator": "120619560579489567",
+    "denominator": "2064121940891564303837709886087620",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "42",
+    "denominator": "715",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "42",
+    "denominator": "715",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "263006669701268600417521695534237024",
+    "numerator": "13473801721",
+    "denominator": "19365990",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "263006669701268600417521695534237024",
+    "numerator": "13473801721",
+    "denominator": "19365990",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "67204758128773849641684763766630011575",
+    "numerator": "41560389144689809226678844",
+    "denominator": "631539477992251088589288834221189",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "67204758128773849641684763766630011575",
+    "numerator": "41560389144689809226678844",
+    "denominator": "631539477992251088589288834221189",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "500690954578095184187194441446186082",
+    "numerator": "82863181861436419468730282156079843",
+    "denominator": "14180609206316978983084282968",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "500690954578095184187194441446186082",
+    "numerator": "82863181861436419468730282156079843",
+    "denominator": "14180609206316978983084282968",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "194990834929224168208721",
+    "numerator": "16955124877057883434303525176222",
+    "denominator": "19322338203832265875425792954255337295",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "194990834929224168208721",
+    "numerator": "16955124877057883434303525176222",
+    "denominator": "19322338203832265875425792954255337295",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "208526288208023826255776037149301487540",
+    "numerator": "241694077021",
+    "denominator": "26",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "208526288208023826255776037149301487540",
+    "numerator": "241694077021",
+    "denominator": "26",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "570745001573660673696763",
+    "numerator": "699275050199830358096",
+    "denominator": "4748004913431350590030434787744175529",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "570745001573660673696763",
+    "numerator": "699275050199830358096",
+    "denominator": "4748004913431350590030434787744175529",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "87765237209762078143931350",
+    "numerator": "19894398104009408603829720120551",
+    "denominator": "1776060010308140",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "87765237209762078143931350",
+    "numerator": "19894398104009408603829720120551",
+    "denominator": "1776060010308140",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20180311789847301080584525109",
+    "numerator": "36017362",
+    "denominator": "820075785206957242697493298707",
+    "rounding": "Floor",
+    "expected": "886310",
+    "overflow": false
+  },
+  {
+    "a": "20180311789847301080584525109",
+    "numerator": "36017362",
+    "denominator": "820075785206957242697493298707",
+    "rounding": "Ceil",
+    "expected": "886311",
+    "overflow": false
+  },
+  {
+    "a": "24011080",
+    "numerator": "56065",
+    "denominator": "1130766",
+    "rounding": "Floor",
+    "expected": "1190503",
+    "overflow": false
+  },
+  {
+    "a": "24011080",
+    "numerator": "56065",
+    "denominator": "1130766",
+    "rounding": "Ceil",
+    "expected": "1190504",
+    "overflow": false
+  },
+  {
+    "a": "1467611161519182010454057363305788287",
+    "numerator": "0",
+    "denominator": "760653856421459101984242832141",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1467611161519182010454057363305788287",
+    "numerator": "0",
+    "denominator": "760653856421459101984242832141",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3990019785866",
+    "numerator": "43",
+    "denominator": "6859664072512",
+    "rounding": "Floor",
+    "expected": "25",
+    "overflow": false
+  },
+  {
+    "a": "3990019785866",
+    "numerator": "43",
+    "denominator": "6859664072512",
+    "rounding": "Ceil",
+    "expected": "26",
+    "overflow": false
+  },
+  {
+    "a": "318910806316827666571362930354521",
+    "numerator": "541952687762258758",
+    "denominator": "9012420024495130749719",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "318910806316827666571362930354521",
+    "numerator": "541952687762258758",
+    "denominator": "9012420024495130749719",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4207879446590477852",
+    "numerator": "42035488544672229",
+    "denominator": "41521494178660674",
+    "rounding": "Floor",
+    "expected": "4259968764934779549",
+    "overflow": false
+  },
+  {
+    "a": "4207879446590477852",
+    "numerator": "42035488544672229",
+    "denominator": "41521494178660674",
+    "rounding": "Ceil",
+    "expected": "4259968764934779550",
+    "overflow": false
+  },
+  {
+    "a": "81921996490051",
+    "numerator": "35726623288",
+    "denominator": "49",
+    "rounding": "Floor",
+    "expected": "59730536889814496263422",
+    "overflow": false
+  },
+  {
+    "a": "81921996490051",
+    "numerator": "35726623288",
+    "denominator": "49",
+    "rounding": "Ceil",
+    "expected": "59730536889814496263423",
+    "overflow": false
+  },
+  {
+    "a": "1684094",
+    "numerator": "14943151",
+    "denominator": "122091885839778274830988107668",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1684094",
+    "numerator": "14943151",
+    "denominator": "122091885839778274830988107668",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "34373644385066227289627069",
+    "numerator": "26",
+    "denominator": "282242953920197211",
+    "rounding": "Floor",
+    "expected": "3166473216",
+    "overflow": false
+  },
+  {
+    "a": "34373644385066227289627069",
+    "numerator": "26",
+    "denominator": "282242953920197211",
+    "rounding": "Ceil",
+    "expected": "3166473217",
+    "overflow": false
+  },
+  {
+    "a": "95845595996084038192",
+    "numerator": "6588416034609566993672590467337",
+    "denominator": "91558058064655960147638",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "95845595996084038192",
+    "numerator": "6588416034609566993672590467337",
+    "denominator": "91558058064655960147638",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "93245239135719526449892336602553769287",
+    "numerator": "284242894998953484",
+    "denominator": "3975593301205653",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "93245239135719526449892336602553769287",
+    "numerator": "284242894998953484",
+    "denominator": "3975593301205653",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "139698",
+    "numerator": "3",
+    "denominator": "5928",
+    "rounding": "Floor",
+    "expected": "70",
+    "overflow": false
+  },
+  {
+    "a": "139698",
+    "numerator": "3",
+    "denominator": "5928",
+    "rounding": "Ceil",
+    "expected": "71",
+    "overflow": false
+  },
+  {
+    "a": "18073632750037971174640781921",
+    "numerator": "6126",
+    "denominator": "5380063",
+    "rounding": "Floor",
+    "expected": "20579512586884691018645958",
+    "overflow": false
+  },
+  {
+    "a": "18073632750037971174640781921",
+    "numerator": "6126",
+    "denominator": "5380063",
+    "rounding": "Ceil",
+    "expected": "20579512586884691018645959",
+    "overflow": false
+  },
+  {
+    "a": "123546173466336000815492",
+    "numerator": "105760090721844784041589441645",
+    "denominator": "3938481641244010",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "123546173466336000815492",
+    "numerator": "105760090721844784041589441645",
+    "denominator": "3938481641244010",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1204194370476707519537523031947",
+    "numerator": "97788095305847818528",
+    "denominator": "8175338619043238059383198284985",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1204194370476707519537523031947",
+    "numerator": "97788095305847818528",
+    "denominator": "8175338619043238059383198284985",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "299517371937510163914182542886",
+    "numerator": "7",
+    "denominator": "17602651876858208473364988",
+    "rounding": "Floor",
+    "expected": "119108",
+    "overflow": false
+  },
+  {
+    "a": "299517371937510163914182542886",
+    "numerator": "7",
+    "denominator": "17602651876858208473364988",
+    "rounding": "Ceil",
+    "expected": "119109",
+    "overflow": false
+  },
+  {
+    "a": "4795945038839930352559002781212485",
+    "numerator": "1229566320924941372960073674922849826",
+    "denominator": "3876630519715",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4795945038839930352559002781212485",
+    "numerator": "1229566320924941372960073674922849826",
+    "denominator": "3876630519715",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13490899746840",
+    "numerator": "3110030661649",
+    "denominator": "16652432144421098385198674270",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "13490899746840",
+    "numerator": "3110030661649",
+    "denominator": "16652432144421098385198674270",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6865496538063997727810782965775",
+    "numerator": "2414452",
+    "denominator": "46169744925358664373021",
+    "rounding": "Floor",
+    "expected": "359031913087679",
+    "overflow": false
+  },
+  {
+    "a": "6865496538063997727810782965775",
+    "numerator": "2414452",
+    "denominator": "46169744925358664373021",
+    "rounding": "Ceil",
+    "expected": "359031913087680",
+    "overflow": false
+  },
+  {
+    "a": "250876890",
+    "numerator": "102587",
+    "denominator": "5630895733776",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "250876890",
+    "numerator": "102587",
+    "denominator": "5630895733776",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "36651521499574752541801",
+    "numerator": "129431958",
+    "denominator": "5213420913239575975",
+    "rounding": "Floor",
+    "expected": "909935773519",
+    "overflow": false
+  },
+  {
+    "a": "36651521499574752541801",
+    "numerator": "129431958",
+    "denominator": "5213420913239575975",
+    "rounding": "Ceil",
+    "expected": "909935773520",
+    "overflow": false
+  },
+  {
+    "a": "553421236567991705430508",
+    "numerator": "1135563833111046732300992501",
+    "denominator": "237800359127549032313486994",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "553421236567991705430508",
+    "numerator": "1135563833111046732300992501",
+    "denominator": "237800359127549032313486994",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6394460566414812572644051",
+    "numerator": "850917304930495920961340181404936",
+    "denominator": "40724728208762456513",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6394460566414812572644051",
+    "numerator": "850917304930495920961340181404936",
+    "denominator": "40724728208762456513",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74033379815956049039065448361528114894",
+    "numerator": "309196887284316261439",
+    "denominator": "66212196",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74033379815956049039065448361528114894",
+    "numerator": "309196887284316261439",
+    "denominator": "66212196",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "336046293716830817344607058527693",
+    "numerator": "43813080227481074200942154",
+    "denominator": "267039753099887836685803",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "336046293716830817344607058527693",
+    "numerator": "43813080227481074200942154",
+    "denominator": "267039753099887836685803",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17152",
+    "numerator": "310290948121",
+    "denominator": "87731543779975430",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "17152",
+    "numerator": "310290948121",
+    "denominator": "87731543779975430",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "23",
+    "numerator": "21150921194435113853742556",
+    "denominator": "30814593549477",
+    "rounding": "Floor",
+    "expected": "15787038913588",
+    "overflow": false
+  },
+  {
+    "a": "23",
+    "numerator": "21150921194435113853742556",
+    "denominator": "30814593549477",
+    "rounding": "Ceil",
+    "expected": "15787038913589",
+    "overflow": false
+  },
+  {
+    "a": "773634818",
+    "numerator": "3",
+    "denominator": "256780605949630107128",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "773634818",
+    "numerator": "3",
+    "denominator": "256780605949630107128",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "401465201",
+    "numerator": "223871038",
+    "denominator": "1515411459040504943",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "401465201",
+    "numerator": "223871038",
+    "denominator": "1515411459040504943",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4",
+    "numerator": "9536605452664065729515209031621024893",
+    "denominator": "68006333626",
+    "rounding": "Floor",
+    "expected": "560924545946588491332071096",
+    "overflow": false
+  },
+  {
+    "a": "4",
+    "numerator": "9536605452664065729515209031621024893",
+    "denominator": "68006333626",
+    "rounding": "Ceil",
+    "expected": "560924545946588491332071097",
+    "overflow": false
+  },
+  {
+    "a": "795",
+    "numerator": "1025105392",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "814958786640",
+    "overflow": false
+  },
+  {
+    "a": "795",
+    "numerator": "1025105392",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "814958786640",
+    "overflow": false
+  },
+  {
+    "a": "118",
+    "numerator": "842009818733453642137385553415",
+    "denominator": "19487782937270601164",
+    "rounding": "Floor",
+    "expected": "5098433153241",
+    "overflow": false
+  },
+  {
+    "a": "118",
+    "numerator": "842009818733453642137385553415",
+    "denominator": "19487782937270601164",
+    "rounding": "Ceil",
+    "expected": "5098433153242",
+    "overflow": false
+  },
+  {
+    "a": "3906127637845",
+    "numerator": "27354595303602570641255282",
+    "denominator": "613702653610991422104883",
+    "rounding": "Floor",
+    "expected": "174107998570259",
+    "overflow": false
+  },
+  {
+    "a": "3906127637845",
+    "numerator": "27354595303602570641255282",
+    "denominator": "613702653610991422104883",
+    "rounding": "Ceil",
+    "expected": "174107998570260",
+    "overflow": false
+  },
+  {
+    "a": "2901076539797077447400",
+    "numerator": "108199521193282436132411168278957332769",
+    "denominator": "287211098753039636240654211331502",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2901076539797077447400",
+    "numerator": "108199521193282436132411168278957332769",
+    "denominator": "287211098753039636240654211331502",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20549439230111",
+    "numerator": "8008936104119427731356772855628100",
+    "denominator": "45",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20549439230111",
+    "numerator": "8008936104119427731356772855628100",
+    "denominator": "45",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42227601736171855394044015139339941674",
+    "numerator": "20896116585633489629580392291403",
+    "denominator": "5065250615389045651523151104339053792",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42227601736171855394044015139339941674",
+    "numerator": "20896116585633489629580392291403",
+    "denominator": "5065250615389045651523151104339053792",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "480121",
+    "numerator": "15701107777954923236326",
+    "denominator": "73038250678063795164938518795319",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "480121",
+    "numerator": "15701107777954923236326",
+    "denominator": "73038250678063795164938518795319",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "11301321597238342076",
+    "numerator": "2673384650740607594246686519835141",
+    "denominator": "2068607835522149715334221794",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11301321597238342076",
+    "numerator": "2673384650740607594246686519835141",
+    "denominator": "2068607835522149715334221794",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4244285159528285283",
+    "numerator": "14596052309954327675137649624",
+    "denominator": "23710968481254911752033708850443985",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4244285159528285283",
+    "numerator": "14596052309954327675137649624",
+    "denominator": "23710968481254911752033708850443985",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10581999607582",
+    "numerator": "281817257266640674384744397007",
+    "denominator": "10297584926141646262482740",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10581999607582",
+    "numerator": "281817257266640674384744397007",
+    "denominator": "10297584926141646262482740",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "73314086599456944092637",
+    "numerator": "14451488413082",
+    "denominator": "239041915",
+    "rounding": "Floor",
+    "expected": "4432267341096821261443993508",
+    "overflow": false
+  },
+  {
+    "a": "73314086599456944092637",
+    "numerator": "14451488413082",
+    "denominator": "239041915",
+    "rounding": "Ceil",
+    "expected": "4432267341096821261443993509",
+    "overflow": false
+  },
+  {
+    "a": "2131806585517270855247731164517486544",
+    "numerator": "138284892550390569",
+    "denominator": "741206",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2131806585517270855247731164517486544",
+    "numerator": "138284892550390569",
+    "denominator": "741206",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "81321575",
+    "numerator": "160172",
+    "denominator": "69053949274806523827595957",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "81321575",
+    "numerator": "160172",
+    "denominator": "69053949274806523827595957",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21179634439381285987197134042325100626",
+    "numerator": "179667811795469310322373432454571923",
+    "denominator": "4682306863670585301192",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21179634439381285987197134042325100626",
+    "numerator": "179667811795469310322373432454571923",
+    "denominator": "4682306863670585301192",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1076564055525713311873",
+    "numerator": "472423687574741033751510158",
+    "denominator": "8162320409353676377744639",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1076564055525713311873",
+    "numerator": "472423687574741033751510158",
+    "denominator": "8162320409353676377744639",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12298400295635561342206244",
+    "numerator": "275105025238052336913901339654285",
+    "denominator": "779184973834",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12298400295635561342206244",
+    "numerator": "275105025238052336913901339654285",
+    "denominator": "779184973834",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121554483765931",
+    "numerator": "0",
+    "denominator": "758453977",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "121554483765931",
+    "numerator": "0",
+    "denominator": "758453977",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1066694",
+    "numerator": "0",
+    "denominator": "1210199120303497151350490524",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1066694",
+    "numerator": "0",
+    "denominator": "1210199120303497151350490524",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "274068127891195395635281765",
+    "numerator": "6599874",
+    "denominator": "119975694019",
+    "rounding": "Floor",
+    "expected": "15076513007804077161035",
+    "overflow": false
+  },
+  {
+    "a": "274068127891195395635281765",
+    "numerator": "6599874",
+    "denominator": "119975694019",
+    "rounding": "Ceil",
+    "expected": "15076513007804077161036",
+    "overflow": false
+  },
+  {
+    "a": "844929022770885220792",
+    "numerator": "527255182897",
+    "denominator": "3754955254029490163198",
+    "rounding": "Floor",
+    "expected": "118641415489",
+    "overflow": false
+  },
+  {
+    "a": "844929022770885220792",
+    "numerator": "527255182897",
+    "denominator": "3754955254029490163198",
+    "rounding": "Ceil",
+    "expected": "118641415490",
+    "overflow": false
+  },
+  {
+    "a": "21842510325094270185790790558031090991",
+    "numerator": "7334166657907623559331016220436",
+    "denominator": "89917",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21842510325094270185790790558031090991",
+    "numerator": "7334166657907623559331016220436",
+    "denominator": "89917",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19692023258447328959783115670236794",
+    "numerator": "3",
+    "denominator": "266672",
+    "rounding": "Floor",
+    "expected": "221530831040911632564908753115",
+    "overflow": false
+  },
+  {
+    "a": "19692023258447328959783115670236794",
+    "numerator": "3",
+    "denominator": "266672",
+    "rounding": "Ceil",
+    "expected": "221530831040911632564908753116",
+    "overflow": false
+  },
+  {
+    "a": "2831040813354643081",
+    "numerator": "1159496279039076243692794422",
+    "denominator": "261831",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2831040813354643081",
+    "numerator": "1159496279039076243692794422",
+    "denominator": "261831",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6546084535352213262017719692",
+    "numerator": "7745583125",
+    "denominator": "398929720626",
+    "rounding": "Floor",
+    "expected": "127098181184104577499104823",
+    "overflow": false
+  },
+  {
+    "a": "6546084535352213262017719692",
+    "numerator": "7745583125",
+    "denominator": "398929720626",
+    "rounding": "Ceil",
+    "expected": "127098181184104577499104824",
+    "overflow": false
+  },
+  {
+    "a": "31385745907",
+    "numerator": "11160523858278365540008",
+    "denominator": "24821659428833",
+    "rounding": "Floor",
+    "expected": "14111923782100038037",
+    "overflow": false
+  },
+  {
+    "a": "31385745907",
+    "numerator": "11160523858278365540008",
+    "denominator": "24821659428833",
+    "rounding": "Ceil",
+    "expected": "14111923782100038038",
+    "overflow": false
+  },
+  {
+    "a": "1267604356426034135522704084374382",
+    "numerator": "104858391365983",
+    "denominator": "11482269819030667457168831228776708",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1267604356426034135522704084374382",
+    "numerator": "104858391365983",
+    "denominator": "11482269819030667457168831228776708",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "27571520348859999906285",
+    "numerator": "1826455096466454395363438301178090",
+    "denominator": "2777616657663359243",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "27571520348859999906285",
+    "numerator": "1826455096466454395363438301178090",
+    "denominator": "2777616657663359243",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "485721832445907050144004663865",
+    "denominator": "352698890878262120870",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "485721832445907050144004663865",
+    "denominator": "352698890878262120870",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "152823",
+    "numerator": "50127661436",
+    "denominator": "120005",
+    "rounding": "Floor",
+    "expected": "63836170189",
+    "overflow": false
+  },
+  {
+    "a": "152823",
+    "numerator": "50127661436",
+    "denominator": "120005",
+    "rounding": "Ceil",
+    "expected": "63836170190",
+    "overflow": false
+  },
+  {
+    "a": "4612352418",
+    "numerator": "1190946753440035",
+    "denominator": "244620157962693810072",
+    "rounding": "Floor",
+    "expected": "22455",
+    "overflow": false
+  },
+  {
+    "a": "4612352418",
+    "numerator": "1190946753440035",
+    "denominator": "244620157962693810072",
+    "rounding": "Ceil",
+    "expected": "22456",
+    "overflow": false
+  },
+  {
+    "a": "14651332059961559660713361",
+    "numerator": "94178526",
+    "denominator": "399",
+    "rounding": "Floor",
+    "expected": "3458247762766223823325925933548",
+    "overflow": false
+  },
+  {
+    "a": "14651332059961559660713361",
+    "numerator": "94178526",
+    "denominator": "399",
+    "rounding": "Ceil",
+    "expected": "3458247762766223823325925933549",
+    "overflow": false
+  },
+  {
+    "a": "4923972975219513080335767164660",
+    "numerator": "681783516102102522042603677",
+    "denominator": "2712929148779222874",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4923972975219513080335767164660",
+    "numerator": "681783516102102522042603677",
+    "denominator": "2712929148779222874",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3",
+    "numerator": "2451161455191367170519843382160",
+    "denominator": "128738021631639351953897",
+    "rounding": "Floor",
+    "expected": "57119755",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "2451161455191367170519843382160",
+    "denominator": "128738021631639351953897",
+    "rounding": "Ceil",
+    "expected": "57119756",
+    "overflow": false
+  },
+  {
+    "a": "14994757952939625173411094",
+    "numerator": "1068850032423",
+    "denominator": "851927625364534317875837292",
+    "rounding": "Floor",
+    "expected": "18812804100",
+    "overflow": false
+  },
+  {
+    "a": "14994757952939625173411094",
+    "numerator": "1068850032423",
+    "denominator": "851927625364534317875837292",
+    "rounding": "Ceil",
+    "expected": "18812804101",
+    "overflow": false
+  },
+  {
+    "a": "61039594441173373170290438601959134581",
+    "numerator": "933549895366609415115282",
+    "denominator": "5217363",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "61039594441173373170290438601959134581",
+    "numerator": "933549895366609415115282",
+    "denominator": "5217363",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "988296",
+    "numerator": "10049",
+    "denominator": "36862542",
+    "rounding": "Floor",
+    "expected": "269",
+    "overflow": false
+  },
+  {
+    "a": "988296",
+    "numerator": "10049",
+    "denominator": "36862542",
+    "rounding": "Ceil",
+    "expected": "270",
+    "overflow": false
+  },
+  {
+    "a": "557624697511198143",
+    "numerator": "15957055295593254161477860",
+    "denominator": "3375638102350714088269",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "557624697511198143",
+    "numerator": "15957055295593254161477860",
+    "denominator": "3375638102350714088269",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "205448930503226213684871854538",
+    "numerator": "21106219207563411925693760405189599083",
+    "denominator": "11711859328",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "205448930503226213684871854538",
+    "numerator": "21106219207563411925693760405189599083",
+    "denominator": "11711859328",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1513146939141279129",
+    "numerator": "2",
+    "denominator": "7605554519",
+    "rounding": "Floor",
+    "expected": "397905750",
+    "overflow": false
+  },
+  {
+    "a": "1513146939141279129",
+    "numerator": "2",
+    "denominator": "7605554519",
+    "rounding": "Ceil",
+    "expected": "397905751",
+    "overflow": false
+  },
+  {
+    "a": "3239140700",
+    "numerator": "316558538551075721733925393990367781",
+    "denominator": "39633848484985052522044976770",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3239140700",
+    "numerator": "316558538551075721733925393990367781",
+    "denominator": "39633848484985052522044976770",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "109789400535939",
+    "numerator": "42360",
+    "denominator": "10888924922119471462248477508738289",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "109789400535939",
+    "numerator": "42360",
+    "denominator": "10888924922119471462248477508738289",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "63409017348398144446",
+    "numerator": "595993102049561017839",
+    "denominator": "4251348",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "63409017348398144446",
+    "numerator": "595993102049561017839",
+    "denominator": "4251348",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "62755944478347624677713437181",
+    "numerator": "217146",
+    "denominator": "945470599838128283",
+    "rounding": "Floor",
+    "expected": "14413142325132429",
+    "overflow": false
+  },
+  {
+    "a": "62755944478347624677713437181",
+    "numerator": "217146",
+    "denominator": "945470599838128283",
+    "rounding": "Ceil",
+    "expected": "14413142325132430",
+    "overflow": false
+  },
+  {
+    "a": "993516359035263077685101936",
+    "numerator": "273006488119588169",
+    "denominator": "157686",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "993516359035263077685101936",
+    "numerator": "273006488119588169",
+    "denominator": "157686",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1",
+    "numerator": "81392083910088012",
+    "denominator": "37028565",
+    "rounding": "Floor",
+    "expected": "2198089067",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "81392083910088012",
+    "denominator": "37028565",
+    "rounding": "Ceil",
+    "expected": "2198089068",
+    "overflow": false
+  },
+  {
+    "a": "7489486578",
+    "numerator": "4955954743500590771",
+    "denominator": "8",
+    "rounding": "Floor",
+    "expected": "4639694566577888414309396454",
+    "overflow": false
+  },
+  {
+    "a": "7489486578",
+    "numerator": "4955954743500590771",
+    "denominator": "8",
+    "rounding": "Ceil",
+    "expected": "4639694566577888414309396455",
+    "overflow": false
+  },
+  {
+    "a": "66917443377559201",
+    "numerator": "503751158037023535406",
+    "denominator": "3155897704996483047577014291677727",
+    "rounding": "Floor",
+    "expected": "10681",
+    "overflow": false
+  },
+  {
+    "a": "66917443377559201",
+    "numerator": "503751158037023535406",
+    "denominator": "3155897704996483047577014291677727",
+    "rounding": "Ceil",
+    "expected": "10682",
+    "overflow": false
+  },
+  {
+    "a": "51406396563652",
+    "numerator": "126051041521433773",
+    "denominator": "244133435497275179665041064710855338",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "51406396563652",
+    "numerator": "126051041521433773",
+    "denominator": "244133435497275179665041064710855338",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "54731",
+    "numerator": "4068978540651861088",
+    "denominator": "2427786462980291657510222990000377",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "54731",
+    "numerator": "4068978540651861088",
+    "denominator": "2427786462980291657510222990000377",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "634899946107823606671517056767846",
+    "numerator": "23",
+    "denominator": "4",
+    "rounding": "Floor",
+    "expected": "3650674690119985738361223076415114",
+    "overflow": false
+  },
+  {
+    "a": "634899946107823606671517056767846",
+    "numerator": "23",
+    "denominator": "4",
+    "rounding": "Ceil",
+    "expected": "3650674690119985738361223076415115",
+    "overflow": false
+  },
+  {
+    "a": "62515607375175079859575414578360197",
+    "numerator": "98",
+    "denominator": "6912592174763491",
+    "rounding": "Floor",
+    "expected": "886285400306690637362",
+    "overflow": false
+  },
+  {
+    "a": "62515607375175079859575414578360197",
+    "numerator": "98",
+    "denominator": "6912592174763491",
+    "rounding": "Ceil",
+    "expected": "886285400306690637363",
+    "overflow": false
+  },
+  {
+    "a": "263517725937562086998872",
+    "numerator": "11695185",
+    "denominator": "69324679596715285074319080094",
+    "rounding": "Floor",
+    "expected": "44",
+    "overflow": false
+  },
+  {
+    "a": "263517725937562086998872",
+    "numerator": "11695185",
+    "denominator": "69324679596715285074319080094",
+    "rounding": "Ceil",
+    "expected": "45",
+    "overflow": false
+  },
+  {
+    "a": "8379240516175",
+    "numerator": "114233078956766900",
+    "denominator": "54262621",
+    "rounding": "Floor",
+    "expected": "17639885907500837633057",
+    "overflow": false
+  },
+  {
+    "a": "8379240516175",
+    "numerator": "114233078956766900",
+    "denominator": "54262621",
+    "rounding": "Ceil",
+    "expected": "17639885907500837633058",
+    "overflow": false
+  },
+  {
+    "a": "3037029984661335843345840362068250",
+    "numerator": "37082160606746363",
+    "denominator": "882468894544",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3037029984661335843345840362068250",
+    "numerator": "37082160606746363",
+    "denominator": "882468894544",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "401448607483793142214825",
+    "numerator": "113366",
+    "denominator": "113968871944863719",
+    "rounding": "Floor",
+    "expected": "399325026732",
+    "overflow": false
+  },
+  {
+    "a": "401448607483793142214825",
+    "numerator": "113366",
+    "denominator": "113968871944863719",
+    "rounding": "Ceil",
+    "expected": "399325026733",
+    "overflow": false
+  },
+  {
+    "a": "215211196716",
+    "numerator": "506879470583861",
+    "denominator": "30442436503668603911453650",
+    "rounding": "Floor",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "215211196716",
+    "numerator": "506879470583861",
+    "denominator": "30442436503668603911453650",
+    "rounding": "Ceil",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "588369992",
+    "denominator": "3039693066343937",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "588369992",
+    "denominator": "3039693066343937",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "29867030542",
+    "numerator": "26406693688959",
+    "denominator": "26648740",
+    "rounding": "Floor",
+    "expected": "29595753004508922",
+    "overflow": false
+  },
+  {
+    "a": "29867030542",
+    "numerator": "26406693688959",
+    "denominator": "26648740",
+    "rounding": "Ceil",
+    "expected": "29595753004508923",
+    "overflow": false
+  },
+  {
+    "a": "3324469915934221",
+    "numerator": "30719970863911300864182479522450181002",
+    "denominator": "3361039509199690870891093035",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3324469915934221",
+    "numerator": "30719970863911300864182479522450181002",
+    "denominator": "3361039509199690870891093035",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8376869594434706666841938406976",
+    "numerator": "17497",
+    "denominator": "676422",
+    "rounding": "Floor",
+    "expected": "216684388286933397420151024518",
+    "overflow": false
+  },
+  {
+    "a": "8376869594434706666841938406976",
+    "numerator": "17497",
+    "denominator": "676422",
+    "rounding": "Ceil",
+    "expected": "216684388286933397420151024519",
+    "overflow": false
+  },
+  {
+    "a": "304845893507407622635502972439",
+    "numerator": "993621429764579443494926578431260",
+    "denominator": "74051677885297049384165",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "304845893507407622635502972439",
+    "numerator": "993621429764579443494926578431260",
+    "denominator": "74051677885297049384165",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3412485550641015651985474",
+    "numerator": "279555220492032067",
+    "denominator": "319589533987128",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3412485550641015651985474",
+    "numerator": "279555220492032067",
+    "denominator": "319589533987128",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "199373875917607525297",
+    "numerator": "2298159925833211241251629438",
+    "denominator": "236747834976651097177050532882097839",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "199373875917607525297",
+    "numerator": "2298159925833211241251629438",
+    "denominator": "236747834976651097177050532882097839",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1061099137503550037652",
+    "numerator": "599811673776646252413876619365229757",
+    "denominator": "1798422544553678868548120702677463546",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1061099137503550037652",
+    "numerator": "599811673776646252413876619365229757",
+    "denominator": "1798422544553678868548120702677463546",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29222235",
+    "numerator": "2635436781222192",
+    "denominator": "9",
+    "rounding": "Floor",
+    "expected": "8557039216502053537680",
+    "overflow": false
+  },
+  {
+    "a": "29222235",
+    "numerator": "2635436781222192",
+    "denominator": "9",
+    "rounding": "Ceil",
+    "expected": "8557039216502053537680",
+    "overflow": false
+  },
+  {
+    "a": "24925229553343997158564121075126",
+    "numerator": "631313547882413898808238151",
+    "denominator": "5632740203556322265213639605305507084",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24925229553343997158564121075126",
+    "numerator": "631313547882413898808238151",
+    "denominator": "5632740203556322265213639605305507084",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2396963627024373371914015131974241685",
+    "numerator": "50",
+    "denominator": "962164269987142787955",
+    "rounding": "Floor",
+    "expected": "124561039200530878",
+    "overflow": false
+  },
+  {
+    "a": "2396963627024373371914015131974241685",
+    "numerator": "50",
+    "denominator": "962164269987142787955",
+    "rounding": "Ceil",
+    "expected": "124561039200530879",
+    "overflow": false
+  },
+  {
+    "a": "39207157616471157626265176672413224",
+    "numerator": "2801388799329",
+    "denominator": "292785902",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39207157616471157626265176672413224",
+    "numerator": "2801388799329",
+    "denominator": "292785902",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "375275633653414623",
+    "numerator": "3839317815120295220551296521846321284",
+    "denominator": "3949",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "375275633653414623",
+    "numerator": "3839317815120295220551296521846321284",
+    "denominator": "3949",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42",
+    "numerator": "4256564007213574402254438114947723",
+    "denominator": "70100303683295121993082787872",
+    "rounding": "Floor",
+    "expected": "2550284",
+    "overflow": false
+  },
+  {
+    "a": "42",
+    "numerator": "4256564007213574402254438114947723",
+    "denominator": "70100303683295121993082787872",
+    "rounding": "Ceil",
+    "expected": "2550285",
+    "overflow": false
+  },
+  {
+    "a": "1802900851005082564016142584285255609",
+    "numerator": "294",
+    "denominator": "351508087",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1802900851005082564016142584285255609",
+    "numerator": "294",
+    "denominator": "351508087",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4659452",
+    "numerator": "176325397681820318464463187528261",
+    "denominator": "500686114",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4659452",
+    "numerator": "176325397681820318464463187528261",
+    "denominator": "500686114",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8417955",
+    "numerator": "81309464",
+    "denominator": "200102069504693009",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8417955",
+    "numerator": "81309464",
+    "denominator": "200102069504693009",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "57052309598",
+    "numerator": "11693093799509545743",
+    "denominator": "797375994881745362081396",
+    "rounding": "Floor",
+    "expected": "836641",
+    "overflow": false
+  },
+  {
+    "a": "57052309598",
+    "numerator": "11693093799509545743",
+    "denominator": "797375994881745362081396",
+    "rounding": "Ceil",
+    "expected": "836642",
+    "overflow": false
+  },
+  {
+    "a": "56861",
+    "numerator": "18163952294618",
+    "denominator": "649237808059",
+    "rounding": "Floor",
+    "expected": "1590820",
+    "overflow": false
+  },
+  {
+    "a": "56861",
+    "numerator": "18163952294618",
+    "denominator": "649237808059",
+    "rounding": "Ceil",
+    "expected": "1590821",
+    "overflow": false
+  },
+  {
+    "a": "2832",
+    "numerator": "131940539550920817508017831675926377",
+    "denominator": "69218152318694051990",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2832",
+    "numerator": "131940539550920817508017831675926377",
+    "denominator": "69218152318694051990",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25071783",
+    "numerator": "387845894769215724",
+    "denominator": "59501301",
+    "rounding": "Floor",
+    "expected": "163424798242556271",
+    "overflow": false
+  },
+  {
+    "a": "25071783",
+    "numerator": "387845894769215724",
+    "denominator": "59501301",
+    "rounding": "Ceil",
+    "expected": "163424798242556272",
+    "overflow": false
+  },
+  {
+    "a": "18",
+    "numerator": "2548114270399035614718002148899472851",
+    "denominator": "548495455013659069448",
+    "rounding": "Floor",
+    "expected": "83621580539879675",
+    "overflow": false
+  },
+  {
+    "a": "18",
+    "numerator": "2548114270399035614718002148899472851",
+    "denominator": "548495455013659069448",
+    "rounding": "Ceil",
+    "expected": "83621580539879676",
+    "overflow": false
+  },
+  {
+    "a": "4125623489",
+    "numerator": "42309322421710",
+    "denominator": "121814707482431",
+    "rounding": "Floor",
+    "expected": "1432933165",
+    "overflow": false
+  },
+  {
+    "a": "4125623489",
+    "numerator": "42309322421710",
+    "denominator": "121814707482431",
+    "rounding": "Ceil",
+    "expected": "1432933166",
+    "overflow": false
+  },
+  {
+    "a": "1216612",
+    "numerator": "20598989",
+    "denominator": "25353546",
+    "rounding": "Floor",
+    "expected": "988460",
+    "overflow": false
+  },
+  {
+    "a": "1216612",
+    "numerator": "20598989",
+    "denominator": "25353546",
+    "rounding": "Ceil",
+    "expected": "988461",
+    "overflow": false
+  },
+  {
+    "a": "4741820602801591191009656502081771",
+    "numerator": "68812860858809053903343505920",
+    "denominator": "38666324679182613273",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4741820602801591191009656502081771",
+    "numerator": "68812860858809053903343505920",
+    "denominator": "38666324679182613273",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20089621664451036963723484498638854",
+    "numerator": "28617771151890312675946220293847",
+    "denominator": "616846765111211609308",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20089621664451036963723484498638854",
+    "numerator": "28617771151890312675946220293847",
+    "denominator": "616846765111211609308",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5",
+    "numerator": "13798128558024055100329173506",
+    "denominator": "1068118138115",
+    "rounding": "Floor",
+    "expected": "64590835346990736",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "13798128558024055100329173506",
+    "denominator": "1068118138115",
+    "rounding": "Ceil",
+    "expected": "64590835346990737",
+    "overflow": false
+  },
+  {
+    "a": "14599120086462878236609346808",
+    "numerator": "0",
+    "denominator": "30",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "14599120086462878236609346808",
+    "numerator": "0",
+    "denominator": "30",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "125735065881794973175663",
+    "numerator": "271227325502740397721788489300",
+    "denominator": "357253338743651259819901",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "125735065881794973175663",
+    "numerator": "271227325502740397721788489300",
+    "denominator": "357253338743651259819901",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9743143867429885642914223034",
+    "numerator": "9226052414648859",
+    "denominator": "125447408",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9743143867429885642914223034",
+    "numerator": "9226052414648859",
+    "denominator": "125447408",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19126765814473",
+    "numerator": "693110",
+    "denominator": "1671474843911",
+    "rounding": "Floor",
+    "expected": "7931290",
+    "overflow": false
+  },
+  {
+    "a": "19126765814473",
+    "numerator": "693110",
+    "denominator": "1671474843911",
+    "rounding": "Ceil",
+    "expected": "7931291",
+    "overflow": false
+  },
+  {
+    "a": "532912217558122357907521594572",
+    "numerator": "5",
+    "denominator": "4866168487117705874779514660072346226",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "532912217558122357907521594572",
+    "numerator": "5",
+    "denominator": "4866168487117705874779514660072346226",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1804326297499591049677322291",
+    "numerator": "72585672110881378680848872",
+    "denominator": "9827850348123169",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1804326297499591049677322291",
+    "numerator": "72585672110881378680848872",
+    "denominator": "9827850348123169",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "324809109052665145234271415470",
+    "numerator": "155639089180084968681723146530386847",
+    "denominator": "522924573325885508",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "324809109052665145234271415470",
+    "numerator": "155639089180084968681723146530386847",
+    "denominator": "522924573325885508",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21513167405",
+    "numerator": "720426",
+    "denominator": "213929803",
+    "rounding": "Floor",
+    "expected": "72447339",
+    "overflow": false
+  },
+  {
+    "a": "21513167405",
+    "numerator": "720426",
+    "denominator": "213929803",
+    "rounding": "Ceil",
+    "expected": "72447340",
+    "overflow": false
+  },
+  {
+    "a": "337459845970423006698464",
+    "numerator": "182088707705",
+    "denominator": "11034682086",
+    "rounding": "Floor",
+    "expected": "5568590628727124431079315",
+    "overflow": false
+  },
+  {
+    "a": "337459845970423006698464",
+    "numerator": "182088707705",
+    "denominator": "11034682086",
+    "rounding": "Ceil",
+    "expected": "5568590628727124431079316",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1622628815036",
+    "denominator": "313632005",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1622628815036",
+    "denominator": "313632005",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "47393960833267426",
+    "numerator": "8289956427511322467",
+    "denominator": "60120848931236037191677154288898906840",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "47393960833267426",
+    "numerator": "8289956427511322467",
+    "denominator": "60120848931236037191677154288898906840",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "22358767088217621732053122868440691153",
+    "numerator": "1566",
+    "denominator": "188136457405314691510212910031",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22358767088217621732053122868440691153",
+    "numerator": "1566",
+    "denominator": "188136457405314691510212910031",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17885157907375312276613155763764",
+    "numerator": "4641689698525",
+    "denominator": "26",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17885157907375312276613155763764",
+    "numerator": "4641689698525",
+    "denominator": "26",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1780324856531890299",
+    "numerator": "21667536",
+    "denominator": "3279660441834647554559544458793",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1780324856531890299",
+    "numerator": "21667536",
+    "denominator": "3279660441834647554559544458793",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "24534750365490685526",
+    "numerator": "35285218896389089239399",
+    "denominator": "447412637868",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24534750365490685526",
+    "numerator": "35285218896389089239399",
+    "denominator": "447412637868",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "533943698621486517",
+    "numerator": "24518552950525778",
+    "denominator": "6346029715",
+    "rounding": "Floor",
+    "expected": "2062947612159186844392105",
+    "overflow": false
+  },
+  {
+    "a": "533943698621486517",
+    "numerator": "24518552950525778",
+    "denominator": "6346029715",
+    "rounding": "Ceil",
+    "expected": "2062947612159186844392106",
+    "overflow": false
+  },
+  {
+    "a": "465978534952372168",
+    "numerator": "131323927346033897956013133280129",
+    "denominator": "13198",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "465978534952372168",
+    "numerator": "131323927346033897956013133280129",
+    "denominator": "13198",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2888196692000551396313384959",
+    "numerator": "18283691796280985268681465222905892",
+    "denominator": "909",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2888196692000551396313384959",
+    "numerator": "18283691796280985268681465222905892",
+    "denominator": "909",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "441821215260701790470567358218",
+    "numerator": "1451",
+    "denominator": "375245878720",
+    "rounding": "Floor",
+    "expected": "1708433375817671919594",
+    "overflow": false
+  },
+  {
+    "a": "441821215260701790470567358218",
+    "numerator": "1451",
+    "denominator": "375245878720",
+    "rounding": "Ceil",
+    "expected": "1708433375817671919595",
+    "overflow": false
+  },
+  {
+    "a": "29145",
+    "numerator": "24006",
+    "denominator": "524165711081771589567917975",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "29145",
+    "numerator": "24006",
+    "denominator": "524165711081771589567917975",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "35471815149478325101149156320412",
+    "numerator": "27237",
+    "denominator": "81148582850",
+    "rounding": "Floor",
+    "expected": "11905886650075259333749407",
+    "overflow": false
+  },
+  {
+    "a": "35471815149478325101149156320412",
+    "numerator": "27237",
+    "denominator": "81148582850",
+    "rounding": "Ceil",
+    "expected": "11905886650075259333749408",
+    "overflow": false
+  },
+  {
+    "a": "280314752634742926204109054173635",
+    "numerator": "396280923020507176526350809175394488",
+    "denominator": "189590623294079965489",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "280314752634742926204109054173635",
+    "numerator": "396280923020507176526350809175394488",
+    "denominator": "189590623294079965489",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15535808350597949501723061798142",
+    "numerator": "1842231343",
+    "denominator": "2321587732",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15535808350597949501723061798142",
+    "numerator": "1842231343",
+    "denominator": "2321587732",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "384408147822881930275389",
+    "numerator": "16734735813517101177320826",
+    "denominator": "245467",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "384408147822881930275389",
+    "numerator": "16734735813517101177320826",
+    "denominator": "245467",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3296813232",
+    "numerator": "88695659994178889158026907847049",
+    "denominator": "3895048605661890870",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3296813232",
+    "numerator": "88695659994178889158026907847049",
+    "denominator": "3895048605661890870",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "352171941307058349587458376135",
+    "numerator": "93533311783308428",
+    "denominator": "3573027803659234585142037",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "352171941307058349587458376135",
+    "numerator": "93533311783308428",
+    "denominator": "3573027803659234585142037",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1036733753528474820016910133107762",
+    "numerator": "3",
+    "denominator": "229018757504424",
+    "rounding": "Floor",
+    "expected": "13580552503544798490",
+    "overflow": false
+  },
+  {
+    "a": "1036733753528474820016910133107762",
+    "numerator": "3",
+    "denominator": "229018757504424",
+    "rounding": "Ceil",
+    "expected": "13580552503544798491",
+    "overflow": false
+  },
+  {
+    "a": "598753",
+    "numerator": "477504296314276462",
+    "denominator": "834345027387850862954629811461467231",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "598753",
+    "numerator": "477504296314276462",
+    "denominator": "834345027387850862954629811461467231",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2111483042968195076",
+    "numerator": "13549",
+    "denominator": "7096705776260175851296763882",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2111483042968195076",
+    "numerator": "13549",
+    "denominator": "7096705776260175851296763882",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "356232544869073655491619851",
+    "numerator": "109557972139739750304",
+    "denominator": "2783956976748033754244597049",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "356232544869073655491619851",
+    "numerator": "109557972139739750304",
+    "denominator": "2783956976748033754244597049",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14525373302173165856934",
+    "numerator": "488386562707037932120684967090167",
+    "denominator": "51324",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14525373302173165856934",
+    "numerator": "488386562707037932120684967090167",
+    "denominator": "51324",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1025662042053",
+    "numerator": "162",
+    "denominator": "25944087755811",
+    "rounding": "Floor",
+    "expected": "6",
+    "overflow": false
+  },
+  {
+    "a": "1025662042053",
+    "numerator": "162",
+    "denominator": "25944087755811",
+    "rounding": "Ceil",
+    "expected": "7",
+    "overflow": false
+  },
+  {
+    "a": "415359272732312",
+    "numerator": "13876315187347013681523460362385",
+    "denominator": "89664441619271399879281950213086",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "415359272732312",
+    "numerator": "13876315187347013681523460362385",
+    "denominator": "89664441619271399879281950213086",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39395683028833596035545364309135",
+    "numerator": "11208359040798855603421500916",
+    "denominator": "353181",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39395683028833596035545364309135",
+    "numerator": "11208359040798855603421500916",
+    "denominator": "353181",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "665136302415091419580227162",
+    "numerator": "1805073169930993584863501627",
+    "denominator": "25800635024",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "665136302415091419580227162",
+    "numerator": "1805073169930993584863501627",
+    "denominator": "25800635024",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42217",
+    "numerator": "113686",
+    "denominator": "9044372107191693830320679",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "42217",
+    "numerator": "113686",
+    "denominator": "9044372107191693830320679",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1956209779497068",
+    "numerator": "0",
+    "denominator": "787362017905318040025817959221770514",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1956209779497068",
+    "numerator": "0",
+    "denominator": "787362017905318040025817959221770514",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "51866212169459168613242278468605898579",
+    "numerator": "904",
+    "denominator": "3566306708866900545",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51866212169459168613242278468605898579",
+    "numerator": "904",
+    "denominator": "3566306708866900545",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "334",
+    "numerator": "9384242087401849200681151",
+    "denominator": "347934697993859669588848612",
+    "rounding": "Floor",
+    "expected": "9",
+    "overflow": false
+  },
+  {
+    "a": "334",
+    "numerator": "9384242087401849200681151",
+    "denominator": "347934697993859669588848612",
+    "rounding": "Ceil",
+    "expected": "10",
+    "overflow": false
+  },
+  {
+    "a": "1238925460409524875320957774145910349",
+    "numerator": "145865096745495052490",
+    "denominator": "104465580097888329491329716843",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1238925460409524875320957774145910349",
+    "numerator": "145865096745495052490",
+    "denominator": "104465580097888329491329716843",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "223501972333217098318720391552",
+    "numerator": "1070548544464201348786329",
+    "denominator": "327973057060348628288390",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "223501972333217098318720391552",
+    "numerator": "1070548544464201348786329",
+    "denominator": "327973057060348628288390",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2592855",
+    "numerator": "76927954579267447770560878099548",
+    "denominator": "15016206260453680421",
+    "rounding": "Floor",
+    "expected": "13283184062004232069",
+    "overflow": false
+  },
+  {
+    "a": "2592855",
+    "numerator": "76927954579267447770560878099548",
+    "denominator": "15016206260453680421",
+    "rounding": "Ceil",
+    "expected": "13283184062004232070",
+    "overflow": false
+  },
+  {
+    "a": "4127820074612685100418",
+    "numerator": "33975157423850242153096835",
+    "denominator": "28842720235994542778848784617329784",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4127820074612685100418",
+    "numerator": "33975157423850242153096835",
+    "denominator": "28842720235994542778848784617329784",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1209056583250476747285914822345103345",
+    "numerator": "115254930716365502",
+    "denominator": "139503",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1209056583250476747285914822345103345",
+    "numerator": "115254930716365502",
+    "denominator": "139503",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "421171516476712469248330456532",
+    "numerator": "330144108937571581",
+    "denominator": "220225099578",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "421171516476712469248330456532",
+    "numerator": "330144108937571581",
+    "denominator": "220225099578",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2971",
+    "numerator": "0",
+    "denominator": "47303202201713004617",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2971",
+    "numerator": "0",
+    "denominator": "47303202201713004617",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3833315062",
+    "numerator": "3018254668430083804987747228496519",
+    "denominator": "18308941985044601201325132",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3833315062",
+    "numerator": "3018254668430083804987747228496519",
+    "denominator": "18308941985044601201325132",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "273157631445",
+    "numerator": "2603794159969778",
+    "denominator": "64513769862832563",
+    "rounding": "Floor",
+    "expected": "11024719947",
+    "overflow": false
+  },
+  {
+    "a": "273157631445",
+    "numerator": "2603794159969778",
+    "denominator": "64513769862832563",
+    "rounding": "Ceil",
+    "expected": "11024719948",
+    "overflow": false
+  },
+  {
+    "a": "104",
+    "numerator": "250867538222982144845970429679808929",
+    "denominator": "6487086789076433134793235401927469102",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "104",
+    "numerator": "250867538222982144845970429679808929",
+    "denominator": "6487086789076433134793235401927469102",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "194258576671",
+    "numerator": "4020168765201627755897210429380",
+    "denominator": "21116357283758142316172724141",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "194258576671",
+    "numerator": "4020168765201627755897210429380",
+    "denominator": "21116357283758142316172724141",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75253284335837315295133949474200854954",
+    "numerator": "3",
+    "denominator": "66929903349806162456961888",
+    "rounding": "Floor",
+    "expected": "3373079023102",
+    "overflow": false
+  },
+  {
+    "a": "75253284335837315295133949474200854954",
+    "numerator": "3",
+    "denominator": "66929903349806162456961888",
+    "rounding": "Ceil",
+    "expected": "3373079023103",
+    "overflow": false
+  },
+  {
+    "a": "1508219897",
+    "numerator": "65073417524635020902",
+    "denominator": "122432857503694210247370692791",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1508219897",
+    "numerator": "65073417524635020902",
+    "denominator": "122432857503694210247370692791",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "24521433170921783356",
+    "numerator": "10034695842740233649395405235327212165",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24521433170921783356",
+    "numerator": "10034695842740233649395405235327212165",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "878560364550798610936226019",
+    "numerator": "263437207308793301871481690600024",
+    "denominator": "94033",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "878560364550798610936226019",
+    "numerator": "263437207308793301871481690600024",
+    "denominator": "94033",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10976997790",
+    "numerator": "263777910402383",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "2895489539537776201733570",
+    "overflow": false
+  },
+  {
+    "a": "10976997790",
+    "numerator": "263777910402383",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "2895489539537776201733570",
+    "overflow": false
+  },
+  {
+    "a": "29",
+    "numerator": "1288455916236383271854106",
+    "denominator": "259076842959810057751035",
+    "rounding": "Floor",
+    "expected": "144",
+    "overflow": false
+  },
+  {
+    "a": "29",
+    "numerator": "1288455916236383271854106",
+    "denominator": "259076842959810057751035",
+    "rounding": "Ceil",
+    "expected": "145",
+    "overflow": false
+  },
+  {
+    "a": "2618616940112",
+    "numerator": "4514626764832424947256233",
+    "denominator": "138777536615423329661873459401174",
+    "rounding": "Floor",
+    "expected": "85187",
+    "overflow": false
+  },
+  {
+    "a": "2618616940112",
+    "numerator": "4514626764832424947256233",
+    "denominator": "138777536615423329661873459401174",
+    "rounding": "Ceil",
+    "expected": "85188",
+    "overflow": false
+  },
+  {
+    "a": "2215180580673594229479",
+    "numerator": "122036502310071118179032236736438316",
+    "denominator": "3991456443189",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2215180580673594229479",
+    "numerator": "122036502310071118179032236736438316",
+    "denominator": "3991456443189",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5973687051791718953137464018",
+    "numerator": "65019101051042544171967507",
+    "denominator": "43219074295314982711434947411784",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5973687051791718953137464018",
+    "numerator": "65019101051042544171967507",
+    "denominator": "43219074295314982711434947411784",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "215948191237996696523009",
+    "numerator": "506557885556712288014",
+    "denominator": "257948583993113803496133191776639",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "215948191237996696523009",
+    "numerator": "506557885556712288014",
+    "denominator": "257948583993113803496133191776639",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1032734869649075910668052858265508",
+    "numerator": "869156727053",
+    "denominator": "1893403136086666",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1032734869649075910668052858265508",
+    "numerator": "869156727053",
+    "denominator": "1893403136086666",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6420186476744491",
+    "numerator": "1021263168",
+    "denominator": "932982434331561172825",
+    "rounding": "Floor",
+    "expected": "7027",
+    "overflow": false
+  },
+  {
+    "a": "6420186476744491",
+    "numerator": "1021263168",
+    "denominator": "932982434331561172825",
+    "rounding": "Ceil",
+    "expected": "7028",
+    "overflow": false
+  },
+  {
+    "a": "876964166",
+    "numerator": "18458477691019610632471",
+    "denominator": "26631226070044",
+    "rounding": "Floor",
+    "expected": "607836208943566439",
+    "overflow": false
+  },
+  {
+    "a": "876964166",
+    "numerator": "18458477691019610632471",
+    "denominator": "26631226070044",
+    "rounding": "Ceil",
+    "expected": "607836208943566440",
+    "overflow": false
+  },
+  {
+    "a": "4435127046240649131488911333",
+    "numerator": "15676394339356760923521994562",
+    "denominator": "3302304579",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4435127046240649131488911333",
+    "numerator": "15676394339356760923521994562",
+    "denominator": "3302304579",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "1148291425261478373487367857",
+    "denominator": "19889773397596735726997193826430",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1148291425261478373487367857",
+    "denominator": "19889773397596735726997193826430",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "178798269571954903384896068012463",
+    "numerator": "28714225921382979280395668",
+    "denominator": "2495597260733",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "178798269571954903384896068012463",
+    "numerator": "28714225921382979280395668",
+    "denominator": "2495597260733",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "119088504126909703436538",
+    "numerator": "1914261172723532649789143029851",
+    "denominator": "2096",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "119088504126909703436538",
+    "numerator": "1914261172723532649789143029851",
+    "denominator": "2096",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "777",
+    "numerator": "2947804312413583039087479697516999862",
+    "denominator": "1172011639623",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "777",
+    "numerator": "2947804312413583039087479697516999862",
+    "denominator": "1172011639623",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32356793723142404825259020",
+    "numerator": "6644520892565",
+    "denominator": "434",
+    "rounding": "Floor",
+    "expected": "495381087349851984345923102368011950",
+    "overflow": false
+  },
+  {
+    "a": "32356793723142404825259020",
+    "numerator": "6644520892565",
+    "denominator": "434",
+    "rounding": "Ceil",
+    "expected": "495381087349851984345923102368011950",
+    "overflow": false
+  },
+  {
+    "a": "971926165689570178675",
+    "numerator": "1320",
+    "denominator": "527651472310369",
+    "rounding": "Floor",
+    "expected": "2431420371",
+    "overflow": false
+  },
+  {
+    "a": "971926165689570178675",
+    "numerator": "1320",
+    "denominator": "527651472310369",
+    "rounding": "Ceil",
+    "expected": "2431420372",
+    "overflow": false
+  },
+  {
+    "a": "1099638298362313934318",
+    "numerator": "301284183839052979679",
+    "denominator": "3638048632708",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1099638298362313934318",
+    "numerator": "301284183839052979679",
+    "denominator": "3638048632708",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "454944183684632344205933",
+    "numerator": "874",
+    "denominator": "4206097151209358301029771",
+    "rounding": "Floor",
+    "expected": "94",
+    "overflow": false
+  },
+  {
+    "a": "454944183684632344205933",
+    "numerator": "874",
+    "denominator": "4206097151209358301029771",
+    "rounding": "Ceil",
+    "expected": "95",
+    "overflow": false
+  },
+  {
+    "a": "185678650811212742669732636448",
+    "numerator": "295567748693213122046930006713",
+    "denominator": "59391201659119033775142",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "185678650811212742669732636448",
+    "numerator": "295567748693213122046930006713",
+    "denominator": "59391201659119033775142",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8416322628069965240695",
+    "numerator": "1234929707046013101242364",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8416322628069965240695",
+    "numerator": "1234929707046013101242364",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "215212858328098",
+    "numerator": "18187683",
+    "denominator": "16612102574559173581708451352",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "215212858328098",
+    "numerator": "18187683",
+    "denominator": "16612102574559173581708451352",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "78311915644958478181546977309244378641",
+    "numerator": "2330165183919563104923180894",
+    "denominator": "2323252029366115984106485263",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "78311915644958478181546977309244378641",
+    "numerator": "2330165183919563104923180894",
+    "denominator": "2323252029366115984106485263",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6062811621768791201863028",
+    "numerator": "476227424694209172332024621341",
+    "denominator": "907616730",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6062811621768791201863028",
+    "numerator": "476227424694209172332024621341",
+    "denominator": "907616730",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "128699",
+    "numerator": "92743965581707434512",
+    "denominator": "2414968000554137163875686199913",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "128699",
+    "numerator": "92743965581707434512",
+    "denominator": "2414968000554137163875686199913",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8178015791010171171678102",
+    "numerator": "465827084939916337035367335",
+    "denominator": "43765466363729539284416714599278572",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8178015791010171171678102",
+    "numerator": "465827084939916337035367335",
+    "denominator": "43765466363729539284416714599278572",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "330846720742263568689219547696403957",
+    "numerator": "6625807506",
+    "denominator": "63343523151304348389047954577619",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "330846720742263568689219547696403957",
+    "numerator": "6625807506",
+    "denominator": "63343523151304348389047954577619",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "153018456537135148811875734665992",
+    "numerator": "2132747251761089",
+    "denominator": "4044096987307951303886",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "153018456537135148811875734665992",
+    "numerator": "2132747251761089",
+    "denominator": "4044096987307951303886",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "188720416973787711",
+    "numerator": "170602583759369195364",
+    "denominator": "6416678165453",
+    "rounding": "Floor",
+    "expected": "5017579176280961974901538",
+    "overflow": false
+  },
+  {
+    "a": "188720416973787711",
+    "numerator": "170602583759369195364",
+    "denominator": "6416678165453",
+    "rounding": "Ceil",
+    "expected": "5017579176280961974901539",
+    "overflow": false
+  },
+  {
+    "a": "33203274",
+    "numerator": "128928747",
+    "denominator": "131749050211625948807342585790718208",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "33203274",
+    "numerator": "128928747",
+    "denominator": "131749050211625948807342585790718208",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "25",
+    "numerator": "956432400686312214278",
+    "denominator": "1674851770524157254073258455",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "25",
+    "numerator": "956432400686312214278",
+    "denominator": "1674851770524157254073258455",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1156414196299336280648668",
+    "numerator": "1471011493",
+    "denominator": "2",
+    "rounding": "Floor",
+    "expected": "850549286712340868553032061570662",
+    "overflow": false
+  },
+  {
+    "a": "1156414196299336280648668",
+    "numerator": "1471011493",
+    "denominator": "2",
+    "rounding": "Ceil",
+    "expected": "850549286712340868553032061570662",
+    "overflow": false
+  },
+  {
+    "a": "38286217900035",
+    "numerator": "15767162866218615740487342950558712",
+    "denominator": "113",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "38286217900035",
+    "numerator": "15767162866218615740487342950558712",
+    "denominator": "113",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66328910632529674858046",
+    "numerator": "45454794909721112785519",
+    "denominator": "1364",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66328910632529674858046",
+    "numerator": "45454794909721112785519",
+    "denominator": "1364",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12925",
+    "numerator": "61167073516218",
+    "denominator": "238412518825919324382491",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "12925",
+    "numerator": "61167073516218",
+    "denominator": "238412518825919324382491",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "26530252795774139376",
+    "numerator": "83856498121",
+    "denominator": "3968267315830",
+    "rounding": "Floor",
+    "expected": "560631105884348745",
+    "overflow": false
+  },
+  {
+    "a": "26530252795774139376",
+    "numerator": "83856498121",
+    "denominator": "3968267315830",
+    "rounding": "Ceil",
+    "expected": "560631105884348746",
+    "overflow": false
+  },
+  {
+    "a": "138419677234909502856557902952420359",
+    "numerator": "77474844506860012729856674708784076",
+    "denominator": "5000983806805",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "138419677234909502856557902952420359",
+    "numerator": "77474844506860012729856674708784076",
+    "denominator": "5000983806805",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2",
+    "numerator": "3166588963635",
+    "denominator": "947145124703247219777208922344",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "3166588963635",
+    "denominator": "947145124703247219777208922344",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1212839150884240645003197440258117409",
+    "numerator": "8653654172217577128141749269537710",
+    "denominator": "218783",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1212839150884240645003197440258117409",
+    "numerator": "8653654172217577128141749269537710",
+    "denominator": "218783",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "228727211004131423919904669508",
+    "numerator": "1",
+    "denominator": "1617754694698282",
+    "rounding": "Floor",
+    "expected": "141385595574976",
+    "overflow": false
+  },
+  {
+    "a": "228727211004131423919904669508",
+    "numerator": "1",
+    "denominator": "1617754694698282",
+    "rounding": "Ceil",
+    "expected": "141385595574977",
+    "overflow": false
+  },
+  {
+    "a": "4290687890301870765598830029916226123",
+    "numerator": "33001146550321408424154374124514016",
+    "denominator": "182698788180134265",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4290687890301870765598830029916226123",
+    "numerator": "33001146550321408424154374124514016",
+    "denominator": "182698788180134265",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22968806",
+    "numerator": "146984820434326421772528052017719",
+    "denominator": "19731427305689681272723091388",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22968806",
+    "numerator": "146984820434326421772528052017719",
+    "denominator": "19731427305689681272723091388",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1809895886853",
+    "numerator": "73186",
+    "denominator": "117988747875",
+    "rounding": "Floor",
+    "expected": "1122641",
+    "overflow": false
+  },
+  {
+    "a": "1809895886853",
+    "numerator": "73186",
+    "denominator": "117988747875",
+    "rounding": "Ceil",
+    "expected": "1122642",
+    "overflow": false
+  },
+  {
+    "a": "1435093334382828046808",
+    "numerator": "997326403226379716257742013672746193",
+    "denominator": "6",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1435093334382828046808",
+    "numerator": "997326403226379716257742013672746193",
+    "denominator": "6",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "921108175",
+    "numerator": "276723019829194247877940",
+    "denominator": "20909021",
+    "rounding": "Floor",
+    "expected": "12190519861037870944954665",
+    "overflow": false
+  },
+  {
+    "a": "921108175",
+    "numerator": "276723019829194247877940",
+    "denominator": "20909021",
+    "rounding": "Ceil",
+    "expected": "12190519861037870944954666",
+    "overflow": false
+  },
+  {
+    "a": "949248922",
+    "numerator": "17540079455560571",
+    "denominator": "28112",
+    "rounding": "Floor",
+    "expected": "592270258785757645398",
+    "overflow": false
+  },
+  {
+    "a": "949248922",
+    "numerator": "17540079455560571",
+    "denominator": "28112",
+    "rounding": "Ceil",
+    "expected": "592270258785757645399",
+    "overflow": false
+  },
+  {
+    "a": "151037862419361764694628649",
+    "numerator": "72560899459361471830",
+    "denominator": "261611317804243607701080215159727207",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "151037862419361764694628649",
+    "numerator": "72560899459361471830",
+    "denominator": "261611317804243607701080215159727207",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2099941863846283554732",
+    "numerator": "631537845",
+    "denominator": "56019306151128979102134389453551186",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2099941863846283554732",
+    "numerator": "631537845",
+    "denominator": "56019306151128979102134389453551186",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "2777738121740709769300744632008",
+    "denominator": "596185414332033",
+    "rounding": "Floor",
+    "expected": "13977554909756849",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "2777738121740709769300744632008",
+    "denominator": "596185414332033",
+    "rounding": "Ceil",
+    "expected": "13977554909756850",
+    "overflow": false
+  },
+  {
+    "a": "938618193034373774",
+    "numerator": "11519849818590504856319",
+    "denominator": "327460",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "938618193034373774",
+    "numerator": "11519849818590504856319",
+    "denominator": "327460",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "806541",
+    "numerator": "239615378001562250764137994",
+    "denominator": "104578959531",
+    "rounding": "Floor",
+    "expected": "1847978096698033205196",
+    "overflow": false
+  },
+  {
+    "a": "806541",
+    "numerator": "239615378001562250764137994",
+    "denominator": "104578959531",
+    "rounding": "Ceil",
+    "expected": "1847978096698033205197",
+    "overflow": false
+  },
+  {
+    "a": "2373829824",
+    "numerator": "130806934088117136845810211991854107865",
+    "denominator": "3302721747488547960006",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2373829824",
+    "numerator": "130806934088117136845810211991854107865",
+    "denominator": "3302721747488547960006",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "620558304584229394920087",
+    "numerator": "621691445580813026146624151052256156",
+    "denominator": "895669605",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "620558304584229394920087",
+    "numerator": "621691445580813026146624151052256156",
+    "denominator": "895669605",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100160812700497870791735127782664536770",
+    "numerator": "23818728643",
+    "denominator": "2387995537864425839933368",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100160812700497870791735127782664536770",
+    "numerator": "23818728643",
+    "denominator": "2387995537864425839933368",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3229978164952705342459296519697372209",
+    "numerator": "831036354179612021259959294",
+    "denominator": "109319834050334390609730351",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3229978164952705342459296519697372209",
+    "numerator": "831036354179612021259959294",
+    "denominator": "109319834050334390609730351",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "487529748",
+    "numerator": "17417973913453191589557565",
+    "denominator": "1024413775394521300090",
+    "rounding": "Floor",
+    "expected": "8289404766571",
+    "overflow": false
+  },
+  {
+    "a": "487529748",
+    "numerator": "17417973913453191589557565",
+    "denominator": "1024413775394521300090",
+    "rounding": "Ceil",
+    "expected": "8289404766572",
+    "overflow": false
+  },
+  {
+    "a": "7016727114314203",
+    "numerator": "2476976252743916701003696",
+    "denominator": "18465332753067992717657857176857748617",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7016727114314203",
+    "numerator": "2476976252743916701003696",
+    "denominator": "18465332753067992717657857176857748617",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "37886727128866870",
+    "numerator": "113352286307527",
+    "denominator": "392062091571283065112634749475466124",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "37886727128866870",
+    "numerator": "113352286307527",
+    "denominator": "392062091571283065112634749475466124",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "101909",
+    "numerator": "300645973988155310934564247086257914674",
+    "denominator": "3418810633288122668220863619059",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "101909",
+    "numerator": "300645973988155310934564247086257914674",
+    "denominator": "3418810633288122668220863619059",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10671596488375603084860306230440",
+    "numerator": "103900538978673188727064392687073",
+    "denominator": "783893867144796034231370094",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10671596488375603084860306230440",
+    "numerator": "103900538978673188727064392687073",
+    "denominator": "783893867144796034231370094",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "659295",
+    "numerator": "47606683871705709012683006765502212",
+    "denominator": "3955832205375650037741",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "659295",
+    "numerator": "47606683871705709012683006765502212",
+    "denominator": "3955832205375650037741",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23157146879363607230186",
+    "numerator": "519921419",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "12039896665510148488076964753934",
+    "overflow": false
+  },
+  {
+    "a": "23157146879363607230186",
+    "numerator": "519921419",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "12039896665510148488076964753934",
+    "overflow": false
+  },
+  {
+    "a": "32710713",
+    "numerator": "41299077538623690667609171071221670",
+    "denominator": "1923831",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32710713",
+    "numerator": "41299077538623690667609171071221670",
+    "denominator": "1923831",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8574478204",
+    "numerator": "1288901",
+    "denominator": "139357331679517391804852068988834",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8574478204",
+    "numerator": "1288901",
+    "denominator": "139357331679517391804852068988834",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "102179",
+    "numerator": "865575873887465179870958943227671960",
+    "denominator": "210331384165224607730577",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "102179",
+    "numerator": "865575873887465179870958943227671960",
+    "denominator": "210331384165224607730577",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "222",
+    "numerator": "336485045508431593064335",
+    "denominator": "575077281603208220708295924",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "222",
+    "numerator": "336485045508431593064335",
+    "denominator": "575077281603208220708295924",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8287514269",
+    "numerator": "990351520848438115086558554",
+    "denominator": "9844346961530939",
+    "rounding": "Floor",
+    "expected": "833732536290135817172",
+    "overflow": false
+  },
+  {
+    "a": "8287514269",
+    "numerator": "990351520848438115086558554",
+    "denominator": "9844346961530939",
+    "rounding": "Ceil",
+    "expected": "833732536290135817173",
+    "overflow": false
+  },
+  {
+    "a": "897107470505544421128421776",
+    "numerator": "16312736890339305",
+    "denominator": "4057976232020579094",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "897107470505544421128421776",
+    "numerator": "16312736890339305",
+    "denominator": "4057976232020579094",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3062530068350285095",
+    "numerator": "908348583080899442540",
+    "denominator": "11125",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3062530068350285095",
+    "numerator": "908348583080899442540",
+    "denominator": "11125",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4579032666110927232240817233938",
+    "numerator": "148051",
+    "denominator": "6620435020810796366000861443781256",
+    "rounding": "Floor",
+    "expected": "102",
+    "overflow": false
+  },
+  {
+    "a": "4579032666110927232240817233938",
+    "numerator": "148051",
+    "denominator": "6620435020810796366000861443781256",
+    "rounding": "Ceil",
+    "expected": "103",
+    "overflow": false
+  },
+  {
+    "a": "71741432915483969",
+    "numerator": "72161607556085540942",
+    "denominator": "7317448853521343",
+    "rounding": "Floor",
+    "expected": "707483882865419482638",
+    "overflow": false
+  },
+  {
+    "a": "71741432915483969",
+    "numerator": "72161607556085540942",
+    "denominator": "7317448853521343",
+    "rounding": "Ceil",
+    "expected": "707483882865419482639",
+    "overflow": false
+  },
+  {
+    "a": "228",
+    "numerator": "3424589",
+    "denominator": "138798801543089489866",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "228",
+    "numerator": "3424589",
+    "denominator": "138798801543089489866",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "363",
+    "numerator": "986753260358700538738264172672",
+    "denominator": "6751129",
+    "rounding": "Floor",
+    "expected": "53056523362271450532494623",
+    "overflow": false
+  },
+  {
+    "a": "363",
+    "numerator": "986753260358700538738264172672",
+    "denominator": "6751129",
+    "rounding": "Ceil",
+    "expected": "53056523362271450532494624",
+    "overflow": false
+  },
+  {
+    "a": "23174",
+    "numerator": "184521559",
+    "denominator": "2913147740",
+    "rounding": "Floor",
+    "expected": "1467",
+    "overflow": false
+  },
+  {
+    "a": "23174",
+    "numerator": "184521559",
+    "denominator": "2913147740",
+    "rounding": "Ceil",
+    "expected": "1468",
+    "overflow": false
+  },
+  {
+    "a": "2251831669480262328173725618213",
+    "numerator": "22223087492071299675030715546754",
+    "denominator": "2435",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2251831669480262328173725618213",
+    "numerator": "22223087492071299675030715546754",
+    "denominator": "2435",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "888",
+    "numerator": "118084744934832538926224113",
+    "denominator": "9707045135274789245929918",
+    "rounding": "Floor",
+    "expected": "10802",
+    "overflow": false
+  },
+  {
+    "a": "888",
+    "numerator": "118084744934832538926224113",
+    "denominator": "9707045135274789245929918",
+    "rounding": "Ceil",
+    "expected": "10803",
+    "overflow": false
+  },
+  {
+    "a": "9519930696811503",
+    "numerator": "112450772",
+    "denominator": "26209849059930949574850557",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "9519930696811503",
+    "numerator": "112450772",
+    "denominator": "26209849059930949574850557",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1026191139098200989242",
+    "numerator": "41651190559719067",
+    "denominator": "3552584560",
+    "rounding": "Floor",
+    "expected": "12031263989188295352164334423",
+    "overflow": false
+  },
+  {
+    "a": "1026191139098200989242",
+    "numerator": "41651190559719067",
+    "denominator": "3552584560",
+    "rounding": "Ceil",
+    "expected": "12031263989188295352164334424",
+    "overflow": false
+  },
+  {
+    "a": "1903490856384681065064386290170850121",
+    "numerator": "1381878",
+    "denominator": "15300916165913003551421831",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1903490856384681065064386290170850121",
+    "numerator": "1381878",
+    "denominator": "15300916165913003551421831",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "535384879108940",
+    "numerator": "6470705517951448799445",
+    "denominator": "18837281704293003014118957763826",
+    "rounding": "Floor",
+    "expected": "183907",
+    "overflow": false
+  },
+  {
+    "a": "535384879108940",
+    "numerator": "6470705517951448799445",
+    "denominator": "18837281704293003014118957763826",
+    "rounding": "Ceil",
+    "expected": "183908",
+    "overflow": false
+  },
+  {
+    "a": "601886877357070945318067",
+    "numerator": "0",
+    "denominator": "22212178963355752386461265057",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "601886877357070945318067",
+    "numerator": "0",
+    "denominator": "22212178963355752386461265057",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1332353041110238162468052782",
+    "numerator": "2721263454239",
+    "denominator": "27825564190054427538027912900",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1332353041110238162468052782",
+    "numerator": "2721263454239",
+    "denominator": "27825564190054427538027912900",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "413835708618371863213",
+    "numerator": "2878367005587850129476543142684842",
+    "denominator": "24258390147262707673046760395",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "413835708618371863213",
+    "numerator": "2878367005587850129476543142684842",
+    "denominator": "24258390147262707673046760395",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1303864089609986665909645920",
+    "numerator": "16625645341734649",
+    "denominator": "15403467394561951078",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1303864089609986665909645920",
+    "numerator": "16625645341734649",
+    "denominator": "15403467394561951078",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7881785005780348668992439",
+    "numerator": "9296895804",
+    "denominator": "16339420168126176534430614917",
+    "rounding": "Floor",
+    "expected": "4484622",
+    "overflow": false
+  },
+  {
+    "a": "7881785005780348668992439",
+    "numerator": "9296895804",
+    "denominator": "16339420168126176534430614917",
+    "rounding": "Ceil",
+    "expected": "4484623",
+    "overflow": false
+  },
+  {
+    "a": "584055430892183082150243832162",
+    "numerator": "348793201641018260291256447971",
+    "denominator": "301659395935314224040197185880",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "584055430892183082150243832162",
+    "numerator": "348793201641018260291256447971",
+    "denominator": "301659395935314224040197185880",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1368356933433075460689",
+    "numerator": "37391318362067057703774366",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1368356933433075460689",
+    "numerator": "37391318362067057703774366",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "468588319893261726900",
+    "numerator": "91449408209493891845788301807708148061",
+    "denominator": "26",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "468588319893261726900",
+    "numerator": "91449408209493891845788301807708148061",
+    "denominator": "26",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6408880789001633019",
+    "numerator": "3110748568994587074558654061237584",
+    "denominator": "165335490961103219107497",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6408880789001633019",
+    "numerator": "3110748568994587074558654061237584",
+    "denominator": "165335490961103219107497",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1606248662",
+    "numerator": "4179813652895854072504468967",
+    "denominator": "1836",
+    "rounding": "Floor",
+    "expected": "3656764753471295222934397749054614",
+    "overflow": false
+  },
+  {
+    "a": "1606248662",
+    "numerator": "4179813652895854072504468967",
+    "denominator": "1836",
+    "rounding": "Ceil",
+    "expected": "3656764753471295222934397749054615",
+    "overflow": false
+  },
+  {
+    "a": "178670727606941025386874909890101",
+    "numerator": "20941261981215008426450",
+    "denominator": "3",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "178670727606941025386874909890101",
+    "numerator": "20941261981215008426450",
+    "denominator": "3",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5243069427747171912",
+    "numerator": "16487597247489",
+    "denominator": "1550",
+    "rounding": "Floor",
+    "expected": "55771365848592256760319544083",
+    "overflow": false
+  },
+  {
+    "a": "5243069427747171912",
+    "numerator": "16487597247489",
+    "denominator": "1550",
+    "rounding": "Ceil",
+    "expected": "55771365848592256760319544084",
+    "overflow": false
+  },
+  {
+    "a": "154770559519477303045954687",
+    "numerator": "64310588266109108906244621813106155172",
+    "denominator": "3852231368118371566772802232857031693",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "154770559519477303045954687",
+    "numerator": "64310588266109108906244621813106155172",
+    "denominator": "3852231368118371566772802232857031693",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "406264968258689856608650",
+    "numerator": "708261799186981777413830279723",
+    "denominator": "137206677316389952",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "406264968258689856608650",
+    "numerator": "708261799186981777413830279723",
+    "denominator": "137206677316389952",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10626757458521",
+    "numerator": "70624691739892678726",
+    "denominator": "39789407721847658707972723053310999",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "10626757458521",
+    "numerator": "70624691739892678726",
+    "denominator": "39789407721847658707972723053310999",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "461655379273826583920295867164",
+    "numerator": "1953555109551942349589221",
+    "denominator": "8700175294871106",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "461655379273826583920295867164",
+    "numerator": "1953555109551942349589221",
+    "denominator": "8700175294871106",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2436199143003983314586449549311555",
+    "numerator": "103827859168491671352",
+    "denominator": "423681005601004607774722155896426929",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2436199143003983314586449549311555",
+    "numerator": "103827859168491671352",
+    "denominator": "423681005601004607774722155896426929",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12312965848870114606705221491734337406",
+    "numerator": "57868506373340848024820214959",
+    "denominator": "221458508477631777096391024887323796",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12312965848870114606705221491734337406",
+    "numerator": "57868506373340848024820214959",
+    "denominator": "221458508477631777096391024887323796",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1672977137446495275753056646832175805",
+    "numerator": "10",
+    "denominator": "129868050906958683",
+    "rounding": "Floor",
+    "expected": "128821301756893666869",
+    "overflow": false
+  },
+  {
+    "a": "1672977137446495275753056646832175805",
+    "numerator": "10",
+    "denominator": "129868050906958683",
+    "rounding": "Ceil",
+    "expected": "128821301756893666870",
+    "overflow": false
+  },
+  {
+    "a": "425584173812995601858248844683171632",
+    "numerator": "132256825650280848165909681657999881",
+    "denominator": "6737365584473852854",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "425584173812995601858248844683171632",
+    "numerator": "132256825650280848165909681657999881",
+    "denominator": "6737365584473852854",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1607",
+    "numerator": "1068964900420364",
+    "denominator": "39083808627955834276155915745715093",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1607",
+    "numerator": "1068964900420364",
+    "denominator": "39083808627955834276155915745715093",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "178",
+    "numerator": "79106736036685571524355214870899",
+    "denominator": "596398058966885099609049343558696",
+    "rounding": "Floor",
+    "expected": "23",
+    "overflow": false
+  },
+  {
+    "a": "178",
+    "numerator": "79106736036685571524355214870899",
+    "denominator": "596398058966885099609049343558696",
+    "rounding": "Ceil",
+    "expected": "24",
+    "overflow": false
+  },
+  {
+    "a": "8403809",
+    "numerator": "0",
+    "denominator": "572992183643645680614392031",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8403809",
+    "numerator": "0",
+    "denominator": "572992183643645680614392031",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "159364",
+    "numerator": "60694072678053623764887371179373",
+    "denominator": "71291443641705124948009425514",
+    "rounding": "Floor",
+    "expected": "135674769",
+    "overflow": false
+  },
+  {
+    "a": "159364",
+    "numerator": "60694072678053623764887371179373",
+    "denominator": "71291443641705124948009425514",
+    "rounding": "Ceil",
+    "expected": "135674770",
+    "overflow": false
+  },
+  {
+    "a": "3794612224304633995",
+    "numerator": "3343826050136055006151570976",
+    "denominator": "13139773595411156409",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3794612224304633995",
+    "numerator": "3343826050136055006151570976",
+    "denominator": "13139773595411156409",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4731400588070",
+    "numerator": "2522729649853459439072484471",
+    "denominator": "56500661733150104700986054396",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4731400588070",
+    "numerator": "2522729649853459439072484471",
+    "denominator": "56500661733150104700986054396",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "168206405",
+    "numerator": "1890897748598565666",
+    "denominator": "18328175581958779542870179",
+    "rounding": "Floor",
+    "expected": "17",
+    "overflow": false
+  },
+  {
+    "a": "168206405",
+    "numerator": "1890897748598565666",
+    "denominator": "18328175581958779542870179",
+    "rounding": "Ceil",
+    "expected": "18",
+    "overflow": false
+  },
+  {
+    "a": "1304",
+    "numerator": "30525713",
+    "denominator": "121561700541230219263921970714206",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1304",
+    "numerator": "30525713",
+    "denominator": "121561700541230219263921970714206",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1710351",
+    "numerator": "954895379445437556",
+    "denominator": "94958621",
+    "rounding": "Floor",
+    "expected": "17199136317806084",
+    "overflow": false
+  },
+  {
+    "a": "1710351",
+    "numerator": "954895379445437556",
+    "denominator": "94958621",
+    "rounding": "Ceil",
+    "expected": "17199136317806085",
+    "overflow": false
+  },
+  {
+    "a": "137737490654069106906",
+    "numerator": "59",
+    "denominator": "5614316520981897209780999530768",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "137737490654069106906",
+    "numerator": "59",
+    "denominator": "5614316520981897209780999530768",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "30778680003945",
+    "numerator": "5865110",
+    "denominator": "2049548402660611751",
+    "rounding": "Floor",
+    "expected": "88",
+    "overflow": false
+  },
+  {
+    "a": "30778680003945",
+    "numerator": "5865110",
+    "denominator": "2049548402660611751",
+    "rounding": "Ceil",
+    "expected": "89",
+    "overflow": false
+  },
+  {
+    "a": "31421023012980999916",
+    "numerator": "4169402302709",
+    "denominator": "914",
+    "rounding": "Floor",
+    "expected": "143333572980082562634831220538",
+    "overflow": false
+  },
+  {
+    "a": "31421023012980999916",
+    "numerator": "4169402302709",
+    "denominator": "914",
+    "rounding": "Ceil",
+    "expected": "143333572980082562634831220539",
+    "overflow": false
+  },
+  {
+    "a": "10316755",
+    "numerator": "185310174763442077084168",
+    "denominator": "106149522618513655102145",
+    "rounding": "Floor",
+    "expected": "18010440",
+    "overflow": false
+  },
+  {
+    "a": "10316755",
+    "numerator": "185310174763442077084168",
+    "denominator": "106149522618513655102145",
+    "rounding": "Ceil",
+    "expected": "18010441",
+    "overflow": false
+  },
+  {
+    "a": "910880120447950",
+    "numerator": "5439",
+    "denominator": "241519856946873372203889732816484",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "910880120447950",
+    "numerator": "5439",
+    "denominator": "241519856946873372203889732816484",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "71865861300383791684849604854998733",
+    "numerator": "316770578057768706123393866",
+    "denominator": "239455810381694156523",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "71865861300383791684849604854998733",
+    "numerator": "316770578057768706123393866",
+    "denominator": "239455810381694156523",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "229696298266840879978311680",
+    "numerator": "695838461551406529036711820275993",
+    "denominator": "256292054534",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "229696298266840879978311680",
+    "numerator": "695838461551406529036711820275993",
+    "denominator": "256292054534",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8197335",
+    "numerator": "137838976103569508357793893845724",
+    "denominator": "52258214824900654298407847333",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8197335",
+    "numerator": "137838976103569508357793893845724",
+    "denominator": "52258214824900654298407847333",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "342353669280325873089286172674",
+    "numerator": "65551247034147775934399235",
+    "denominator": "878655012036893432",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "342353669280325873089286172674",
+    "numerator": "65551247034147775934399235",
+    "denominator": "878655012036893432",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "471915076214443228179950790463601",
+    "numerator": "633938944074328120991520728382",
+    "denominator": "15",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "471915076214443228179950790463601",
+    "numerator": "633938944074328120991520728382",
+    "denominator": "15",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1708303448349780",
+    "numerator": "2727019441762581885",
+    "denominator": "146890881160917246394",
+    "rounding": "Floor",
+    "expected": "31714539931015",
+    "overflow": false
+  },
+  {
+    "a": "1708303448349780",
+    "numerator": "2727019441762581885",
+    "denominator": "146890881160917246394",
+    "rounding": "Ceil",
+    "expected": "31714539931016",
+    "overflow": false
+  },
+  {
+    "a": "2451395991674159894208970274159335451",
+    "numerator": "752",
+    "denominator": "14537",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2451395991674159894208970274159335451",
+    "numerator": "752",
+    "denominator": "14537",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1060979062",
+    "numerator": "10847483238878451463",
+    "denominator": "64066447149837456581324",
+    "rounding": "Floor",
+    "expected": "179640",
+    "overflow": false
+  },
+  {
+    "a": "1060979062",
+    "numerator": "10847483238878451463",
+    "denominator": "64066447149837456581324",
+    "rounding": "Ceil",
+    "expected": "179641",
+    "overflow": false
+  },
+  {
+    "a": "3398237923089118841804205653",
+    "numerator": "649620242536571152343154",
+    "denominator": "19",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3398237923089118841804205653",
+    "numerator": "649620242536571152343154",
+    "denominator": "19",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12872419176658771944",
+    "numerator": "3888007593602402849",
+    "denominator": "120067697711790",
+    "rounding": "Floor",
+    "expected": "416832041095829606378377",
+    "overflow": false
+  },
+  {
+    "a": "12872419176658771944",
+    "numerator": "3888007593602402849",
+    "denominator": "120067697711790",
+    "rounding": "Ceil",
+    "expected": "416832041095829606378378",
+    "overflow": false
+  },
+  {
+    "a": "54616975075235794499999",
+    "numerator": "828260766625496644",
+    "denominator": "2003253333514962249271718414652962861",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "54616975075235794499999",
+    "numerator": "828260766625496644",
+    "denominator": "2003253333514962249271718414652962861",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "409728376917790133627989370448088106",
+    "numerator": "11",
+    "denominator": "381555210067266423217469920",
+    "rounding": "Floor",
+    "expected": "11812214922",
+    "overflow": false
+  },
+  {
+    "a": "409728376917790133627989370448088106",
+    "numerator": "11",
+    "denominator": "381555210067266423217469920",
+    "rounding": "Ceil",
+    "expected": "11812214923",
+    "overflow": false
+  },
+  {
+    "a": "30719927417",
+    "numerator": "955846886",
+    "denominator": "245333845187895",
+    "rounding": "Floor",
+    "expected": "119688",
+    "overflow": false
+  },
+  {
+    "a": "30719927417",
+    "numerator": "955846886",
+    "denominator": "245333845187895",
+    "rounding": "Ceil",
+    "expected": "119689",
+    "overflow": false
+  },
+  {
+    "a": "108422017414292363751296700",
+    "numerator": "15551020162700356665272136465157",
+    "denominator": "470562315974864171649954279261410",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "108422017414292363751296700",
+    "numerator": "15551020162700356665272136465157",
+    "denominator": "470562315974864171649954279261410",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22510947",
+    "numerator": "35043906953987156342522402141632728",
+    "denominator": "81",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22510947",
+    "numerator": "35043906953987156342522402141632728",
+    "denominator": "81",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4773255508427806",
+    "numerator": "15",
+    "denominator": "180956761366647518260",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4773255508427806",
+    "numerator": "15",
+    "denominator": "180956761366647518260",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "562911123165",
+    "numerator": "2",
+    "denominator": "1690199471846200955",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "562911123165",
+    "numerator": "2",
+    "denominator": "1690199471846200955",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "9046097411280",
+    "numerator": "7662084734252841166255145",
+    "denominator": "21286126092644208601257046",
+    "rounding": "Floor",
+    "expected": "3256203809836",
+    "overflow": false
+  },
+  {
+    "a": "9046097411280",
+    "numerator": "7662084734252841166255145",
+    "denominator": "21286126092644208601257046",
+    "rounding": "Ceil",
+    "expected": "3256203809837",
+    "overflow": false
+  },
+  {
+    "a": "38610791",
+    "numerator": "105921279542423775737158649007788",
+    "denominator": "38316981",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "38610791",
+    "numerator": "105921279542423775737158649007788",
+    "denominator": "38316981",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "100304733085010",
+    "numerator": "4652056273043",
+    "denominator": "546028298202528751575754184",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "100304733085010",
+    "numerator": "4652056273043",
+    "denominator": "546028298202528751575754184",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8983630377863260545",
+    "numerator": "826694759269488732360357699982",
+    "denominator": "39725154609761791",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8983630377863260545",
+    "numerator": "826694759269488732360357699982",
+    "denominator": "39725154609761791",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1004707921444",
+    "numerator": "6899077693258435058547376101773",
+    "denominator": "11644514453425293105302097305894154",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1004707921444",
+    "numerator": "6899077693258435058547376101773",
+    "denominator": "11644514453425293105302097305894154",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "622584048226588290895231915",
+    "numerator": "51408006942542727009521917605741974464",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "622584048226588290895231915",
+    "numerator": "51408006942542727009521917605741974464",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24760439162244038",
+    "numerator": "73772086450468247",
+    "denominator": "1005656119136145464047568970396",
+    "rounding": "Floor",
+    "expected": "1816",
+    "overflow": false
+  },
+  {
+    "a": "24760439162244038",
+    "numerator": "73772086450468247",
+    "denominator": "1005656119136145464047568970396",
+    "rounding": "Ceil",
+    "expected": "1817",
+    "overflow": false
+  },
+  {
+    "a": "525298222579813",
+    "numerator": "16112404401351106",
+    "denominator": "41403845593429451442115",
+    "rounding": "Floor",
+    "expected": "204421045",
+    "overflow": false
+  },
+  {
+    "a": "525298222579813",
+    "numerator": "16112404401351106",
+    "denominator": "41403845593429451442115",
+    "rounding": "Ceil",
+    "expected": "204421046",
+    "overflow": false
+  },
+  {
+    "a": "338394728639555256",
+    "numerator": "1147076027122900207856589250498353",
+    "denominator": "1389916608724015100670",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "338394728639555256",
+    "numerator": "1147076027122900207856589250498353",
+    "denominator": "1389916608724015100670",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "587356127606363494055471",
+    "numerator": "899483199302560382633221140",
+    "denominator": "3470179360309309",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "587356127606363494055471",
+    "numerator": "899483199302560382633221140",
+    "denominator": "3470179360309309",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "34172767636360737601662437376890",
+    "numerator": "123039980073544200178781988059",
+    "denominator": "200641640966684262833585840",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "34172767636360737601662437376890",
+    "numerator": "123039980073544200178781988059",
+    "denominator": "200641640966684262833585840",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4611408359211712393",
+    "numerator": "7605757923601533514434492214",
+    "denominator": "53573230027335914080199",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4611408359211712393",
+    "numerator": "7605757923601533514434492214",
+    "denominator": "53573230027335914080199",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "304416873163929351693051677324",
+    "numerator": "2918342762684413524245",
+    "denominator": "21631560242",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "304416873163929351693051677324",
+    "numerator": "2918342762684413524245",
+    "denominator": "21631560242",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3644139709985523",
+    "numerator": "936",
+    "denominator": "39137",
+    "rounding": "Floor",
+    "expected": "87153199492716",
+    "overflow": false
+  },
+  {
+    "a": "3644139709985523",
+    "numerator": "936",
+    "denominator": "39137",
+    "rounding": "Ceil",
+    "expected": "87153199492717",
+    "overflow": false
+  },
+  {
+    "a": "3917670427169827293738629230",
+    "numerator": "3994514015",
+    "denominator": "27359225274249619998553824611844",
+    "rounding": "Floor",
+    "expected": "571989",
+    "overflow": false
+  },
+  {
+    "a": "3917670427169827293738629230",
+    "numerator": "3994514015",
+    "denominator": "27359225274249619998553824611844",
+    "rounding": "Ceil",
+    "expected": "571990",
+    "overflow": false
+  },
+  {
+    "a": "3186839573719962052217581",
+    "numerator": "944025780507049408871914",
+    "denominator": "1101127560754286486114827",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3186839573719962052217581",
+    "numerator": "944025780507049408871914",
+    "denominator": "1101127560754286486114827",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "654137",
+    "denominator": "75355814",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "654137",
+    "denominator": "75355814",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "39119557303775934340599",
+    "numerator": "34428",
+    "denominator": "4818858568007228723194182218760230341",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "39119557303775934340599",
+    "numerator": "34428",
+    "denominator": "4818858568007228723194182218760230341",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "31170210",
+    "numerator": "6466280236882203105842621695959587",
+    "denominator": "1756444271785058338409689785496",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31170210",
+    "numerator": "6466280236882203105842621695959587",
+    "denominator": "1756444271785058338409689785496",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "613726627356013900114804751000094353",
+    "numerator": "6",
+    "denominator": "92815",
+    "rounding": "Floor",
+    "expected": "39674188052966475253879529235582",
+    "overflow": false
+  },
+  {
+    "a": "613726627356013900114804751000094353",
+    "numerator": "6",
+    "denominator": "92815",
+    "rounding": "Ceil",
+    "expected": "39674188052966475253879529235583",
+    "overflow": false
+  },
+  {
+    "a": "11993516165253168649932964025332",
+    "numerator": "236476425140637",
+    "denominator": "110396635058271214342538977438810",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11993516165253168649932964025332",
+    "numerator": "236476425140637",
+    "denominator": "110396635058271214342538977438810",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1044173200504729128092475",
+    "numerator": "31902906777211024",
+    "denominator": "3888095877865",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1044173200504729128092475",
+    "numerator": "31902906777211024",
+    "denominator": "3888095877865",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15151149312534",
+    "numerator": "15532914155506627653171239",
+    "denominator": "2400838653548",
+    "rounding": "Floor",
+    "expected": "98024705359130328947191734",
+    "overflow": false
+  },
+  {
+    "a": "15151149312534",
+    "numerator": "15532914155506627653171239",
+    "denominator": "2400838653548",
+    "rounding": "Ceil",
+    "expected": "98024705359130328947191735",
+    "overflow": false
+  },
+  {
+    "a": "550450217178741",
+    "numerator": "133007122",
+    "denominator": "4122824909929420115",
+    "rounding": "Floor",
+    "expected": "17758",
+    "overflow": false
+  },
+  {
+    "a": "550450217178741",
+    "numerator": "133007122",
+    "denominator": "4122824909929420115",
+    "rounding": "Ceil",
+    "expected": "17759",
+    "overflow": false
+  },
+  {
+    "a": "2253192",
+    "numerator": "1",
+    "denominator": "1693045610797529816910",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2253192",
+    "numerator": "1",
+    "denominator": "1693045610797529816910",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2876815032320612575045311",
+    "numerator": "291370188835241813652712932",
+    "denominator": "80531542432526937237863034525493398605",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2876815032320612575045311",
+    "numerator": "291370188835241813652712932",
+    "denominator": "80531542432526937237863034525493398605",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "223346355504069858854449640885962",
+    "numerator": "9762923",
+    "denominator": "896",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "223346355504069858854449640885962",
+    "numerator": "9762923",
+    "denominator": "896",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65764520305092590935163584798361",
+    "numerator": "13954533699596605095391523206",
+    "denominator": "10688309990746680469154095142487",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65764520305092590935163584798361",
+    "numerator": "13954533699596605095391523206",
+    "denominator": "10688309990746680469154095142487",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "107608668",
+    "numerator": "1707569831844870949",
+    "denominator": "748907406210",
+    "rounding": "Floor",
+    "expected": "245356520176121",
+    "overflow": false
+  },
+  {
+    "a": "107608668",
+    "numerator": "1707569831844870949",
+    "denominator": "748907406210",
+    "rounding": "Ceil",
+    "expected": "245356520176122",
+    "overflow": false
+  },
+  {
+    "a": "583762123288923267",
+    "numerator": "101312652337989792376",
+    "denominator": "48303187966019964401",
+    "rounding": "Floor",
+    "expected": "1224401360143405421",
+    "overflow": false
+  },
+  {
+    "a": "583762123288923267",
+    "numerator": "101312652337989792376",
+    "denominator": "48303187966019964401",
+    "rounding": "Ceil",
+    "expected": "1224401360143405422",
+    "overflow": false
+  },
+  {
+    "a": "25361679825727779422961854",
+    "numerator": "151653603736945238599855410744551151",
+    "denominator": "16196282571732",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25361679825727779422961854",
+    "numerator": "151653603736945238599855410744551151",
+    "denominator": "16196282571732",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "52310370972154629786075901",
+    "numerator": "6456833656352480614847377990970",
+    "denominator": "574923891795587483",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "52310370972154629786075901",
+    "numerator": "6456833656352480614847377990970",
+    "denominator": "574923891795587483",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "112",
+    "numerator": "2403141420081139852709745247302420041",
+    "denominator": "69203991758301719798",
+    "rounding": "Floor",
+    "expected": "3889253093797153313",
+    "overflow": false
+  },
+  {
+    "a": "112",
+    "numerator": "2403141420081139852709745247302420041",
+    "denominator": "69203991758301719798",
+    "rounding": "Ceil",
+    "expected": "3889253093797153314",
+    "overflow": false
+  },
+  {
+    "a": "153811930985346447495",
+    "numerator": "127564573188183436816277868532879700556",
+    "denominator": "9745029007706910604907210212309",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "153811930985346447495",
+    "numerator": "127564573188183436816277868532879700556",
+    "denominator": "9745029007706910604907210212309",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "691434482",
+    "numerator": "370253689735091",
+    "denominator": "136549472994820695749774405485270888",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "691434482",
+    "numerator": "370253689735091",
+    "denominator": "136549472994820695749774405485270888",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2757460895649",
+    "numerator": "46",
+    "denominator": "6291136567386138520687341431583",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2757460895649",
+    "numerator": "46",
+    "denominator": "6291136567386138520687341431583",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "196",
+    "numerator": "116105788527282267643309",
+    "denominator": "4343182442355204315908943786",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "196",
+    "numerator": "116105788527282267643309",
+    "denominator": "4343182442355204315908943786",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "203",
+    "numerator": "11985921271117579543637176123744",
+    "denominator": "255939065",
+    "rounding": "Floor",
+    "expected": "9506723868186627341778976",
+    "overflow": false
+  },
+  {
+    "a": "203",
+    "numerator": "11985921271117579543637176123744",
+    "denominator": "255939065",
+    "rounding": "Ceil",
+    "expected": "9506723868186627341778977",
+    "overflow": false
+  },
+  {
+    "a": "33993420393670370655543702445158",
+    "numerator": "27748791280954131121462967",
+    "denominator": "537292209072160316",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33993420393670370655543702445158",
+    "numerator": "27748791280954131121462967",
+    "denominator": "537292209072160316",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15855749",
+    "numerator": "98",
+    "denominator": "1084020874413795",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "15855749",
+    "numerator": "98",
+    "denominator": "1084020874413795",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "196710488",
+    "numerator": "307193169",
+    "denominator": "127363857195415794851294832733262978974",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "196710488",
+    "numerator": "307193169",
+    "denominator": "127363857195415794851294832733262978974",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1481370201819645470026587009132229455",
+    "numerator": "8023549096884",
+    "denominator": "7261",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1481370201819645470026587009132229455",
+    "numerator": "8023549096884",
+    "denominator": "7261",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "189541914",
+    "numerator": "107466487208390651",
+    "denominator": "95971037956512228432",
+    "rounding": "Floor",
+    "expected": "212245",
+    "overflow": false
+  },
+  {
+    "a": "189541914",
+    "numerator": "107466487208390651",
+    "denominator": "95971037956512228432",
+    "rounding": "Ceil",
+    "expected": "212246",
+    "overflow": false
+  },
+  {
+    "a": "11021674004905",
+    "numerator": "4443149812973526",
+    "denominator": "19117573143591278213810000428547705063",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11021674004905",
+    "numerator": "4443149812973526",
+    "denominator": "19117573143591278213810000428547705063",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2096643050970668",
+    "numerator": "53",
+    "denominator": "1936205379951539136341094610",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2096643050970668",
+    "numerator": "53",
+    "denominator": "1936205379951539136341094610",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2579",
+    "numerator": "20545728816625229128",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "52987434618076465921112",
+    "overflow": false
+  },
+  {
+    "a": "2579",
+    "numerator": "20545728816625229128",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "52987434618076465921112",
+    "overflow": false
+  },
+  {
+    "a": "18408288882468430137990414",
+    "numerator": "270833256550203263",
+    "denominator": "477615762436604838490211742659927460",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18408288882468430137990414",
+    "numerator": "270833256550203263",
+    "denominator": "477615762436604838490211742659927460",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "55748628430605",
+    "numerator": "7560296149587113740293812488069258",
+    "denominator": "226603",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "55748628430605",
+    "numerator": "7560296149587113740293812488069258",
+    "denominator": "226603",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "392531966751493544768",
+    "numerator": "162876536028877716921963865",
+    "denominator": "640507418438",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "392531966751493544768",
+    "numerator": "162876536028877716921963865",
+    "denominator": "640507418438",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14103",
+    "numerator": "623966485153764135452",
+    "denominator": "62949",
+    "rounding": "Floor",
+    "expected": "139792519978451374958",
+    "overflow": false
+  },
+  {
+    "a": "14103",
+    "numerator": "623966485153764135452",
+    "denominator": "62949",
+    "rounding": "Ceil",
+    "expected": "139792519978451374959",
+    "overflow": false
+  },
+  {
+    "a": "17268275744459726674563538242",
+    "numerator": "151875",
+    "denominator": "2012567627801211191934520",
+    "rounding": "Floor",
+    "expected": "1303121118",
+    "overflow": false
+  },
+  {
+    "a": "17268275744459726674563538242",
+    "numerator": "151875",
+    "denominator": "2012567627801211191934520",
+    "rounding": "Ceil",
+    "expected": "1303121119",
+    "overflow": false
+  },
+  {
+    "a": "252721589360945144428483857585",
+    "numerator": "475705404329598",
+    "denominator": "156722827183",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "252721589360945144428483857585",
+    "numerator": "475705404329598",
+    "denominator": "156722827183",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17437584939211956978698583336442772",
+    "numerator": "7996917181",
+    "denominator": "1083334117114",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17437584939211956978698583336442772",
+    "numerator": "7996917181",
+    "denominator": "1083334117114",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20971099",
+    "numerator": "189625943215973936",
+    "denominator": "822537",
+    "rounding": "Floor",
+    "expected": "4834632883567022265",
+    "overflow": false
+  },
+  {
+    "a": "20971099",
+    "numerator": "189625943215973936",
+    "denominator": "822537",
+    "rounding": "Ceil",
+    "expected": "4834632883567022266",
+    "overflow": false
+  },
+  {
+    "a": "1218902930392681338207843639990",
+    "numerator": "80116246855",
+    "denominator": "12",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1218902930392681338207843639990",
+    "numerator": "80116246855",
+    "denominator": "12",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3733",
+    "numerator": "50",
+    "denominator": "1139",
+    "rounding": "Floor",
+    "expected": "163",
+    "overflow": false
+  },
+  {
+    "a": "3733",
+    "numerator": "50",
+    "denominator": "1139",
+    "rounding": "Ceil",
+    "expected": "164",
+    "overflow": false
+  },
+  {
+    "a": "73237544593564818236180468693168936",
+    "numerator": "3022638512354477721148061281",
+    "denominator": "10974190",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "73237544593564818236180468693168936",
+    "numerator": "3022638512354477721148061281",
+    "denominator": "10974190",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5774573792846516185441247",
+    "numerator": "34325501399795685733890951490948",
+    "denominator": "1603657689956085051501",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5774573792846516185441247",
+    "numerator": "34325501399795685733890951490948",
+    "denominator": "1603657689956085051501",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "249258346",
+    "numerator": "19339",
+    "denominator": "54822176",
+    "rounding": "Floor",
+    "expected": "87928",
+    "overflow": false
+  },
+  {
+    "a": "249258346",
+    "numerator": "19339",
+    "denominator": "54822176",
+    "rounding": "Ceil",
+    "expected": "87929",
+    "overflow": false
+  },
+  {
+    "a": "39287807977949685945",
+    "numerator": "182949668737018014423555004646629926",
+    "denominator": "74535858922287237439351",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39287807977949685945",
+    "numerator": "182949668737018014423555004646629926",
+    "denominator": "74535858922287237439351",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15806117372",
+    "numerator": "30051037845123459953691461",
+    "denominator": "123114018",
+    "rounding": "Floor",
+    "expected": "3858132802801021130337805376",
+    "overflow": false
+  },
+  {
+    "a": "15806117372",
+    "numerator": "30051037845123459953691461",
+    "denominator": "123114018",
+    "rounding": "Ceil",
+    "expected": "3858132802801021130337805377",
+    "overflow": false
+  },
+  {
+    "a": "2829394658537881114565113785251",
+    "numerator": "23783343976446049304",
+    "denominator": "182668618010337709915151364113425",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2829394658537881114565113785251",
+    "numerator": "23783343976446049304",
+    "denominator": "182668618010337709915151364113425",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19904197030864642413823446366",
+    "numerator": "137639309196303",
+    "denominator": "239653748",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19904197030864642413823446366",
+    "numerator": "137639309196303",
+    "denominator": "239653748",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "796522866430214728810983784221",
+    "numerator": "302919642",
+    "denominator": "59",
+    "rounding": "Floor",
+    "expected": "4089532568539906163297462603119162184",
+    "overflow": false
+  },
+  {
+    "a": "796522866430214728810983784221",
+    "numerator": "302919642",
+    "denominator": "59",
+    "rounding": "Ceil",
+    "expected": "4089532568539906163297462603119162185",
+    "overflow": false
+  },
+  {
+    "a": "11313300480955361359888",
+    "numerator": "2509143286479946112995485801",
+    "denominator": "46114131218496936367510",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11313300480955361359888",
+    "numerator": "2509143286479946112995485801",
+    "denominator": "46114131218496936367510",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4861300071970101671",
+    "numerator": "26092",
+    "denominator": "32093642184027125",
+    "rounding": "Floor",
+    "expected": "3952217",
+    "overflow": false
+  },
+  {
+    "a": "4861300071970101671",
+    "numerator": "26092",
+    "denominator": "32093642184027125",
+    "rounding": "Ceil",
+    "expected": "3952218",
+    "overflow": false
+  },
+  {
+    "a": "61854487973084217767562895825554",
+    "numerator": "812039891",
+    "denominator": "264",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "61854487973084217767562895825554",
+    "numerator": "812039891",
+    "denominator": "264",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "145558035020821953",
+    "numerator": "105166",
+    "denominator": "176022482652420571535936278504790079",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "145558035020821953",
+    "numerator": "105166",
+    "denominator": "176022482652420571535936278504790079",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "15836011521854820",
+    "numerator": "183705219533",
+    "denominator": "37505872458",
+    "rounding": "Floor",
+    "expected": "77565399295995684",
+    "overflow": false
+  },
+  {
+    "a": "15836011521854820",
+    "numerator": "183705219533",
+    "denominator": "37505872458",
+    "rounding": "Ceil",
+    "expected": "77565399295995685",
+    "overflow": false
+  },
+  {
+    "a": "7892513259",
+    "numerator": "0",
+    "denominator": "7302536229244864613981719577",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7892513259",
+    "numerator": "0",
+    "denominator": "7302536229244864613981719577",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "471987289350",
+    "numerator": "4577228777789399",
+    "denominator": "43061647529273820",
+    "rounding": "Floor",
+    "expected": "50169789766",
+    "overflow": false
+  },
+  {
+    "a": "471987289350",
+    "numerator": "4577228777789399",
+    "denominator": "43061647529273820",
+    "rounding": "Ceil",
+    "expected": "50169789767",
+    "overflow": false
+  },
+  {
+    "a": "307365",
+    "numerator": "2",
+    "denominator": "225580547",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "307365",
+    "numerator": "2",
+    "denominator": "225580547",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5515830884370936",
+    "numerator": "831596235278764913",
+    "denominator": "6636887102",
+    "rounding": "Floor",
+    "expected": "691128857155782132156319",
+    "overflow": false
+  },
+  {
+    "a": "5515830884370936",
+    "numerator": "831596235278764913",
+    "denominator": "6636887102",
+    "rounding": "Ceil",
+    "expected": "691128857155782132156320",
+    "overflow": false
+  },
+  {
+    "a": "63599",
+    "numerator": "3841876042939702962669169663187796",
+    "denominator": "17513878276221",
+    "rounding": "Floor",
+    "expected": "13951191769253504393934015",
+    "overflow": false
+  },
+  {
+    "a": "63599",
+    "numerator": "3841876042939702962669169663187796",
+    "denominator": "17513878276221",
+    "rounding": "Ceil",
+    "expected": "13951191769253504393934016",
+    "overflow": false
+  },
+  {
+    "a": "3303610",
+    "numerator": "61885792126343940231115677092635",
+    "denominator": "21815071905754061296",
+    "rounding": "Floor",
+    "expected": "9371801413709078107",
+    "overflow": false
+  },
+  {
+    "a": "3303610",
+    "numerator": "61885792126343940231115677092635",
+    "denominator": "21815071905754061296",
+    "rounding": "Ceil",
+    "expected": "9371801413709078108",
+    "overflow": false
+  },
+  {
+    "a": "24445972076720903444485065",
+    "numerator": "88855075707307380620014089408911478",
+    "denominator": "1035736724840962567",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24445972076720903444485065",
+    "numerator": "88855075707307380620014089408911478",
+    "denominator": "1035736724840962567",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "44402147995514717186047295948",
+    "numerator": "294170200661580117",
+    "denominator": "11945842",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "44402147995514717186047295948",
+    "numerator": "294170200661580117",
+    "denominator": "11945842",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28400103514594781361123635",
+    "numerator": "252656030864894916794170674920",
+    "denominator": "2169156404513",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28400103514594781361123635",
+    "numerator": "252656030864894916794170674920",
+    "denominator": "2169156404513",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2264796113314705281833603502",
+    "numerator": "1425093830036692127",
+    "denominator": "61979972",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2264796113314705281833603502",
+    "numerator": "1425093830036692127",
+    "denominator": "61979972",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "603145005",
+    "numerator": "6396398905826526209033491242",
+    "denominator": "25307211",
+    "rounding": "Floor",
+    "expected": "152444931606123435706927014609",
+    "overflow": false
+  },
+  {
+    "a": "603145005",
+    "numerator": "6396398905826526209033491242",
+    "denominator": "25307211",
+    "rounding": "Ceil",
+    "expected": "152444931606123435706927014610",
+    "overflow": false
+  },
+  {
+    "a": "290488917579211021708213675739360",
+    "numerator": "767513509753",
+    "denominator": "8055620895054454884384908107032550",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "290488917579211021708213675739360",
+    "numerator": "767513509753",
+    "denominator": "8055620895054454884384908107032550",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3227900123750459181637687",
+    "numerator": "0",
+    "denominator": "736526296581",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3227900123750459181637687",
+    "numerator": "0",
+    "denominator": "736526296581",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "31726014708329859927054325074420886498",
+    "numerator": "4007930466403",
+    "denominator": "294215341224661916854232",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31726014708329859927054325074420886498",
+    "numerator": "4007930466403",
+    "denominator": "294215341224661916854232",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2470339281",
+    "numerator": "30",
+    "denominator": "16008399",
+    "rounding": "Floor",
+    "expected": "4629",
+    "overflow": false
+  },
+  {
+    "a": "2470339281",
+    "numerator": "30",
+    "denominator": "16008399",
+    "rounding": "Ceil",
+    "expected": "4630",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1754198113455503626096802341341",
+    "denominator": "110005372508367098580577329717932442",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1754198113455503626096802341341",
+    "denominator": "110005372508367098580577329717932442",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2645711828981722047392516842536847739",
+    "numerator": "32387501966166992",
+    "denominator": "20265",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2645711828981722047392516842536847739",
+    "numerator": "32387501966166992",
+    "denominator": "20265",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "828761761069133126096952450788182",
+    "numerator": "285559024583046950808167",
+    "denominator": "29894055357868",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "828761761069133126096952450788182",
+    "numerator": "285559024583046950808167",
+    "denominator": "29894055357868",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3520253335705199105717",
+    "numerator": "4418999761383031391314",
+    "denominator": "915",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3520253335705199105717",
+    "numerator": "4418999761383031391314",
+    "denominator": "915",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4773740066295193657943574813824200",
+    "numerator": "129",
+    "denominator": "743566",
+    "rounding": "Floor",
+    "expected": "828188040539884800911716177156",
+    "overflow": false
+  },
+  {
+    "a": "4773740066295193657943574813824200",
+    "numerator": "129",
+    "denominator": "743566",
+    "rounding": "Ceil",
+    "expected": "828188040539884800911716177157",
+    "overflow": false
+  },
+  {
+    "a": "4462067812124931648082636599551",
+    "numerator": "10390566794665802257890596",
+    "denominator": "73065613",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4462067812124931648082636599551",
+    "numerator": "10390566794665802257890596",
+    "denominator": "73065613",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "88224525861898",
+    "numerator": "133634850417713690783403",
+    "denominator": "2686350550337649954506583476101833408",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "88224525861898",
+    "numerator": "133634850417713690783403",
+    "denominator": "2686350550337649954506583476101833408",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "8153105113",
+    "numerator": "7653906293082794399548351174",
+    "denominator": "7039833345092958359",
+    "rounding": "Floor",
+    "expected": "8864286904753737176",
+    "overflow": false
+  },
+  {
+    "a": "8153105113",
+    "numerator": "7653906293082794399548351174",
+    "denominator": "7039833345092958359",
+    "rounding": "Ceil",
+    "expected": "8864286904753737177",
+    "overflow": false
+  },
+  {
+    "a": "178890947413248362902077852",
+    "numerator": "861842477706239519589",
+    "denominator": "572763871326748168386",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "178890947413248362902077852",
+    "numerator": "861842477706239519589",
+    "denominator": "572763871326748168386",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3663460527938202683448003",
+    "numerator": "2069944",
+    "denominator": "2609",
+    "rounding": "Floor",
+    "expected": "2906538190510737836484129214",
+    "overflow": false
+  },
+  {
+    "a": "3663460527938202683448003",
+    "numerator": "2069944",
+    "denominator": "2609",
+    "rounding": "Ceil",
+    "expected": "2906538190510737836484129215",
+    "overflow": false
+  },
+  {
+    "a": "14",
+    "numerator": "893231",
+    "denominator": "967025062908186779030243980614420",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "14",
+    "numerator": "893231",
+    "denominator": "967025062908186779030243980614420",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2594144034595514145808319029414717",
+    "numerator": "148458106",
+    "denominator": "24132162766709292948536416219",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2594144034595514145808319029414717",
+    "numerator": "148458106",
+    "denominator": "24132162766709292948536416219",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "451412577712",
+    "numerator": "19749513",
+    "denominator": "7873564041750023734",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "451412577712",
+    "numerator": "19749513",
+    "denominator": "7873564041750023734",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "161966434186419833543",
+    "numerator": "4",
+    "denominator": "143102754036092298877035943804986389",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "161966434186419833543",
+    "numerator": "4",
+    "denominator": "143102754036092298877035943804986389",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "107170173234",
+    "numerator": "51307360474805174063638355363315",
+    "denominator": "53996200",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "107170173234",
+    "numerator": "51307360474805174063638355363315",
+    "denominator": "53996200",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3060589428317416545866721",
+    "numerator": "28526",
+    "denominator": "4426700602905630227641718111",
+    "rounding": "Floor",
+    "expected": "19",
+    "overflow": false
+  },
+  {
+    "a": "3060589428317416545866721",
+    "numerator": "28526",
+    "denominator": "4426700602905630227641718111",
+    "rounding": "Ceil",
+    "expected": "20",
+    "overflow": false
+  },
+  {
+    "a": "43043512683780",
+    "numerator": "8673947793826244335085",
+    "denominator": "213426901754146680933680362",
+    "rounding": "Floor",
+    "expected": "1749344524",
+    "overflow": false
+  },
+  {
+    "a": "43043512683780",
+    "numerator": "8673947793826244335085",
+    "denominator": "213426901754146680933680362",
+    "rounding": "Ceil",
+    "expected": "1749344525",
+    "overflow": false
+  },
+  {
+    "a": "584008971",
+    "numerator": "364732969664818660634545312",
+    "denominator": "13336986965101697619513",
+    "rounding": "Floor",
+    "expected": "15971173013896",
+    "overflow": false
+  },
+  {
+    "a": "584008971",
+    "numerator": "364732969664818660634545312",
+    "denominator": "13336986965101697619513",
+    "rounding": "Ceil",
+    "expected": "15971173013897",
+    "overflow": false
+  },
+  {
+    "a": "314024686967044457163673244888486",
+    "numerator": "3600668839856881009312686327",
+    "denominator": "17904851268724092",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "314024686967044457163673244888486",
+    "numerator": "3600668839856881009312686327",
+    "denominator": "17904851268724092",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "277767740904964617020707799237",
+    "numerator": "73925606820041072103627422624023970",
+    "denominator": "535304337402082595",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "277767740904964617020707799237",
+    "numerator": "73925606820041072103627422624023970",
+    "denominator": "535304337402082595",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "86936",
+    "numerator": "276446156171908167582097",
+    "denominator": "1052296190706182366",
+    "rounding": "Floor",
+    "expected": "22838743735",
+    "overflow": false
+  },
+  {
+    "a": "86936",
+    "numerator": "276446156171908167582097",
+    "denominator": "1052296190706182366",
+    "rounding": "Ceil",
+    "expected": "22838743736",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "6012016575369972",
+    "denominator": "48740844196703561686287517",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "6012016575369972",
+    "denominator": "48740844196703561686287517",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "34808215106394",
+    "numerator": "30267",
+    "denominator": "226486234619848355589629768148549230480",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "34808215106394",
+    "numerator": "30267",
+    "denominator": "226486234619848355589629768148549230480",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "325111687345848303483609943947960382953",
+    "numerator": "147734",
+    "denominator": "496253735",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "325111687345848303483609943947960382953",
+    "numerator": "147734",
+    "denominator": "496253735",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3906443853805406219814996817260",
+    "numerator": "5",
+    "denominator": "3836261719550263688378970254866",
+    "rounding": "Floor",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "3906443853805406219814996817260",
+    "numerator": "5",
+    "denominator": "3836261719550263688378970254866",
+    "rounding": "Ceil",
+    "expected": "6",
+    "overflow": false
+  },
+  {
+    "a": "275661434438752822205147219",
+    "numerator": "136",
+    "denominator": "4076653597948651351665234753",
+    "rounding": "Floor",
+    "expected": "9",
+    "overflow": false
+  },
+  {
+    "a": "275661434438752822205147219",
+    "numerator": "136",
+    "denominator": "4076653597948651351665234753",
+    "rounding": "Ceil",
+    "expected": "10",
+    "overflow": false
+  },
+  {
+    "a": "64774805747570333262",
+    "numerator": "10700073421247",
+    "denominator": "60644",
+    "rounding": "Floor",
+    "expected": "11428915924840293108708005765",
+    "overflow": false
+  },
+  {
+    "a": "64774805747570333262",
+    "numerator": "10700073421247",
+    "denominator": "60644",
+    "rounding": "Ceil",
+    "expected": "11428915924840293108708005766",
+    "overflow": false
+  },
+  {
+    "a": "77",
+    "numerator": "999905892603338",
+    "denominator": "45640555",
+    "rounding": "Floor",
+    "expected": "1686937280",
+    "overflow": false
+  },
+  {
+    "a": "77",
+    "numerator": "999905892603338",
+    "denominator": "45640555",
+    "rounding": "Ceil",
+    "expected": "1686937281",
+    "overflow": false
+  },
+  {
+    "a": "103876224",
+    "numerator": "16734628710950599580039577",
+    "denominator": "1443974",
+    "rounding": "Floor",
+    "expected": "1203851343954625038200478006",
+    "overflow": false
+  },
+  {
+    "a": "103876224",
+    "numerator": "16734628710950599580039577",
+    "denominator": "1443974",
+    "rounding": "Ceil",
+    "expected": "1203851343954625038200478007",
+    "overflow": false
+  },
+  {
+    "a": "23",
+    "numerator": "1798121759204211743068",
+    "denominator": "1573",
+    "rounding": "Floor",
+    "expected": "26291672257912822689",
+    "overflow": false
+  },
+  {
+    "a": "23",
+    "numerator": "1798121759204211743068",
+    "denominator": "1573",
+    "rounding": "Ceil",
+    "expected": "26291672257912822690",
+    "overflow": false
+  },
+  {
+    "a": "100994",
+    "numerator": "413289344243284110630787",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "41739744032506235469045702278",
+    "overflow": false
+  },
+  {
+    "a": "100994",
+    "numerator": "413289344243284110630787",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "41739744032506235469045702278",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "11142318280994273214",
+    "denominator": "1414248565231",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "11142318280994273214",
+    "denominator": "1414248565231",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1618195264881220308",
+    "numerator": "67437469213271612452178792460783101",
+    "denominator": "6925556869629924830266",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1618195264881220308",
+    "numerator": "67437469213271612452178792460783101",
+    "denominator": "6925556869629924830266",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3417243",
+    "numerator": "33079664",
+    "denominator": "216867145",
+    "rounding": "Floor",
+    "expected": "521246",
+    "overflow": false
+  },
+  {
+    "a": "3417243",
+    "numerator": "33079664",
+    "denominator": "216867145",
+    "rounding": "Ceil",
+    "expected": "521247",
+    "overflow": false
+  },
+  {
+    "a": "104123025718272200591348357035555275766",
+    "numerator": "97159",
+    "denominator": "804661942712561887332611635653497164",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "104123025718272200591348357035555275766",
+    "numerator": "97159",
+    "denominator": "804661942712561887332611635653497164",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "34795539109090841308885",
+    "numerator": "754",
+    "denominator": "72371",
+    "rounding": "Floor",
+    "expected": "362518639900712914660",
+    "overflow": false
+  },
+  {
+    "a": "34795539109090841308885",
+    "numerator": "754",
+    "denominator": "72371",
+    "rounding": "Ceil",
+    "expected": "362518639900712914661",
+    "overflow": false
+  },
+  {
+    "a": "6254626408",
+    "numerator": "1669607015639654261409",
+    "denominator": "36142",
+    "rounding": "Floor",
+    "expected": "288937195811019051391690185",
+    "overflow": false
+  },
+  {
+    "a": "6254626408",
+    "numerator": "1669607015639654261409",
+    "denominator": "36142",
+    "rounding": "Ceil",
+    "expected": "288937195811019051391690186",
+    "overflow": false
+  },
+  {
+    "a": "259116575",
+    "numerator": "0",
+    "denominator": "13",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "259116575",
+    "numerator": "0",
+    "denominator": "13",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "15229307605906650794",
+    "numerator": "11",
+    "denominator": "11737182073262176",
+    "rounding": "Floor",
+    "expected": "14272",
+    "overflow": false
+  },
+  {
+    "a": "15229307605906650794",
+    "numerator": "11",
+    "denominator": "11737182073262176",
+    "rounding": "Ceil",
+    "expected": "14273",
+    "overflow": false
+  },
+  {
+    "a": "154399799236128608259423350682889465",
+    "numerator": "7390156638810982",
+    "denominator": "686267760916788416149441798583",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "154399799236128608259423350682889465",
+    "numerator": "7390156638810982",
+    "denominator": "686267760916788416149441798583",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20273118164724915224792669500",
+    "numerator": "1170750126807941",
+    "denominator": "1793890",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20273118164724915224792669500",
+    "numerator": "1170750126807941",
+    "denominator": "1793890",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "399843",
+    "numerator": "2695688863576",
+    "denominator": "10740992690701485885049732135151624273",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "399843",
+    "numerator": "2695688863576",
+    "denominator": "10740992690701485885049732135151624273",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1000762850529618469738142",
+    "numerator": "1620738112705140303",
+    "denominator": "479356878809637925556",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1000762850529618469738142",
+    "numerator": "1620738112705140303",
+    "denominator": "479356878809637925556",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "116993763426401003357",
+    "numerator": "2772940058",
+    "denominator": "30476815395584808419173551104763",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "116993763426401003357",
+    "numerator": "2772940058",
+    "denominator": "30476815395584808419173551104763",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "718788725699408",
+    "numerator": "17127655802307140777",
+    "denominator": "22",
+    "rounding": "Floor",
+    "expected": "559598449470837330312516910980000",
+    "overflow": false
+  },
+  {
+    "a": "718788725699408",
+    "numerator": "17127655802307140777",
+    "denominator": "22",
+    "rounding": "Ceil",
+    "expected": "559598449470837330312516910980001",
+    "overflow": false
+  },
+  {
+    "a": "73054604263",
+    "numerator": "21729164588",
+    "denominator": "2103077941",
+    "rounding": "Floor",
+    "expected": "754805843851",
+    "overflow": false
+  },
+  {
+    "a": "73054604263",
+    "numerator": "21729164588",
+    "denominator": "2103077941",
+    "rounding": "Ceil",
+    "expected": "754805843852",
+    "overflow": false
+  },
+  {
+    "a": "2872795177376561893248255711612065746",
+    "numerator": "6279291763797143477523",
+    "denominator": "48794930248",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2872795177376561893248255711612065746",
+    "numerator": "6279291763797143477523",
+    "denominator": "48794930248",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35978426160374590256120321",
+    "numerator": "444050986800142",
+    "denominator": "179695194649064322993250943",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35978426160374590256120321",
+    "numerator": "444050986800142",
+    "denominator": "179695194649064322993250943",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "181824218043459017892",
+    "numerator": "1009238012123406022744017421",
+    "denominator": "1234640106388063970969508652938",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "181824218043459017892",
+    "numerator": "1009238012123406022744017421",
+    "denominator": "1234640106388063970969508652938",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "995542555246113569097218500585515",
+    "numerator": "92736",
+    "denominator": "464958562438164569",
+    "rounding": "Floor",
+    "expected": "198560994165112708506",
+    "overflow": false
+  },
+  {
+    "a": "995542555246113569097218500585515",
+    "numerator": "92736",
+    "denominator": "464958562438164569",
+    "rounding": "Ceil",
+    "expected": "198560994165112708507",
+    "overflow": false
+  },
+  {
+    "a": "19728178287699966369287539424931398",
+    "numerator": "23",
+    "denominator": "24731114238222315804",
+    "rounding": "Floor",
+    "expected": "18347256668113424",
+    "overflow": false
+  },
+  {
+    "a": "19728178287699966369287539424931398",
+    "numerator": "23",
+    "denominator": "24731114238222315804",
+    "rounding": "Ceil",
+    "expected": "18347256668113425",
+    "overflow": false
+  },
+  {
+    "a": "229",
+    "numerator": "446841434612283864515650",
+    "denominator": "81045077563501139109033314280515",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "229",
+    "numerator": "446841434612283864515650",
+    "denominator": "81045077563501139109033314280515",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "55234900296536482696266933792239807800",
+    "numerator": "1101252529",
+    "denominator": "720580986238",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "55234900296536482696266933792239807800",
+    "numerator": "1101252529",
+    "denominator": "720580986238",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "59057091247",
+    "numerator": "377674388",
+    "denominator": "789026160971927741",
+    "rounding": "Floor",
+    "expected": "28",
+    "overflow": false
+  },
+  {
+    "a": "59057091247",
+    "numerator": "377674388",
+    "denominator": "789026160971927741",
+    "rounding": "Ceil",
+    "expected": "29",
+    "overflow": false
+  },
+  {
+    "a": "71015381939811741641596098104826",
+    "numerator": "45403",
+    "denominator": "48",
+    "rounding": "Floor",
+    "expected": "67173153879443177203195575880279476",
+    "overflow": false
+  },
+  {
+    "a": "71015381939811741641596098104826",
+    "numerator": "45403",
+    "denominator": "48",
+    "rounding": "Ceil",
+    "expected": "67173153879443177203195575880279477",
+    "overflow": false
+  },
+  {
+    "a": "11121540863304605649446840329",
+    "numerator": "26317043677622",
+    "denominator": "404551",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11121540863304605649446840329",
+    "numerator": "26317043677622",
+    "denominator": "404551",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3864676491033513621772",
+    "numerator": "83917345315872665404906896310581653",
+    "denominator": "50",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3864676491033513621772",
+    "numerator": "83917345315872665404906896310581653",
+    "denominator": "50",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65643543308499677410220787281779",
+    "numerator": "2209437581371537890828840",
+    "denominator": "130527585",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65643543308499677410220787281779",
+    "numerator": "2209437581371537890828840",
+    "denominator": "130527585",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10178981913587534244047598",
+    "numerator": "178419579465140092020655839",
+    "denominator": "6239724991689418617323908228",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10178981913587534244047598",
+    "numerator": "178419579465140092020655839",
+    "denominator": "6239724991689418617323908228",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "842955629",
+    "numerator": "1176009699332095074811435853930",
+    "denominator": "1024750769815179",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "842955629",
+    "numerator": "1176009699332095074811435853930",
+    "denominator": "1024750769815179",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "4313272475567841936925465232313",
+    "denominator": "2185519623167777349898226744834046246",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "4313272475567841936925465232313",
+    "denominator": "2185519623167777349898226744834046246",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8364064235430519",
+    "numerator": "4",
+    "denominator": "37810753800922622715778332229",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8364064235430519",
+    "numerator": "4",
+    "denominator": "37810753800922622715778332229",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5294747696892180770",
+    "numerator": "4890894239822541803748114083",
+    "denominator": "67529030331160",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5294747696892180770",
+    "numerator": "4890894239822541803748114083",
+    "denominator": "67529030331160",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1557238312539510124388925201",
+    "numerator": "798823401649429152862",
+    "denominator": "352015",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1557238312539510124388925201",
+    "numerator": "798823401649429152862",
+    "denominator": "352015",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9579122039170720060096001777848948",
+    "numerator": "479956811532435426293405043460637",
+    "denominator": "2621636038107952647598602327898371802",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9579122039170720060096001777848948",
+    "numerator": "479956811532435426293405043460637",
+    "denominator": "2621636038107952647598602327898371802",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4137455286418116539",
+    "numerator": "492259088",
+    "denominator": "105",
+    "rounding": "Floor",
+    "expected": "19397142532694865087293870",
+    "overflow": false
+  },
+  {
+    "a": "4137455286418116539",
+    "numerator": "492259088",
+    "denominator": "105",
+    "rounding": "Ceil",
+    "expected": "19397142532694865087293871",
+    "overflow": false
+  },
+  {
+    "a": "2722205865962719371675686832835603606",
+    "numerator": "28401746309908397821591919783",
+    "denominator": "607552748",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2722205865962719371675686832835603606",
+    "numerator": "28401746309908397821591919783",
+    "denominator": "607552748",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2781881781995191386946665670451959541",
+    "numerator": "278838453624801214866",
+    "denominator": "467",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2781881781995191386946665670451959541",
+    "numerator": "278838453624801214866",
+    "denominator": "467",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "138081779250228701923336",
+    "numerator": "2266557534780494770369",
+    "denominator": "44932986112045920314824991183310",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "138081779250228701923336",
+    "numerator": "2266557534780494770369",
+    "denominator": "44932986112045920314824991183310",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3261253800721227561791",
+    "numerator": "245126514508318969055999323507812",
+    "denominator": "31949",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3261253800721227561791",
+    "numerator": "245126514508318969055999323507812",
+    "denominator": "31949",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1084120234314",
+    "numerator": "268470370836915435",
+    "denominator": "122772868122397623808715066880",
+    "rounding": "Floor",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "1084120234314",
+    "numerator": "268470370836915435",
+    "denominator": "122772868122397623808715066880",
+    "rounding": "Ceil",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "9716929944155381141629998086",
+    "denominator": "2592749385876360657049638768810711",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "9716929944155381141629998086",
+    "denominator": "2592749385876360657049638768810711",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "565299420",
+    "numerator": "46593716924719493617100112322239397",
+    "denominator": "3737157774765247058787842",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "565299420",
+    "numerator": "46593716924719493617100112322239397",
+    "denominator": "3737157774765247058787842",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14250479978464132442371",
+    "numerator": "131405035046460518318629833113644218616",
+    "denominator": "4321270946073854887537",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14250479978464132442371",
+    "numerator": "131405035046460518318629833113644218616",
+    "denominator": "4321270946073854887537",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "830",
+    "numerator": "1648717465824201400752427773246511983",
+    "denominator": "72337444137867860",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "830",
+    "numerator": "1648717465824201400752427773246511983",
+    "denominator": "72337444137867860",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4989",
+    "numerator": "67203002",
+    "denominator": "7026839154579800161819",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4989",
+    "numerator": "67203002",
+    "denominator": "7026839154579800161819",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "223472",
+    "numerator": "277573321",
+    "denominator": "6732158619135674558365864816502",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "223472",
+    "numerator": "277573321",
+    "denominator": "6732158619135674558365864816502",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "10346152787239051833682571199978759",
+    "numerator": "33648773910989201612",
+    "denominator": "65338409249459410183961506219093",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10346152787239051833682571199978759",
+    "numerator": "33648773910989201612",
+    "denominator": "65338409249459410183961506219093",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "83344492678291884067468835633269370482",
+    "numerator": "590086171071392205669427",
+    "denominator": "31241008400158585388520",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "83344492678291884067468835633269370482",
+    "numerator": "590086171071392205669427",
+    "denominator": "31241008400158585388520",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "60211425041891361",
+    "numerator": "8189766882128464046",
+    "denominator": "505607896654184351",
+    "rounding": "Floor",
+    "expected": "975296347222826453",
+    "overflow": false
+  },
+  {
+    "a": "60211425041891361",
+    "numerator": "8189766882128464046",
+    "denominator": "505607896654184351",
+    "rounding": "Ceil",
+    "expected": "975296347222826454",
+    "overflow": false
+  },
+  {
+    "a": "118758766836804",
+    "numerator": "23638314541",
+    "denominator": "1935619190499460001743180129363565098",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "118758766836804",
+    "numerator": "23638314541",
+    "denominator": "1935619190499460001743180129363565098",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2023132846103371",
+    "numerator": "0",
+    "denominator": "121",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2023132846103371",
+    "numerator": "0",
+    "denominator": "121",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "742",
+    "numerator": "23",
+    "denominator": "1212",
+    "rounding": "Floor",
+    "expected": "14",
+    "overflow": false
+  },
+  {
+    "a": "742",
+    "numerator": "23",
+    "denominator": "1212",
+    "rounding": "Ceil",
+    "expected": "15",
+    "overflow": false
+  },
+  {
+    "a": "71705864259695613895069957",
+    "numerator": "23863939810",
+    "denominator": "13834629324186467",
+    "rounding": "Floor",
+    "expected": "123688491293786869009",
+    "overflow": false
+  },
+  {
+    "a": "71705864259695613895069957",
+    "numerator": "23863939810",
+    "denominator": "13834629324186467",
+    "rounding": "Ceil",
+    "expected": "123688491293786869010",
+    "overflow": false
+  },
+  {
+    "a": "6538902090131770841403492947672",
+    "numerator": "61601507401169",
+    "denominator": "797221010798476799031695647765022",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6538902090131770841403492947672",
+    "numerator": "61601507401169",
+    "denominator": "797221010798476799031695647765022",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1043604153632316175113078467258319",
+    "numerator": "9880499220200684505699950345302580",
+    "denominator": "361245917",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1043604153632316175113078467258319",
+    "numerator": "9880499220200684505699950345302580",
+    "denominator": "361245917",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2717878771579034",
+    "numerator": "13800471675",
+    "denominator": "15567459666717391935640877637878799056",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2717878771579034",
+    "numerator": "13800471675",
+    "denominator": "15567459666717391935640877637878799056",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "271327856589041437238897240617",
+    "numerator": "2417801028087306289750",
+    "denominator": "237940071",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "271327856589041437238897240617",
+    "numerator": "2417801028087306289750",
+    "denominator": "237940071",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3244",
+    "numerator": "1210381675416902302954490852868533",
+    "denominator": "291172937146155821906",
+    "rounding": "Floor",
+    "expected": "13485038113557628",
+    "overflow": false
+  },
+  {
+    "a": "3244",
+    "numerator": "1210381675416902302954490852868533",
+    "denominator": "291172937146155821906",
+    "rounding": "Ceil",
+    "expected": "13485038113557629",
+    "overflow": false
+  },
+  {
+    "a": "1834827534049609363",
+    "numerator": "151072607329833038955464",
+    "denominator": "122549746441780146533936996225",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1834827534049609363",
+    "numerator": "151072607329833038955464",
+    "denominator": "122549746441780146533936996225",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "63930623927749737327084960090852872078",
+    "numerator": "388198526188863866387024532479",
+    "denominator": "843134319652",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "63930623927749737327084960090852872078",
+    "numerator": "388198526188863866387024532479",
+    "denominator": "843134319652",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2695559131021",
+    "numerator": "7219978310498182957834",
+    "denominator": "1591335428523",
+    "rounding": "Floor",
+    "expected": "12229903332637115355197",
+    "overflow": false
+  },
+  {
+    "a": "2695559131021",
+    "numerator": "7219978310498182957834",
+    "denominator": "1591335428523",
+    "rounding": "Ceil",
+    "expected": "12229903332637115355198",
+    "overflow": false
+  },
+  {
+    "a": "3728601536",
+    "numerator": "56793",
+    "denominator": "2755126359986476922832796102",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3728601536",
+    "numerator": "56793",
+    "denominator": "2755126359986476922832796102",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "287758810714191998482528268336023",
+    "numerator": "154979972711204429924193419125596316",
+    "denominator": "110156142711021535132803705159016650341",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "287758810714191998482528268336023",
+    "numerator": "154979972711204429924193419125596316",
+    "denominator": "110156142711021535132803705159016650341",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14851864094750658",
+    "numerator": "17720044303577199339941920707150654915",
+    "denominator": "838800792627351798968",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14851864094750658",
+    "numerator": "17720044303577199339941920707150654915",
+    "denominator": "838800792627351798968",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1589851370339792767616305",
+    "numerator": "37796854040184338756083966",
+    "denominator": "306595596239001165647704450843695",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1589851370339792767616305",
+    "numerator": "37796854040184338756083966",
+    "denominator": "306595596239001165647704450843695",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70707497917604424751636",
+    "numerator": "140449790574488962614105661",
+    "denominator": "9520924626592378002433978674764403066",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70707497917604424751636",
+    "numerator": "140449790574488962614105661",
+    "denominator": "9520924626592378002433978674764403066",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1",
+    "numerator": "121837407083696",
+    "denominator": "6534049804039915959689",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "121837407083696",
+    "denominator": "6534049804039915959689",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "26538879421695366276544787926471",
+    "denominator": "123310901388",
+    "rounding": "Floor",
+    "expected": "430438495266372243843",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "26538879421695366276544787926471",
+    "denominator": "123310901388",
+    "rounding": "Ceil",
+    "expected": "430438495266372243844",
+    "overflow": false
+  },
+  {
+    "a": "18898078095267520080366056476437",
+    "numerator": "270280833465375109724058972369189517362",
+    "denominator": "6387",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18898078095267520080366056476437",
+    "numerator": "270280833465375109724058972369189517362",
+    "denominator": "6387",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14592473815464",
+    "numerator": "2336454735112808050990129352417",
+    "denominator": "9422541902190274158",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14592473815464",
+    "numerator": "2336454735112808050990129352417",
+    "denominator": "9422541902190274158",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75545182273484768407337055",
+    "numerator": "182995972",
+    "denominator": "255320301",
+    "rounding": "Floor",
+    "expected": "54145573250180035710891380",
+    "overflow": false
+  },
+  {
+    "a": "75545182273484768407337055",
+    "numerator": "182995972",
+    "denominator": "255320301",
+    "rounding": "Ceil",
+    "expected": "54145573250180035710891381",
+    "overflow": false
+  },
+  {
+    "a": "31768564100697869290",
+    "numerator": "12390364842326636555",
+    "denominator": "7789472",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31768564100697869290",
+    "numerator": "12390364842326636555",
+    "denominator": "7789472",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "120954921660729",
+    "numerator": "6748394549550127725984715490526374",
+    "denominator": "503",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "120954921660729",
+    "numerator": "6748394549550127725984715490526374",
+    "denominator": "503",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6636668",
+    "numerator": "474887026596471106717149527394773957",
+    "denominator": "2348703461071081794722",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6636668",
+    "numerator": "474887026596471106717149527394773957",
+    "denominator": "2348703461071081794722",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35",
+    "numerator": "40035526379627854944502971400856",
+    "denominator": "7379035693155302545",
+    "rounding": "Floor",
+    "expected": "189895195192882",
+    "overflow": false
+  },
+  {
+    "a": "35",
+    "numerator": "40035526379627854944502971400856",
+    "denominator": "7379035693155302545",
+    "rounding": "Ceil",
+    "expected": "189895195192883",
+    "overflow": false
+  },
+  {
+    "a": "48020993668763726847966",
+    "numerator": "143",
+    "denominator": "2368729947169973033521225351278154228",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "48020993668763726847966",
+    "numerator": "143",
+    "denominator": "2368729947169973033521225351278154228",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "33488388604648913634769832277544861",
+    "numerator": "28211802",
+    "denominator": "987113564475",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33488388604648913634769832277544861",
+    "numerator": "28211802",
+    "denominator": "987113564475",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "43420420574265864907089287678699351696",
+    "numerator": "1956284129231493517086953",
+    "denominator": "21073117781571531886089017366",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "43420420574265864907089287678699351696",
+    "numerator": "1956284129231493517086953",
+    "denominator": "21073117781571531886089017366",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "379768703286823",
+    "numerator": "15215421110094651136702972616103020",
+    "denominator": "2561700375457228030626521003568245",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "379768703286823",
+    "numerator": "15215421110094651136702972616103020",
+    "denominator": "2561700375457228030626521003568245",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1102716982546",
+    "numerator": "372162850156507839315",
+    "denominator": "12939530601258567286664",
+    "rounding": "Floor",
+    "expected": "31716011019",
+    "overflow": false
+  },
+  {
+    "a": "1102716982546",
+    "numerator": "372162850156507839315",
+    "denominator": "12939530601258567286664",
+    "rounding": "Ceil",
+    "expected": "31716011020",
+    "overflow": false
+  },
+  {
+    "a": "136515391041",
+    "numerator": "6405161271673414536526",
+    "denominator": "14232767",
+    "rounding": "Floor",
+    "expected": "61435917252292897220725995",
+    "overflow": false
+  },
+  {
+    "a": "136515391041",
+    "numerator": "6405161271673414536526",
+    "denominator": "14232767",
+    "rounding": "Ceil",
+    "expected": "61435917252292897220725996",
+    "overflow": false
+  },
+  {
+    "a": "2588345483120769463242990702242788",
+    "numerator": "174333651208315469",
+    "denominator": "95531350195734736705181670602",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2588345483120769463242990702242788",
+    "numerator": "174333651208315469",
+    "denominator": "95531350195734736705181670602",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1460282580587",
+    "numerator": "8955420611968",
+    "denominator": "23489483929",
+    "rounding": "Floor",
+    "expected": "556736144609004",
+    "overflow": false
+  },
+  {
+    "a": "1460282580587",
+    "numerator": "8955420611968",
+    "denominator": "23489483929",
+    "rounding": "Ceil",
+    "expected": "556736144609005",
+    "overflow": false
+  },
+  {
+    "a": "3415942",
+    "numerator": "58031121341527",
+    "denominator": "7196620892",
+    "rounding": "Floor",
+    "expected": "27545003088",
+    "overflow": false
+  },
+  {
+    "a": "3415942",
+    "numerator": "58031121341527",
+    "denominator": "7196620892",
+    "rounding": "Ceil",
+    "expected": "27545003089",
+    "overflow": false
+  },
+  {
+    "a": "973941376831781",
+    "numerator": "41893141376981815980418",
+    "denominator": "11889393388913833931395",
+    "rounding": "Floor",
+    "expected": "3431753198657814",
+    "overflow": false
+  },
+  {
+    "a": "973941376831781",
+    "numerator": "41893141376981815980418",
+    "denominator": "11889393388913833931395",
+    "rounding": "Ceil",
+    "expected": "3431753198657815",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1009",
+    "denominator": "3125909727801022",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1009",
+    "denominator": "3125909727801022",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "16166127",
+    "numerator": "825112124611028",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "13338867395701704248556",
+    "overflow": false
+  },
+  {
+    "a": "16166127",
+    "numerator": "825112124611028",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "13338867395701704248556",
+    "overflow": false
+  },
+  {
+    "a": "547658642780986",
+    "numerator": "534912396932003387291",
+    "denominator": "1185826843039591739508064234180720",
+    "rounding": "Floor",
+    "expected": "247",
+    "overflow": false
+  },
+  {
+    "a": "547658642780986",
+    "numerator": "534912396932003387291",
+    "denominator": "1185826843039591739508064234180720",
+    "rounding": "Ceil",
+    "expected": "248",
+    "overflow": false
+  },
+  {
+    "a": "59212217417",
+    "numerator": "5016103343284662573084225570413302",
+    "denominator": "220275237655873506378628743",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "59212217417",
+    "numerator": "5016103343284662573084225570413302",
+    "denominator": "220275237655873506378628743",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "659681356",
+    "numerator": "83092235173835682929534176403478997",
+    "denominator": "29968077743770871910883723883823602",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "659681356",
+    "numerator": "83092235173835682929534176403478997",
+    "denominator": "29968077743770871910883723883823602",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2391098453427",
+    "numerator": "170136838530806080606086790074126759272",
+    "denominator": "79589326251794651127201",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2391098453427",
+    "numerator": "170136838530806080606086790074126759272",
+    "denominator": "79589326251794651127201",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "10776997598374366554535723480827572511",
+    "denominator": "23267990468",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "10776997598374366554535723480827572511",
+    "denominator": "23267990468",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "84868133831701421",
+    "numerator": "17229754370145706",
+    "denominator": "63992431788189764443215051",
+    "rounding": "Floor",
+    "expected": "22850469",
+    "overflow": false
+  },
+  {
+    "a": "84868133831701421",
+    "numerator": "17229754370145706",
+    "denominator": "63992431788189764443215051",
+    "rounding": "Ceil",
+    "expected": "22850470",
+    "overflow": false
+  },
+  {
+    "a": "11256778660824901467939465778405216",
+    "numerator": "9",
+    "denominator": "16996506828693506662",
+    "rounding": "Floor",
+    "expected": "5960695863481244",
+    "overflow": false
+  },
+  {
+    "a": "11256778660824901467939465778405216",
+    "numerator": "9",
+    "denominator": "16996506828693506662",
+    "rounding": "Ceil",
+    "expected": "5960695863481245",
+    "overflow": false
+  },
+  {
+    "a": "88958135",
+    "numerator": "228412",
+    "denominator": "1635835871964808837",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "88958135",
+    "numerator": "228412",
+    "denominator": "1635835871964808837",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "17042371210331746",
+    "numerator": "2070258279439253832871139",
+    "denominator": "448636823915289823236155633240",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17042371210331746",
+    "numerator": "2070258279439253832871139",
+    "denominator": "448636823915289823236155633240",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "88913",
+    "numerator": "3486",
+    "denominator": "14583704136982240796631064878577662287",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "88913",
+    "numerator": "3486",
+    "denominator": "14583704136982240796631064878577662287",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "62417468715954938637583389507137972",
+    "numerator": "256979549",
+    "denominator": "15852235642186471547812890",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "62417468715954938637583389507137972",
+    "numerator": "256979549",
+    "denominator": "15852235642186471547812890",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2914326011",
+    "numerator": "3804788171029932390295351738844496464",
+    "denominator": "1624542013339916600539049",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2914326011",
+    "numerator": "3804788171029932390295351738844496464",
+    "denominator": "1624542013339916600539049",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "856556659199500544832179604876758",
+    "numerator": "14033914671047510691559",
+    "denominator": "213932530732",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "856556659199500544832179604876758",
+    "numerator": "14033914671047510691559",
+    "denominator": "213932530732",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42374944160984297266255669",
+    "numerator": "884835810777860701906",
+    "denominator": "19",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42374944160984297266255669",
+    "numerator": "884835810777860701906",
+    "denominator": "19",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17555359821914439133625160",
+    "numerator": "1",
+    "denominator": "2222761745930725363017452302",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "17555359821914439133625160",
+    "numerator": "1",
+    "denominator": "2222761745930725363017452302",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "111959602949519049370863030977919",
+    "numerator": "982255942468229823546973092",
+    "denominator": "6913536999231744398605",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "111959602949519049370863030977919",
+    "numerator": "982255942468229823546973092",
+    "denominator": "6913536999231744398605",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "443734572812398218",
+    "numerator": "2859",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "1268637143670646505262",
+    "overflow": false
+  },
+  {
+    "a": "443734572812398218",
+    "numerator": "2859",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "1268637143670646505262",
+    "overflow": false
+  },
+  {
+    "a": "232281",
+    "numerator": "336522062185798",
+    "denominator": "30301352808452196366055544758025495",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "232281",
+    "numerator": "336522062185798",
+    "denominator": "30301352808452196366055544758025495",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "87732738069024751470022684",
+    "numerator": "2564667526117",
+    "denominator": "910216872647616179548120675801787202",
+    "rounding": "Floor",
+    "expected": "247",
+    "overflow": false
+  },
+  {
+    "a": "87732738069024751470022684",
+    "numerator": "2564667526117",
+    "denominator": "910216872647616179548120675801787202",
+    "rounding": "Ceil",
+    "expected": "248",
+    "overflow": false
+  },
+  {
+    "a": "80062817011887994691",
+    "numerator": "19610983275576",
+    "denominator": "7935668630857138865",
+    "rounding": "Floor",
+    "expected": "197854854890286",
+    "overflow": false
+  },
+  {
+    "a": "80062817011887994691",
+    "numerator": "19610983275576",
+    "denominator": "7935668630857138865",
+    "rounding": "Ceil",
+    "expected": "197854854890287",
+    "overflow": false
+  },
+  {
+    "a": "351752368243604319722860051582",
+    "numerator": "549533701551",
+    "denominator": "302736215595412",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "351752368243604319722860051582",
+    "numerator": "549533701551",
+    "denominator": "302736215595412",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1531071764440171877281749063850941",
+    "numerator": "1274",
+    "denominator": "25691",
+    "rounding": "Floor",
+    "expected": "75924854147241406393559935671873",
+    "overflow": false
+  },
+  {
+    "a": "1531071764440171877281749063850941",
+    "numerator": "1274",
+    "denominator": "25691",
+    "rounding": "Ceil",
+    "expected": "75924854147241406393559935671874",
+    "overflow": false
+  },
+  {
+    "a": "7058685632725653504252831475408356400",
+    "numerator": "9460358725386510360935514889",
+    "denominator": "1383124866139197622",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7058685632725653504252831475408356400",
+    "numerator": "9460358725386510360935514889",
+    "denominator": "1383124866139197622",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "302984416863447385350063450192310087",
+    "numerator": "28889454604",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "302984416863447385350063450192310087",
+    "numerator": "28889454604",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3390444585439163601164103557103225778",
+    "numerator": "113064063238771",
+    "denominator": "39738081029750410729967912",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3390444585439163601164103557103225778",
+    "numerator": "113064063238771",
+    "denominator": "39738081029750410729967912",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "253848673",
+    "numerator": "8477734181495278",
+    "denominator": "476080841784206492330463",
+    "rounding": "Floor",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "253848673",
+    "numerator": "8477734181495278",
+    "denominator": "476080841784206492330463",
+    "rounding": "Ceil",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "54483267070852",
+    "numerator": "4115872258162657150271534810733",
+    "denominator": "12002955751274",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "54483267070852",
+    "numerator": "4115872258162657150271534810733",
+    "denominator": "12002955751274",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6699822859182464503039078795",
+    "numerator": "5350176",
+    "denominator": "6242024274373806956217",
+    "rounding": "Floor",
+    "expected": "5742565214398",
+    "overflow": false
+  },
+  {
+    "a": "6699822859182464503039078795",
+    "numerator": "5350176",
+    "denominator": "6242024274373806956217",
+    "rounding": "Ceil",
+    "expected": "5742565214399",
+    "overflow": false
+  },
+  {
+    "a": "25276828780736813430231078",
+    "numerator": "4595386293455103351",
+    "denominator": "18849666345222992892",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25276828780736813430231078",
+    "numerator": "4595386293455103351",
+    "denominator": "18849666345222992892",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "43569528625783109",
+    "numerator": "708341668385649926103074",
+    "denominator": "1086816484033873052815779",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "43569528625783109",
+    "numerator": "708341668385649926103074",
+    "denominator": "1086816484033873052815779",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30545024034410633752",
+    "numerator": "4604844832059591802996980306786833",
+    "denominator": "5651870858078",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30545024034410633752",
+    "numerator": "4604844832059591802996980306786833",
+    "denominator": "5651870858078",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70097630880405323029217807",
+    "numerator": "1276286262759796",
+    "denominator": "2239335649762590972154919867764643101",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "70097630880405323029217807",
+    "numerator": "1276286262759796",
+    "denominator": "2239335649762590972154919867764643101",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6712247008762876288428096986",
+    "numerator": "2164493148014474966804381538239163",
+    "denominator": "114229438757541392",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6712247008762876288428096986",
+    "numerator": "2164493148014474966804381538239163",
+    "denominator": "114229438757541392",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5769990552171331922245567585897",
+    "numerator": "1052964291478",
+    "denominator": "221095",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5769990552171331922245567585897",
+    "numerator": "1052964291478",
+    "denominator": "221095",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "163167920702907039005899105260",
+    "numerator": "132381658848936437",
+    "denominator": "157842",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "163167920702907039005899105260",
+    "numerator": "132381658848936437",
+    "denominator": "157842",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2160420051",
+    "numerator": "3744269069149578447628606895880",
+    "denominator": "233754357869505",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2160420051",
+    "numerator": "3744269069149578447628606895880",
+    "denominator": "233754357869505",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "535254423697329979592292743262144718",
+    "numerator": "39302569535",
+    "denominator": "824167268",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "535254423697329979592292743262144718",
+    "numerator": "39302569535",
+    "denominator": "824167268",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3553420105205709",
+    "numerator": "4462425840009641988875140301176906",
+    "denominator": "1010636779",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3553420105205709",
+    "numerator": "4462425840009641988875140301176906",
+    "denominator": "1010636779",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32138730752",
+    "numerator": "21946940934341145",
+    "denominator": "1025380191591599646829622094586620678",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "32138730752",
+    "numerator": "21946940934341145",
+    "denominator": "1025380191591599646829622094586620678",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "16655539405028532450549243351",
+    "numerator": "4688738330759003183425500",
+    "denominator": "17778286885310531237",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16655539405028532450549243351",
+    "numerator": "4688738330759003183425500",
+    "denominator": "17778286885310531237",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1057588227695229897322281116930",
+    "numerator": "3819761171274369123606729742433283",
+    "denominator": "26616",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1057588227695229897322281116930",
+    "numerator": "3819761171274369123606729742433283",
+    "denominator": "26616",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "590908548958175601",
+    "numerator": "3385968183870",
+    "denominator": "50650347930323475724451439",
+    "rounding": "Floor",
+    "expected": "39502",
+    "overflow": false
+  },
+  {
+    "a": "590908548958175601",
+    "numerator": "3385968183870",
+    "denominator": "50650347930323475724451439",
+    "rounding": "Ceil",
+    "expected": "39503",
+    "overflow": false
+  },
+  {
+    "a": "25772765873708952072200060770644",
+    "numerator": "67051342749309",
+    "denominator": "186",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25772765873708952072200060770644",
+    "numerator": "67051342749309",
+    "denominator": "186",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1678208556266781321546117403",
+    "numerator": "14320",
+    "denominator": "119637546934989134365717757381773769",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1678208556266781321546117403",
+    "numerator": "14320",
+    "denominator": "119637546934989134365717757381773769",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1001078",
+    "numerator": "213818274955141085635836873598853799943",
+    "denominator": "972",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1001078",
+    "numerator": "213818274955141085635836873598853799943",
+    "denominator": "972",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12117",
+    "numerator": "243962687178564319441582028892902770",
+    "denominator": "3274110095117667853663427193797629747",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12117",
+    "numerator": "243962687178564319441582028892902770",
+    "denominator": "3274110095117667853663427193797629747",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "338511588584",
+    "numerator": "2319722542267983988104461089",
+    "denominator": "5824618956979816857518",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "338511588584",
+    "numerator": "2319722542267983988104461089",
+    "denominator": "5824618956979816857518",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1893023",
+    "numerator": "32735979732941636",
+    "denominator": "13",
+    "rounding": "Floor",
+    "expected": "4766920197076336508125",
+    "overflow": false
+  },
+  {
+    "a": "1893023",
+    "numerator": "32735979732941636",
+    "denominator": "13",
+    "rounding": "Ceil",
+    "expected": "4766920197076336508126",
+    "overflow": false
+  },
+  {
+    "a": "2580409257795287616133006828921130",
+    "numerator": "36603373887889873659231817124295085643",
+    "denominator": "221783806240480",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2580409257795287616133006828921130",
+    "numerator": "36603373887889873659231817124295085643",
+    "denominator": "221783806240480",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "90511930745",
+    "numerator": "1803605478",
+    "denominator": "201105530053239452180882588771895",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "90511930745",
+    "numerator": "1803605478",
+    "denominator": "201105530053239452180882588771895",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "7895515724762819516",
+    "numerator": "5",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "39477578623814097580",
+    "overflow": false
+  },
+  {
+    "a": "7895515724762819516",
+    "numerator": "5",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "39477578623814097580",
+    "overflow": false
+  },
+  {
+    "a": "103388751101895862236771",
+    "numerator": "1429909139170843985368",
+    "denominator": "5198263683738794331437412582383966417",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "103388751101895862236771",
+    "numerator": "1429909139170843985368",
+    "denominator": "5198263683738794331437412582383966417",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "136615090183708967248857284119619512606",
+    "numerator": "6404863764051626703",
+    "denominator": "45364",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "136615090183708967248857284119619512606",
+    "numerator": "6404863764051626703",
+    "denominator": "45364",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1027225844748881652561885",
+    "numerator": "51533039435674",
+    "denominator": "2786699404089274235",
+    "rounding": "Floor",
+    "expected": "18995974194097830663",
+    "overflow": false
+  },
+  {
+    "a": "1027225844748881652561885",
+    "numerator": "51533039435674",
+    "denominator": "2786699404089274235",
+    "rounding": "Ceil",
+    "expected": "18995974194097830664",
+    "overflow": false
+  },
+  {
+    "a": "7645648",
+    "numerator": "9",
+    "denominator": "677397558690860153804314966",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "7645648",
+    "numerator": "9",
+    "denominator": "677397558690860153804314966",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "13054394886656225263654844882055271",
+    "numerator": "5026685719219716382687875103861676",
+    "denominator": "10715931198958773",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13054394886656225263654844882055271",
+    "numerator": "5026685719219716382687875103861676",
+    "denominator": "10715931198958773",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "785116741802843021832852050",
+    "numerator": "6108155906120083",
+    "denominator": "2301433645848697258830131245768",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "785116741802843021832852050",
+    "numerator": "6108155906120083",
+    "denominator": "2301433645848697258830131245768",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1",
+    "numerator": "13541147920059821442750891662",
+    "denominator": "347307920340735",
+    "rounding": "Floor",
+    "expected": "38988883140859",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "13541147920059821442750891662",
+    "denominator": "347307920340735",
+    "rounding": "Ceil",
+    "expected": "38988883140860",
+    "overflow": false
+  },
+  {
+    "a": "181923505253733497636",
+    "numerator": "13",
+    "denominator": "452710922",
+    "rounding": "Floor",
+    "expected": "5224096555590",
+    "overflow": false
+  },
+  {
+    "a": "181923505253733497636",
+    "numerator": "13",
+    "denominator": "452710922",
+    "rounding": "Ceil",
+    "expected": "5224096555591",
+    "overflow": false
+  },
+  {
+    "a": "931100217447595",
+    "numerator": "19096460066931887606988992",
+    "denominator": "8460358466646898582263585404041433",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "931100217447595",
+    "numerator": "19096460066931887606988992",
+    "denominator": "8460358466646898582263585404041433",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "510998532294",
+    "numerator": "23",
+    "denominator": "178163790591273175358189489487772",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "510998532294",
+    "numerator": "23",
+    "denominator": "178163790591273175358189489487772",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "15407021064549",
+    "numerator": "9641666",
+    "denominator": "68632771",
+    "rounding": "Floor",
+    "expected": "2164408474187",
+    "overflow": false
+  },
+  {
+    "a": "15407021064549",
+    "numerator": "9641666",
+    "denominator": "68632771",
+    "rounding": "Ceil",
+    "expected": "2164408474188",
+    "overflow": false
+  },
+  {
+    "a": "4574368753039688179824285774776",
+    "numerator": "188004430027040661568950073065521",
+    "denominator": "258756218428876813096958",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4574368753039688179824285774776",
+    "numerator": "188004430027040661568950073065521",
+    "denominator": "258756218428876813096958",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3988796716394444038919964720390465327",
+    "numerator": "8448627871538261387301586845161298196",
+    "denominator": "1983565811131999770527047997",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3988796716394444038919964720390465327",
+    "numerator": "8448627871538261387301586845161298196",
+    "denominator": "1983565811131999770527047997",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1018424248643757627514",
+    "numerator": "2672115163",
+    "denominator": "44627913648",
+    "rounding": "Floor",
+    "expected": "60978581670483807282",
+    "overflow": false
+  },
+  {
+    "a": "1018424248643757627514",
+    "numerator": "2672115163",
+    "denominator": "44627913648",
+    "rounding": "Ceil",
+    "expected": "60978581670483807283",
+    "overflow": false
+  },
+  {
+    "a": "137",
+    "numerator": "624167866521218584280529189942",
+    "denominator": "445273948719206076615",
+    "rounding": "Floor",
+    "expected": "192041321885",
+    "overflow": false
+  },
+  {
+    "a": "137",
+    "numerator": "624167866521218584280529189942",
+    "denominator": "445273948719206076615",
+    "rounding": "Ceil",
+    "expected": "192041321886",
+    "overflow": false
+  },
+  {
+    "a": "16300098972414759641988742954231692",
+    "numerator": "544196414683669",
+    "denominator": "1160344508938554015594715438898",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16300098972414759641988742954231692",
+    "numerator": "544196414683669",
+    "denominator": "1160344508938554015594715438898",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16720897501514787827",
+    "numerator": "2231546552913779611700807848",
+    "denominator": "9927273101432199039457",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16720897501514787827",
+    "numerator": "2231546552913779611700807848",
+    "denominator": "9927273101432199039457",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "366",
+    "numerator": "16242940767",
+    "denominator": "9235029956537807180155063044",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "366",
+    "numerator": "16242940767",
+    "denominator": "9235029956537807180155063044",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "279595622341537761744505181416429",
+    "numerator": "1006684699077132181494056227562",
+    "denominator": "829674733949315787531",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "279595622341537761744505181416429",
+    "numerator": "1006684699077132181494056227562",
+    "denominator": "829674733949315787531",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "981951612780679359136",
+    "numerator": "3139528274918775202417721",
+    "denominator": "134007790502",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "981951612780679359136",
+    "numerator": "3139528274918775202417721",
+    "denominator": "134007790502",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3",
+    "numerator": "20630922218551747452",
+    "denominator": "96854300120773",
+    "rounding": "Floor",
+    "expected": "639029",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "20630922218551747452",
+    "denominator": "96854300120773",
+    "rounding": "Ceil",
+    "expected": "639030",
+    "overflow": false
+  },
+  {
+    "a": "87175423087522",
+    "numerator": "10288262754378155099850647883824880419",
+    "denominator": "108700742040",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "87175423087522",
+    "numerator": "10288262754378155099850647883824880419",
+    "denominator": "108700742040",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "188602621737601415057",
+    "numerator": "5854",
+    "denominator": "157440238231070422980186493839",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "188602621737601415057",
+    "numerator": "5854",
+    "denominator": "157440238231070422980186493839",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4340",
+    "numerator": "6813",
+    "denominator": "105477616281601505242426917585242",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4340",
+    "numerator": "6813",
+    "denominator": "105477616281601505242426917585242",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "92994661535303957904",
+    "denominator": "3810929641",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "92994661535303957904",
+    "denominator": "3810929641",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "58978070",
+    "numerator": "325446431799063994290469748147937591591",
+    "denominator": "1640678227171570540",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58978070",
+    "numerator": "325446431799063994290469748147937591591",
+    "denominator": "1640678227171570540",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "248837425997660893431717028222837",
+    "numerator": "904966280313874",
+    "denominator": "83",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "248837425997660893431717028222837",
+    "numerator": "904966280313874",
+    "denominator": "83",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1283944110120291448744685192",
+    "numerator": "2096970646818113857",
+    "denominator": "7371041911608001614",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1283944110120291448744685192",
+    "numerator": "2096970646818113857",
+    "denominator": "7371041911608001614",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "200639",
+    "numerator": "168312301219109497572",
+    "denominator": "50584120457727849098573",
+    "rounding": "Floor",
+    "expected": "667",
+    "overflow": false
+  },
+  {
+    "a": "200639",
+    "numerator": "168312301219109497572",
+    "denominator": "50584120457727849098573",
+    "rounding": "Ceil",
+    "expected": "668",
+    "overflow": false
+  },
+  {
+    "a": "970",
+    "numerator": "7924924240235",
+    "denominator": "16266512770176",
+    "rounding": "Floor",
+    "expected": "472",
+    "overflow": false
+  },
+  {
+    "a": "970",
+    "numerator": "7924924240235",
+    "denominator": "16266512770176",
+    "rounding": "Ceil",
+    "expected": "473",
+    "overflow": false
+  },
+  {
+    "a": "28569",
+    "numerator": "1670",
+    "denominator": "411767483704348450505596759",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "28569",
+    "numerator": "1670",
+    "denominator": "411767483704348450505596759",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "26569656990902425436",
+    "numerator": "37",
+    "denominator": "80034229859838932400959193358817410",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "26569656990902425436",
+    "numerator": "37",
+    "denominator": "80034229859838932400959193358817410",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "101615049441029098407299",
+    "numerator": "24282352746973717397299821963558776",
+    "denominator": "2753462001",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "101615049441029098407299",
+    "numerator": "24282352746973717397299821963558776",
+    "denominator": "2753462001",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "204106350746632234430",
+    "numerator": "594020841688006184943",
+    "denominator": "1055295289084110035156",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "204106350746632234430",
+    "numerator": "594020841688006184943",
+    "denominator": "1055295289084110035156",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3811970435239101750506131039229",
+    "numerator": "752306032903135919649718247085406778",
+    "denominator": "27",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3811970435239101750506131039229",
+    "numerator": "752306032903135919649718247085406778",
+    "denominator": "27",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "243359600",
+    "numerator": "16148298865187772233",
+    "denominator": "160246",
+    "rounding": "Floor",
+    "expected": "24523816834819902996105",
+    "overflow": false
+  },
+  {
+    "a": "243359600",
+    "numerator": "16148298865187772233",
+    "denominator": "160246",
+    "rounding": "Ceil",
+    "expected": "24523816834819902996106",
+    "overflow": false
+  },
+  {
+    "a": "270607637069775334406273499527",
+    "numerator": "26015545723106086256537752440652",
+    "denominator": "414407394517",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "270607637069775334406273499527",
+    "numerator": "26015545723106086256537752440652",
+    "denominator": "414407394517",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17351429236133155295546861810",
+    "numerator": "2255405235",
+    "denominator": "50932066518999789455697911114097768",
+    "rounding": "Floor",
+    "expected": "768",
+    "overflow": false
+  },
+  {
+    "a": "17351429236133155295546861810",
+    "numerator": "2255405235",
+    "denominator": "50932066518999789455697911114097768",
+    "rounding": "Ceil",
+    "expected": "769",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "14923986424050175849908555119039970094",
+    "denominator": "3439935994631199",
+    "rounding": "Floor",
+    "expected": "4338448868625010603171",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "14923986424050175849908555119039970094",
+    "denominator": "3439935994631199",
+    "rounding": "Ceil",
+    "expected": "4338448868625010603172",
+    "overflow": false
+  },
+  {
+    "a": "662212",
+    "numerator": "119769780711204256070257131181",
+    "denominator": "497289199484848143270726866883118250",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "662212",
+    "numerator": "119769780711204256070257131181",
+    "denominator": "497289199484848143270726866883118250",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1995",
+    "numerator": "4406199395744793814248284318805600",
+    "denominator": "543256273657",
+    "rounding": "Floor",
+    "expected": "16180885929466334213440266",
+    "overflow": false
+  },
+  {
+    "a": "1995",
+    "numerator": "4406199395744793814248284318805600",
+    "denominator": "543256273657",
+    "rounding": "Ceil",
+    "expected": "16180885929466334213440267",
+    "overflow": false
+  },
+  {
+    "a": "3645798",
+    "numerator": "7",
+    "denominator": "2643189863340860",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3645798",
+    "numerator": "7",
+    "denominator": "2643189863340860",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "25295437905551262167402507664470405",
+    "numerator": "1169146453824397323618",
+    "denominator": "1425100082732220387",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25295437905551262167402507664470405",
+    "numerator": "1169146453824397323618",
+    "denominator": "1425100082732220387",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21240691221664996880186349985112",
+    "numerator": "5263485589073",
+    "denominator": "1978057886",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21240691221664996880186349985112",
+    "numerator": "5263485589073",
+    "denominator": "1978057886",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "153626955153628239",
+    "numerator": "3748020",
+    "denominator": "3421",
+    "rounding": "Floor",
+    "expected": "168312452632242535029",
+    "overflow": false
+  },
+  {
+    "a": "153626955153628239",
+    "numerator": "3748020",
+    "denominator": "3421",
+    "rounding": "Ceil",
+    "expected": "168312452632242535030",
+    "overflow": false
+  },
+  {
+    "a": "1612733767364875305754",
+    "numerator": "53142855107823867",
+    "denominator": "8484134818128",
+    "rounding": "Floor",
+    "expected": "10101828738440193139680067",
+    "overflow": false
+  },
+  {
+    "a": "1612733767364875305754",
+    "numerator": "53142855107823867",
+    "denominator": "8484134818128",
+    "rounding": "Ceil",
+    "expected": "10101828738440193139680068",
+    "overflow": false
+  },
+  {
+    "a": "9882112681",
+    "numerator": "598000854",
+    "denominator": "3369226727",
+    "rounding": "Floor",
+    "expected": "1753966800",
+    "overflow": false
+  },
+  {
+    "a": "9882112681",
+    "numerator": "598000854",
+    "denominator": "3369226727",
+    "rounding": "Ceil",
+    "expected": "1753966801",
+    "overflow": false
+  },
+  {
+    "a": "16257857333344743324460",
+    "numerator": "16949",
+    "denominator": "2062042617562650355154",
+    "rounding": "Floor",
+    "expected": "133631",
+    "overflow": false
+  },
+  {
+    "a": "16257857333344743324460",
+    "numerator": "16949",
+    "denominator": "2062042617562650355154",
+    "rounding": "Ceil",
+    "expected": "133632",
+    "overflow": false
+  },
+  {
+    "a": "275",
+    "numerator": "21332912712",
+    "denominator": "17351508966159400540349062281217",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "275",
+    "numerator": "21332912712",
+    "denominator": "17351508966159400540349062281217",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "905929498046939907376046445153714702",
+    "numerator": "127",
+    "denominator": "923750540069858650722540196",
+    "rounding": "Floor",
+    "expected": "124549909592",
+    "overflow": false
+  },
+  {
+    "a": "905929498046939907376046445153714702",
+    "numerator": "127",
+    "denominator": "923750540069858650722540196",
+    "rounding": "Ceil",
+    "expected": "124549909593",
+    "overflow": false
+  },
+  {
+    "a": "35935926642202832214285066253",
+    "numerator": "378158436181773053374215162017162",
+    "denominator": "43",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35935926642202832214285066253",
+    "numerator": "378158436181773053374215162017162",
+    "denominator": "43",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6297111946270361094208",
+    "numerator": "255577",
+    "denominator": "270117245666882019187782",
+    "rounding": "Floor",
+    "expected": "5958",
+    "overflow": false
+  },
+  {
+    "a": "6297111946270361094208",
+    "numerator": "255577",
+    "denominator": "270117245666882019187782",
+    "rounding": "Ceil",
+    "expected": "5959",
+    "overflow": false
+  },
+  {
+    "a": "3555351",
+    "numerator": "127212945727201123501996944739561244",
+    "denominator": "6543718117",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3555351",
+    "numerator": "127212945727201123501996944739561244",
+    "denominator": "6543718117",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1381867641758370380173890",
+    "numerator": "143869904319469036195502099011",
+    "denominator": "959075175224",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1381867641758370380173890",
+    "numerator": "143869904319469036195502099011",
+    "denominator": "959075175224",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "265892052401",
+    "numerator": "216409224062",
+    "denominator": "9548696749024188751290274453780655",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "265892052401",
+    "numerator": "216409224062",
+    "denominator": "9548696749024188751290274453780655",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6292",
+    "numerator": "76228254492349",
+    "denominator": "147057599091629050",
+    "rounding": "Floor",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "6292",
+    "numerator": "76228254492349",
+    "denominator": "147057599091629050",
+    "rounding": "Ceil",
+    "expected": "4",
+    "overflow": false
+  },
+  {
+    "a": "58735548792804069888890715",
+    "numerator": "3844114670536574989767472",
+    "denominator": "5254879403529",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58735548792804069888890715",
+    "numerator": "3844114670536574989767472",
+    "denominator": "5254879403529",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "2784533221220643625789862471",
+    "denominator": "77240489800716894734015240025868",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "2784533221220643625789862471",
+    "denominator": "77240489800716894734015240025868",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "165847214428757949419413",
+    "numerator": "102552012602763886519667558479147698",
+    "denominator": "19",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "165847214428757949419413",
+    "numerator": "102552012602763886519667558479147698",
+    "denominator": "19",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3506257960",
+    "numerator": "33699080033",
+    "denominator": "38066407189638676547487425637603566",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3506257960",
+    "numerator": "33699080033",
+    "denominator": "38066407189638676547487425637603566",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "244695477296320329141471",
+    "numerator": "279220773454178948",
+    "denominator": "6059650801340781",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "244695477296320329141471",
+    "numerator": "279220773454178948",
+    "denominator": "6059650801340781",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "96417386",
+    "numerator": "152024815139780783815917262323590283",
+    "denominator": "8003031882528710181925408",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "96417386",
+    "numerator": "152024815139780783815917262323590283",
+    "denominator": "8003031882528710181925408",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15191596926370295058191002659992205753",
+    "numerator": "806",
+    "denominator": "1091703",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15191596926370295058191002659992205753",
+    "numerator": "806",
+    "denominator": "1091703",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "526618546940",
+    "numerator": "1096565366344773",
+    "denominator": "320850183970",
+    "rounding": "Floor",
+    "expected": "1799817138029777",
+    "overflow": false
+  },
+  {
+    "a": "526618546940",
+    "numerator": "1096565366344773",
+    "denominator": "320850183970",
+    "rounding": "Ceil",
+    "expected": "1799817138029778",
+    "overflow": false
+  },
+  {
+    "a": "36389446819",
+    "numerator": "428378304208685336",
+    "denominator": "2822921439542297151591677758119982353",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "36389446819",
+    "numerator": "428378304208685336",
+    "denominator": "2822921439542297151591677758119982353",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "395080286",
+    "numerator": "42255",
+    "denominator": "1562890085229678595765817460",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "395080286",
+    "numerator": "42255",
+    "denominator": "1562890085229678595765817460",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "50877416634195856924701",
+    "numerator": "8767514760630803819119834",
+    "denominator": "46964798907",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "50877416634195856924701",
+    "numerator": "8767514760630803819119834",
+    "denominator": "46964798907",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "105748505269420090640",
+    "numerator": "9",
+    "denominator": "55958",
+    "rounding": "Floor",
+    "expected": "17008051528374509",
+    "overflow": false
+  },
+  {
+    "a": "105748505269420090640",
+    "numerator": "9",
+    "denominator": "55958",
+    "rounding": "Ceil",
+    "expected": "17008051528374510",
+    "overflow": false
+  },
+  {
+    "a": "1909415",
+    "numerator": "497140460",
+    "denominator": "52704699048075806600622067371149028597",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1909415",
+    "numerator": "497140460",
+    "denominator": "52704699048075806600622067371149028597",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2460659650450",
+    "numerator": "19",
+    "denominator": "15295648653460088055304",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2460659650450",
+    "numerator": "19",
+    "denominator": "15295648653460088055304",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "46926398066049539983693259040449",
+    "numerator": "3610574798",
+    "denominator": "1662704517439",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "46926398066049539983693259040449",
+    "numerator": "3610574798",
+    "denominator": "1662704517439",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16955952180755900297094105700",
+    "numerator": "19158979318477",
+    "denominator": "853454383581002",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16955952180755900297094105700",
+    "numerator": "19158979318477",
+    "denominator": "853454383581002",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6731963238972916010486507",
+    "numerator": "208174382349963914193920",
+    "denominator": "4125004166744174968703108357401",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6731963238972916010486507",
+    "numerator": "208174382349963914193920",
+    "denominator": "4125004166744174968703108357401",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20528662618063846928864583799718406",
+    "numerator": "3",
+    "denominator": "416866164022158190686944855772",
+    "rounding": "Floor",
+    "expected": "147735",
+    "overflow": false
+  },
+  {
+    "a": "20528662618063846928864583799718406",
+    "numerator": "3",
+    "denominator": "416866164022158190686944855772",
+    "rounding": "Ceil",
+    "expected": "147736",
+    "overflow": false
+  },
+  {
+    "a": "13949558753834804281296688174657957",
+    "numerator": "455265334015063709868392143424514",
+    "denominator": "7507463939",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13949558753834804281296688174657957",
+    "numerator": "455265334015063709868392143424514",
+    "denominator": "7507463939",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12719864",
+    "numerator": "5784744311921",
+    "denominator": "318",
+    "rounding": "Floor",
+    "expected": "231387298498140562",
+    "overflow": false
+  },
+  {
+    "a": "12719864",
+    "numerator": "5784744311921",
+    "denominator": "318",
+    "rounding": "Ceil",
+    "expected": "231387298498140563",
+    "overflow": false
+  },
+  {
+    "a": "15057872304571370216579439",
+    "numerator": "124662087038450085469034580",
+    "denominator": "1022743110347133",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15057872304571370216579439",
+    "numerator": "124662087038450085469034580",
+    "denominator": "1022743110347133",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4570414546648271912378",
+    "numerator": "668153038366231478461467",
+    "denominator": "343654569815069933176560",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4570414546648271912378",
+    "numerator": "668153038366231478461467",
+    "denominator": "343654569815069933176560",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "517733392563054042850505",
+    "numerator": "9319258211071729014",
+    "denominator": "16972795552749503357703",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "517733392563054042850505",
+    "numerator": "9319258211071729014",
+    "denominator": "16972795552749503357703",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8441369721608548779123908300",
+    "numerator": "258145904987831589632766262336085",
+    "denominator": "228690466779315314",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8441369721608548779123908300",
+    "numerator": "258145904987831589632766262336085",
+    "denominator": "228690466779315314",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "113619932424755",
+    "numerator": "361802150438028925983720",
+    "denominator": "2491525219010842242186885740065",
+    "rounding": "Floor",
+    "expected": "16499104",
+    "overflow": false
+  },
+  {
+    "a": "113619932424755",
+    "numerator": "361802150438028925983720",
+    "denominator": "2491525219010842242186885740065",
+    "rounding": "Ceil",
+    "expected": "16499105",
+    "overflow": false
+  },
+  {
+    "a": "203190477647587341998",
+    "numerator": "141957947652577329718706668474811807",
+    "denominator": "68",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "203190477647587341998",
+    "numerator": "141957947652577329718706668474811807",
+    "denominator": "68",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29353944109",
+    "numerator": "11650157849496843155296894176092530730",
+    "denominator": "134616571248271748713628400353611",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29353944109",
+    "numerator": "11650157849496843155296894176092530730",
+    "denominator": "134616571248271748713628400353611",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3263867619241260512",
+    "numerator": "1155351167228580845142961574009",
+    "denominator": "2223064834397400294",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3263867619241260512",
+    "numerator": "1155351167228580845142961574009",
+    "denominator": "2223064834397400294",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "68062346979639",
+    "numerator": "41836645904647581477571260",
+    "denominator": "306806175570406084362361200256773",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "68062346979639",
+    "numerator": "41836645904647581477571260",
+    "denominator": "306806175570406084362361200256773",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58396269098737890",
+    "numerator": "10996067",
+    "denominator": "130856152",
+    "rounding": "Floor",
+    "expected": "4907138699598559",
+    "overflow": false
+  },
+  {
+    "a": "58396269098737890",
+    "numerator": "10996067",
+    "denominator": "130856152",
+    "rounding": "Ceil",
+    "expected": "4907138699598560",
+    "overflow": false
+  },
+  {
+    "a": "19441090979342139096098872736699345",
+    "numerator": "30",
+    "denominator": "88374016595997315743292821220815",
+    "rounding": "Floor",
+    "expected": "6599",
+    "overflow": false
+  },
+  {
+    "a": "19441090979342139096098872736699345",
+    "numerator": "30",
+    "denominator": "88374016595997315743292821220815",
+    "rounding": "Ceil",
+    "expected": "6600",
+    "overflow": false
+  },
+  {
+    "a": "303018036",
+    "numerator": "5545018077",
+    "denominator": "8820675258708995092829211853850266",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "303018036",
+    "numerator": "5545018077",
+    "denominator": "8820675258708995092829211853850266",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2571297403",
+    "numerator": "40245070239174834538969259831163088",
+    "denominator": "17110405795931200380426130661417",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2571297403",
+    "numerator": "40245070239174834538969259831163088",
+    "denominator": "17110405795931200380426130661417",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12374",
+    "numerator": "17574149302833273802601319",
+    "denominator": "1060437483065344338344110818511532",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "12374",
+    "numerator": "17574149302833273802601319",
+    "denominator": "1060437483065344338344110818511532",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "437",
+    "numerator": "29634378066",
+    "denominator": "76552471861439147155",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "437",
+    "numerator": "29634378066",
+    "denominator": "76552471861439147155",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2073032",
+    "numerator": "1081484949884212609",
+    "denominator": "361933862695330833165628849550",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2073032",
+    "numerator": "1081484949884212609",
+    "denominator": "361933862695330833165628849550",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "770713073057240870119694211583",
+    "numerator": "80420",
+    "denominator": "7807664461324698361221271700877",
+    "rounding": "Floor",
+    "expected": "7938",
+    "overflow": false
+  },
+  {
+    "a": "770713073057240870119694211583",
+    "numerator": "80420",
+    "denominator": "7807664461324698361221271700877",
+    "rounding": "Ceil",
+    "expected": "7939",
+    "overflow": false
+  },
+  {
+    "a": "33941857753241190113346557883750666",
+    "numerator": "2177475831640103080636038776767154091",
+    "denominator": "4032",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33941857753241190113346557883750666",
+    "numerator": "2177475831640103080636038776767154091",
+    "denominator": "4032",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11135980505",
+    "numerator": "289887193917016342543079935043526",
+    "denominator": "23",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11135980505",
+    "numerator": "289887193917016342543079935043526",
+    "denominator": "23",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4008243139436188",
+    "numerator": "494698598796553317",
+    "denominator": "122471325446281591907407754707043778",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4008243139436188",
+    "numerator": "494698598796553317",
+    "denominator": "122471325446281591907407754707043778",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5059",
+    "numerator": "32718003604005298872",
+    "denominator": "720362368447755582322899761",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5059",
+    "numerator": "32718003604005298872",
+    "denominator": "720362368447755582322899761",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "23166968595231075203583742",
+    "numerator": "736895462695763591436055851633199",
+    "denominator": "2068",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23166968595231075203583742",
+    "numerator": "736895462695763591436055851633199",
+    "denominator": "2068",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "142397",
+    "numerator": "60553781114",
+    "denominator": "3666139",
+    "rounding": "Floor",
+    "expected": "2351977589",
+    "overflow": false
+  },
+  {
+    "a": "142397",
+    "numerator": "60553781114",
+    "denominator": "3666139",
+    "rounding": "Ceil",
+    "expected": "2351977590",
+    "overflow": false
+  },
+  {
+    "a": "26979813172787888",
+    "numerator": "219757148124340971300137865",
+    "denominator": "6",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "26979813172787888",
+    "numerator": "219757148124340971300137865",
+    "denominator": "6",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "455",
+    "numerator": "1676",
+    "denominator": "21",
+    "rounding": "Floor",
+    "expected": "36313",
+    "overflow": false
+  },
+  {
+    "a": "455",
+    "numerator": "1676",
+    "denominator": "21",
+    "rounding": "Ceil",
+    "expected": "36314",
+    "overflow": false
+  },
+  {
+    "a": "987839254364030514",
+    "numerator": "594711428851",
+    "denominator": "47016",
+    "rounding": "Floor",
+    "expected": "12495305735025077086104814",
+    "overflow": false
+  },
+  {
+    "a": "987839254364030514",
+    "numerator": "594711428851",
+    "denominator": "47016",
+    "rounding": "Ceil",
+    "expected": "12495305735025077086104815",
+    "overflow": false
+  },
+  {
+    "a": "511270582585163819351406249185",
+    "numerator": "1834880308919359582395376391278",
+    "denominator": "7775",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "511270582585163819351406249185",
+    "numerator": "1834880308919359582395376391278",
+    "denominator": "7775",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18948",
+    "numerator": "1603878825611419416301",
+    "denominator": "10",
+    "rounding": "Floor",
+    "expected": "3039029598768517510007134",
+    "overflow": false
+  },
+  {
+    "a": "18948",
+    "numerator": "1603878825611419416301",
+    "denominator": "10",
+    "rounding": "Ceil",
+    "expected": "3039029598768517510007135",
+    "overflow": false
+  },
+  {
+    "a": "1547",
+    "numerator": "306182560",
+    "denominator": "1849",
+    "rounding": "Floor",
+    "expected": "256173293",
+    "overflow": false
+  },
+  {
+    "a": "1547",
+    "numerator": "306182560",
+    "denominator": "1849",
+    "rounding": "Ceil",
+    "expected": "256173294",
+    "overflow": false
+  },
+  {
+    "a": "19641241160956045312162569400998",
+    "numerator": "152050936758440749559",
+    "denominator": "886915163519089418267771565389775484",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19641241160956045312162569400998",
+    "numerator": "152050936758440749559",
+    "denominator": "886915163519089418267771565389775484",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8064467354053",
+    "numerator": "35674143641697204898",
+    "denominator": "543797427853075822047372858140192291",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8064467354053",
+    "numerator": "35674143641697204898",
+    "denominator": "543797427853075822047372858140192291",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6100022712414070146517360792",
+    "numerator": "145",
+    "denominator": "1253247406091111902",
+    "rounding": "Floor",
+    "expected": "705769099541",
+    "overflow": false
+  },
+  {
+    "a": "6100022712414070146517360792",
+    "numerator": "145",
+    "denominator": "1253247406091111902",
+    "rounding": "Ceil",
+    "expected": "705769099542",
+    "overflow": false
+  },
+  {
+    "a": "1832591",
+    "numerator": "102986004189029530692420952826236916",
+    "denominator": "41470620444061",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1832591",
+    "numerator": "102986004189029530692420952826236916",
+    "denominator": "41470620444061",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6454524720761522279384881988339802",
+    "numerator": "34084831698620219",
+    "denominator": "1955155088",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6454524720761522279384881988339802",
+    "numerator": "34084831698620219",
+    "denominator": "1955155088",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17436198183558282395731689",
+    "numerator": "22",
+    "denominator": "123438119",
+    "rounding": "Floor",
+    "expected": "3107600497689714574",
+    "overflow": false
+  },
+  {
+    "a": "17436198183558282395731689",
+    "numerator": "22",
+    "denominator": "123438119",
+    "rounding": "Ceil",
+    "expected": "3107600497689714575",
+    "overflow": false
+  },
+  {
+    "a": "344551089836652",
+    "numerator": "9965262436112455442066653033089335925",
+    "denominator": "881589576147698500641554",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "344551089836652",
+    "numerator": "9965262436112455442066653033089335925",
+    "denominator": "881589576147698500641554",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "862580764700512407030522195",
+    "numerator": "73376473914789160356544781704",
+    "denominator": "65536905319315317093565505",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "862580764700512407030522195",
+    "numerator": "73376473914789160356544781704",
+    "denominator": "65536905319315317093565505",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "270867714872242511657806",
+    "numerator": "137847051382906239906495",
+    "denominator": "29477337776979683812",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "270867714872242511657806",
+    "numerator": "137847051382906239906495",
+    "denominator": "29477337776979683812",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "106683485081650793159735642392082509",
+    "numerator": "1255402010703084217714453965514",
+    "denominator": "752712396709225720081728619",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "106683485081650793159735642392082509",
+    "numerator": "1255402010703084217714453965514",
+    "denominator": "752712396709225720081728619",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "29596772118656675582420084955132971673",
+    "denominator": "3462",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "29596772118656675582420084955132971673",
+    "denominator": "3462",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4274194155450191892422136668759",
+    "numerator": "14002298012311828143922707186939484",
+    "denominator": "22606373660453",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4274194155450191892422136668759",
+    "numerator": "14002298012311828143922707186939484",
+    "denominator": "22606373660453",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1223503169543474722517925762",
+    "numerator": "70374987907",
+    "denominator": "6188664",
+    "rounding": "Floor",
+    "expected": "13913183970045587271818151072909",
+    "overflow": false
+  },
+  {
+    "a": "1223503169543474722517925762",
+    "numerator": "70374987907",
+    "denominator": "6188664",
+    "rounding": "Ceil",
+    "expected": "13913183970045587271818151072910",
+    "overflow": false
+  },
+  {
+    "a": "1259870031183527280610839951857",
+    "numerator": "18898110",
+    "denominator": "132828569232962637198063",
+    "rounding": "Floor",
+    "expected": "179247300279594",
+    "overflow": false
+  },
+  {
+    "a": "1259870031183527280610839951857",
+    "numerator": "18898110",
+    "denominator": "132828569232962637198063",
+    "rounding": "Ceil",
+    "expected": "179247300279595",
+    "overflow": false
+  },
+  {
+    "a": "84",
+    "numerator": "1244703536331351369561911847333629",
+    "denominator": "52920222010",
+    "rounding": "Floor",
+    "expected": "1975711610432707537373398",
+    "overflow": false
+  },
+  {
+    "a": "84",
+    "numerator": "1244703536331351369561911847333629",
+    "denominator": "52920222010",
+    "rounding": "Ceil",
+    "expected": "1975711610432707537373399",
+    "overflow": false
+  },
+  {
+    "a": "238404436095629737371",
+    "numerator": "101885308942793551472",
+    "denominator": "5356153650932848652873",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "238404436095629737371",
+    "numerator": "101885308942793551472",
+    "denominator": "5356153650932848652873",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10883439649466081007498390653174",
+    "numerator": "148615",
+    "denominator": "4",
+    "rounding": "Floor",
+    "expected": "404360595876350407232343331730363502",
+    "overflow": false
+  },
+  {
+    "a": "10883439649466081007498390653174",
+    "numerator": "148615",
+    "denominator": "4",
+    "rounding": "Ceil",
+    "expected": "404360595876350407232343331730363503",
+    "overflow": false
+  },
+  {
+    "a": "31480263836147244345938192674773",
+    "numerator": "105631518706",
+    "denominator": "114883226347844744941558337557664691",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31480263836147244345938192674773",
+    "numerator": "105631518706",
+    "denominator": "114883226347844744941558337557664691",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3107914790079725859825410727531368",
+    "numerator": "1866727160897238645271237537",
+    "denominator": "46",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3107914790079725859825410727531368",
+    "numerator": "1866727160897238645271237537",
+    "denominator": "46",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10574769009186223438100124893241734943",
+    "numerator": "72891668650920662331218372",
+    "denominator": "2477",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10574769009186223438100124893241734943",
+    "numerator": "72891668650920662331218372",
+    "denominator": "2477",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4055426812431274",
+    "numerator": "301098891979",
+    "denominator": "96",
+    "rounding": "Floor",
+    "expected": "12719630413801921505076575",
+    "overflow": false
+  },
+  {
+    "a": "4055426812431274",
+    "numerator": "301098891979",
+    "denominator": "96",
+    "rounding": "Ceil",
+    "expected": "12719630413801921505076576",
+    "overflow": false
+  },
+  {
+    "a": "33768048039939957521345233337849",
+    "numerator": "1935342787744262340229222",
+    "denominator": "158391",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33768048039939957521345233337849",
+    "numerator": "1935342787744262340229222",
+    "denominator": "158391",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6437436",
+    "numerator": "2388600949163174456302725",
+    "denominator": "459474205505906501137822384329826",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "6437436",
+    "numerator": "2388600949163174456302725",
+    "denominator": "459474205505906501137822384329826",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "5160614760441465452252248",
+    "denominator": "5398286673",
+    "rounding": "Floor",
+    "expected": "2867918141279563",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "5160614760441465452252248",
+    "denominator": "5398286673",
+    "rounding": "Ceil",
+    "expected": "2867918141279564",
+    "overflow": false
+  },
+  {
+    "a": "212136607326614973905822",
+    "numerator": "234448543275009301329587364476077866831",
+    "denominator": "920608114383078414549102833588",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "212136607326614973905822",
+    "numerator": "234448543275009301329587364476077866831",
+    "denominator": "920608114383078414549102833588",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16578988125",
+    "numerator": "6209172477986866023516698",
+    "denominator": "285399940091",
+    "rounding": "Floor",
+    "expected": "360693126795324488055164",
+    "overflow": false
+  },
+  {
+    "a": "16578988125",
+    "numerator": "6209172477986866023516698",
+    "denominator": "285399940091",
+    "rounding": "Ceil",
+    "expected": "360693126795324488055165",
+    "overflow": false
+  },
+  {
+    "a": "674608472144",
+    "numerator": "1449",
+    "denominator": "4789851002630876208086",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "674608472144",
+    "numerator": "1449",
+    "denominator": "4789851002630876208086",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2271314075818415063241959",
+    "numerator": "149500889593296496479112994916068268588",
+    "denominator": "1333",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2271314075818415063241959",
+    "numerator": "149500889593296496479112994916068268588",
+    "denominator": "1333",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "167343785467382374255826",
+    "numerator": "0",
+    "denominator": "108789559573772675629722392105441608",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "167343785467382374255826",
+    "numerator": "0",
+    "denominator": "108789559573772675629722392105441608",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "497726209",
+    "numerator": "36296611260025304431524110",
+    "denominator": "2124806639436917332197093566909311",
+    "rounding": "Floor",
+    "expected": "8",
+    "overflow": false
+  },
+  {
+    "a": "497726209",
+    "numerator": "36296611260025304431524110",
+    "denominator": "2124806639436917332197093566909311",
+    "rounding": "Ceil",
+    "expected": "9",
+    "overflow": false
+  },
+  {
+    "a": "3714568454042727831972",
+    "numerator": "1",
+    "denominator": "9692133163969736735301860490",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3714568454042727831972",
+    "numerator": "1",
+    "denominator": "9692133163969736735301860490",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "23800164159843943619898458411",
+    "numerator": "29275937281856",
+    "denominator": "761151119577675445156220347367769",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23800164159843943619898458411",
+    "numerator": "29275937281856",
+    "denominator": "761151119577675445156220347367769",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "253685092304085516111263480673094",
+    "numerator": "17175",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "4357041460322668739210950280560389450",
+    "overflow": false
+  },
+  {
+    "a": "253685092304085516111263480673094",
+    "numerator": "17175",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "4357041460322668739210950280560389450",
+    "overflow": false
+  },
+  {
+    "a": "24113922632781070492534583462830565",
+    "numerator": "2",
+    "denominator": "76266002335376121155",
+    "rounding": "Floor",
+    "expected": "632363619289791",
+    "overflow": false
+  },
+  {
+    "a": "24113922632781070492534583462830565",
+    "numerator": "2",
+    "denominator": "76266002335376121155",
+    "rounding": "Ceil",
+    "expected": "632363619289792",
+    "overflow": false
+  },
+  {
+    "a": "20354240617221749155461688",
+    "numerator": "4077745",
+    "denominator": "188537072254",
+    "rounding": "Floor",
+    "expected": "440228555123921986591",
+    "overflow": false
+  },
+  {
+    "a": "20354240617221749155461688",
+    "numerator": "4077745",
+    "denominator": "188537072254",
+    "rounding": "Ceil",
+    "expected": "440228555123921986592",
+    "overflow": false
+  },
+  {
+    "a": "943",
+    "numerator": "20",
+    "denominator": "74796625129917",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "943",
+    "numerator": "20",
+    "denominator": "74796625129917",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1024805992263254467322",
+    "numerator": "128049369614354694952082655835",
+    "denominator": "560",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1024805992263254467322",
+    "numerator": "128049369614354694952082655835",
+    "denominator": "560",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2313",
+    "numerator": "476357478657638070",
+    "denominator": "821771760967",
+    "rounding": "Floor",
+    "expected": "1340779642",
+    "overflow": false
+  },
+  {
+    "a": "2313",
+    "numerator": "476357478657638070",
+    "denominator": "821771760967",
+    "rounding": "Ceil",
+    "expected": "1340779643",
+    "overflow": false
+  },
+  {
+    "a": "798674103210137041822045708",
+    "numerator": "1797438101",
+    "denominator": "4619266794661866251803638585778",
+    "rounding": "Floor",
+    "expected": "310778",
+    "overflow": false
+  },
+  {
+    "a": "798674103210137041822045708",
+    "numerator": "1797438101",
+    "denominator": "4619266794661866251803638585778",
+    "rounding": "Ceil",
+    "expected": "310779",
+    "overflow": false
+  },
+  {
+    "a": "11841819453555",
+    "numerator": "3185466960170397490157137704",
+    "denominator": "1294151563928161",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11841819453555",
+    "numerator": "3185466960170397490157137704",
+    "denominator": "1294151563928161",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20462",
+    "numerator": "179353931565339080656774660360056799",
+    "denominator": "237470427524",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20462",
+    "numerator": "179353931565339080656774660360056799",
+    "denominator": "237470427524",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "108096561780575965641825389",
+    "numerator": "1029522084638449816931232415082",
+    "denominator": "4003723",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "108096561780575965641825389",
+    "numerator": "1029522084638449816931232415082",
+    "denominator": "4003723",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8064129829312461193504",
+    "numerator": "1",
+    "denominator": "38",
+    "rounding": "Floor",
+    "expected": "212213942876643715618",
+    "overflow": false
+  },
+  {
+    "a": "8064129829312461193504",
+    "numerator": "1",
+    "denominator": "38",
+    "rounding": "Ceil",
+    "expected": "212213942876643715619",
+    "overflow": false
+  },
+  {
+    "a": "4473691059151317879",
+    "numerator": "33983169258292490748",
+    "denominator": "37134592925535257860716357",
+    "rounding": "Floor",
+    "expected": "4094031696464",
+    "overflow": false
+  },
+  {
+    "a": "4473691059151317879",
+    "numerator": "33983169258292490748",
+    "denominator": "37134592925535257860716357",
+    "rounding": "Ceil",
+    "expected": "4094031696465",
+    "overflow": false
+  },
+  {
+    "a": "9966252810448418",
+    "numerator": "163",
+    "denominator": "173406154339496118854655438682136",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "9966252810448418",
+    "numerator": "163",
+    "denominator": "173406154339496118854655438682136",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "462493473681425",
+    "numerator": "132397415005503934840569413939363555678",
+    "denominator": "2708186904152079",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "462493473681425",
+    "numerator": "132397415005503934840569413939363555678",
+    "denominator": "2708186904152079",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "763961575605930360515357",
+    "denominator": "385077496794",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "763961575605930360515357",
+    "denominator": "385077496794",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "10427",
+    "numerator": "1040",
+    "denominator": "105",
+    "rounding": "Floor",
+    "expected": "103276",
+    "overflow": false
+  },
+  {
+    "a": "10427",
+    "numerator": "1040",
+    "denominator": "105",
+    "rounding": "Ceil",
+    "expected": "103277",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "141108635047",
+    "denominator": "496173881210242452618018856069587436",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "141108635047",
+    "denominator": "496173881210242452618018856069587436",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "124850535669045237",
+    "numerator": "256245266186417810",
+    "denominator": "10765796473498733608764181203",
+    "rounding": "Floor",
+    "expected": "2971666",
+    "overflow": false
+  },
+  {
+    "a": "124850535669045237",
+    "numerator": "256245266186417810",
+    "denominator": "10765796473498733608764181203",
+    "rounding": "Ceil",
+    "expected": "2971667",
+    "overflow": false
+  },
+  {
+    "a": "8",
+    "numerator": "6985906221103068455361",
+    "denominator": "78",
+    "rounding": "Floor",
+    "expected": "716503202164417277472",
+    "overflow": false
+  },
+  {
+    "a": "8",
+    "numerator": "6985906221103068455361",
+    "denominator": "78",
+    "rounding": "Ceil",
+    "expected": "716503202164417277473",
+    "overflow": false
+  },
+  {
+    "a": "1101535299331135",
+    "numerator": "22563901954592089728753519053156",
+    "denominator": "2051509965355762798498907373985229",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1101535299331135",
+    "numerator": "22563901954592089728753519053156",
+    "denominator": "2051509965355762798498907373985229",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "872010",
+    "numerator": "112987040830183093923233922539",
+    "denominator": "15104",
+    "rounding": "Floor",
+    "expected": "6523161379391416825476642796162",
+    "overflow": false
+  },
+  {
+    "a": "872010",
+    "numerator": "112987040830183093923233922539",
+    "denominator": "15104",
+    "rounding": "Ceil",
+    "expected": "6523161379391416825476642796163",
+    "overflow": false
+  },
+  {
+    "a": "54720537",
+    "numerator": "15659107493760462996629137053958",
+    "denominator": "7",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "54720537",
+    "numerator": "15659107493760462996629137053958",
+    "denominator": "7",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51195176412",
+    "numerator": "197725936805",
+    "denominator": "57730033946391474946",
+    "rounding": "Floor",
+    "expected": "175",
+    "overflow": false
+  },
+  {
+    "a": "51195176412",
+    "numerator": "197725936805",
+    "denominator": "57730033946391474946",
+    "rounding": "Ceil",
+    "expected": "176",
+    "overflow": false
+  },
+  {
+    "a": "259857064518873225288948370702885379",
+    "numerator": "1391961119232345592",
+    "denominator": "245173393752157902190449",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "259857064518873225288948370702885379",
+    "numerator": "1391961119232345592",
+    "denominator": "245173393752157902190449",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3521298890178480283747465278",
+    "numerator": "72007355436074095",
+    "denominator": "7221553940672361089242964",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3521298890178480283747465278",
+    "numerator": "72007355436074095",
+    "denominator": "7221553940672361089242964",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1117555106578541924349053",
+    "numerator": "58",
+    "denominator": "117173652077489832973997851",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1117555106578541924349053",
+    "numerator": "58",
+    "denominator": "117173652077489832973997851",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "16",
+    "numerator": "1653605735086594257793728457",
+    "denominator": "6450807791352781831001910832395382",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "16",
+    "numerator": "1653605735086594257793728457",
+    "denominator": "6450807791352781831001910832395382",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3490382459037191",
+    "numerator": "456848857563401473879566171596",
+    "denominator": "113057924437",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3490382459037191",
+    "numerator": "456848857563401473879566171596",
+    "denominator": "113057924437",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "1761082675",
+    "denominator": "111527268355604294847208",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "1761082675",
+    "denominator": "111527268355604294847208",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "190176298379702561",
+    "numerator": "733267435285934",
+    "denominator": "68790431",
+    "rounding": "Floor",
+    "expected": "2027172741003134907939490",
+    "overflow": false
+  },
+  {
+    "a": "190176298379702561",
+    "numerator": "733267435285934",
+    "denominator": "68790431",
+    "rounding": "Ceil",
+    "expected": "2027172741003134907939491",
+    "overflow": false
+  },
+  {
+    "a": "441760068",
+    "numerator": "23114204697483289167398932737837",
+    "denominator": "735410517778328907562",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "441760068",
+    "numerator": "23114204697483289167398932737837",
+    "denominator": "735410517778328907562",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "149712268293195",
+    "numerator": "1248",
+    "denominator": "618020092351766100626243464057",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "149712268293195",
+    "numerator": "1248",
+    "denominator": "618020092351766100626243464057",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "36008756198",
+    "numerator": "203566135",
+    "denominator": "25202279423158338794148751804",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "36008756198",
+    "numerator": "203566135",
+    "denominator": "25202279423158338794148751804",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "146198673419990394507183198725",
+    "numerator": "527527231402837986",
+    "denominator": "7267",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "146198673419990394507183198725",
+    "numerator": "527527231402837986",
+    "denominator": "7267",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "260692476824813546573961106931114968",
+    "numerator": "18682788597457",
+    "denominator": "1100606159025916761629628190",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "260692476824813546573961106931114968",
+    "numerator": "18682788597457",
+    "denominator": "1100606159025916761629628190",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2708286572869946087231695",
+    "numerator": "2632172219688942172241347572531965748",
+    "denominator": "1662308547055478613019545053",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2708286572869946087231695",
+    "numerator": "2632172219688942172241347572531965748",
+    "denominator": "1662308547055478613019545053",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4349408339712642458",
+    "numerator": "71035",
+    "denominator": "521022621648",
+    "rounding": "Floor",
+    "expected": "592988113326",
+    "overflow": false
+  },
+  {
+    "a": "4349408339712642458",
+    "numerator": "71035",
+    "denominator": "521022621648",
+    "rounding": "Ceil",
+    "expected": "592988113327",
+    "overflow": false
+  },
+  {
+    "a": "3757423401",
+    "numerator": "31230721527364709048397028271982422",
+    "denominator": "296928073938535",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3757423401",
+    "numerator": "31230721527364709048397028271982422",
+    "denominator": "296928073938535",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1921341768159504090367748524",
+    "numerator": "3431947360335455097291445",
+    "denominator": "16595091203132577728827795562578",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1921341768159504090367748524",
+    "numerator": "3431947360335455097291445",
+    "denominator": "16595091203132577728827795562578",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "865402771",
+    "numerator": "242806113214075048136",
+    "denominator": "1428780171579521",
+    "rounding": "Floor",
+    "expected": "147066068924309",
+    "overflow": false
+  },
+  {
+    "a": "865402771",
+    "numerator": "242806113214075048136",
+    "denominator": "1428780171579521",
+    "rounding": "Ceil",
+    "expected": "147066068924310",
+    "overflow": false
+  },
+  {
+    "a": "14",
+    "numerator": "232870011862271",
+    "denominator": "4378120369254731771690888390145767716",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "14",
+    "numerator": "232870011862271",
+    "denominator": "4378120369254731771690888390145767716",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2625677",
+    "numerator": "333069019185647418695690",
+    "denominator": "18404378109294344875",
+    "rounding": "Floor",
+    "expected": "47517588363",
+    "overflow": false
+  },
+  {
+    "a": "2625677",
+    "numerator": "333069019185647418695690",
+    "denominator": "18404378109294344875",
+    "rounding": "Ceil",
+    "expected": "47517588364",
+    "overflow": false
+  },
+  {
+    "a": "1635607884940674905799323164352",
+    "numerator": "178505165303513",
+    "denominator": "19146549793494433329938772936687302",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1635607884940674905799323164352",
+    "numerator": "178505165303513",
+    "denominator": "19146549793494433329938772936687302",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1269836476990590134958033683607",
+    "numerator": "26323830219062684",
+    "denominator": "375905833105450318749593949172488037",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1269836476990590134958033683607",
+    "numerator": "26323830219062684",
+    "denominator": "375905833105450318749593949172488037",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "26733762",
+    "numerator": "74080574161449593221941323459",
+    "denominator": "7492024",
+    "rounding": "Floor",
+    "expected": "264341443441123920611064849674",
+    "overflow": false
+  },
+  {
+    "a": "26733762",
+    "numerator": "74080574161449593221941323459",
+    "denominator": "7492024",
+    "rounding": "Ceil",
+    "expected": "264341443441123920611064849675",
+    "overflow": false
+  },
+  {
+    "a": "45784567603754545",
+    "numerator": "61791196081632138191128062",
+    "denominator": "47488576815",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "45784567603754545",
+    "numerator": "61791196081632138191128062",
+    "denominator": "47488576815",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "82556343686932",
+    "numerator": "92024715069",
+    "denominator": "3106243830582447001894479482",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "82556343686932",
+    "numerator": "92024715069",
+    "denominator": "3106243830582447001894479482",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8633598827112304225461211",
+    "numerator": "126931145769359845638618713207245232",
+    "denominator": "18369049577079346395069080389257",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8633598827112304225461211",
+    "numerator": "126931145769359845638618713207245232",
+    "denominator": "18369049577079346395069080389257",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4485643058672953910",
+    "numerator": "9880656257189113647241238215",
+    "denominator": "489504798696844",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4485643058672953910",
+    "numerator": "9880656257189113647241238215",
+    "denominator": "489504798696844",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "346070836423411908461549666275349",
+    "numerator": "8896500156838473288402138100999761202",
+    "denominator": "4165777533456689705250918899",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "346070836423411908461549666275349",
+    "numerator": "8896500156838473288402138100999761202",
+    "denominator": "4165777533456689705250918899",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11586349160672075677275136921151144",
+    "numerator": "2047969",
+    "denominator": "6361274765404719982",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11586349160672075677275136921151144",
+    "numerator": "2047969",
+    "denominator": "6361274765404719982",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15923109323103",
+    "numerator": "73954713168336371288324",
+    "denominator": "265092415981",
+    "rounding": "Floor",
+    "expected": "4442182845481881124738007",
+    "overflow": false
+  },
+  {
+    "a": "15923109323103",
+    "numerator": "73954713168336371288324",
+    "denominator": "265092415981",
+    "rounding": "Ceil",
+    "expected": "4442182845481881124738008",
+    "overflow": false
+  },
+  {
+    "a": "1632609804522",
+    "numerator": "134588522289618126205907833099",
+    "denominator": "160",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1632609804522",
+    "numerator": "134588522289618126205907833099",
+    "denominator": "160",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1856528354656825",
+    "numerator": "123575253223667264208751014",
+    "denominator": "21962536188738750531233761881335",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1856528354656825",
+    "numerator": "123575253223667264208751014",
+    "denominator": "21962536188738750531233761881335",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32069351980634081633478274252956028",
+    "numerator": "78645898437",
+    "denominator": "215097762",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "32069351980634081633478274252956028",
+    "numerator": "78645898437",
+    "denominator": "215097762",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2324879928675737660493684389970211",
+    "numerator": "24",
+    "denominator": "14425337233",
+    "rounding": "Floor",
+    "expected": "3867994029323203681102352",
+    "overflow": false
+  },
+  {
+    "a": "2324879928675737660493684389970211",
+    "numerator": "24",
+    "denominator": "14425337233",
+    "rounding": "Ceil",
+    "expected": "3867994029323203681102353",
+    "overflow": false
+  },
+  {
+    "a": "279125710509406193773364446",
+    "numerator": "23357397391",
+    "denominator": "892521394507734470686026592931572",
+    "rounding": "Floor",
+    "expected": "7304",
+    "overflow": false
+  },
+  {
+    "a": "279125710509406193773364446",
+    "numerator": "23357397391",
+    "denominator": "892521394507734470686026592931572",
+    "rounding": "Ceil",
+    "expected": "7305",
+    "overflow": false
+  },
+  {
+    "a": "14386195701502842070187370640421021",
+    "numerator": "68030298",
+    "denominator": "237633075904552845883",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14386195701502842070187370640421021",
+    "numerator": "68030298",
+    "denominator": "237633075904552845883",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "114292993746463172820545057921936",
+    "numerator": "90957390313863547478505",
+    "denominator": "1205441502268295115808022",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "114292993746463172820545057921936",
+    "numerator": "90957390313863547478505",
+    "denominator": "1205441502268295115808022",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "865848043035888469148700521849898791",
+    "numerator": "15162079700632567343395180",
+    "denominator": "2206783545549880676578746066634485109",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "865848043035888469148700521849898791",
+    "numerator": "15162079700632567343395180",
+    "denominator": "2206783545549880676578746066634485109",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "140179633952398789138",
+    "numerator": "1107",
+    "denominator": "17665482068230264753288",
+    "rounding": "Floor",
+    "expected": "8",
+    "overflow": false
+  },
+  {
+    "a": "140179633952398789138",
+    "numerator": "1107",
+    "denominator": "17665482068230264753288",
+    "rounding": "Ceil",
+    "expected": "9",
+    "overflow": false
+  },
+  {
+    "a": "1857",
+    "numerator": "32795669070",
+    "denominator": "21951",
+    "rounding": "Floor",
+    "expected": "2774432028",
+    "overflow": false
+  },
+  {
+    "a": "1857",
+    "numerator": "32795669070",
+    "denominator": "21951",
+    "rounding": "Ceil",
+    "expected": "2774432029",
+    "overflow": false
+  },
+  {
+    "a": "38879750372",
+    "numerator": "333",
+    "denominator": "1772210054457053844910538",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "38879750372",
+    "numerator": "333",
+    "denominator": "1772210054457053844910538",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1899",
+    "numerator": "1138628575872",
+    "denominator": "39109291527662675353",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1899",
+    "numerator": "1138628575872",
+    "denominator": "39109291527662675353",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "351411047321986182",
+    "numerator": "152707864876787031",
+    "denominator": "309694322012",
+    "rounding": "Floor",
+    "expected": "173278058125252752406861",
+    "overflow": false
+  },
+  {
+    "a": "351411047321986182",
+    "numerator": "152707864876787031",
+    "denominator": "309694322012",
+    "rounding": "Ceil",
+    "expected": "173278058125252752406862",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "7796712220290",
+    "denominator": "4052003715",
+    "rounding": "Floor",
+    "expected": "9620",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "7796712220290",
+    "denominator": "4052003715",
+    "rounding": "Ceil",
+    "expected": "9621",
+    "overflow": false
+  },
+  {
+    "a": "7544",
+    "numerator": "48198897",
+    "denominator": "6820798",
+    "rounding": "Floor",
+    "expected": "53309",
+    "overflow": false
+  },
+  {
+    "a": "7544",
+    "numerator": "48198897",
+    "denominator": "6820798",
+    "rounding": "Ceil",
+    "expected": "53310",
+    "overflow": false
+  },
+  {
+    "a": "2375364526590416679543416381431682543",
+    "numerator": "13017804643252516134204307030202068",
+    "denominator": "278192230135937021095072315901",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2375364526590416679543416381431682543",
+    "numerator": "13017804643252516134204307030202068",
+    "denominator": "278192230135937021095072315901",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "339424836552762",
+    "numerator": "118640068024529051",
+    "denominator": "48",
+    "rounding": "Floor",
+    "expected": "838945535371548716547611735184",
+    "overflow": false
+  },
+  {
+    "a": "339424836552762",
+    "numerator": "118640068024529051",
+    "denominator": "48",
+    "rounding": "Ceil",
+    "expected": "838945535371548716547611735185",
+    "overflow": false
+  },
+  {
+    "a": "6845992085457337541263308734827849",
+    "numerator": "12261890368544758",
+    "denominator": "9904008940694668478343",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6845992085457337541263308734827849",
+    "numerator": "12261890368544758",
+    "denominator": "9904008940694668478343",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19788",
+    "numerator": "219902270165",
+    "denominator": "769665088413009400681916643058",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "19788",
+    "numerator": "219902270165",
+    "denominator": "769665088413009400681916643058",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "14928584178296499",
+    "numerator": "548361131760509633128",
+    "denominator": "7579225761",
+    "rounding": "Floor",
+    "expected": "1080091235402468693073293030",
+    "overflow": false
+  },
+  {
+    "a": "14928584178296499",
+    "numerator": "548361131760509633128",
+    "denominator": "7579225761",
+    "rounding": "Ceil",
+    "expected": "1080091235402468693073293031",
+    "overflow": false
+  },
+  {
+    "a": "137143692589947979207728924041666062638",
+    "numerator": "3",
+    "denominator": "2481056408062849687130197793937604",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "137143692589947979207728924041666062638",
+    "numerator": "3",
+    "denominator": "2481056408062849687130197793937604",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17089146480383149",
+    "numerator": "234658667375942640795674788236433134250",
+    "denominator": "195896578495048911576197623737803",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17089146480383149",
+    "numerator": "234658667375942640795674788236433134250",
+    "denominator": "195896578495048911576197623737803",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30761768972600900040149060704",
+    "numerator": "134166697777401",
+    "denominator": "962644570024908687454835625830",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30761768972600900040149060704",
+    "numerator": "134166697777401",
+    "denominator": "962644570024908687454835625830",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15862579208647470928293303",
+    "numerator": "37198140",
+    "denominator": "232701902727815900613268174374789",
+    "rounding": "Floor",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "15862579208647470928293303",
+    "numerator": "37198140",
+    "denominator": "232701902727815900613268174374789",
+    "rounding": "Ceil",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "19103447468235232079312660946156386",
+    "numerator": "14262265999943139",
+    "denominator": "74622703301236179106648",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19103447468235232079312660946156386",
+    "numerator": "14262265999943139",
+    "denominator": "74622703301236179106648",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "39148239180929640844369",
+    "numerator": "4766",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "186580507936310668264262654",
+    "overflow": false
+  },
+  {
+    "a": "39148239180929640844369",
+    "numerator": "4766",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "186580507936310668264262654",
+    "overflow": false
+  },
+  {
+    "a": "4328961298060619444",
+    "numerator": "843315609017494551131345757",
+    "denominator": "26",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4328961298060619444",
+    "numerator": "843315609017494551131345757",
+    "denominator": "26",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74894975916184212975355",
+    "numerator": "699029253308561043280",
+    "denominator": "1062125433873320105",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74894975916184212975355",
+    "numerator": "699029253308561043280",
+    "denominator": "1062125433873320105",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14230801093548079950232302940886",
+    "numerator": "28485181550528138975369191",
+    "denominator": "2462447609447178261182764",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "14230801093548079950232302940886",
+    "numerator": "28485181550528138975369191",
+    "denominator": "2462447609447178261182764",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10605937367167527491637",
+    "numerator": "99561546246287001602216099366431749074",
+    "denominator": "501583631072975776960353642771",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10605937367167527491637",
+    "numerator": "99561546246287001602216099366431749074",
+    "denominator": "501583631072975776960353642771",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "346184",
+    "numerator": "890476686849",
+    "denominator": "12833564474291470548277042245646",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "346184",
+    "numerator": "890476686849",
+    "denominator": "12833564474291470548277042245646",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2060973986585505407",
+    "numerator": "7250124264563579044",
+    "denominator": "1549",
+    "rounding": "Floor",
+    "expected": "9646428346531894777961667791823041",
+    "overflow": false
+  },
+  {
+    "a": "2060973986585505407",
+    "numerator": "7250124264563579044",
+    "denominator": "1549",
+    "rounding": "Ceil",
+    "expected": "9646428346531894777961667791823042",
+    "overflow": false
+  },
+  {
+    "a": "29816228762568587587175531402",
+    "numerator": "367515109205937429646525662868523",
+    "denominator": "6300849042316760032832",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "29816228762568587587175531402",
+    "numerator": "367515109205937429646525662868523",
+    "denominator": "6300849042316760032832",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7257",
+    "numerator": "83348558489678203884436535750655412806",
+    "denominator": "89559244706894952950679063",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7257",
+    "numerator": "83348558489678203884436535750655412806",
+    "denominator": "89559244706894952950679063",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "624553590009116",
+    "numerator": "42802034479368187432799461",
+    "denominator": "17838539361981283919737104474178",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "624553590009116",
+    "numerator": "42802034479368187432799461",
+    "denominator": "17838539361981283919737104474178",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121903425335363",
+    "numerator": "73221674220207644550444024447314232",
+    "denominator": "5041",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121903425335363",
+    "numerator": "73221674220207644550444024447314232",
+    "denominator": "5041",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "965360301121918",
+    "numerator": "13067894447",
+    "denominator": "1429920079130973844",
+    "rounding": "Floor",
+    "expected": "8822329",
+    "overflow": false
+  },
+  {
+    "a": "965360301121918",
+    "numerator": "13067894447",
+    "denominator": "1429920079130973844",
+    "rounding": "Ceil",
+    "expected": "8822330",
+    "overflow": false
+  },
+  {
+    "a": "1069475180006800573",
+    "numerator": "67127932220799179614714",
+    "denominator": "389585010011",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1069475180006800573",
+    "numerator": "67127932220799179614714",
+    "denominator": "389585010011",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "12592",
+    "numerator": "103433",
+    "denominator": "60559739186683024822",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "12592",
+    "numerator": "103433",
+    "denominator": "60559739186683024822",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "11470321638458007581431409883207",
+    "numerator": "881932",
+    "denominator": "413595790367876501",
+    "rounding": "Floor",
+    "expected": "24458768534009355741",
+    "overflow": false
+  },
+  {
+    "a": "11470321638458007581431409883207",
+    "numerator": "881932",
+    "denominator": "413595790367876501",
+    "rounding": "Ceil",
+    "expected": "24458768534009355742",
+    "overflow": false
+  },
+  {
+    "a": "590002",
+    "numerator": "40109035301476507426219896162572696435",
+    "denominator": "3332520587505045831931655172578942504",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "590002",
+    "numerator": "40109035301476507426219896162572696435",
+    "denominator": "3332520587505045831931655172578942504",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4060519777",
+    "numerator": "27285740844834316438075171151991228142",
+    "denominator": "66272815886711306622898911",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4060519777",
+    "numerator": "27285740844834316438075171151991228142",
+    "denominator": "66272815886711306622898911",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "364386150653208611842180",
+    "numerator": "3875915059013485",
+    "denominator": "67847439466",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "364386150653208611842180",
+    "numerator": "3875915059013485",
+    "denominator": "67847439466",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "31486162147154060534897503431690891",
+    "numerator": "32",
+    "denominator": "17326298030492116813348548537",
+    "rounding": "Floor",
+    "expected": "58151902",
+    "overflow": false
+  },
+  {
+    "a": "31486162147154060534897503431690891",
+    "numerator": "32",
+    "denominator": "17326298030492116813348548537",
+    "rounding": "Ceil",
+    "expected": "58151903",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "816453633455863754335956599",
+    "denominator": "6951164",
+    "rounding": "Floor",
+    "expected": "704734027385223902934",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "816453633455863754335956599",
+    "denominator": "6951164",
+    "rounding": "Ceil",
+    "expected": "704734027385223902935",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "103056196605272441366713634",
+    "denominator": "1536323132918435",
+    "rounding": "Floor",
+    "expected": "335398831134",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "103056196605272441366713634",
+    "denominator": "1536323132918435",
+    "rounding": "Ceil",
+    "expected": "335398831135",
+    "overflow": false
+  },
+  {
+    "a": "2732144437085503832074008",
+    "numerator": "1",
+    "denominator": "38739558823783728836557856862",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2732144437085503832074008",
+    "numerator": "1",
+    "denominator": "38739558823783728836557856862",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "9937976650740525839",
+    "numerator": "6653096911334626834239092",
+    "denominator": "45987757647227598365",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9937976650740525839",
+    "numerator": "6653096911334626834239092",
+    "denominator": "45987757647227598365",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2",
+    "numerator": "12840343157365691",
+    "denominator": "126347092853520",
+    "rounding": "Floor",
+    "expected": "203",
+    "overflow": false
+  },
+  {
+    "a": "2",
+    "numerator": "12840343157365691",
+    "denominator": "126347092853520",
+    "rounding": "Ceil",
+    "expected": "204",
+    "overflow": false
+  },
+  {
+    "a": "28521",
+    "numerator": "61927774552985373308018084583999638",
+    "denominator": "11141262775986343",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "28521",
+    "numerator": "61927774552985373308018084583999638",
+    "denominator": "11141262775986343",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17320230489400582650571763427901676",
+    "numerator": "906667243928323248964341",
+    "denominator": "13596772457874",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17320230489400582650571763427901676",
+    "numerator": "906667243928323248964341",
+    "denominator": "13596772457874",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "930978463551521171277285753445843",
+    "numerator": "99670386179407981901761823752",
+    "denominator": "304497502898103580744897",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "930978463551521171277285753445843",
+    "numerator": "99670386179407981901761823752",
+    "denominator": "304497502898103580744897",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "27652653666324961422798",
+    "numerator": "3000849581859546836830952281326044991",
+    "denominator": "206330453417027401953478994856036",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "27652653666324961422798",
+    "numerator": "3000849581859546836830952281326044991",
+    "denominator": "206330453417027401953478994856036",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30564233580843603665758234829",
+    "numerator": "6766109351239008327374154",
+    "denominator": "683382599891120363",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "30564233580843603665758234829",
+    "numerator": "6766109351239008327374154",
+    "denominator": "683382599891120363",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16934804199721154792868352",
+    "numerator": "3429145",
+    "denominator": "6",
+    "rounding": "Floor",
+    "expected": "9678649857908799892031757486506",
+    "overflow": false
+  },
+  {
+    "a": "16934804199721154792868352",
+    "numerator": "3429145",
+    "denominator": "6",
+    "rounding": "Ceil",
+    "expected": "9678649857908799892031757486507",
+    "overflow": false
+  },
+  {
+    "a": "11180779223",
+    "numerator": "0",
+    "denominator": "3350194537937401371936677",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11180779223",
+    "numerator": "0",
+    "denominator": "3350194537937401371936677",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1783041317378",
+    "numerator": "2700614432003",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "4815307114568668323248134",
+    "overflow": false
+  },
+  {
+    "a": "1783041317378",
+    "numerator": "2700614432003",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "4815307114568668323248134",
+    "overflow": false
+  },
+  {
+    "a": "1789377317628949429629553",
+    "numerator": "5324183924542",
+    "denominator": "1901345786448235652949871",
+    "rounding": "Floor",
+    "expected": "5010647730340",
+    "overflow": false
+  },
+  {
+    "a": "1789377317628949429629553",
+    "numerator": "5324183924542",
+    "denominator": "1901345786448235652949871",
+    "rounding": "Ceil",
+    "expected": "5010647730341",
+    "overflow": false
+  },
+  {
+    "a": "1052730214066571318868",
+    "numerator": "246033641959234769564401533",
+    "denominator": "48830083581324372094239901148038663098",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1052730214066571318868",
+    "numerator": "246033641959234769564401533",
+    "denominator": "48830083581324372094239901148038663098",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "54244565629870754253339",
+    "numerator": "55354608",
+    "denominator": "3303935737015637962250953",
+    "rounding": "Floor",
+    "expected": "908821",
+    "overflow": false
+  },
+  {
+    "a": "54244565629870754253339",
+    "numerator": "55354608",
+    "denominator": "3303935737015637962250953",
+    "rounding": "Ceil",
+    "expected": "908822",
+    "overflow": false
+  },
+  {
+    "a": "63419604607684960997818257197942",
+    "numerator": "10503",
+    "denominator": "318779136019332717772",
+    "rounding": "Floor",
+    "expected": "2089522280260270",
+    "overflow": false
+  },
+  {
+    "a": "63419604607684960997818257197942",
+    "numerator": "10503",
+    "denominator": "318779136019332717772",
+    "rounding": "Ceil",
+    "expected": "2089522280260271",
+    "overflow": false
+  },
+  {
+    "a": "85",
+    "numerator": "752847474",
+    "denominator": "1429370643001757747",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "85",
+    "numerator": "752847474",
+    "denominator": "1429370643001757747",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "272477838330433770086719404520",
+    "numerator": "13498583310692876081530242182177",
+    "denominator": "1098602022612841424046",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "272477838330433770086719404520",
+    "numerator": "13498583310692876081530242182177",
+    "denominator": "1098602022612841424046",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2975",
+    "numerator": "172659710349638858820",
+    "denominator": "6735151050471981",
+    "rounding": "Floor",
+    "expected": "76265941",
+    "overflow": false
+  },
+  {
+    "a": "2975",
+    "numerator": "172659710349638858820",
+    "denominator": "6735151050471981",
+    "rounding": "Ceil",
+    "expected": "76265942",
+    "overflow": false
+  },
+  {
+    "a": "59201369642",
+    "numerator": "129506032706454233802571",
+    "denominator": "1414112",
+    "rounding": "Floor",
+    "expected": "5421730749137083041867898031",
+    "overflow": false
+  },
+  {
+    "a": "59201369642",
+    "numerator": "129506032706454233802571",
+    "denominator": "1414112",
+    "rounding": "Ceil",
+    "expected": "5421730749137083041867898032",
+    "overflow": false
+  },
+  {
+    "a": "1657",
+    "numerator": "17154864618214",
+    "denominator": "349147598600580919",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1657",
+    "numerator": "17154864618214",
+    "denominator": "349147598600580919",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "116924",
+    "numerator": "28376325",
+    "denominator": "4756092776340981509408634642525922",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "116924",
+    "numerator": "28376325",
+    "denominator": "4756092776340981509408634642525922",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "89222924456332576157539",
+    "numerator": "149776862153265099378234028988633816",
+    "denominator": "139441324900082300997204049086929",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89222924456332576157539",
+    "numerator": "149776862153265099378234028988633816",
+    "denominator": "139441324900082300997204049086929",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "121199104740894",
+    "numerator": "4193726923049497551",
+    "denominator": "34119770820476555924969891128049118772",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "121199104740894",
+    "numerator": "4193726923049497551",
+    "denominator": "34119770820476555924969891128049118772",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "789338333",
+    "numerator": "431467732633333994650",
+    "denominator": "2717076142285888979945595",
+    "rounding": "Floor",
+    "expected": "125345",
+    "overflow": false
+  },
+  {
+    "a": "789338333",
+    "numerator": "431467732633333994650",
+    "denominator": "2717076142285888979945595",
+    "rounding": "Ceil",
+    "expected": "125346",
+    "overflow": false
+  },
+  {
+    "a": "1744",
+    "numerator": "1757723440228281398389382174249",
+    "denominator": "5297278176984292950",
+    "rounding": "Floor",
+    "expected": "578687691553943",
+    "overflow": false
+  },
+  {
+    "a": "1744",
+    "numerator": "1757723440228281398389382174249",
+    "denominator": "5297278176984292950",
+    "rounding": "Ceil",
+    "expected": "578687691553944",
+    "overflow": false
+  },
+  {
+    "a": "359",
+    "numerator": "146378350397612",
+    "denominator": "55946677",
+    "rounding": "Floor",
+    "expected": "939284165",
+    "overflow": false
+  },
+  {
+    "a": "359",
+    "numerator": "146378350397612",
+    "denominator": "55946677",
+    "rounding": "Ceil",
+    "expected": "939284166",
+    "overflow": false
+  },
+  {
+    "a": "18",
+    "numerator": "1407814161043",
+    "denominator": "18543618656770569987097526216",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "18",
+    "numerator": "1407814161043",
+    "denominator": "18543618656770569987097526216",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6935839431592833",
+    "numerator": "1327975257163867882926856422813641614",
+    "denominator": "1454762733560314417805259366399",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6935839431592833",
+    "numerator": "1327975257163867882926856422813641614",
+    "denominator": "1454762733560314417805259366399",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "834491758628",
+    "numerator": "9275975187923520019341",
+    "denominator": "51814605637622842812060018442",
+    "rounding": "Floor",
+    "expected": "149392",
+    "overflow": false
+  },
+  {
+    "a": "834491758628",
+    "numerator": "9275975187923520019341",
+    "denominator": "51814605637622842812060018442",
+    "rounding": "Ceil",
+    "expected": "149393",
+    "overflow": false
+  },
+  {
+    "a": "511243546027",
+    "numerator": "5803007234209481682726336",
+    "denominator": "94845188131349996218755306375641",
+    "rounding": "Floor",
+    "expected": "31279",
+    "overflow": false
+  },
+  {
+    "a": "511243546027",
+    "numerator": "5803007234209481682726336",
+    "denominator": "94845188131349996218755306375641",
+    "rounding": "Ceil",
+    "expected": "31280",
+    "overflow": false
+  },
+  {
+    "a": "55100786445321383185037343200710",
+    "numerator": "4889023010321514682210973534103",
+    "denominator": "135856428018522156765910842508024988",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "55100786445321383185037343200710",
+    "numerator": "4889023010321514682210973534103",
+    "denominator": "135856428018522156765910842508024988",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1557093",
+    "numerator": "149502319345030082",
+    "denominator": "195011",
+    "rounding": "Floor",
+    "expected": "1193722481992866686",
+    "overflow": false
+  },
+  {
+    "a": "1557093",
+    "numerator": "149502319345030082",
+    "denominator": "195011",
+    "rounding": "Ceil",
+    "expected": "1193722481992866687",
+    "overflow": false
+  },
+  {
+    "a": "51291108212920",
+    "numerator": "58541591680376815898390833",
+    "denominator": "14",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "51291108212920",
+    "numerator": "58541591680376815898390833",
+    "denominator": "14",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "46028951081007",
+    "numerator": "33363543858583213588",
+    "denominator": "29",
+    "rounding": "Floor",
+    "expected": "52954790626060629828166778314590",
+    "overflow": false
+  },
+  {
+    "a": "46028951081007",
+    "numerator": "33363543858583213588",
+    "denominator": "29",
+    "rounding": "Ceil",
+    "expected": "52954790626060629828166778314591",
+    "overflow": false
+  },
+  {
+    "a": "2340956461658068875046266",
+    "numerator": "109310465755",
+    "denominator": "3142036658267132434466574477328898224",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2340956461658068875046266",
+    "numerator": "109310465755",
+    "denominator": "3142036658267132434466574477328898224",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8472277107776529731554514491960222089",
+    "numerator": "583728953704758",
+    "denominator": "1634641855342471109063",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8472277107776529731554514491960222089",
+    "numerator": "583728953704758",
+    "denominator": "1634641855342471109063",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "40655714023590401243576239244",
+    "numerator": "15275478099835669",
+    "denominator": "2033886924211908710550819890",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "40655714023590401243576239244",
+    "numerator": "15275478099835669",
+    "denominator": "2033886924211908710550819890",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1168780566324467",
+    "numerator": "14715665225128",
+    "denominator": "5225818893049860200960504454909983457",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1168780566324467",
+    "numerator": "14715665225128",
+    "denominator": "5225818893049860200960504454909983457",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2195820665056498004050542",
+    "numerator": "2574312648783671742498449536042079",
+    "denominator": "1637073729600022027126788",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2195820665056498004050542",
+    "numerator": "2574312648783671742498449536042079",
+    "denominator": "1637073729600022027126788",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2905186169353676918613315357933",
+    "numerator": "46774222060163117344746",
+    "denominator": "474088459",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2905186169353676918613315357933",
+    "numerator": "46774222060163117344746",
+    "denominator": "474088459",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "101105536812610542621397948320",
+    "numerator": "6645222100997447755275807345810745",
+    "denominator": "10842704195957320939205057003348134",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "101105536812610542621397948320",
+    "numerator": "6645222100997447755275807345810745",
+    "denominator": "10842704195957320939205057003348134",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "166661260314214340981615770485256183",
+    "numerator": "29278332",
+    "denominator": "5163823020338119101267318725",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "166661260314214340981615770485256183",
+    "numerator": "29278332",
+    "denominator": "5163823020338119101267318725",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "3811158558262535582065369373414435",
+    "denominator": "664",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "3811158558262535582065369373414435",
+    "denominator": "664",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "489471234275141784672034564241",
+    "numerator": "0",
+    "denominator": "3025377736990976039097007441394831",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "489471234275141784672034564241",
+    "numerator": "0",
+    "denominator": "3025377736990976039097007441394831",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3572",
+    "numerator": "925",
+    "denominator": "4034639468122",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3572",
+    "numerator": "925",
+    "denominator": "4034639468122",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "71043351999803",
+    "numerator": "144",
+    "denominator": "23162410060855940118086621961733897449",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "71043351999803",
+    "numerator": "144",
+    "denominator": "23162410060855940118086621961733897449",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2632522221837390012191896598",
+    "numerator": "2034215",
+    "denominator": "910174098946130989164",
+    "rounding": "Floor",
+    "expected": "5883617428462",
+    "overflow": false
+  },
+  {
+    "a": "2632522221837390012191896598",
+    "numerator": "2034215",
+    "denominator": "910174098946130989164",
+    "rounding": "Ceil",
+    "expected": "5883617428463",
+    "overflow": false
+  },
+  {
+    "a": "225327390147755767491273278904437",
+    "numerator": "1212161844291653846593810",
+    "denominator": "7964499",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "225327390147755767491273278904437",
+    "numerator": "1212161844291653846593810",
+    "denominator": "7964499",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "326536",
+    "numerator": "1",
+    "denominator": "1839737252174",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "326536",
+    "numerator": "1",
+    "denominator": "1839737252174",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "38085900479",
+    "numerator": "4",
+    "denominator": "77",
+    "rounding": "Floor",
+    "expected": "1978488336",
+    "overflow": false
+  },
+  {
+    "a": "38085900479",
+    "numerator": "4",
+    "denominator": "77",
+    "rounding": "Ceil",
+    "expected": "1978488337",
+    "overflow": false
+  },
+  {
+    "a": "225867978",
+    "numerator": "43627",
+    "denominator": "2072106643395858816",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "225867978",
+    "numerator": "43627",
+    "denominator": "2072106643395858816",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1162510489",
+    "numerator": "6",
+    "denominator": "260143742262421591",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1162510489",
+    "numerator": "6",
+    "denominator": "260143742262421591",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21960402089052",
+    "numerator": "2528485965093",
+    "denominator": "576254877782539995899666289888628098",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "21960402089052",
+    "numerator": "2528485965093",
+    "denominator": "576254877782539995899666289888628098",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "381402516042539255029304897162360",
+    "denominator": "83704135295095754568785425528647665",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3",
+    "numerator": "381402516042539255029304897162360",
+    "denominator": "83704135295095754568785425528647665",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "58098205302442686",
+    "numerator": "473327",
+    "denominator": "20",
+    "rounding": "Floor",
+    "expected": "1374972461059464461816",
+    "overflow": false
+  },
+  {
+    "a": "58098205302442686",
+    "numerator": "473327",
+    "denominator": "20",
+    "rounding": "Ceil",
+    "expected": "1374972461059464461817",
+    "overflow": false
+  },
+  {
+    "a": "11226431224189109356596285470000381",
+    "numerator": "560954",
+    "denominator": "533428643782073951131",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11226431224189109356596285470000381",
+    "numerator": "560954",
+    "denominator": "533428643782073951131",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "48",
+    "numerator": "7213486852468189257",
+    "denominator": "40151296761384496849687446186345527030",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "48",
+    "numerator": "7213486852468189257",
+    "denominator": "40151296761384496849687446186345527030",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1588429254478471",
+    "numerator": "5608215325832438341192194354252",
+    "denominator": "11792289207043385253529126357",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1588429254478471",
+    "numerator": "5608215325832438341192194354252",
+    "denominator": "11792289207043385253529126357",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5015252660931384991218",
+    "numerator": "20950553455288537891769807976151475",
+    "denominator": "820949352",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5015252660931384991218",
+    "numerator": "20950553455288537891769807976151475",
+    "denominator": "820949352",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "37891253623494707617",
+    "numerator": "801529902",
+    "denominator": "148312326460836311808556245040415",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "37891253623494707617",
+    "numerator": "801529902",
+    "denominator": "148312326460836311808556245040415",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "50380908814922129895727720616974276",
+    "numerator": "524383790989165535852044205",
+    "denominator": "202092048214752954826480042",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "50380908814922129895727720616974276",
+    "numerator": "524383790989165535852044205",
+    "denominator": "202092048214752954826480042",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "238373276837604253899",
+    "numerator": "3543756915480058720",
+    "denominator": "1062605990160150862065071097",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "238373276837604253899",
+    "numerator": "3543756915480058720",
+    "denominator": "1062605990160150862065071097",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36955053985485390177894",
+    "numerator": "1196910976626962611683761549495",
+    "denominator": "825255391000462094301244",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36955053985485390177894",
+    "numerator": "1196910976626962611683761549495",
+    "denominator": "825255391000462094301244",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "362835964549",
+    "numerator": "1036147679842",
+    "denominator": "162019",
+    "rounding": "Floor",
+    "expected": "2320417005602309074",
+    "overflow": false
+  },
+  {
+    "a": "362835964549",
+    "numerator": "1036147679842",
+    "denominator": "162019",
+    "rounding": "Ceil",
+    "expected": "2320417005602309075",
+    "overflow": false
+  },
+  {
+    "a": "2648",
+    "numerator": "542459729",
+    "denominator": "111679974223775638288926583318494407070",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2648",
+    "numerator": "542459729",
+    "denominator": "111679974223775638288926583318494407070",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "956110198121645391",
+    "numerator": "52",
+    "denominator": "8878378802781",
+    "rounding": "Floor",
+    "expected": "5599865",
+    "overflow": false
+  },
+  {
+    "a": "956110198121645391",
+    "numerator": "52",
+    "denominator": "8878378802781",
+    "rounding": "Ceil",
+    "expected": "5599866",
+    "overflow": false
+  },
+  {
+    "a": "309384861853194307417828841498",
+    "numerator": "223352279639338383356439538275574267",
+    "denominator": "49233729781965181970153040",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "309384861853194307417828841498",
+    "numerator": "223352279639338383356439538275574267",
+    "denominator": "49233729781965181970153040",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2046668817575101328185370974497498025",
+    "numerator": "70898006773464320470",
+    "denominator": "6887",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2046668817575101328185370974497498025",
+    "numerator": "70898006773464320470",
+    "denominator": "6887",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "92395564",
+    "numerator": "1101456812017887028527925",
+    "denominator": "36765675083660973847419602",
+    "rounding": "Floor",
+    "expected": "2768063",
+    "overflow": false
+  },
+  {
+    "a": "92395564",
+    "numerator": "1101456812017887028527925",
+    "denominator": "36765675083660973847419602",
+    "rounding": "Ceil",
+    "expected": "2768064",
+    "overflow": false
+  },
+  {
+    "a": "102154175846180963713900562611219",
+    "numerator": "10480795617865283400",
+    "denominator": "12892432737250267485992838816147713",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "102154175846180963713900562611219",
+    "numerator": "10480795617865283400",
+    "denominator": "12892432737250267485992838816147713",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35569369977359446695470862",
+    "numerator": "70551377429118672359807",
+    "denominator": "174254535111966971812",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35569369977359446695470862",
+    "numerator": "70551377429118672359807",
+    "denominator": "174254535111966971812",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13928437556726168156209421",
+    "numerator": "1186838343633650248370431593098",
+    "denominator": "204089131",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13928437556726168156209421",
+    "numerator": "1186838343633650248370431593098",
+    "denominator": "204089131",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1371060054561108350973248",
+    "numerator": "2343551042207367189664769251276633",
+    "denominator": "836724665922619877024514983207238",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1371060054561108350973248",
+    "numerator": "2343551042207367189664769251276633",
+    "denominator": "836724665922619877024514983207238",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4761681360688944306927822572444272919",
+    "numerator": "28",
+    "denominator": "68393855486721879792466895679158245",
+    "rounding": "Floor",
+    "expected": "1949",
+    "overflow": false
+  },
+  {
+    "a": "4761681360688944306927822572444272919",
+    "numerator": "28",
+    "denominator": "68393855486721879792466895679158245",
+    "rounding": "Ceil",
+    "expected": "1950",
+    "overflow": false
+  },
+  {
+    "a": "1114996162501854484235552578",
+    "numerator": "12855545524890190863778627",
+    "denominator": "402179095319694339993849063790648",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1114996162501854484235552578",
+    "numerator": "12855545524890190863778627",
+    "denominator": "402179095319694339993849063790648",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "801404787699332731232601001000775345",
+    "numerator": "408079358078",
+    "denominator": "32177628100568850469708207",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "801404787699332731232601001000775345",
+    "numerator": "408079358078",
+    "denominator": "32177628100568850469708207",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1235612352471664988447434951710100",
+    "numerator": "41504409275825268108068797",
+    "denominator": "6104215802",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1235612352471664988447434951710100",
+    "numerator": "41504409275825268108068797",
+    "denominator": "6104215802",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "109216595900813394311282340933723",
+    "numerator": "331101732224634256992143540272",
+    "denominator": "658906531549534021466205961",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "109216595900813394311282340933723",
+    "numerator": "331101732224634256992143540272",
+    "denominator": "658906531549534021466205961",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "35443204200753295788993718",
+    "numerator": "640983006023",
+    "denominator": "10660888377679848444699976679724044",
+    "rounding": "Floor",
+    "expected": "2131",
+    "overflow": false
+  },
+  {
+    "a": "35443204200753295788993718",
+    "numerator": "640983006023",
+    "denominator": "10660888377679848444699976679724044",
+    "rounding": "Ceil",
+    "expected": "2132",
+    "overflow": false
+  },
+  {
+    "a": "1314965",
+    "numerator": "426158002",
+    "denominator": "973321402777010622067",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1314965",
+    "numerator": "426158002",
+    "denominator": "973321402777010622067",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "40",
+    "numerator": "1520142065169784032283613281",
+    "denominator": "212462",
+    "rounding": "Floor",
+    "expected": "286195567239277429805539",
+    "overflow": false
+  },
+  {
+    "a": "40",
+    "numerator": "1520142065169784032283613281",
+    "denominator": "212462",
+    "rounding": "Ceil",
+    "expected": "286195567239277429805540",
+    "overflow": false
+  },
+  {
+    "a": "70640989663",
+    "numerator": "436100",
+    "denominator": "122156120394852037229",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "70640989663",
+    "numerator": "436100",
+    "denominator": "122156120394852037229",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3598579159033913841422745074486676330",
+    "numerator": "225630825018272972171",
+    "denominator": "2047421626732764960",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3598579159033913841422745074486676330",
+    "numerator": "225630825018272972171",
+    "denominator": "2047421626732764960",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22809273",
+    "numerator": "26844654288728728605469734",
+    "denominator": "23",
+    "rounding": "Floor",
+    "expected": "26622045576618886682829063306234",
+    "overflow": false
+  },
+  {
+    "a": "22809273",
+    "numerator": "26844654288728728605469734",
+    "denominator": "23",
+    "rounding": "Ceil",
+    "expected": "26622045576618886682829063306234",
+    "overflow": false
+  },
+  {
+    "a": "28668",
+    "numerator": "167446121797",
+    "denominator": "111552706040021495623897067534941218",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "28668",
+    "numerator": "167446121797",
+    "denominator": "111552706040021495623897067534941218",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "75518075056153304483",
+    "numerator": "7337970594810863900184",
+    "denominator": "9453804830098767749960017425",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "75518075056153304483",
+    "numerator": "7337970594810863900184",
+    "denominator": "9453804830098767749960017425",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "48093664172300418875842659515124553566",
+    "numerator": "44273167",
+    "denominator": "26678043765640711540",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "48093664172300418875842659515124553566",
+    "numerator": "44273167",
+    "denominator": "26678043765640711540",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "424105228980181824954384669",
+    "numerator": "18751779299549884327380191631834",
+    "denominator": "3771",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "424105228980181824954384669",
+    "numerator": "18751779299549884327380191631834",
+    "denominator": "3771",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "0",
+    "numerator": "593201769",
+    "denominator": "3949589127062",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "593201769",
+    "denominator": "3949589127062",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "358579596199",
+    "numerator": "236",
+    "denominator": "206079327542139333736426997",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "358579596199",
+    "numerator": "236",
+    "denominator": "206079327542139333736426997",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "64947346",
+    "numerator": "11710675",
+    "denominator": "391799386064401160",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "64947346",
+    "numerator": "11710675",
+    "denominator": "391799386064401160",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "193",
+    "numerator": "567954902886440341434865301611726",
+    "denominator": "904211007",
+    "rounding": "Floor",
+    "expected": "121227562381446420389493227",
+    "overflow": false
+  },
+  {
+    "a": "193",
+    "numerator": "567954902886440341434865301611726",
+    "denominator": "904211007",
+    "rounding": "Ceil",
+    "expected": "121227562381446420389493228",
+    "overflow": false
+  },
+  {
+    "a": "30653679851689002852",
+    "numerator": "1554314189",
+    "denominator": "1139460293890989130",
+    "rounding": "Floor",
+    "expected": "41814049856",
+    "overflow": false
+  },
+  {
+    "a": "30653679851689002852",
+    "numerator": "1554314189",
+    "denominator": "1139460293890989130",
+    "rounding": "Ceil",
+    "expected": "41814049857",
+    "overflow": false
+  },
+  {
+    "a": "3591109348090859",
+    "numerator": "853430917376",
+    "denominator": "44569",
+    "rounding": "Floor",
+    "expected": "68764471837795577880811",
+    "overflow": false
+  },
+  {
+    "a": "3591109348090859",
+    "numerator": "853430917376",
+    "denominator": "44569",
+    "rounding": "Ceil",
+    "expected": "68764471837795577880812",
+    "overflow": false
+  },
+  {
+    "a": "4493798124941260293894",
+    "numerator": "3115386728220736039383",
+    "denominator": "612251790444493939676",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4493798124941260293894",
+    "numerator": "3115386728220736039383",
+    "denominator": "612251790444493939676",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "58706859057252355617445",
+    "numerator": "149078274",
+    "denominator": "3",
+    "rounding": "Floor",
+    "expected": "2917305740072149452627634963310",
+    "overflow": false
+  },
+  {
+    "a": "58706859057252355617445",
+    "numerator": "149078274",
+    "denominator": "3",
+    "rounding": "Ceil",
+    "expected": "2917305740072149452627634963310",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "961905",
+    "denominator": "3237380818625813528970718422590",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "961905",
+    "denominator": "3237380818625813528970718422590",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "103576087317290356418169784943",
+    "numerator": "827466306506315886990676",
+    "denominator": "2685",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "103576087317290356418169784943",
+    "numerator": "827466306506315886990676",
+    "denominator": "2685",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "505494071972538",
+    "numerator": "26810878251105563",
+    "denominator": "46146864716110503146480",
+    "rounding": "Floor",
+    "expected": "293687124",
+    "overflow": false
+  },
+  {
+    "a": "505494071972538",
+    "numerator": "26810878251105563",
+    "denominator": "46146864716110503146480",
+    "rounding": "Ceil",
+    "expected": "293687125",
+    "overflow": false
+  },
+  {
+    "a": "1267748693439945",
+    "numerator": "41590",
+    "denominator": "40591541903837215484935",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1267748693439945",
+    "numerator": "41590",
+    "denominator": "40591541903837215484935",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "657398747275721676",
+    "numerator": "71883248797066941424098133",
+    "denominator": "668018",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "657398747275721676",
+    "numerator": "71883248797066941424098133",
+    "denominator": "668018",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9011",
+    "numerator": "20876957712809765096",
+    "denominator": "24585602309030449566683986182172337953",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "9011",
+    "numerator": "20876957712809765096",
+    "denominator": "24585602309030449566683986182172337953",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1066884014",
+    "numerator": "271538526599147167",
+    "denominator": "194867307099972",
+    "rounding": "Floor",
+    "expected": "1486653238683",
+    "overflow": false
+  },
+  {
+    "a": "1066884014",
+    "numerator": "271538526599147167",
+    "denominator": "194867307099972",
+    "rounding": "Ceil",
+    "expected": "1486653238684",
+    "overflow": false
+  },
+  {
+    "a": "3881043245",
+    "numerator": "1718643984137514",
+    "denominator": "39723764934836629439723461195",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3881043245",
+    "numerator": "1718643984137514",
+    "denominator": "39723764934836629439723461195",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "398361417407977431776",
+    "numerator": "26691871536144272674914486510570824057",
+    "denominator": "2915236630218862143680998",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "398361417407977431776",
+    "numerator": "26691871536144272674914486510570824057",
+    "denominator": "2915236630218862143680998",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3869041800063431223",
+    "numerator": "360117081123417761327036",
+    "denominator": "4782771469253092519732976179931141",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3869041800063431223",
+    "numerator": "360117081123417761327036",
+    "denominator": "4782771469253092519732976179931141",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2558940960226",
+    "numerator": "2119926624944739",
+    "denominator": "76405441162723800",
+    "rounding": "Floor",
+    "expected": "70999748063",
+    "overflow": false
+  },
+  {
+    "a": "2558940960226",
+    "numerator": "2119926624944739",
+    "denominator": "76405441162723800",
+    "rounding": "Ceil",
+    "expected": "70999748064",
+    "overflow": false
+  },
+  {
+    "a": "193980661847051748561",
+    "numerator": "1055722697370764574",
+    "denominator": "985146436100036303",
+    "rounding": "Floor",
+    "expected": "207877509432658936628",
+    "overflow": false
+  },
+  {
+    "a": "193980661847051748561",
+    "numerator": "1055722697370764574",
+    "denominator": "985146436100036303",
+    "rounding": "Ceil",
+    "expected": "207877509432658936629",
+    "overflow": false
+  },
+  {
+    "a": "471353444206707191092",
+    "numerator": "52913117",
+    "denominator": "128595452779227798342294608794",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "471353444206707191092",
+    "numerator": "52913117",
+    "denominator": "128595452779227798342294608794",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1363565661738489890666141038141864827",
+    "numerator": "517584",
+    "denominator": "1607069993",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1363565661738489890666141038141864827",
+    "numerator": "517584",
+    "denominator": "1607069993",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "399359731100550785616323917142",
+    "numerator": "10928815207",
+    "denominator": "51342060093961692603227953648936876",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "399359731100550785616323917142",
+    "numerator": "10928815207",
+    "denominator": "51342060093961692603227953648936876",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2158689700201793552839244896437",
+    "numerator": "8400466",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "18133999431095359879645280218192539642",
+    "overflow": false
+  },
+  {
+    "a": "2158689700201793552839244896437",
+    "numerator": "8400466",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "18133999431095359879645280218192539642",
+    "overflow": false
+  },
+  {
+    "a": "257736",
+    "numerator": "83585",
+    "denominator": "205255985604766210197980193422",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "257736",
+    "numerator": "83585",
+    "denominator": "205255985604766210197980193422",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2511502090509876539641571820287",
+    "numerator": "19317806936184780580",
+    "denominator": "23301819115149",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2511502090509876539641571820287",
+    "numerator": "19317806936184780580",
+    "denominator": "23301819115149",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "91272691248650",
+    "numerator": "454990097840300131882746465738923",
+    "denominator": "36997961314903092247744",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "91272691248650",
+    "numerator": "454990097840300131882746465738923",
+    "denominator": "36997961314903092247744",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9192434009301241079001",
+    "numerator": "12528838",
+    "denominator": "3276167287941441139612404375",
+    "rounding": "Floor",
+    "expected": "35",
+    "overflow": false
+  },
+  {
+    "a": "9192434009301241079001",
+    "numerator": "12528838",
+    "denominator": "3276167287941441139612404375",
+    "rounding": "Ceil",
+    "expected": "36",
+    "overflow": false
+  },
+  {
+    "a": "432707587177275809692572",
+    "numerator": "359785704805",
+    "denominator": "7125698",
+    "rounding": "Floor",
+    "expected": "21847965522401757367505480500",
+    "overflow": false
+  },
+  {
+    "a": "432707587177275809692572",
+    "numerator": "359785704805",
+    "denominator": "7125698",
+    "rounding": "Ceil",
+    "expected": "21847965522401757367505480501",
+    "overflow": false
+  },
+  {
+    "a": "116410257268903107",
+    "numerator": "0",
+    "denominator": "4116031936488947990475992113",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "116410257268903107",
+    "numerator": "0",
+    "denominator": "4116031936488947990475992113",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5105306926126821706744247294",
+    "numerator": "9215515797750760977025495855",
+    "denominator": "118523005193096234420303795510874150164",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5105306926126821706744247294",
+    "numerator": "9215515797750760977025495855",
+    "denominator": "118523005193096234420303795510874150164",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42302148074931993165749471172932980029",
+    "numerator": "9270394",
+    "denominator": "61705588050395",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "42302148074931993165749471172932980029",
+    "numerator": "9270394",
+    "denominator": "61705588050395",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15988518668459559077736163248",
+    "numerator": "69243223035300622903026219023137929",
+    "denominator": "1676334981416120757494290843720914998",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15988518668459559077736163248",
+    "numerator": "69243223035300622903026219023137929",
+    "denominator": "1676334981416120757494290843720914998",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1593158053367107552649289702599",
+    "numerator": "16211231737544615148712903484300",
+    "denominator": "1004483328473806997990860309",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1593158053367107552649289702599",
+    "numerator": "16211231737544615148712903484300",
+    "denominator": "1004483328473806997990860309",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "306",
+    "numerator": "5552115",
+    "denominator": "35127235966966462570765020916034536616",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "306",
+    "numerator": "5552115",
+    "denominator": "35127235966966462570765020916034536616",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3820140001",
+    "numerator": "14",
+    "denominator": "13928754390879",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3820140001",
+    "numerator": "14",
+    "denominator": "13928754390879",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "25727010564",
+    "numerator": "6449478632059918316514385243461613",
+    "denominator": "1810280266665604375776286672228134634",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25727010564",
+    "numerator": "6449478632059918316514385243461613",
+    "denominator": "1810280266665604375776286672228134634",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "168753832162077590508531725170443",
+    "numerator": "12875549418205301013749482911934112",
+    "denominator": "8088708577337",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "168753832162077590508531725170443",
+    "numerator": "12875549418205301013749482911934112",
+    "denominator": "8088708577337",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3466580750632911488874406",
+    "numerator": "1275687671",
+    "denominator": "3401893674263910894092623740",
+    "rounding": "Floor",
+    "expected": "1299944",
+    "overflow": false
+  },
+  {
+    "a": "3466580750632911488874406",
+    "numerator": "1275687671",
+    "denominator": "3401893674263910894092623740",
+    "rounding": "Ceil",
+    "expected": "1299945",
+    "overflow": false
+  },
+  {
+    "a": "3531056068999971525",
+    "numerator": "61346",
+    "denominator": "35126410804936133973229076358947",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "3531056068999971525",
+    "numerator": "61346",
+    "denominator": "35126410804936133973229076358947",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "241087579331103713815960",
+    "numerator": "742902972242535313",
+    "denominator": "956642014",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "241087579331103713815960",
+    "numerator": "742902972242535313",
+    "denominator": "956642014",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18103814468198287",
+    "numerator": "177952729338573343988",
+    "denominator": "29",
+    "rounding": "Floor",
+    "expected": "111090455036380616834877686587701674",
+    "overflow": false
+  },
+  {
+    "a": "18103814468198287",
+    "numerator": "177952729338573343988",
+    "denominator": "29",
+    "rounding": "Ceil",
+    "expected": "111090455036380616834877686587701675",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "557761348441554040760379",
+    "denominator": "524677069200",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "557761348441554040760379",
+    "denominator": "524677069200",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "984407190181865",
+    "numerator": "1167998311820486473575516950",
+    "denominator": "300432700241005863",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "984407190181865",
+    "numerator": "1167998311820486473575516950",
+    "denominator": "300432700241005863",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17433319016267222783879564095340",
+    "numerator": "27491994880541557",
+    "denominator": "62016549916785611264472811423830677522",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17433319016267222783879564095340",
+    "numerator": "27491994880541557",
+    "denominator": "62016549916785611264472811423830677522",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "155713270354804049318321642067",
+    "numerator": "551601452058122349192",
+    "denominator": "238814675448681522771967738110588225",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "155713270354804049318321642067",
+    "numerator": "551601452058122349192",
+    "denominator": "238814675448681522771967738110588225",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "78",
+    "numerator": "368221119",
+    "denominator": "55593560289229421585426709374692",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "78",
+    "numerator": "368221119",
+    "denominator": "55593560289229421585426709374692",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "36450592696389724215351629",
+    "numerator": "125715441581559745337638858",
+    "denominator": "2408638671853941472435563",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "36450592696389724215351629",
+    "numerator": "125715441581559745337638858",
+    "denominator": "2408638671853941472435563",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3518193792",
+    "numerator": "278513441689",
+    "denominator": "956604781190",
+    "rounding": "Floor",
+    "expected": "1024314618",
+    "overflow": false
+  },
+  {
+    "a": "3518193792",
+    "numerator": "278513441689",
+    "denominator": "956604781190",
+    "rounding": "Ceil",
+    "expected": "1024314619",
+    "overflow": false
+  },
+  {
+    "a": "109362318965699676973911",
+    "numerator": "2640549909340",
+    "denominator": "268832481710008357",
+    "rounding": "Floor",
+    "expected": "1074188132301646591",
+    "overflow": false
+  },
+  {
+    "a": "109362318965699676973911",
+    "numerator": "2640549909340",
+    "denominator": "268832481710008357",
+    "rounding": "Ceil",
+    "expected": "1074188132301646592",
+    "overflow": false
+  },
+  {
+    "a": "1391588482",
+    "numerator": "14287610729373488746844547",
+    "denominator": "837909368",
+    "rounding": "Floor",
+    "expected": "23728669574077092805895786",
+    "overflow": false
+  },
+  {
+    "a": "1391588482",
+    "numerator": "14287610729373488746844547",
+    "denominator": "837909368",
+    "rounding": "Ceil",
+    "expected": "23728669574077092805895787",
+    "overflow": false
+  },
+  {
+    "a": "2801",
+    "numerator": "173244862",
+    "denominator": "458241004634702578411839724018671",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2801",
+    "numerator": "173244862",
+    "denominator": "458241004634702578411839724018671",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2921504893459547852436919508",
+    "numerator": "73178475136383729790935482587560169469",
+    "denominator": "58",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2921504893459547852436919508",
+    "numerator": "73178475136383729790935482587560169469",
+    "denominator": "58",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "105452606222696551650623437934435915419",
+    "numerator": "314101894088820762829754899312",
+    "denominator": "2183899203953673033",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "105452606222696551650623437934435915419",
+    "numerator": "314101894088820762829754899312",
+    "denominator": "2183899203953673033",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "118",
+    "numerator": "4290494008523270056310545566338439",
+    "denominator": "13882057734272493192597900108",
+    "rounding": "Floor",
+    "expected": "36469974",
+    "overflow": false
+  },
+  {
+    "a": "118",
+    "numerator": "4290494008523270056310545566338439",
+    "denominator": "13882057734272493192597900108",
+    "rounding": "Ceil",
+    "expected": "36469975",
+    "overflow": false
+  },
+  {
+    "a": "33386943357025471719804668397519220949",
+    "numerator": "321196252303679300015416870130",
+    "denominator": "386461762830454885555",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "33386943357025471719804668397519220949",
+    "numerator": "321196252303679300015416870130",
+    "denominator": "386461762830454885555",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1220880081839355829483481293365352",
+    "numerator": "1",
+    "denominator": "3466854002188611835694",
+    "rounding": "Floor",
+    "expected": "352157916390",
+    "overflow": false
+  },
+  {
+    "a": "1220880081839355829483481293365352",
+    "numerator": "1",
+    "denominator": "3466854002188611835694",
+    "rounding": "Ceil",
+    "expected": "352157916391",
+    "overflow": false
+  },
+  {
+    "a": "1582571551",
+    "numerator": "685819903440393924",
+    "denominator": "2006328523339590317",
+    "rounding": "Floor",
+    "expected": "540967770",
+    "overflow": false
+  },
+  {
+    "a": "1582571551",
+    "numerator": "685819903440393924",
+    "denominator": "2006328523339590317",
+    "rounding": "Ceil",
+    "expected": "540967771",
+    "overflow": false
+  },
+  {
+    "a": "276757386121541635339591850",
+    "numerator": "11",
+    "denominator": "77219934044072058906045024",
+    "rounding": "Floor",
+    "expected": "39",
+    "overflow": false
+  },
+  {
+    "a": "276757386121541635339591850",
+    "numerator": "11",
+    "denominator": "77219934044072058906045024",
+    "rounding": "Ceil",
+    "expected": "40",
+    "overflow": false
+  },
+  {
+    "a": "434843438841",
+    "numerator": "6",
+    "denominator": "1259792855603954264904378344272823",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "434843438841",
+    "numerator": "6",
+    "denominator": "1259792855603954264904378344272823",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "18320935769916",
+    "numerator": "21578777650355589",
+    "denominator": "8078141344098",
+    "rounding": "Floor",
+    "expected": "48939896256495550",
+    "overflow": false
+  },
+  {
+    "a": "18320935769916",
+    "numerator": "21578777650355589",
+    "denominator": "8078141344098",
+    "rounding": "Ceil",
+    "expected": "48939896256495551",
+    "overflow": false
+  },
+  {
+    "a": "82603153903778958307",
+    "numerator": "100836628824",
+    "denominator": "1365867947970297872977",
+    "rounding": "Floor",
+    "expected": "6098264171",
+    "overflow": false
+  },
+  {
+    "a": "82603153903778958307",
+    "numerator": "100836628824",
+    "denominator": "1365867947970297872977",
+    "rounding": "Ceil",
+    "expected": "6098264172",
+    "overflow": false
+  },
+  {
+    "a": "36151454",
+    "numerator": "387151",
+    "denominator": "111381220859240217245149300478520500",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "36151454",
+    "numerator": "387151",
+    "denominator": "111381220859240217245149300478520500",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "56366289545565",
+    "numerator": "282",
+    "denominator": "1898945594771610387396670866083681531",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "56366289545565",
+    "numerator": "282",
+    "denominator": "1898945594771610387396670866083681531",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "21948888382633890991440",
+    "numerator": "1",
+    "denominator": "31328248284884091733287126",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "21948888382633890991440",
+    "numerator": "1",
+    "denominator": "31328248284884091733287126",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "50831618788443529034464058855",
+    "numerator": "558368784610260780",
+    "denominator": "31108117931191861",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "50831618788443529034464058855",
+    "numerator": "558368784610260780",
+    "denominator": "31108117931191861",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "278994",
+    "numerator": "2774792363691233043",
+    "denominator": "180364872",
+    "rounding": "Floor",
+    "expected": "4292135226396367",
+    "overflow": false
+  },
+  {
+    "a": "278994",
+    "numerator": "2774792363691233043",
+    "denominator": "180364872",
+    "rounding": "Ceil",
+    "expected": "4292135226396368",
+    "overflow": false
+  },
+  {
+    "a": "12215297",
+    "numerator": "3697003261993770510",
+    "denominator": "594723550857294242755711",
+    "rounding": "Floor",
+    "expected": "75",
+    "overflow": false
+  },
+  {
+    "a": "12215297",
+    "numerator": "3697003261993770510",
+    "denominator": "594723550857294242755711",
+    "rounding": "Ceil",
+    "expected": "76",
+    "overflow": false
+  },
+  {
+    "a": "109708212326739996886274423234172580",
+    "numerator": "4681934418730817490043993050576112653",
+    "denominator": "1888355599831434",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "109708212326739996886274423234172580",
+    "numerator": "4681934418730817490043993050576112653",
+    "denominator": "1888355599831434",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "182061082379011110492781845035",
+    "numerator": "64",
+    "denominator": "10818863959678467079752601771528793",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "182061082379011110492781845035",
+    "numerator": "64",
+    "denominator": "10818863959678467079752601771528793",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "34420806",
+    "numerator": "52397025764985879",
+    "denominator": "7523346387904473551596316",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "34420806",
+    "numerator": "52397025764985879",
+    "denominator": "7523346387904473551596316",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "741",
+    "numerator": "159298",
+    "denominator": "3586540590659",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "741",
+    "numerator": "159298",
+    "denominator": "3586540590659",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "747134551864",
+    "numerator": "191287845502119094705",
+    "denominator": "49581931519100609655504314666878",
+    "rounding": "Floor",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "747134551864",
+    "numerator": "191287845502119094705",
+    "denominator": "49581931519100609655504314666878",
+    "rounding": "Ceil",
+    "expected": "3",
+    "overflow": false
+  },
+  {
+    "a": "9461798374529436985894256673967",
+    "numerator": "545320698420729351885972",
+    "denominator": "5139468989",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9461798374529436985894256673967",
+    "numerator": "545320698420729351885972",
+    "denominator": "5139468989",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "94542797694104010751014906",
+    "numerator": "432879206268904175842681691",
+    "denominator": "16109955491483723605106225663792",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "94542797694104010751014906",
+    "numerator": "432879206268904175842681691",
+    "denominator": "16109955491483723605106225663792",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1132832726401851786447369",
+    "numerator": "17334",
+    "denominator": "57947045447",
+    "rounding": "Floor",
+    "expected": "338870124058521938",
+    "overflow": false
+  },
+  {
+    "a": "1132832726401851786447369",
+    "numerator": "17334",
+    "denominator": "57947045447",
+    "rounding": "Ceil",
+    "expected": "338870124058521939",
+    "overflow": false
+  },
+  {
+    "a": "16433635674358470498606891925746444",
+    "numerator": "559765007267685120917",
+    "denominator": "382669894593302194",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16433635674358470498606891925746444",
+    "numerator": "559765007267685120917",
+    "denominator": "382669894593302194",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1350542219795130760850526937459",
+    "numerator": "841515622730551849650027560",
+    "denominator": "3567918788776801",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1350542219795130760850526937459",
+    "numerator": "841515622730551849650027560",
+    "denominator": "3567918788776801",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1124989850454837301949757150147822",
+    "numerator": "219359",
+    "denominator": "970088031771516288543750383236",
+    "rounding": "Floor",
+    "expected": "254385829",
+    "overflow": false
+  },
+  {
+    "a": "1124989850454837301949757150147822",
+    "numerator": "219359",
+    "denominator": "970088031771516288543750383236",
+    "rounding": "Ceil",
+    "expected": "254385830",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "12937089642",
+    "denominator": "139",
+    "rounding": "Floor",
+    "expected": "93072587",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "12937089642",
+    "denominator": "139",
+    "rounding": "Ceil",
+    "expected": "93072588",
+    "overflow": false
+  },
+  {
+    "a": "32",
+    "numerator": "58809",
+    "denominator": "17190",
+    "rounding": "Floor",
+    "expected": "109",
+    "overflow": false
+  },
+  {
+    "a": "32",
+    "numerator": "58809",
+    "denominator": "17190",
+    "rounding": "Ceil",
+    "expected": "110",
+    "overflow": false
+  },
+  {
+    "a": "105354856948651091207090591399588983",
+    "numerator": "52988",
+    "denominator": "276978863695106387451181125",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "105354856948651091207090591399588983",
+    "numerator": "52988",
+    "denominator": "276978863695106387451181125",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "68178731810",
+    "numerator": "49722469315577316460933283",
+    "denominator": "253173423239713293592",
+    "rounding": "Floor",
+    "expected": "13390089911561995",
+    "overflow": false
+  },
+  {
+    "a": "68178731810",
+    "numerator": "49722469315577316460933283",
+    "denominator": "253173423239713293592",
+    "rounding": "Ceil",
+    "expected": "13390089911561996",
+    "overflow": false
+  },
+  {
+    "a": "4096461480209",
+    "numerator": "6257277020386767798657140022422097502",
+    "denominator": "471311",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4096461480209",
+    "numerator": "6257277020386767798657140022422097502",
+    "denominator": "471311",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "642164",
+    "numerator": "8068665096883229",
+    "denominator": "130932954",
+    "rounding": "Floor",
+    "expected": "39572972998645",
+    "overflow": false
+  },
+  {
+    "a": "642164",
+    "numerator": "8068665096883229",
+    "denominator": "130932954",
+    "rounding": "Ceil",
+    "expected": "39572972998646",
+    "overflow": false
+  },
+  {
+    "a": "238510140051681100219",
+    "numerator": "1872221280058955669776",
+    "denominator": "1221993",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "238510140051681100219",
+    "numerator": "1872221280058955669776",
+    "denominator": "1221993",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "150",
+    "numerator": "127512019050146278553693863",
+    "denominator": "73448221369006632877761801764588",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "150",
+    "numerator": "127512019050146278553693863",
+    "denominator": "73448221369006632877761801764588",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "47028640504439331960620816629",
+    "numerator": "3852938130",
+    "denominator": "3122975450833411056600606049235",
+    "rounding": "Floor",
+    "expected": "58021090",
+    "overflow": false
+  },
+  {
+    "a": "47028640504439331960620816629",
+    "numerator": "3852938130",
+    "denominator": "3122975450833411056600606049235",
+    "rounding": "Ceil",
+    "expected": "58021091",
+    "overflow": false
+  },
+  {
+    "a": "7852031827709196574527423128072",
+    "numerator": "21185",
+    "denominator": "2699541798562749390",
+    "rounding": "Floor",
+    "expected": "61619825393547327",
+    "overflow": false
+  },
+  {
+    "a": "7852031827709196574527423128072",
+    "numerator": "21185",
+    "denominator": "2699541798562749390",
+    "rounding": "Ceil",
+    "expected": "61619825393547328",
+    "overflow": false
+  },
+  {
+    "a": "26060444076254377209732599103",
+    "numerator": "1046214084724324",
+    "denominator": "1058040780765279577294801813197",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "26060444076254377209732599103",
+    "numerator": "1046214084724324",
+    "denominator": "1058040780765279577294801813197",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "89432906",
+    "numerator": "26207055530605274486507",
+    "denominator": "1222639963338738599410100224",
+    "rounding": "Floor",
+    "expected": "1916",
+    "overflow": false
+  },
+  {
+    "a": "89432906",
+    "numerator": "26207055530605274486507",
+    "denominator": "1222639963338738599410100224",
+    "rounding": "Ceil",
+    "expected": "1917",
+    "overflow": false
+  },
+  {
+    "a": "1588628634847779525660707097",
+    "numerator": "7686",
+    "denominator": "229342117189244174120608953655962839",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1588628634847779525660707097",
+    "numerator": "7686",
+    "denominator": "229342117189244174120608953655962839",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2763912192378622684371937760182993628",
+    "numerator": "124824923815020764581",
+    "denominator": "405487767692468889555183618",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2763912192378622684371937760182993628",
+    "numerator": "124824923815020764581",
+    "denominator": "405487767692468889555183618",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1248042054912473559925644663555",
+    "numerator": "119421742008767621433301074037645038328",
+    "denominator": "122832138479729",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1248042054912473559925644663555",
+    "numerator": "119421742008767621433301074037645038328",
+    "denominator": "122832138479729",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "722732232518837609094462",
+    "numerator": "14933600775773496284723838049155018095",
+    "denominator": "10498839109498800510036",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "722732232518837609094462",
+    "numerator": "14933600775773496284723838049155018095",
+    "denominator": "10498839109498800510036",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8092478838156669199586685",
+    "numerator": "6586",
+    "denominator": "53839334918173551706148290670619",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "8092478838156669199586685",
+    "numerator": "6586",
+    "denominator": "53839334918173551706148290670619",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "76095782697926034936522425072",
+    "numerator": "2554939641430184044336950612169",
+    "denominator": "2404680989046",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "76095782697926034936522425072",
+    "numerator": "2554939641430184044336950612169",
+    "denominator": "2404680989046",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2126269981900189447",
+    "numerator": "137932",
+    "denominator": "5286240030128367720638580309",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "2126269981900189447",
+    "numerator": "137932",
+    "denominator": "5286240030128367720638580309",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8745191315756199409717103091690035314",
+    "numerator": "240481843",
+    "denominator": "8",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8745191315756199409717103091690035314",
+    "numerator": "240481843",
+    "denominator": "8",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18697511092817773683221025",
+    "numerator": "226641336782961227409344280154798",
+    "denominator": "329437599",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "18697511092817773683221025",
+    "numerator": "226641336782961227409344280154798",
+    "denominator": "329437599",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "67171908",
+    "numerator": "1216249211684739539435034292914016301",
+    "denominator": "9403959898415339255926894740522",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "67171908",
+    "numerator": "1216249211684739539435034292914016301",
+    "denominator": "9403959898415339255926894740522",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9066499403",
+    "numerator": "45536",
+    "denominator": "3750476921",
+    "rounding": "Floor",
+    "expected": "110079",
+    "overflow": false
+  },
+  {
+    "a": "9066499403",
+    "numerator": "45536",
+    "denominator": "3750476921",
+    "rounding": "Ceil",
+    "expected": "110080",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "7",
+    "denominator": "7421503158051180103747581544124",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "7",
+    "denominator": "7421503158051180103747581544124",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "3139845346",
+    "denominator": "33088345443",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "5",
+    "numerator": "3139845346",
+    "denominator": "33088345443",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "15035873188282609734799008821464",
+    "numerator": "1546846367465425",
+    "denominator": "4271817658824951987062111878174",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "15035873188282609734799008821464",
+    "numerator": "1546846367465425",
+    "denominator": "4271817658824951987062111878174",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47567",
+    "numerator": "20425780",
+    "denominator": "33372232023961309",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "47567",
+    "numerator": "20425780",
+    "denominator": "33372232023961309",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1019689898472252058",
+    "numerator": "68436903572368168654339859900544560763",
+    "denominator": "43021259927290199521904211152",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1019689898472252058",
+    "numerator": "68436903572368168654339859900544560763",
+    "denominator": "43021259927290199521904211152",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "123340459049",
+    "numerator": "3905073667137578190067960918",
+    "denominator": "212839",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "123340459049",
+    "numerator": "3905073667137578190067960918",
+    "denominator": "212839",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23348602633417485010604",
+    "numerator": "10222587876666298569122459704129881013",
+    "denominator": "66409810",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23348602633417485010604",
+    "numerator": "10222587876666298569122459704129881013",
+    "denominator": "66409810",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3919070156464119871635",
+    "numerator": "35000829728539636163835420104",
+    "denominator": "4292641153",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3919070156464119871635",
+    "numerator": "35000829728539636163835420104",
+    "denominator": "4292641153",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2139604359566",
+    "numerator": "42495",
+    "denominator": "96400121280036",
+    "rounding": "Floor",
+    "expected": "943",
+    "overflow": false
+  },
+  {
+    "a": "2139604359566",
+    "numerator": "42495",
+    "denominator": "96400121280036",
+    "rounding": "Ceil",
+    "expected": "944",
+    "overflow": false
+  },
+  {
+    "a": "8285215981975568683637612999053",
+    "numerator": "8521186982493889116582688010",
+    "denominator": "11",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8285215981975568683637612999053",
+    "numerator": "8521186982493889116582688010",
+    "denominator": "11",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13428852167915184623824707831113337792",
+    "numerator": "335747893816305319897",
+    "denominator": "57685395351914693574",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "13428852167915184623824707831113337792",
+    "numerator": "335747893816305319897",
+    "denominator": "57685395351914693574",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "143760213644413870733806999",
+    "numerator": "222695901566556828",
+    "denominator": "229539136289675365",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "143760213644413870733806999",
+    "numerator": "222695901566556828",
+    "denominator": "229539136289675365",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11828522374444061221158945890754",
+    "numerator": "709408595907",
+    "denominator": "232479615931155543956179152690872",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11828522374444061221158945890754",
+    "numerator": "709408595907",
+    "denominator": "232479615931155543956179152690872",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "530224159818376561742653948357764913",
+    "numerator": "1967770137488126",
+    "denominator": "16067306634603238959",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "530224159818376561742653948357764913",
+    "numerator": "1967770137488126",
+    "denominator": "16067306634603238959",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2446359414340226083748318398485524",
+    "numerator": "22589",
+    "denominator": "172224510842",
+    "rounding": "Floor",
+    "expected": "320864971776450754715569978",
+    "overflow": false
+  },
+  {
+    "a": "2446359414340226083748318398485524",
+    "numerator": "22589",
+    "denominator": "172224510842",
+    "rounding": "Ceil",
+    "expected": "320864971776450754715569979",
+    "overflow": false
+  },
+  {
+    "a": "25244122331",
+    "numerator": "558728468805453975444874088335701680",
+    "denominator": "564007490393534075553966113527689",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "25244122331",
+    "numerator": "558728468805453975444874088335701680",
+    "denominator": "564007490393534075553966113527689",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "296220590205845153739492224822",
+    "numerator": "1108607492039",
+    "denominator": "6488543576716",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "296220590205845153739492224822",
+    "numerator": "1108607492039",
+    "denominator": "6488543576716",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4373",
+    "numerator": "46053761586",
+    "denominator": "409454645680632012966643",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4373",
+    "numerator": "46053761586",
+    "denominator": "409454645680632012966643",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "548254405657774085878483752022952",
+    "numerator": "1",
+    "denominator": "14",
+    "rounding": "Floor",
+    "expected": "39161028975555291848463125144496",
+    "overflow": false
+  },
+  {
+    "a": "548254405657774085878483752022952",
+    "numerator": "1",
+    "denominator": "14",
+    "rounding": "Ceil",
+    "expected": "39161028975555291848463125144497",
+    "overflow": false
+  },
+  {
+    "a": "9603679",
+    "numerator": "246156019204",
+    "denominator": "31217969225179885",
+    "rounding": "Floor",
+    "expected": "75",
+    "overflow": false
+  },
+  {
+    "a": "9603679",
+    "numerator": "246156019204",
+    "denominator": "31217969225179885",
+    "rounding": "Ceil",
+    "expected": "76",
+    "overflow": false
+  },
+  {
+    "a": "4268909834523885336042",
+    "numerator": "607033288692667490875591492796934667",
+    "denominator": "1058791206621615260579232",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4268909834523885336042",
+    "numerator": "607033288692667490875591492796934667",
+    "denominator": "1058791206621615260579232",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1",
+    "numerator": "691878",
+    "denominator": "8461294469700742634103178408556023",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1",
+    "numerator": "691878",
+    "denominator": "8461294469700742634103178408556023",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "258433057988596752595033971195516",
+    "numerator": "463590447508682818197247558806981",
+    "denominator": "4641183394",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "258433057988596752595033971195516",
+    "numerator": "463590447508682818197247558806981",
+    "denominator": "4641183394",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10892425763",
+    "numerator": "32896071286041570195299867800",
+    "denominator": "385514413713",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "10892425763",
+    "numerator": "32896071286041570195299867800",
+    "denominator": "385514413713",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5925342",
+    "numerator": "706823411024184833413356154710033039",
+    "denominator": "6474740",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5925342",
+    "numerator": "706823411024184833413356154710033039",
+    "denominator": "6474740",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2932919255568172184884794741149",
+    "numerator": "1114",
+    "denominator": "56123",
+    "rounding": "Floor",
+    "expected": "58216275870907539047478954112",
+    "overflow": false
+  },
+  {
+    "a": "2932919255568172184884794741149",
+    "numerator": "1114",
+    "denominator": "56123",
+    "rounding": "Ceil",
+    "expected": "58216275870907539047478954113",
+    "overflow": false
+  },
+  {
+    "a": "17309703550279630634022617541019792",
+    "numerator": "39010385807602432586473",
+    "denominator": "71276718641229686270476034582",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17309703550279630634022617541019792",
+    "numerator": "39010385807602432586473",
+    "denominator": "71276718641229686270476034582",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "558785168925406899468574039117863",
+    "numerator": "132470632556260599216010971549292",
+    "denominator": "3375374459383413",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "558785168925406899468574039117863",
+    "numerator": "132470632556260599216010971549292",
+    "denominator": "3375374459383413",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "16475831120346898",
+    "numerator": "49793456020925779",
+    "denominator": "548572482823486201401825672",
+    "rounding": "Floor",
+    "expected": "1495497",
+    "overflow": false
+  },
+  {
+    "a": "16475831120346898",
+    "numerator": "49793456020925779",
+    "denominator": "548572482823486201401825672",
+    "rounding": "Ceil",
+    "expected": "1495498",
+    "overflow": false
+  },
+  {
+    "a": "7401537",
+    "numerator": "4433633630538405710",
+    "denominator": "114327231",
+    "rounding": "Floor",
+    "expected": "287033133522444357",
+    "overflow": false
+  },
+  {
+    "a": "7401537",
+    "numerator": "4433633630538405710",
+    "denominator": "114327231",
+    "rounding": "Ceil",
+    "expected": "287033133522444358",
+    "overflow": false
+  },
+  {
+    "a": "19062360566858913195492",
+    "numerator": "245345417205424122735219653796941",
+    "denominator": "759768748974278346",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "19062360566858913195492",
+    "numerator": "245345417205424122735219653796941",
+    "denominator": "759768748974278346",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "485299884139",
+    "numerator": "1067741056",
+    "denominator": "16210453891829159604074137",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "485299884139",
+    "numerator": "1067741056",
+    "denominator": "16210453891829159604074137",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "65179093908105606",
+    "numerator": "331319847873371462938199",
+    "denominator": "1794734805118673285724",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "65179093908105606",
+    "numerator": "331319847873371462938199",
+    "denominator": "1794734805118673285724",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4191416719638844197",
+    "numerator": "259540867970",
+    "denominator": "1139017032885379",
+    "rounding": "Floor",
+    "expected": "955072577521768",
+    "overflow": false
+  },
+  {
+    "a": "4191416719638844197",
+    "numerator": "259540867970",
+    "denominator": "1139017032885379",
+    "rounding": "Ceil",
+    "expected": "955072577521769",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "357786048736978417",
+    "denominator": "82899208347062921738571304970399201470",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "0",
+    "numerator": "357786048736978417",
+    "denominator": "82899208347062921738571304970399201470",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "98031",
+    "numerator": "27393542938407949268",
+    "denominator": "7654321871613",
+    "rounding": "Floor",
+    "expected": "350836619211",
+    "overflow": false
+  },
+  {
+    "a": "98031",
+    "numerator": "27393542938407949268",
+    "denominator": "7654321871613",
+    "rounding": "Ceil",
+    "expected": "350836619212",
+    "overflow": false
+  },
+  {
+    "a": "127063441429662175373085347719069211962",
+    "numerator": "465330042654898559378633555315099",
+    "denominator": "2315236497445038102735472",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "127063441429662175373085347719069211962",
+    "numerator": "465330042654898559378633555315099",
+    "denominator": "2315236497445038102735472",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "137589862247963831066185",
+    "numerator": "149642093814",
+    "denominator": "7",
+    "rounding": "Floor",
+    "expected": "2941319296337877219840700487582798",
+    "overflow": false
+  },
+  {
+    "a": "137589862247963831066185",
+    "numerator": "149642093814",
+    "denominator": "7",
+    "rounding": "Ceil",
+    "expected": "2941319296337877219840700487582799",
+    "overflow": false
+  },
+  {
+    "a": "4106828",
+    "numerator": "2115816872917",
+    "denominator": "4011269532658",
+    "rounding": "Floor",
+    "expected": "2166220",
+    "overflow": false
+  },
+  {
+    "a": "4106828",
+    "numerator": "2115816872917",
+    "denominator": "4011269532658",
+    "rounding": "Ceil",
+    "expected": "2166221",
+    "overflow": false
+  },
+  {
+    "a": "5315050725299",
+    "numerator": "292545014090908726104316359469098635112",
+    "denominator": "9092865398544042867108554864590753",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5315050725299",
+    "numerator": "292545014090908726104316359469098635112",
+    "denominator": "9092865398544042867108554864590753",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66858622351677345326",
+    "numerator": "6760323777311",
+    "denominator": "29774178382235549549233187084732323268",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "66858622351677345326",
+    "numerator": "6760323777311",
+    "denominator": "29774178382235549549233187084732323268",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2811235423681787815429279757741",
+    "numerator": "7038520944554",
+    "denominator": "1789675211",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2811235423681787815429279757741",
+    "numerator": "7038520944554",
+    "denominator": "1789675211",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "397037447037022959968",
+    "numerator": "9",
+    "denominator": "991890526018776689695973078111334",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "397037447037022959968",
+    "numerator": "9",
+    "denominator": "991890526018776689695973078111334",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1865399",
+    "numerator": "1247481411132",
+    "denominator": "233033444474592243800217394274715781",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1865399",
+    "numerator": "1247481411132",
+    "denominator": "233033444474592243800217394274715781",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2971658513582036799133260099682",
+    "numerator": "84255418596648722147",
+    "denominator": "79366232",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "2971658513582036799133260099682",
+    "numerator": "84255418596648722147",
+    "denominator": "79366232",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1426782110366290148967300201648176465",
+    "numerator": "55068955498056953358873909150",
+    "denominator": "589828551481789263",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1426782110366290148967300201648176465",
+    "numerator": "55068955498056953358873909150",
+    "denominator": "589828551481789263",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "850930913906947018459811968396212",
+    "numerator": "2229068106348613582156893",
+    "denominator": "221206183412793339307546",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "850930913906947018459811968396212",
+    "numerator": "2229068106348613582156893",
+    "denominator": "221206183412793339307546",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23226330304890875",
+    "numerator": "279940222452330814213954640",
+    "denominator": "37504412097343475980963316204270229929",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23226330304890875",
+    "numerator": "279940222452330814213954640",
+    "denominator": "37504412097343475980963316204270229929",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "69882551144544214",
+    "numerator": "18395756537786976275303899367",
+    "denominator": "1787142298639737209689644",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "69882551144544214",
+    "numerator": "18395756537786976275303899367",
+    "denominator": "1787142298639737209689644",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "104757",
+    "numerator": "26834",
+    "denominator": "24730685368307046284357837331",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "104757",
+    "numerator": "26834",
+    "denominator": "24730685368307046284357837331",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "35373539190919646909768",
+    "numerator": "7937",
+    "denominator": "14",
+    "rounding": "Floor",
+    "expected": "20054270039880659823059186",
+    "overflow": false
+  },
+  {
+    "a": "35373539190919646909768",
+    "numerator": "7937",
+    "denominator": "14",
+    "rounding": "Ceil",
+    "expected": "20054270039880659823059187",
+    "overflow": false
+  },
+  {
+    "a": "238775909158386052440442214061951",
+    "numerator": "7417826161357745051817380",
+    "denominator": "128414761436040337400040003341",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "238775909158386052440442214061951",
+    "numerator": "7417826161357745051817380",
+    "denominator": "128414761436040337400040003341",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "85237102577366794892352414483978378",
+    "numerator": "6368804392661168650779196067115",
+    "denominator": "97282318679376357360128832",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "85237102577366794892352414483978378",
+    "numerator": "6368804392661168650779196067115",
+    "denominator": "97282318679376357360128832",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "11556380760225702063449",
+    "numerator": "2117446",
+    "denominator": "17991791376984275003854615",
+    "rounding": "Floor",
+    "expected": "1360",
+    "overflow": false
+  },
+  {
+    "a": "11556380760225702063449",
+    "numerator": "2117446",
+    "denominator": "17991791376984275003854615",
+    "rounding": "Ceil",
+    "expected": "1361",
+    "overflow": false
+  },
+  {
+    "a": "1559068",
+    "numerator": "2187084716002789",
+    "denominator": "575453730117960127810",
+    "rounding": "Floor",
+    "expected": "5",
+    "overflow": false
+  },
+  {
+    "a": "1559068",
+    "numerator": "2187084716002789",
+    "denominator": "575453730117960127810",
+    "rounding": "Ceil",
+    "expected": "6",
+    "overflow": false
+  },
+  {
+    "a": "981122083139",
+    "numerator": "3115988006649542200",
+    "denominator": "1036840979408049",
+    "rounding": "Floor",
+    "expected": "2948537630009115",
+    "overflow": false
+  },
+  {
+    "a": "981122083139",
+    "numerator": "3115988006649542200",
+    "denominator": "1036840979408049",
+    "rounding": "Ceil",
+    "expected": "2948537630009116",
+    "overflow": false
+  },
+  {
+    "a": "14",
+    "numerator": "3",
+    "denominator": "172788314935444628153333089360565140",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "14",
+    "numerator": "3",
+    "denominator": "172788314935444628153333089360565140",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1112776940555799406326409567677",
+    "numerator": "148762733130182584957535935987450",
+    "denominator": "1064402897041086322500984739419",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1112776940555799406326409567677",
+    "numerator": "148762733130182584957535935987450",
+    "denominator": "1064402897041086322500984739419",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9378259426861823750725629538214125104",
+    "numerator": "1083863819529",
+    "denominator": "2742",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "9378259426861823750725629538214125104",
+    "numerator": "1083863819529",
+    "denominator": "2742",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "327",
+    "numerator": "42569880076",
+    "denominator": "300276239483886804459022187849365",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "327",
+    "numerator": "42569880076",
+    "denominator": "300276239483886804459022187849365",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "434",
+    "numerator": "27003459762709484185351283",
+    "denominator": "11753731279662765711712195848014064424",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "434",
+    "numerator": "27003459762709484185351283",
+    "denominator": "11753731279662765711712195848014064424",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "588420956152131958591073",
+    "numerator": "718682287713262",
+    "denominator": "39060667954540513539869785635807",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "588420956152131958591073",
+    "numerator": "718682287713262",
+    "denominator": "39060667954540513539869785635807",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1945265753819226251264170272132",
+    "numerator": "59947229932925796561924667419723885",
+    "denominator": "2122259739600443315427690",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1945265753819226251264170272132",
+    "numerator": "59947229932925796561924667419723885",
+    "denominator": "2122259739600443315427690",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "278430091560399655658192313574283",
+    "numerator": "26958079951529227910432",
+    "denominator": "122539507040441",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "278430091560399655658192313574283",
+    "numerator": "26958079951529227910432",
+    "denominator": "122539507040441",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "54819290773314086",
+    "numerator": "215044695275383",
+    "denominator": "1632744937236570820062126956162556",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "54819290773314086",
+    "numerator": "215044695275383",
+    "denominator": "1632744937236570820062126956162556",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "267631203377989",
+    "numerator": "546",
+    "denominator": "22822555644363221243372258211",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "267631203377989",
+    "numerator": "546",
+    "denominator": "22822555644363221243372258211",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "13336",
+    "numerator": "7259700398025186321",
+    "denominator": "5277022",
+    "rounding": "Floor",
+    "expected": "18346591033363871",
+    "overflow": false
+  },
+  {
+    "a": "13336",
+    "numerator": "7259700398025186321",
+    "denominator": "5277022",
+    "rounding": "Ceil",
+    "expected": "18346591033363872",
+    "overflow": false
+  },
+  {
+    "a": "118491821560847",
+    "numerator": "2932",
+    "denominator": "3599482683837863709",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "118491821560847",
+    "numerator": "2932",
+    "denominator": "3599482683837863709",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "210960349231927153601651304410",
+    "numerator": "783547",
+    "denominator": "16",
+    "rounding": "Floor",
+    "expected": "10331084297476801588944567163533891",
+    "overflow": false
+  },
+  {
+    "a": "210960349231927153601651304410",
+    "numerator": "783547",
+    "denominator": "16",
+    "rounding": "Ceil",
+    "expected": "10331084297476801588944567163533892",
+    "overflow": false
+  },
+  {
+    "a": "133868515518080027858944105",
+    "numerator": "2",
+    "denominator": "13197045848247759271",
+    "rounding": "Floor",
+    "expected": "20287648",
+    "overflow": false
+  },
+  {
+    "a": "133868515518080027858944105",
+    "numerator": "2",
+    "denominator": "13197045848247759271",
+    "rounding": "Ceil",
+    "expected": "20287649",
+    "overflow": false
+  },
+  {
+    "a": "17077556221070498918539451884",
+    "numerator": "174692254466122490233845",
+    "denominator": "872593499730512925330",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17077556221070498918539451884",
+    "numerator": "174692254466122490233845",
+    "denominator": "872593499730512925330",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24017655806972514994286258902739",
+    "numerator": "31132562404372684145197121704200",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "24017655806972514994286258902739",
+    "numerator": "31132562404372684145197121704200",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "233132750",
+    "numerator": "147492198893770440718741567",
+    "denominator": "34391530831880209764",
+    "rounding": "Floor",
+    "expected": "999817719651410",
+    "overflow": false
+  },
+  {
+    "a": "233132750",
+    "numerator": "147492198893770440718741567",
+    "denominator": "34391530831880209764",
+    "rounding": "Ceil",
+    "expected": "999817719651411",
+    "overflow": false
+  },
+  {
+    "a": "32540314265931183996384136424163789",
+    "numerator": "2634",
+    "denominator": "43885320940432507394476498072327801323",
+    "rounding": "Floor",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "32540314265931183996384136424163789",
+    "numerator": "2634",
+    "denominator": "43885320940432507394476498072327801323",
+    "rounding": "Ceil",
+    "expected": "2",
+    "overflow": false
+  },
+  {
+    "a": "4850265371671980498253568",
+    "numerator": "13314788793245718850884887577",
+    "denominator": "11782948336902",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4850265371671980498253568",
+    "numerator": "13314788793245718850884887577",
+    "denominator": "11782948336902",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "128960049033457623",
+    "numerator": "315835159701311224799708",
+    "denominator": "52663062944977814152882132355237",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "128960049033457623",
+    "numerator": "315835159701311224799708",
+    "denominator": "52663062944977814152882132355237",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74089421655623656806724338770087682",
+    "numerator": "22203186383886087785141166227093106179",
+    "denominator": "504",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "74089421655623656806724338770087682",
+    "numerator": "22203186383886087785141166227093106179",
+    "denominator": "504",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "759810297502441736120919757923185",
+    "numerator": "24183294304892261438",
+    "denominator": "300469215085301718061167",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "759810297502441736120919757923185",
+    "numerator": "24183294304892261438",
+    "denominator": "300469215085301718061167",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "4",
+    "numerator": "30903057424509",
+    "denominator": "9617413848004851009416346344267962",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "4",
+    "numerator": "30903057424509",
+    "denominator": "9617413848004851009416346344267962",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8117221380648785186487362331",
+    "numerator": "3435918904365552",
+    "denominator": "3773045189577",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8117221380648785186487362331",
+    "numerator": "3435918904365552",
+    "denominator": "3773045189577",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6",
+    "numerator": "221809358171065138535202484743",
+    "denominator": "261973055912396",
+    "rounding": "Floor",
+    "expected": "5080126062549845",
+    "overflow": false
+  },
+  {
+    "a": "6",
+    "numerator": "221809358171065138535202484743",
+    "denominator": "261973055912396",
+    "rounding": "Ceil",
+    "expected": "5080126062549846",
+    "overflow": false
+  },
+  {
+    "a": "1665766931239347476143911253",
+    "numerator": "2741628593196762356481906",
+    "denominator": "1017596211",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1665766931239347476143911253",
+    "numerator": "2741628593196762356481906",
+    "denominator": "1017596211",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "226524305908023598344966932200",
+    "numerator": "1",
+    "denominator": "14918635915439912888289353755609518",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "226524305908023598344966932200",
+    "numerator": "1",
+    "denominator": "14918635915439912888289353755609518",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "309721745697636824223",
+    "numerator": "329482177199077058170565027314422756676",
+    "denominator": "414042704687240157997",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "309721745697636824223",
+    "numerator": "329482177199077058170565027314422756676",
+    "denominator": "414042704687240157997",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1377239968856109549547634896931626",
+    "numerator": "15198175307",
+    "denominator": "21985678243280672432438001888",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1377239968856109549547634896931626",
+    "numerator": "15198175307",
+    "denominator": "21985678243280672432438001888",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "874951415632326855573741868921",
+    "numerator": "5469370281664957651531812593638",
+    "denominator": "534225399952552770263624899186931767",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "874951415632326855573741868921",
+    "numerator": "5469370281664957651531812593638",
+    "denominator": "534225399952552770263624899186931767",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1308091836",
+    "numerator": "5452941629179256112509271557",
+    "denominator": "2723843410778399714",
+    "rounding": "Floor",
+    "expected": "2618707227841531222",
+    "overflow": false
+  },
+  {
+    "a": "1308091836",
+    "numerator": "5452941629179256112509271557",
+    "denominator": "2723843410778399714",
+    "rounding": "Ceil",
+    "expected": "2618707227841531223",
+    "overflow": false
+  },
+  {
+    "a": "99",
+    "numerator": "10843118215128",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "1073468703297672",
+    "overflow": false
+  },
+  {
+    "a": "99",
+    "numerator": "10843118215128",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "1073468703297672",
+    "overflow": false
+  },
+  {
+    "a": "286",
+    "numerator": "1231",
+    "denominator": "2824354435793570474804",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "286",
+    "numerator": "1231",
+    "denominator": "2824354435793570474804",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "6621",
+    "numerator": "228281103106020418234778",
+    "denominator": "24955",
+    "rounding": "Floor",
+    "expected": "60566987924863201327688",
+    "overflow": false
+  },
+  {
+    "a": "6621",
+    "numerator": "228281103106020418234778",
+    "denominator": "24955",
+    "rounding": "Ceil",
+    "expected": "60566987924863201327689",
+    "overflow": false
+  },
+  {
+    "a": "891404526126032",
+    "numerator": "252692252767739211294505",
+    "denominator": "31160600145472288627188566",
+    "rounding": "Floor",
+    "expected": "7228712437583",
+    "overflow": false
+  },
+  {
+    "a": "891404526126032",
+    "numerator": "252692252767739211294505",
+    "denominator": "31160600145472288627188566",
+    "rounding": "Ceil",
+    "expected": "7228712437584",
+    "overflow": false
+  },
+  {
+    "a": "56073443031751246579136662209127",
+    "numerator": "115504663762716256732591547820",
+    "denominator": "2208284178295581172106835340355055285",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "56073443031751246579136662209127",
+    "numerator": "115504663762716256732591547820",
+    "denominator": "2208284178295581172106835340355055285",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23523585245475413157658655826",
+    "numerator": "1563243343043465989011",
+    "denominator": "4672828478688346950856",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "23523585245475413157658655826",
+    "numerator": "1563243343043465989011",
+    "denominator": "4672828478688346950856",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7212136065463760841325697",
+    "numerator": "69802373829694103087849345166",
+    "denominator": "297480520567039",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7212136065463760841325697",
+    "numerator": "69802373829694103087849345166",
+    "denominator": "297480520567039",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17299049811446685666709959972",
+    "numerator": "508782212988353677",
+    "denominator": "40823969939039186762671392519997914122",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17299049811446685666709959972",
+    "numerator": "508782212988353677",
+    "denominator": "40823969939039186762671392519997914122",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1418955397116279178923",
+    "numerator": "30292762786673363882571153356249792",
+    "denominator": "2148310759844910299451287804046826201",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1418955397116279178923",
+    "numerator": "30292762786673363882571153356249792",
+    "denominator": "2148310759844910299451287804046826201",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8028101472083320855238",
+    "numerator": "422221446351841705021591",
+    "denominator": "153446658264952925464482780175219100",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8028101472083320855238",
+    "numerator": "422221446351841705021591",
+    "denominator": "153446658264952925464482780175219100",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "197477",
+    "numerator": "1363937584737257666",
+    "denominator": "1301682673202128381490159607575917251",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "197477",
+    "numerator": "1363937584737257666",
+    "denominator": "1301682673202128381490159607575917251",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "249921119825190204961984941496",
+    "numerator": "310550815281",
+    "denominator": "79520194152449244927578125771262",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "249921119825190204961984941496",
+    "numerator": "310550815281",
+    "denominator": "79520194152449244927578125771262",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "47",
+    "numerator": "179118977299474289428",
+    "denominator": "370234898665155273417533",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "47",
+    "numerator": "179118977299474289428",
+    "denominator": "370234898665155273417533",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "144844004098682",
+    "numerator": "6493628887003",
+    "denominator": "8712419961699812784",
+    "rounding": "Floor",
+    "expected": "107956596",
+    "overflow": false
+  },
+  {
+    "a": "144844004098682",
+    "numerator": "6493628887003",
+    "denominator": "8712419961699812784",
+    "rounding": "Ceil",
+    "expected": "107956597",
+    "overflow": false
+  },
+  {
+    "a": "79009725685965979916181197435529",
+    "numerator": "855232814625497504847769847350",
+    "denominator": "711",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "79009725685965979916181197435529",
+    "numerator": "855232814625497504847769847350",
+    "denominator": "711",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6217666261176479703436",
+    "numerator": "37862127563365053185670165",
+    "denominator": "3643033906",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "6217666261176479703436",
+    "numerator": "37862127563365053185670165",
+    "denominator": "3643033906",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66602819059",
+    "numerator": "1178834611633692058194670961255080",
+    "denominator": "302713087441735278537697",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "66602819059",
+    "numerator": "1178834611633692058194670961255080",
+    "denominator": "302713087441735278537697",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17898439220811495265041643052115822",
+    "numerator": "1035201887",
+    "denominator": "4437421085442561700955396",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "17898439220811495265041643052115822",
+    "numerator": "1035201887",
+    "denominator": "4437421085442561700955396",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "344121437677",
+    "numerator": "13720536736781686914282",
+    "denominator": "267",
+    "rounding": "Floor",
+    "expected": "17683636058282427816584343461434",
+    "overflow": false
+  },
+  {
+    "a": "344121437677",
+    "numerator": "13720536736781686914282",
+    "denominator": "267",
+    "rounding": "Ceil",
+    "expected": "17683636058282427816584343461435",
+    "overflow": false
+  },
+  {
+    "a": "3306465044015527146454041760",
+    "numerator": "1826711284361653736156729",
+    "denominator": "365634731382045812134",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3306465044015527146454041760",
+    "numerator": "1826711284361653736156729",
+    "denominator": "365634731382045812134",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1501023451298885961688278707745356023",
+    "numerator": "3399036",
+    "denominator": "56416453",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1501023451298885961688278707745356023",
+    "numerator": "3399036",
+    "denominator": "56416453",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "79483724415003766854680794480034",
+    "numerator": "4401092767534818650494881059",
+    "denominator": "27539574718826880439199612586904",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "79483724415003766854680794480034",
+    "numerator": "4401092767534818650494881059",
+    "denominator": "27539574718826880439199612586904",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "191068531078454122897",
+    "numerator": "27081201628192990",
+    "denominator": "38521533308374759940302223",
+    "rounding": "Floor",
+    "expected": "134323973386",
+    "overflow": false
+  },
+  {
+    "a": "191068531078454122897",
+    "numerator": "27081201628192990",
+    "denominator": "38521533308374759940302223",
+    "rounding": "Ceil",
+    "expected": "134323973387",
+    "overflow": false
+  },
+  {
+    "a": "1114807454452",
+    "numerator": "8248477",
+    "denominator": "18709553955907292997975712124470569818",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1114807454452",
+    "numerator": "8248477",
+    "denominator": "18709553955907292997975712124470569818",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "78908987",
+    "numerator": "51766384528",
+    "denominator": "1217627571549535522281",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "78908987",
+    "numerator": "51766384528",
+    "denominator": "1217627571549535522281",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "4704407451926",
+    "numerator": "21287",
+    "denominator": "1",
+    "rounding": "Floor",
+    "expected": "100142721429148762",
+    "overflow": false
+  },
+  {
+    "a": "4704407451926",
+    "numerator": "21287",
+    "denominator": "1",
+    "rounding": "Ceil",
+    "expected": "100142721429148762",
+    "overflow": false
+  },
+  {
+    "a": "7233115561122165",
+    "numerator": "27100038062690161063049401929950357010",
+    "denominator": "324848580996891513837410381961592915",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7233115561122165",
+    "numerator": "27100038062690161063049401929950357010",
+    "denominator": "324848580996891513837410381961592915",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "98493259183023212680",
+    "numerator": "1567103945562204993",
+    "denominator": "3402776590683726",
+    "rounding": "Floor",
+    "expected": "45359773397871794833497",
+    "overflow": false
+  },
+  {
+    "a": "98493259183023212680",
+    "numerator": "1567103945562204993",
+    "denominator": "3402776590683726",
+    "rounding": "Ceil",
+    "expected": "45359773397871794833498",
+    "overflow": false
+  },
+  {
+    "a": "11690431",
+    "numerator": "59966451541220",
+    "denominator": "56615100683958753496084301",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "11690431",
+    "numerator": "59966451541220",
+    "denominator": "56615100683958753496084301",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "3570857326305454988379882183445962",
+    "numerator": "34550508919722097158062106665550699",
+    "denominator": "97920",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "3570857326305454988379882183445962",
+    "numerator": "34550508919722097158062106665550699",
+    "denominator": "97920",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5845586329",
+    "numerator": "1024828586205123616549962694790",
+    "denominator": "99243136686723326020492114023657815",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "5845586329",
+    "numerator": "1024828586205123616549962694790",
+    "denominator": "99243136686723326020492114023657815",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "610780648572392821084",
+    "numerator": "11154221653311013",
+    "denominator": "994260478554634059194039321218",
+    "rounding": "Floor",
+    "expected": "6852110",
+    "overflow": false
+  },
+  {
+    "a": "610780648572392821084",
+    "numerator": "11154221653311013",
+    "denominator": "994260478554634059194039321218",
+    "rounding": "Ceil",
+    "expected": "6852111",
+    "overflow": false
+  },
+  {
+    "a": "25884547",
+    "numerator": "28257527869681228152",
+    "denominator": "188871618453397745",
+    "rounding": "Floor",
+    "expected": "3872648067",
+    "overflow": false
+  },
+  {
+    "a": "25884547",
+    "numerator": "28257527869681228152",
+    "denominator": "188871618453397745",
+    "rounding": "Ceil",
+    "expected": "3872648068",
+    "overflow": false
+  },
+  {
+    "a": "554627006",
+    "numerator": "230479733231",
+    "denominator": "39452547397617472949091228111572",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "554627006",
+    "numerator": "230479733231",
+    "denominator": "39452547397617472949091228111572",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "1908541924906753840604669",
+    "numerator": "1737034454965056474258506228794",
+    "denominator": "4251344688689321491946714327586815131",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1908541924906753840604669",
+    "numerator": "1737034454965056474258506228794",
+    "denominator": "4251344688689321491946714327586815131",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "368",
+    "numerator": "2890723009974151420705097",
+    "denominator": "22",
+    "rounding": "Floor",
+    "expected": "48353912166840351037248895",
+    "overflow": false
+  },
+  {
+    "a": "368",
+    "numerator": "2890723009974151420705097",
+    "denominator": "22",
+    "rounding": "Ceil",
+    "expected": "48353912166840351037248896",
+    "overflow": false
+  },
+  {
+    "a": "156236916428102144903",
+    "numerator": "519784819453562577144140",
+    "denominator": "75589209700763349",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "156236916428102144903",
+    "numerator": "519784819453562577144140",
+    "denominator": "75589209700763349",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1594098",
+    "numerator": "2732723",
+    "denominator": "3227874988206888194777906792",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "1594098",
+    "numerator": "2732723",
+    "denominator": "3227874988206888194777906792",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "8748036674422793091745",
+    "numerator": "7360908971958147523495214",
+    "denominator": "31",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "8748036674422793091745",
+    "numerator": "7360908971958147523495214",
+    "denominator": "31",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "49162399305163791319938587838026948",
+    "numerator": "2506509761193364550724456644781",
+    "denominator": "285852653786106033993330346",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "49162399305163791319938587838026948",
+    "numerator": "2506509761193364550724456644781",
+    "denominator": "285852653786106033993330346",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22100311715077836931348939",
+    "numerator": "118586785884309600",
+    "denominator": "25",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22100311715077836931348939",
+    "numerator": "118586785884309600",
+    "denominator": "25",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21398386311102933862",
+    "numerator": "1936223376793562888079357034428855",
+    "denominator": "39448518231902091257642124089562428",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "21398386311102933862",
+    "numerator": "1936223376793562888079357034428855",
+    "denominator": "39448518231902091257642124089562428",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "20725969797",
+    "numerator": "4437555451746",
+    "denominator": "307187182128432320742994303777157603",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "20725969797",
+    "numerator": "4437555451746",
+    "denominator": "307187182128432320742994303777157603",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "856",
+    "numerator": "3804117073",
+    "denominator": "1718561533693580105748126",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": false
+  },
+  {
+    "a": "856",
+    "numerator": "3804117073",
+    "denominator": "1718561533693580105748126",
+    "rounding": "Ceil",
+    "expected": "1",
+    "overflow": false
+  },
+  {
+    "a": "2830182705228885583",
+    "numerator": "692",
+    "denominator": "16221",
+    "rounding": "Floor",
+    "expected": "120737712349324260",
+    "overflow": false
+  },
+  {
+    "a": "2830182705228885583",
+    "numerator": "692",
+    "denominator": "16221",
+    "rounding": "Ceil",
+    "expected": "120737712349324261",
+    "overflow": false
+  },
+  {
+    "a": "23629917466",
+    "numerator": "322075387",
+    "denominator": "27472",
+    "rounding": "Floor",
+    "expected": "277031698188701",
+    "overflow": false
+  },
+  {
+    "a": "23629917466",
+    "numerator": "322075387",
+    "denominator": "27472",
+    "rounding": "Ceil",
+    "expected": "277031698188702",
+    "overflow": false
+  },
+  {
+    "a": "658968698715985211758618821381698729",
+    "numerator": "69035784556767876127311515350",
+    "denominator": "443062059838530577383",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "658968698715985211758618821381698729",
+    "numerator": "69035784556767876127311515350",
+    "denominator": "443062059838530577383",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22098333311674583684740129938610173228",
+    "numerator": "246162695483278389",
+    "denominator": "993746846358364302512082",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "22098333311674583684740129938610173228",
+    "numerator": "246162695483278389",
+    "denominator": "993746846358364302512082",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1864019901350212883",
+    "numerator": "135789239368329847398138952",
+    "denominator": "1232656897",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "1864019901350212883",
+    "numerator": "135789239368329847398138952",
+    "denominator": "1232656897",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7472232879640565080924187985464334",
+    "numerator": "155476907895812852484893544316893823",
+    "denominator": "5284",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "7472232879640565080924187985464334",
+    "numerator": "155476907895812852484893544316893823",
+    "denominator": "5284",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "120519460872717",
+    "numerator": "29562152398004376816738186",
+    "denominator": "7408390355255339",
+    "rounding": "Floor",
+    "expected": "0",
+    "overflow": true
+  },
+  {
+    "a": "120519460872717",
+    "numerator": "29562152398004376816738186",
+    "denominator": "7408390355255339",
+    "rounding": "Ceil",
+    "expected": "0",
+    "overflow": true
+  }
+]


### PR DESCRIPTION
…snapshot

- Add math_utils module with mul_div function for safe multiplication/division
- Add snap_mul_div snapshot test with 4096 test cases
- Fix missing storage keys (PROTOCOL_FEE_BPS, DEFAULT_FEE_SHARE_BPS, MARKET_FEE_SHARE_BPS, TREASURY_BALANCE, BOUNTY_BALANCE)
- Add ProtocolFeeBpsExceeded error variant
- Add SetProtocolFeeBps execute message and GetProtocolFeeBps query message
- Add execute_set_protocol_fee_bps handler function
- Fix duplicate category function in error.rs
- Fix unused import in fees.rs
- Fix closure signature in snap_mul_div.rs test

closes #781