### PR TITLE
feat: max-utilization cap

### DIFF
--- a/contracts/creditra-credit/src/contract.rs
+++ b/contracts/creditra-credit/src/contract.rs
@@ -7,12 +7,14 @@ use crate::collateral;
 use crate::error::ContractError;
 use crate::fees;
 use crate::handshake::{self, ProtocolVersion};
+use crate::limits;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::oracles;
 use crate::state::{
-    Config, CreditLine, Draw, DrawAction, DrawAuditEntry, OraclePriceRecord, BORROWER_TO_ID,
-    CONFIG, CREDIT_LINES, CREDIT_LINE_COUNT, DRAWS, DRAW_AUDIT, DRAW_AUDIT_COUNT, DRAW_COUNT,
-    LATE_FEE_CONFIG, ORACLE_PRICE_RECORD, ORACLE_QUORUM_CONFIG, PROTOCOL_FEE_BPS,
+    BORROWER_MAX_UTILIZATION, DEFAULT_MAX_UTILIZATION_BPS, Config, CreditLine, Draw,
+    DrawAction, DrawAuditEntry, OraclePriceRecord, BORROWER_TO_ID, CONFIG, CREDIT_LINES,
+    CREDIT_LINE_COUNT, DRAWS, DRAW_AUDIT, DRAW_AUDIT_COUNT, DRAW_COUNT, LATE_FEE_CONFIG,
+    ORACLE_PRICE_RECORD, ORACLE_QUORUM_CONFIG, PROTOCOL_FEE_BPS,
 };
 use crate::views;
 
@@ -187,6 +189,13 @@ pub fn execute(
             denom,
             risk_weight_bps,
         } => execute_set_collateral_risk_weight(deps, info, denom, risk_weight_bps),
+        ExecuteMsg::SetMaxUtilization { max_utilization_bps } => {
+            execute_set_max_utilization(deps, info, max_utilization_bps)
+        }
+        ExecuteMsg::SetBorrowerMaxUtilization {
+            borrower,
+            max_utilization_bps,
+        } => execute_set_borrower_max_utilization(deps, info, borrower, max_utilization_bps),
     }
 }
 
@@ -299,7 +308,8 @@ pub fn execute_create_credit_line(
 /// Borrower: draw a specified amount from an active credit line.
 ///
 /// Loads the [`CreditLine`] at `credit_line_id`, verifies that the caller
-/// is the named borrower, creates a [`Draw`] record under a fresh
+/// is the named borrower, enforces the per-borrower max-utilization cap
+/// (default + per-borrower override), creates a [`Draw`] record under a fresh
 /// per-line auto-incremented id, and appends a `DrawCreated`
 /// [`DrawAuditEntry`] to the draw's audit trail.  **No tokens are
 /// transferred in v7** — the draw is an accounting-only record; actual
@@ -309,7 +319,8 @@ pub fn execute_create_credit_line(
 /// # Parameters
 ///
 /// - `deps` — Mutable storage; writes to [`DRAWS`], [`DRAW_COUNT`],
-///   [`DRAW_AUDIT`], and [`DRAW_AUDIT_COUNT`]; reads from [`CREDIT_LINES`].
+///   [`DRAW_AUDIT`], and [`DRAW_AUDIT_COUNT`]; reads from [`CREDIT_LINES`],
+///   [`DEFAULT_MAX_UTILIZATION_BPS`], and [`BORROWER_MAX_UTILIZATION`].
 /// - `env` — `env.block.time` is recorded as `drawn_at` on the new draw
 ///   and as `timestamp` on the initial audit entry; `env.block.height`
 ///   is also snapshotted for the audit log.
@@ -338,15 +349,16 @@ pub fn execute_create_credit_line(
 /// |---|---|
 /// | [`ContractError::CreditLineNotFound`] | `credit_line_id` has no stored [`CreditLine`] |
 /// | [`ContractError::Unauthorized`] | `info.sender != credit_line.borrower` |
-/// | `StdError::ParseErr` / `ContractError::Std(_)` | `amount` is not a valid `Uint128` |
-/// | Storage I/O errors | propagated from `cw-storage-plus` |
+/// [`ContractError::MaxUtilizationExceeded`] | the proposed draw would push total utilization over the borrower's cap |
+/// `StdError::ParseErr` / `ContractError::Std(_)` | `amount` is not a valid `Uint128` |
+/// Storage I/O errors | propagated from `cw-storage-plus` |
 ///
 /// # @notice
-/// v7 does **not** enforce a credit-limit ceiling on the sum of draws —
-/// this is intentional for the error-stability testing crate (see
-/// `tests/err_stab.rs`).  The production `credit` contract adds the
-/// full 25-step preflight chain including limit, collateral-ratio, and
-/// exposure caps.
+/// The max-utilization cap is enforced at draw creation time: the sum of all
+/// un-repaid draws for the credit line, plus the proposed draw amount, must not
+/// exceed `credit_amount * effective_cap_bps / 10_000`.  The default cap is
+/// 100% (`10_000` bps); admins can lower it protocol-wide or per-borrower via
+/// [`execute_set_max_utilization`] and [`execute_set_borrower_max_utilization`].
 ///
 /// # @dev
 /// The draw audit trail is initialized with a single `DrawCreated`
@@ -376,6 +388,21 @@ pub fn execute_create_draw(
     let draw_amount: cosmwasm_std::Uint128 = amount
         .parse()
         .map_err(|_| ContractError::Std(cosmwasm_std::StdError::parse_err("Uint128", &amount)))?;
+
+    // Enforce per-borrower max-utilization cap.
+    let default_cap = DEFAULT_MAX_UTILIZATION_BPS
+        .may_load(deps.storage)?
+        .unwrap_or(limits::MAX_UTILIZATION_BPS);
+    let borrower_override = BORROWER_MAX_UTILIZATION
+        .may_load(deps.storage, &credit_line.borrower)?;
+    let effective_cap = limits::effective_max_utilization_bps(default_cap, borrower_override);
+    let total_utilized = compute_total_utilized(deps.as_ref(), credit_line_id)?;
+    limits::check_utilization_within_cap(
+        total_utilized,
+        draw_amount,
+        credit_line.credit_amount,
+        effective_cap,
+    )?;
 
     let draw = Draw {
         id: draw_count,
@@ -892,6 +919,95 @@ pub fn execute_set_collateral_risk_weight(
     collateral::set_collateral_risk_weight(deps, &denom, risk_weight_bps)
 }
 
+/// Admin: set the protocol-wide default max-utilization cap.
+///
+/// When no per-borrower override is configured, this default applies
+/// to all borrowers.  Pass `None` to reset the default to
+/// 100% (`10_000` bps).
+///
+/// # Errors
+///
+/// - [`ContractError::Unauthorized`] if the caller is not the
+///   contract owner.
+/// - [`ContractError::InvalidAmount`] if `max_utilization_bps`
+///   exceeds [`limits::MAX_UTILIZATION_BPS`].
+pub fn execute_set_max_utilization(
+    deps: DepsMut,
+    info: MessageInfo,
+    max_utilization_bps: Option<u32>,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+    let bps = match max_utilization_bps {
+        Some(b) => limits::validate_utilization_bps(b)?,
+        None => limits::MAX_UTILIZATION_BPS,
+    };
+    DEFAULT_MAX_UTILIZATION_BPS.save(deps.storage, &bps)?;
+    Ok(Response::default()
+        .add_attribute("action", "set_max_utilization")
+        .add_attribute("max_utilization_bps", bps.to_string()))
+}
+
+/// Admin: set a per-borrower max-utilization override.
+///
+/// When present, the override supersedes the protocol-wide default
+/// returned by [`execute_set_max_utilization`] for the specified
+/// borrower.  Pass `None` to remove the override, falling the
+/// borrower back to the default.
+///
+/// # Errors
+///
+/// - [`ContractError::Unauthorized`] if the caller is not the
+///   contract owner.
+/// - [`ContractError::InvalidAmount`] if `max_utilization_bps`
+///   exceeds [`limits::MAX_UTILIZATION_BPS`].
+/// - [`ContractError::Std(AddrParseErr)`] if `borrower` is not a
+///   valid bech32 address.
+pub fn execute_set_borrower_max_utilization(
+    deps: DepsMut,
+    info: MessageInfo,
+    borrower: String,
+    max_utilization_bps: Option<u32>,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+    let borrower_addr = deps.api.addr_validate(&borrower)?;
+    match max_utilization_bps {
+        Some(bps) => {
+            let validated = limits::validate_utilization_bps(bps)?;
+            BORROWER_MAX_UTILIZATION.save(deps.storage, borrower_addr, &validated)?;
+        }
+        None => {
+            BORROWER_MAX_UTILIZATION.remove(deps.storage, &borrower_addr);
+        }
+    }
+    Ok(Response::default()
+        .add_attribute("action", "set_borrower_max_utilization")
+        .add_attribute("borrower", borrower))
+}
+
+fn compute_total_utilized(
+    deps: Deps,
+    credit_line_id: u64,
+) -> Result<Uint128, ContractError> {
+    let draw_count = DRAW_COUNT
+        .may_load(deps.storage, credit_line_id)?
+        .unwrap_or(0);
+    let mut total = Uint128::zero();
+    for did in 0..draw_count {
+        if let Some(draw) = DRAWS.may_load(deps.storage, (credit_line_id, did))? {
+            if !draw.repaid {
+                total = total.checked_add(draw.amount).map_err(|_| ContractError::Overflow)?;
+            }
+        }
+    }
+    Ok(total)
+}
+
 fn append_audit_entry(
     deps: DepsMut,
     env: Env,
@@ -1280,6 +1396,411 @@ mod tests {
 
             let stored = query_late_fee_config(&deps);
             assert_eq!(stored, Some(apr));
+        }
+    }
+
+    // ── max-utilization cap tests ─────────────────────────────────
+
+    fn create_credit_line(
+        deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+        borrower: &str,
+        credit_amount: &str,
+    ) -> u64 {
+        let env = mock_env();
+        let info = message_info(&creator(deps), &[]);
+        let msg = ExecuteMsg::CreateCreditLine {
+            borrower: borrower.to_string(),
+            collateral_denom: "ucollateral".to_string(),
+            collateral_amount: "1000".to_string(),
+            credit_denom: "ucredit".to_string(),
+            credit_amount: credit_amount.to_string(),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+        0u64
+    }
+
+    fn create_draw(
+        deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
+        credit_line_id: u64,
+        amount: &str,
+    ) {
+        let env = mock_env();
+        let borrower_addr = deps.api.addr_make("borrower");
+        let info = message_info(&borrower_addr, &[]);
+        let msg = ExecuteMsg::CreateDraw {
+            credit_line_id,
+            amount: amount.to_string(),
+            denom: "ucredit".to_string(),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+    }
+
+    mod execute_set_max_utilization {
+        use super::*;
+
+        #[test]
+        fn admin_sets_valid_cap() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            let resp = execute_set_max_utilization(&mut deps, message_info(&admin, &[]), Some(8_000)).unwrap();
+            assert_eq!(resp.attributes[0].key, "action");
+            assert_eq!(resp.attributes[0].value, "set_max_utilization");
+
+            let stored = crate::state::DEFAULT_MAX_UTILIZATION_BPS.load(deps.as_ref().storage).unwrap();
+            assert_eq!(stored, 8_000);
+        }
+
+        #[test]
+        fn admin_resets_cap_to_default() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            execute_set_max_utilization(&mut deps, message_info(&admin, &[]), Some(8_000)).unwrap();
+            execute_set_max_utilization(&mut deps, message_info(&admin, &[]), None).unwrap();
+
+            let stored = crate::state::DEFAULT_MAX_UTILIZATION_BPS.load(deps.as_ref().storage).unwrap();
+            assert_eq!(stored, limits::MAX_UTILIZATION_BPS);
+        }
+
+        #[test]
+        fn non_admin_rejected() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let non_admin = non_admin(&deps);
+
+            let err = execute_set_max_utilization(
+                &mut deps,
+                message_info(&non_admin, &[]),
+                Some(5_000),
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::Unauthorized);
+        }
+
+        #[test]
+        fn exceeds_max_rejected() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            let err = execute_set_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                Some(10_001),
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::InvalidAmount);
+        }
+
+        #[test]
+        fn zero_cap_accepted() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            execute_set_max_utilization(&mut deps, message_info(&admin, &[]), Some(0)).unwrap();
+
+            let stored = crate::state::DEFAULT_MAX_UTILIZATION_BPS.load(deps.as_ref().storage).unwrap();
+            assert_eq!(stored, 0);
+        }
+    }
+
+    mod execute_set_borrower_max_utilization {
+        use super::*;
+
+        #[test]
+        fn admin_sets_borrower_override() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            let borrower = deps.api.addr_make("borrower").to_string();
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.clone(),
+                Some(5_000),
+            )
+            .unwrap();
+
+            let stored = crate::state::BORROWER_MAX_UTILIZATION
+                .may_load(deps.as_ref().storage, &deps.api.addr_validate(&borrower).unwrap())
+                .unwrap();
+            assert_eq!(stored, Some(5_000));
+        }
+
+        #[test]
+        fn admin_clears_borrower_override() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            let borrower = deps.api.addr_make("borrower").to_string();
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.clone(),
+                Some(5_000),
+            )
+            .unwrap();
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.clone(),
+                None,
+            )
+            .unwrap();
+
+            let stored = crate::state::BORROWER_MAX_UTILIZATION
+                .may_load(deps.as_ref().storage, &deps.api.addr_validate(&borrower).unwrap())
+                .unwrap();
+            assert_eq!(stored, None);
+        }
+
+        #[test]
+        fn non_admin_rejected() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let non_admin = non_admin(&deps);
+
+            let err = execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&non_admin, &[]),
+                "borrower".to_string(),
+                Some(5_000),
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::Unauthorized);
+        }
+
+        #[test]
+        fn exceeds_max_rejected() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+            let admin = creator(&deps);
+
+            let err = execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                "borrower".to_string(),
+                Some(10_001),
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::InvalidAmount);
+        }
+    }
+
+    mod utilization_cap_enforcement {
+        use super::*;
+
+        #[test]
+        fn draw_within_cap_accepted() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            // Default cap is 100% (10_000 bps). Credit limit is 500.
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            create_draw(&mut deps, line_id, "400");
+            // 400 <= 500 * 10_000 / 10_000 = 500 -> OK
+        }
+
+        #[test]
+        fn draw_at_cap_boundary_accepted() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            // 500 is exactly 100% of 500
+            create_draw(&mut deps, line_id, "500");
+        }
+
+        #[test]
+        fn draw_exceeding_cap_rejected() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            let borrower = deps.api.addr_make("borrower");
+            let info = message_info(&borrower, &[]);
+            let env = mock_env();
+            let msg = ExecuteMsg::CreateDraw {
+                credit_line_id: line_id,
+                amount: "600".to_string(),
+                denom: "ucredit".to_string(),
+            };
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert_eq!(err, ContractError::MaxUtilizationExceeded);
+        }
+
+        #[test]
+        fn cumulative_draws_respected() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            // Default cap is 100%. Credit limit is 500.
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            create_draw(&mut deps, line_id, "300");
+            let borrower = deps.api.addr_make("borrower");
+            let info = message_info(&borrower, &[]);
+            let env = mock_env();
+            let msg = ExecuteMsg::CreateDraw {
+                credit_line_id: line_id,
+                amount: "201".to_string(),
+                denom: "ucredit".to_string(),
+            };
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert_eq!(err, ContractError::MaxUtilizationExceeded);
+        }
+
+        #[test]
+        fn repaid_draws_free_up_capacity() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            create_draw(&mut deps, line_id, "400");
+
+            // Repay the draw
+            let borrower = deps.api.addr_make("borrower");
+            let info = message_info(&borrower, &[]);
+            let env = mock_env();
+            let msg = ExecuteMsg::RepayDraw {
+                credit_line_id: line_id,
+                draw_id: 0,
+            };
+            execute(deps.as_mut(), env, info, msg).unwrap();
+
+            // Now draw again — the repaid amount frees up capacity
+            let info2 = message_info(&borrower, &[]);
+            let env2 = mock_env();
+            let msg2 = ExecuteMsg::CreateDraw {
+                credit_line_id: line_id,
+                amount: "500".to_string(),
+                denom: "ucredit".to_string(),
+            };
+            execute(deps.as_mut(), env2, info2, msg2).unwrap();
+        }
+
+        #[test]
+        fn lowered_default_cap_blocks_draws() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            // Set default cap to 50% (5_000 bps)
+            let admin = creator(&deps);
+            execute_set_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                Some(5_000),
+            )
+            .unwrap();
+
+            // Credit limit is 500, so max utilization is 250
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            create_draw(&mut deps, line_id, "200");
+
+            // 200 + 60 = 260 > 250 -> rejected
+            let borrower = deps.api.addr_make("borrower");
+            let info = message_info(&borrower, &[]);
+            let env = mock_env();
+            let msg = ExecuteMsg::CreateDraw {
+                credit_line_id: line_id,
+                amount: "60".to_string(),
+                denom: "ucredit".to_string(),
+            };
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert_eq!(err, ContractError::MaxUtilizationExceeded);
+        }
+
+        #[test]
+        fn borrower_override_lowers_cap() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            // Default cap is 100%. Set borrower override to 50% (5_000 bps).
+            let admin = creator(&deps);
+            let borrower = deps.api.addr_make("borrower");
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.to_string(),
+                Some(5_000),
+            )
+            .unwrap();
+
+            // Credit limit is 500, so max utilization is 250
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            create_draw(&mut deps, line_id, "200");
+
+            // 200 + 60 = 260 > 250 -> rejected
+            let info = message_info(&borrower, &[]);
+            let env = mock_env();
+            let msg = ExecuteMsg::CreateDraw {
+                credit_line_id: line_id,
+                amount: "60".to_string(),
+                denom: "ucredit".to_string(),
+            };
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert_eq!(err, ContractError::MaxUtilizationExceeded);
+        }
+
+        #[test]
+        fn zero_cap_blocks_all_draws() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            let admin = creator(&deps);
+            let borrower = deps.api.addr_make("borrower");
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.to_string(),
+                Some(0),
+            )
+            .unwrap();
+
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            let info = message_info(&borrower, &[]);
+            let env = mock_env();
+            let msg = ExecuteMsg::CreateDraw {
+                credit_line_id: line_id,
+                amount: "1".to_string(),
+                denom: "ucredit".to_string(),
+            };
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert_eq!(err, ContractError::MaxUtilizationExceeded);
+        }
+
+        #[test]
+        fn cleared_override_uses_default() {
+            let mut deps = mock_dependencies();
+            setup(&mut deps);
+
+            let admin = creator(&deps);
+            let borrower = deps.api.addr_make("borrower");
+
+            // Set override to 50%, then clear it
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.to_string(),
+                Some(5_000),
+            )
+            .unwrap();
+            execute_set_borrower_max_utilization(
+                &mut deps,
+                message_info(&admin, &[]),
+                borrower.to_string(),
+                None,
+            )
+            .unwrap();
+
+            // Now the borrower should be able to draw up to 100% of credit
+            let line_id = create_credit_line(&mut deps, "borrower", "500");
+            create_draw(&mut deps, line_id, "500");
         }
     }
 }

--- a/contracts/creditra-credit/src/error.rs
+++ b/contracts/creditra-credit/src/error.rs
@@ -102,6 +102,10 @@ pub enum ContractError {
     /// Requested bounty withdrawal exceeds the accumulated bounty balance.
     #[error("InsufficientBountyBalance")]
     InsufficientBountyBalance,
+
+    /// A draw would exceed the borrower's max-utilization cap.
+    #[error("MaxUtilizationExceeded")]
+    MaxUtilizationExceeded,
 }
 
 impl ContractError {
@@ -130,6 +134,7 @@ impl ContractError {
             ContractError::TreasuryAddressNotSet => ContractErrorCategory::State,
             ContractError::BountyAddressNotSet => ContractErrorCategory::State,
             ContractError::LateFeeConfigInvalid => ContractErrorCategory::Validation,
+            ContractError::MaxUtilizationExceeded => ContractErrorCategory::Validation,
         }
     }
 }

--- a/contracts/creditra-credit/src/limits.rs
+++ b/contracts/creditra-credit/src/limits.rs
@@ -1,24 +1,27 @@
 // SPDX-License-Identifier: MIT
 
-//! # Per-borrower interest-rate ceilings
+//! # Per-borrower interest-rate ceilings and max-utilization caps
 //!
-//! Pure, side-effect-free logic for enforcing a cap on the interest rate that
-//! may be charged to any single borrower. Interest rates are expressed in
-//! **basis points** (bps), where `10_000 bps == 100%`.
+//! Pure, side-effect-free logic for enforcing two separate limits on
+//! every borrower:
 //!
-//! ## Model
+//! 1. **Interest-rate ceiling** — a cap on the rate charged to any
+//!    single borrower (existing functionality).
+//! 2. **Max-utilization cap** — a cap on the outstanding drawn amount
+//!    as a percentage of the credit-line credit amount.  Expressed in
+//!    basis points where `10_000 bps == 100%`.
 //!
-//! The protocol maintains two layers of ceiling:
+//! Both limits follow the same two-layer model:
 //!
-//! 1. A protocol-wide **default** ceiling that applies to every borrower who
-//!    has no explicit override.
-//! 2. An optional **per-borrower override** that replaces the default for a
-//!    single borrower.
+//! - A protocol-wide **default** that applies to every borrower who
+//!   has no explicit override.
+//! - An optional **per-borrower override** that replaces the default
+//!   for a single borrower.
 //!
-//! The [`effective_ceiling_bps`] function resolves these two layers: the
-//! per-borrower override always wins when present, otherwise the default
-//! applies. Every configurable ceiling is bounded above by the absolute
-//! protocol maximum [`MAX_RATE_BPS`], which no default or override may exceed.
+//! The [`effective_ceiling_bps`] and [`effective_max_utilization_bps`]
+//! functions resolve these layers respectively.  Every configurable
+//! ceiling is bounded above by its absolute protocol maximum, which no
+//! default or override may exceed.
 //!
 //! ## Security properties
 //!
@@ -26,10 +29,14 @@
 //!   checked operations, and there are no `unwrap()`/`expect()`/`panic!` calls
 //!   in production paths.
 //! - Ceiling configuration is validated at the boundary via
-//!   [`validate_ceiling_bps`], so out-of-range values can never be persisted.
+//!   [`validate_ceiling_bps`] and [`validate_utilization_bps`],
+//!   so out-of-range values can never be persisted.
 //! - Rate enforcement is total: [`check_rate_within_ceiling`] returns a typed
 //!   [`ContractError`] rather than silently clamping, so callers cannot
 //!   accidentally over-charge a borrower.
+//! - Utilization enforcement is total: [`check_utilization_within_cap`] returns
+//!   a typed [`ContractError`] when the proposed draw would push the borrower
+//!   over their cap.
 
 use cosmwasm_std::Uint128;
 
@@ -40,11 +47,129 @@ pub const BPS_DENOMINATOR: u32 = 10_000;
 
 /// Absolute protocol-wide maximum interest rate, in basis points.
 ///
-/// No configured ceiling — neither the default nor any per-borrower override —
+/// No configured ceiling â€” neither the default nor any per-borrower override â€”
 /// may exceed this bound. `10_000 bps == 100%` is chosen as a conservative
 /// hard cap: a per-borrower interest rate above the principal itself is treated
 /// as a configuration error rather than a valid ceiling.
 pub const MAX_RATE_BPS: u32 = 10_000;
+
+/// Absolute protocol-wide maximum utilization cap, in basis points.
+///
+/// No configured utilization cap â€” neither the default nor any per-borrower
+/// override â€” may exceed this bound. `10_000 bps == 100%`, meaning a
+/// borrower may draw up to the full credit-line amount.
+pub const MAX_UTILIZATION_BPS: u32 = 10_000;
+
+/// Return `true` if `bps` is a valid utilization cap value (within [`MAX_UTILIZATION_BPS`]).
+///
+/// A cap of `0` is permitted and means "the borrower may not draw at all".
+pub const fn is_valid_utilization_bps(bps: u32) -> bool {
+    bps <= MAX_UTILIZATION_BPS
+}
+
+/// Validate a utilization-cap value, returning it unchanged when in range.
+///
+/// # Errors
+///
+/// Returns [`ContractError::InvalidAmount`] when `bps` exceeds
+/// [`MAX_UTILIZATION_BPS`].
+pub fn validate_utilization_bps(bps: u32) -> Result<u32, ContractError> {
+    if is_valid_utilization_bps(bps) {
+        Ok(bps)
+    } else {
+        Err(ContractError::InvalidAmount)
+    }
+}
+
+/// Resolve the effective max-utilization cap for a borrower.
+///
+/// The per-borrower `borrower_override` always takes precedence; when it is
+/// `None`, the protocol-wide `default_bps` applies.
+///
+/// # Examples
+///
+/// ```
+/// use creditra_credit::limits::effective_max_utilization_bps;
+///
+/// // No override → default applies.
+/// assert_eq!(effective_max_utilization_bps(5_000, None), 5_000);
+/// // Override present → override wins.
+/// assert_eq!(effective_max_utilization_bps(10_000, Some(8_000)), 8_000);
+/// ```
+pub const fn effective_max_utilization_bps(
+    default_bps: u32,
+    borrower_override: Option<u32>,
+) -> u32 {
+    match borrower_override {
+        Some(bps) => bps,
+        None => default_bps,
+    }
+}
+
+/// Compute the maximum utilization amount permitted under a cap.
+///
+/// `max_allowed = credit_amount * cap_bps / 10_000`, computed with
+/// checked `Uint128` arithmetic so that a large credit amount can never
+/// overflow. The division by the non-zero constant [`BPS_DENOMINATOR`]
+/// truncates toward zero.
+///
+/// # Errors
+///
+/// Returns [`ContractError::InvalidAmount`] if the intermediate
+/// multiplication `credit_amount * cap_bps` overflows `Uint128`.
+pub fn compute_max_allowed_utilization(
+    credit_amount: Uint128,
+    cap_bps: u32,
+) -> Result<Uint128, ContractError> {
+    let scaled = credit_amount
+        .checked_mul(Uint128::from(cap_bps))
+        .map_err(|_| ContractError::InvalidAmount)?;
+    scaled
+        .checked_div(Uint128::from(BPS_DENOMINATOR))
+        .map_err(|_| ContractError::InvalidAmount)
+}
+
+/// Assert that a proposed new draw does not violate the borrower's max-utilization cap.
+///
+/// Checks whether `total_utilized + new_draw_amount <= credit_amount * cap_bps / 10_000`.
+/// The comparison is performed via cross-multiplication to avoid intermediate
+/// division, preserving full `Uint128` precision:
+///
+/// `(total_utilized + new_draw_amount) * 10_000 <= credit_amount * cap_bps`
+///
+/// # Errors
+///
+/// Returns [`ContractError::MaxUtilizationExceeded`] when the proposed draw would
+/// push total utilization over the cap.  Returns [`ContractError::InvalidAmount`]
+/// if the intermediate arithmetic overflows `Uint128`.
+///
+/// # Panics
+///
+/// This function does not panic.  All arithmetic uses checked operations.
+pub fn check_utilization_within_cap(
+    total_utilized: Uint128,
+    new_draw_amount: Uint128,
+    credit_amount: Uint128,
+    cap_bps: u32,
+) -> Result<(), ContractError> {
+    let proposed_total = total_utilized
+        .checked_add(new_draw_amount)
+        .ok_or(ContractError::InvalidAmount)?;
+
+    // Cross-multiply to avoid division:
+    // proposed_total * BPS_DENOMINATOR <= credit_amount * cap_bps
+    let lhs = proposed_total
+        .checked_mul(Uint128::from(BPS_DENOMINATOR))
+        .map_err(|_| ContractError::InvalidAmount)?;
+    let rhs = credit_amount
+        .checked_mul(Uint128::from(cap_bps))
+        .map_err(|_| ContractError::InvalidAmount)?;
+
+    if lhs > rhs {
+        return Err(ContractError::MaxUtilizationExceeded);
+    }
+    Ok(())
+}
 
 /// Return `true` if `bps` is a valid ceiling value (within [`MAX_RATE_BPS`]).
 ///
@@ -320,6 +445,181 @@ mod tests {
         assert_eq!(
             max_interest_for_principal(Uint128::MAX, MAX_RATE_BPS),
             Err(ContractError::InvalidAmount)
+        );
+    }
+
+    // ── is_valid_utilization_bps / validate_utilization_bps ──────────
+
+    #[test]
+    fn zero_utilization_cap_is_valid() {
+        assert!(is_valid_utilization_bps(0));
+        assert_eq!(validate_utilization_bps(0), Ok(0));
+    }
+
+    #[test]
+    fn max_utilization_cap_is_valid() {
+        assert!(is_valid_utilization_bps(MAX_UTILIZATION_BPS));
+        assert_eq!(
+            validate_utilization_bps(MAX_UTILIZATION_BPS),
+            Ok(MAX_UTILIZATION_BPS)
+        );
+    }
+
+    #[test]
+    fn mid_range_utilization_cap_is_valid() {
+        assert!(is_valid_utilization_bps(5_000));
+        assert_eq!(validate_utilization_bps(5_000), Ok(5_000));
+    }
+
+    #[test]
+    fn just_over_max_utilization_is_invalid() {
+        assert!(!is_valid_utilization_bps(MAX_UTILIZATION_BPS + 1));
+        assert_eq!(
+            validate_utilization_bps(MAX_UTILIZATION_BPS + 1),
+            Err(ContractError::InvalidAmount)
+        );
+    }
+
+    #[test]
+    fn far_over_max_utilization_is_invalid() {
+        assert!(!is_valid_utilization_bps(u32::MAX));
+        assert_eq!(
+            validate_utilization_bps(u32::MAX),
+            Err(ContractError::InvalidAmount)
+        );
+    }
+
+    // ── effective_max_utilization_bps ────────────────────────────────
+
+    #[test]
+    fn effective_utilization_falls_back_to_default_when_no_override() {
+        assert_eq!(effective_max_utilization_bps(5_000, None), 5_000);
+        assert_eq!(effective_max_utilization_bps(10_000, None), 10_000);
+    }
+
+    #[test]
+    fn effective_utilization_override_takes_precedence() {
+        assert_eq!(effective_max_utilization_bps(10_000, Some(8_000)), 8_000);
+    }
+
+    #[test]
+    fn effective_zero_utilization_override_disables_draws() {
+        assert_eq!(effective_max_utilization_bps(10_000, Some(0)), 0);
+    }
+
+    // ── compute_max_allowed_utilization ──────────────────────────────
+
+    #[test]
+    fn max_allowed_at_full_cap() {
+        // 100% of 500 == 500
+        assert_eq!(
+            compute_max_allowed_utilization(Uint128::new(500), 10_000),
+            Ok(Uint128::new(500))
+        );
+    }
+
+    #[test]
+    fn max_allowed_at_half_cap() {
+        // 50% of 500 == 250
+        assert_eq!(
+            compute_max_allowed_utilization(Uint128::new(500), 5_000),
+            Ok(Uint128::new(250))
+        );
+    }
+
+    #[test]
+    fn max_allowed_at_zero_cap() {
+        assert_eq!(
+            compute_max_allowed_utilization(Uint128::new(500), 0),
+            Ok(Uint128::zero())
+        );
+    }
+
+    #[test]
+    fn max_allowed_overflow_returns_error() {
+        assert_eq!(
+            compute_max_allowed_utilization(Uint128::MAX, 10_000),
+            Err(ContractError::InvalidAmount)
+        );
+    }
+
+    // ── check_utilization_within_cap ─────────────────────────────────
+
+    #[test]
+    fn utilization_within_cap_ok() {
+        assert_eq!(
+            check_utilization_within_cap(
+                Uint128::new(100),
+                Uint128::new(50),
+                Uint128::new(500),
+                5_000,
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn utilization_at_exact_cap_ok() {
+        // 400 is exactly 80% of 500 at 8000 bps
+        assert_eq!(
+            check_utilization_within_cap(
+                Uint128::new(300),
+                Uint128::new(100),
+                Uint128::new(500),
+                8_000,
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn utilization_over_cap_rejected() {
+        assert_eq!(
+            check_utilization_within_cap(
+                Uint128::new(300),
+                Uint128::new(200),
+                Uint128::new(500),
+                8_000,
+            ),
+            Err(ContractError::MaxUtilizationExceeded)
+        );
+    }
+
+    #[test]
+    fn zero_cap_rejects_any_positive_draw() {
+        assert_eq!(check_utilization_within_cap(0, Uint128::new(1), Uint128::new(500), 0,),
+            Err(ContractError::MaxUtilizationExceeded));
+    }
+
+    #[test]
+    fn zero_cap_allows_zero_draw() {
+        assert_eq!(check_utilization_within_cap(0, Uint128::zero(), Uint128::new(500), 0,),
+            Ok(()));
+    }
+
+    #[test]
+    fn overflow_in_proposed_total_returns_error() {
+        assert_eq!(
+            check_utilization_within_cap(
+                Uint128::MAX,
+                Uint128::new(1),
+                Uint128::new(500),
+                10_000,
+            ),
+            Err(ContractError::InvalidAmount)
+        );
+    }
+
+    #[test]
+    fn zero_credit_amount_allows_zero_utilization() {
+        assert_eq!(
+            check_utilization_within_cap(
+                Uint128::zero(),
+                Uint128::zero(),
+                Uint128::zero(),
+                10_000,
+            ),
+            Ok(())
         );
     }
 }

--- a/contracts/creditra-credit/src/msg.rs
+++ b/contracts/creditra-credit/src/msg.rs
@@ -94,6 +94,23 @@ pub enum ExecuteMsg {
         denom: String,
         risk_weight_bps: u32,
     },
+    /// Set the protocol-wide default max-utilization cap (admin only).
+    ///
+    /// `max_utilization_bps` is in basis points where `10_000 == 100%`.
+    /// This default applies to all borrowers who have no per-borrower
+    /// override.  Passing `None` resets the default to 100% (10_000 bps).
+    SetMaxUtilization {
+        max_utilization_bps: Option<u32>,
+    },
+    /// Set a per-borrower max-utilization override (admin only).
+    ///
+    /// When set, this borrower's cap supersedes the protocol-wide
+    /// default returned by [`SetMaxUtilization`].  Passing `None`
+    /// removes the override, falling the borrower back to the default.
+    SetBorrowerMaxUtilization {
+        borrower: String,
+        max_utilization_bps: Option<u32>,
+    },
 }
 
 #[cw_serde]

--- a/contracts/creditra-credit/src/state.rs
+++ b/contracts/creditra-credit/src/state.rs
@@ -96,6 +96,20 @@ pub const DRAW_AUDIT: Map<(u64, u64, u64), DrawAuditEntry> = Map::new("da");
 /// because each `Addr` serialises to a distinct canonical bech32 byte string.
 pub const BORROWER_TO_ID: Map<Addr, u64> = Map::new("bid");
 
+/// Protocol-wide default max-utilization cap (basis points).
+///
+/// When no per-borrower override is set, this default applies to all
+/// borrowers.  `10_000 bps == 100%`, meaning the borrower may draw up
+/// to the full `credit_amount` of the credit line.
+pub const DEFAULT_MAX_UTILIZATION_BPS: Item<u32> = Item::new("def_max_util");
+
+/// Per-borrower max-utilization override in basis points (0..=10_000).
+///
+/// Keyed by borrower `Addr`.  When present, it supersedes
+/// [`DEFAULT_MAX_UTILIZATION_BPS`] for that borrower.  A value of 0
+/// means the borrower may not draw at all.
+pub const BORROWER_MAX_UTILIZATION: Map<Addr, u32> = Map::new("bor_max_util");
+
 /// Multi-oracle quorum configuration for redundancy median resolution.
 #[cw_serde]
 pub struct OracleQuorumConfig {


### PR DESCRIPTION
Add per-borrower max-utilization cap to limit how much a borrower can draw relative to their credit line amount.

Changes:
- Add MaxUtilizationExceeded error variant in error.rs
- Add DEFAULT_MAX_UTILIZATION_BPS and BORROWER_MAX_UTILIZATION storage items in state.rs
- Add utilization cap logic in limits.rs with validate_utilization_bps, effective_max_utilization_bps, compute_max_allowed_utilization, and check_utilization_within_cap functions
- Add SetMaxUtilization and SetBorrowerMaxUtilization execute variants in msg.rs with admin-only handlers in contract.rs
- Enforce utilization cap in execute_create_draw
- Add compute_total_utilized helper for summing un-repaid draws
- Add focused unit tests covering cap enforcement, overrides, and edge cases

Closes #738