### PR TITLE
#781 Add credit-lines pagination view

### DIFF
--- a/CREDIT_LINES_PAGINATION_API.md
+++ b/CREDIT_LINES_PAGINATION_API.md
@@ -1,0 +1,103 @@
+# Credit Lines Pagination API Documentation
+
+## Overview
+This document describes the cursor-based pagination API for credit lines added to the Creditra credit contract as part of issue #781.
+
+## New Type
+
+### `CreditLinesPage`
+A paginated view of credit lines for off-chain reporting and indexing.
+
+**Location:** `contracts/credit/src/types.rs`
+
+```rust
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLinesPage {
+    /// Vector of credit line data for this page.
+    pub lines: soroban_sdk::Vec<CreditLineData>,
+    /// Cursor for the next page, or `None` if this is the last page.
+    pub next_cursor: Option<u32>,
+    /// Whether more results are available beyond this page.
+    pub has_more: bool,
+}
+```
+
+## New Function
+
+### `get_credit_lines_paginated`
+Returns a paginated view of credit lines using cursor-based pagination.
+
+**Location:** `contracts/credit/src/views.rs`
+
+**Signature:**
+```rust
+pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> CreditLinesPage
+```
+
+**Parameters:**
+- `cursor`: Optional starting cursor (numeric ID). Pass `None` for the first page.
+- `limit`: Maximum number of credit lines to return. Must be <= `MAX_ENUMERATION_LIMIT` (100).
+
+**Returns:**
+- `CreditLinesPage` containing:
+  - `lines`: Vector of credit line data for this page.
+  - `next_cursor`: Cursor for the next page, or `None` if this is the last page.
+  - `has_more`: Boolean indicating if more results are available.
+
+**Behavior:**
+- Starts enumeration from `cursor.unwrap_or(0)`.
+- Returns at most `limit` credit lines.
+- Iterates through stable numeric IDs in ascending order.
+- Skips IDs that have no corresponding borrower (gaps in the sequence).
+- Bumps TTL for each credit line entry that is loaded.
+- Enforces maximum limit to prevent unbounded gas consumption (panics with `ContractError::Overflow` if limit exceeds `MAX_ENUMERATION_LIMIT`).
+
+**Example Usage:**
+```text
+// First page
+let page1 = client.get_credit_lines_paginated(None, 10);
+
+// Second page
+if let Some(cursor) = page1.next_cursor {
+    let page2 = client.get_credit_lines_paginated(Some(cursor), 10);
+}
+```
+
+**Security:**
+This is a read-only function with no authentication requirement. It only reads storage and does not mutate any state. The TTL bump on loaded entries is a side effect but does not change the logical state of the contract.
+
+## Contract Entry Point
+
+The function is exposed as a public contract method in `contracts/credit/src/lib.rs`:
+
+```rust
+pub fn get_credit_lines_paginated(env: Env, cursor: Option<u32>, limit: u32) -> CreditLinesPage {
+    views::get_credit_lines_paginated(env, cursor, limit)
+}
+```
+
+## Testing
+
+Focused tests have been added in `contracts/credit/src/views_tests.rs`:
+
+1. `test_credit_lines_pagination_first_page` - Tests retrieving the first page of results
+2. `test_credit_lines_pagination_multiple_pages` - Tests navigating through multiple pages using cursors
+3. `test_credit_lines_pagination_empty_result` - Tests behavior when no credit lines exist
+4. `test_credit_lines_pagination_limit_enforcement` - Tests that limits exceeding MAX_ENUMERATION_LIMIT are rejected
+5. `test_credit_lines_pagination_cursor_beyond_end` - Tests behavior when cursor is beyond the last credit line
+
+## Storage Dependencies
+
+The pagination function relies on the following storage helpers from `contracts/credit/src/storage.rs`:
+
+- `get_credit_line_count()` - Returns the total number of indexed credit lines
+- `get_borrower_by_credit_line_id(id)` - Returns the borrower address for a given numeric ID
+- `get_credit_line(borrower)` - Returns the credit line data for a borrower
+
+## Implementation Notes
+
+- Uses stable numeric IDs assigned to each borrower via `ensure_credit_line_id()`
+- Cursor-based pagination avoids offset-based limitations and is stateless
+- Efficient for large datasets as it doesn't require skipping through previous results
+- TTL bump on loaded entries ensures active borrower data remains accessible

--- a/contracts/credit/src/lifecycle.rs
+++ b/contracts/credit/src/lifecycle.rs
@@ -224,7 +224,7 @@ fn suspend_credit_line_internal(env: &Env, borrower: Address) {
         &credit_line,
         previous_utilized,
         Some(previous_status),
-nano +100 contracts/credit/src/lifecycle.rs    );
+    );
 
     publish_credit_line_event(
         env,

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -293,8 +293,6 @@ impl ContractError {
         }
     }
 }
-    }
-}
 
 /// Configuration emitted when the risk admin cooldown is set or changed.
 #[contracttype]
@@ -693,6 +691,21 @@ pub struct BorrowStateSnapshot {
     pub collateral_balance: i128,
     /// The borrower's current borrow capabilities.
     pub capabilities: BorrowCapabilities,
+}
+
+/// Paginated view of credit lines for off-chain reporting.
+///
+/// Returned by `get_credit_lines_paginated` to enable efficient navigation
+/// through large sets of credit lines using cursor-based pagination.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreditLinesPage {
+    /// Vector of credit line data for this page.
+    pub lines: soroban_sdk::Vec<CreditLineData>,
+    /// Cursor for the next page, or `None` if this is the last page.
+    pub next_cursor: Option<u32>,
+    /// Whether more results are available beyond this page.
+    pub has_more: bool,
 }
 
 

--- a/contracts/credit/src/views_tests.rs
+++ b/contracts/credit/src/views_tests.rs
@@ -55,3 +55,161 @@ fn test_protocol_summary_view_active_lines() {
     client.close_credit_line(&b3, &admin);
     assert_eq!(client.get_protocol_summary_view().active_line_count, 0);
 }
+
+#[test]
+fn test_credit_lines_pagination_first_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Initialize with dummy token/source
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Open 5 credit lines
+    for i in 0..5 {
+        let borrower = Address::generate(&env);
+        client.open_credit_line(&borrower, &(1000 + i as i128), &500, &10 + i);
+    }
+
+    // Get first page with limit 2
+    let page1 = client.get_credit_lines_paginated(None, &2);
+    assert_eq!(page1.lines.len(), 2);
+    assert!(page1.next_cursor.is_some());
+    assert!(page1.has_more);
+}
+
+#[test]
+fn test_credit_lines_pagination_multiple_pages() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Initialize with dummy token/source
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Open 5 credit lines
+    for i in 0..5 {
+        let borrower = Address::generate(&env);
+        client.open_credit_line(&borrower, &(1000 + i as i128), &500, &10 + i);
+    }
+
+    // Get first page with limit 2
+    let page1 = client.get_credit_lines_paginated(None, &2);
+    assert_eq!(page1.lines.len(), 2);
+    assert!(page1.next_cursor.is_some());
+    assert!(page1.has_more);
+
+    // Get second page using cursor
+    let cursor = page1.next_cursor.unwrap();
+    let page2 = client.get_credit_lines_paginated(Some(cursor), &2);
+    assert_eq!(page2.lines.len(), 2);
+    assert!(page2.next_cursor.is_some());
+    assert!(page2.has_more);
+
+    // Get third page using cursor
+    let cursor = page2.next_cursor.unwrap();
+    let page3 = client.get_credit_lines_paginated(Some(cursor), &2);
+    assert_eq!(page3.lines.len(), 1);
+    assert!(page3.next_cursor.is_none());
+    assert!(!page3.has_more);
+}
+
+#[test]
+fn test_credit_lines_pagination_empty_result() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Initialize with dummy token/source
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Get first page with no credit lines
+    let page = client.get_credit_lines_paginated(None, &10);
+    assert_eq!(page.lines.len(), 0);
+    assert!(page.next_cursor.is_none());
+    assert!(!page.has_more);
+}
+
+#[test]
+fn test_credit_lines_pagination_limit_enforcement() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Initialize with dummy token/source
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Open 5 credit lines
+    for i in 0..5 {
+        let borrower = Address::generate(&env);
+        client.open_credit_line(&borrower, &(1000 + i as i128), &500, &10 + i);
+    }
+
+    // Request limit larger than MAX_ENUMERATION_LIMIT should panic
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.get_credit_lines_paginated(None, &101);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_credit_lines_pagination_cursor_beyond_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, Credit);
+    let client = CreditClient::new(&env, &contract_id);
+
+    // Initialize with dummy token/source
+    let token = Address::generate(&env);
+    let source = Address::generate(&env);
+    client.init(&admin);
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&source);
+
+    // Open 3 credit lines
+    for i in 0..3 {
+        let borrower = Address::generate(&env);
+        client.open_credit_line(&borrower, &(1000 + i as i128), &500, &10 + i);
+    }
+
+    // Request page with cursor beyond the last credit line
+    let page = client.get_credit_lines_paginated(Some(100), &10);
+    assert_eq!(page.lines.len(), 0);
+    assert!(page.next_cursor.is_none());
+    assert!(!page.has_more);
+}


### PR DESCRIPTION
- Add CreditLinesPage type to types.rs for paginated responses
- Fix syntax errors in types.rs (extra closing braces)
- Fix syntax error in lifecycle.rs (stray text)
- Add comprehensive tests for pagination in views_tests.rs:
  - First page retrieval
  - Multi-page navigation with cursors
  - Empty result handling
  - Limit enforcement
  - Cursor beyond end handling
- Add API documentation in CREDIT_LINES_PAGINATION_API.md

The get_credit_lines_paginated function was already implemented in views.rs and provides cursor-based pagination for efficient credit line enumeration.

closes #781