### PR TITLE
feat: collateral capabilities view

### DIFF
--- a/contracts/collateral/Cargo.toml
+++ b/contracts/collateral/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+name = "creditra_collateral"
 
 [dependencies]
 soroban-sdk = { workspace = true }
@@ -18,6 +19,14 @@ creditra-credit = { path = "../credit" }
 [[test]]
 name = "admin_cooldown"
 path = "tests/admin_cooldown.rs"
+
+[[test]]
+name = "capabilities"
+path = "tests/capabilities.rs"
+
+[[test]]
+name = "capabilities"
+path = "tests/capabilities.rs"
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/collateral/src/lib.rs
+++ b/contracts/collateral/src/lib.rs
@@ -6,5 +6,17 @@
 //! Implementation lives in [`creditra_credit`] via
 //! `contracts/collateral/src/admin.rs` (compiled into the credit crate).
 //! This crate anchors focused integration tests for the v7 admin cooldown guard.
+//!
+//! # Modules
+//!
+//! - [`views`] — read-only `collateral_capabilities` bitmap view (#861).
 
 pub use creditra_credit::*;
+
+/// Read-only capabilities view for collateral operations.
+///
+/// Re-exports [`views::collateral_capabilities`] at the crate root so callers
+/// can use `creditra_collateral::collateral_capabilities` without knowing the
+/// internal module structure.
+pub mod views;
+pub use views::collateral_capabilities;

--- a/contracts/collateral/src/views.rs
+++ b/contracts/collateral/src/views.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+
+//! Read-only capabilities view for collateral operations (v7).
+//!
+//! This module exposes [`collateral_capabilities`] — a pure read that computes
+//! which collateral operations are currently permitted for a given borrower by
+//! querying the credit contract's public entrypoints via [`CreditClient`].
+//!
+//! # Why a separate module
+//!
+//! The capabilities bitmap is a convenient utility for off-chain dashboards,
+//! integration tests, and on-chain composability layers that want to check
+//! collateral pre-conditions before constructing a transaction. Rather than
+//! replicating the logic in every caller, this helper centralizes it in the
+//! collateral crate.
+//!
+//! # No authentication required
+//!
+//! [`collateral_capabilities`] only calls read-only entrypoints on the credit
+//! contract. It does not mutate state and requires no auth on the caller side.
+//!
+//! # What is evaluated
+//!
+//! The function evaluates the same structural pre-flight checks that
+//! `deposit_collateral`, `withdraw_collateral`, and
+//! `partial_release_collateral` perform, **except** amount-dependent checks
+//! (health-factor post-withdrawal, exposure caps). A `true` value means the
+//! structural preconditions pass; the actual entrypoint may still revert if
+//! the supplied amount violates numeric limits.
+//!
+//! # See also
+//! - `contracts/credit/src/views.rs::borrow_capabilities` — borrow-side bitmap.
+//! - `contracts/credit/src/types.rs::CollateralCapabilities` — returned struct.
+
+use creditra_credit::types::{CollateralCapabilities, CreditStatus};
+use creditra_credit::CreditClient;
+use soroban_sdk::{Address, Env};
+
+/// Return the collateral-operation capabilities bitmap for `borrower`.
+///
+/// Queries the Creditra credit contract at `contract_id` on `env` for all
+/// relevant state, then derives the capability flags from that state.
+///
+/// # Parameters
+///
+/// - `env` — the Soroban environment.
+/// - `contract_id` — the address of the deployed `Credit` contract.
+/// - `borrower` — the borrower address to query.
+///
+/// # Returns
+///
+/// A [`CollateralCapabilities`] struct with six fields:
+///
+/// | Field                  | Meaning                                               |
+/// |------------------------|-------------------------------------------------------|
+/// | `can_deposit`          | `deposit_collateral` structural preconditions pass    |
+/// | `can_withdraw`         | `can_deposit` AND `collateral_balance > 0`            |
+/// | `can_partial_release`  | `can_withdraw` AND positive utilization               |
+/// | `collateral_required`  | `min_ratio_bps > 0` AND positive utilization          |
+/// | `collateral_balance`   | Current accounting collateral balance (i128 units)    |
+/// | `min_ratio_bps`        | Configured minimum collateral ratio bps (`0` = off)   |
+///
+/// # Examples
+///
+/// ```ignore
+/// let caps = collateral_capabilities(env, contract_id, borrower);
+/// if caps.can_deposit {
+///     // safe to construct a deposit_collateral transaction
+/// }
+/// if caps.collateral_required && !caps.can_deposit {
+///     // borrower is blocked or line is closed — warn the user
+/// }
+/// ```
+///
+/// # Security
+///
+/// Pure read-only. No state mutations. No `require_auth`. TTL may be bumped
+/// on the borrower's persistent storage entry as a side-effect of reading
+/// the credit line.
+pub fn collateral_capabilities(
+    env: Env,
+    contract_id: Address,
+    borrower: Address,
+) -> CollateralCapabilities {
+    let client = CreditClient::new(&env, &contract_id);
+
+    // ── Fetch all relevant state via read-only query entrypoints ────────────
+
+    // Per-borrower credit line (status, utilized_amount).
+    let line_opt = client.get_credit_line(&borrower);
+
+    // Per-borrower collateral accounting balance.
+    let collateral_balance = client.get_collateral(&borrower);
+
+    // Protocol-wide minimum collateral ratio (0 = disabled / not set).
+    let min_ratio_bps = client.get_min_collateral_ratio_bps().unwrap_or(0);
+
+    // Protocol pause flag.
+    let paused = client.is_protocol_paused();
+
+    // Borrower-level block flag.
+    let blocked = client.is_borrower_blocked(&borrower);
+
+    // ── Derive structural capability flags ──────────────────────────────────
+
+    // Line exists and is NOT permanently Closed.
+    let line_open = line_opt
+        .as_ref()
+        .map(|l| l.status != CreditStatus::Closed)
+        .unwrap_or(false);
+
+    // Shared base condition: protocol is live, line exists/open, borrower unblocked.
+    let base_ok = !paused && line_open && !blocked;
+
+    // `can_deposit` — all base preconditions pass; amount checks are deferred.
+    let can_deposit = base_ok;
+
+    // `can_withdraw` — additionally requires a positive collateral balance.
+    let can_withdraw = base_ok && collateral_balance > 0;
+
+    // Outstanding principal drawn by the borrower.
+    let utilized = line_opt.as_ref().map(|l| l.utilized_amount).unwrap_or(0);
+
+    // `can_partial_release` — partial release only makes sense when the
+    // borrower has both collateral AND outstanding debt to partially release
+    // against.
+    let can_partial_release = can_withdraw && utilized > 0;
+
+    // `collateral_required` — the protocol enforces a minimum ratio AND the
+    // borrower has active debt (so the constraint is binding for this line).
+    let collateral_required = min_ratio_bps > 0 && utilized > 0;
+
+    CollateralCapabilities {
+        can_deposit,
+        can_withdraw,
+        can_partial_release,
+        collateral_required,
+        collateral_balance,
+        min_ratio_bps,
+    }
+}

--- a/contracts/collateral/tests/capabilities.rs
+++ b/contracts/collateral/tests/capabilities.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+
+//! Focused tests for the `collateral_capabilities` view (v7, issue #861).
+//!
+//! # What
+//!
+//! Exercises the [`creditra_collateral::views::collateral_capabilities`] helper
+//! across all permutations of protocol state that affect each capability flag:
+//!
+//! - `can_deposit` — blocked by: paused protocol, no credit line, Closed line, blocked borrower.
+//! - `can_withdraw` — additionally blocked when collateral balance is zero.
+//! - `can_partial_release` — additionally blocked when utilization is zero.
+//! - `collateral_required` — true only when `min_ratio_bps > 0` AND utilization > 0.
+//! - `collateral_balance` — mirrors `get_collateral` value.
+//! - `min_ratio_bps` — mirrors `get_min_collateral_ratio_bps` value.
+//!
+//! # See also
+//! - `contracts/credit/src/types.rs::CollateralCapabilities` — struct definition.
+//! - `contracts/collateral/src/views.rs` — implementation.
+
+use creditra_collateral::views::collateral_capabilities;
+use creditra_collateral::Credit;
+use creditra_collateral::CreditClient;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{token, Address, Env};
+
+const INITIAL_TS: u64 = 1_000;
+
+// ── Setup helpers ────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, CreditClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = INITIAL_TS);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token_addr = token_id.address();
+    client.set_liquidity_token(&token_addr);
+    client.set_liquidity_source(&contract_id);
+
+    token::StellarAssetClient::new(&env, &token_addr).mint(&contract_id, &5_000_000_i128);
+
+    (env, contract_id, client, admin)
+}
+
+// ── Test 1: no credit line ───────────────────────────────────────────────────
+
+/// A phantom borrower with no credit line must get all-false structural flags.
+#[test]
+fn caps_no_credit_line_all_blocked() {
+    let (env, contract_id, _client, _) = setup();
+    let phantom = Address::generate(&env);
+
+    let caps = collateral_capabilities(env, contract_id, phantom);
+
+    assert!(!caps.can_deposit, "no line: can_deposit must be false");
+    assert!(!caps.can_withdraw, "no line: can_withdraw must be false");
+    assert!(!caps.can_partial_release, "no line: can_partial_release must be false");
+    assert!(!caps.collateral_required, "no line: collateral_required must be false");
+    assert_eq!(caps.collateral_balance, 0);
+    assert_eq!(caps.min_ratio_bps, 0);
+}
+
+// ── Test 2: active line, no collateral ───────────────────────────────────────
+
+/// An active line with no collateral deposited: can_deposit=true, rest structural flags false.
+#[test]
+fn caps_active_line_no_collateral() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(caps.can_deposit, "active line: can_deposit must be true");
+    assert!(!caps.can_withdraw, "no collateral: can_withdraw must be false");
+    assert!(!caps.can_partial_release, "no collateral: can_partial_release must be false");
+    assert!(!caps.collateral_required, "no min ratio set: collateral_required must be false");
+    assert_eq!(caps.collateral_balance, 0);
+    assert_eq!(caps.min_ratio_bps, 0);
+}
+
+// ── Test 3: active line, collateral deposited, no utilization ────────────────
+
+/// After depositing collateral: can_withdraw=true, but can_partial_release=false (no draw).
+#[test]
+fn caps_active_line_with_collateral_no_draw() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    // Mint collateral token for borrower.
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let col_token = token_id.address();
+    token::StellarAssetClient::new(&env, &col_token).mint(&borrower, &100_000_i128);
+
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    client.deposit_collateral(&borrower, &10_000_i128);
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(caps.can_deposit, "active line: can_deposit must be true");
+    assert!(caps.can_withdraw, "collateral deposited: can_withdraw must be true");
+    assert!(!caps.can_partial_release, "no draw: can_partial_release must be false");
+    assert_eq!(caps.collateral_balance, 10_000_i128);
+}
+
+// ── Test 4: active line, collateral deposited, drawn ─────────────────────────
+
+/// With collateral AND utilization: all three operation flags true.
+#[test]
+fn caps_active_line_with_collateral_and_draw() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let col_token = token_id.address();
+    token::StellarAssetClient::new(&env, &col_token).mint(&borrower, &100_000_i128);
+
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    client.deposit_collateral(&borrower, &20_000_i128);
+    client.draw_credit(&borrower, &5_000_i128);
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(caps.can_deposit);
+    assert!(caps.can_withdraw);
+    assert!(caps.can_partial_release, "collateral + draw: can_partial_release must be true");
+    assert_eq!(caps.collateral_balance, 20_000_i128);
+}
+
+// ── Test 5: paused protocol blocks deposit and withdraw ───────────────────────
+
+/// Pausing the protocol must set all structural operation flags to false.
+#[test]
+fn caps_paused_protocol_blocks_all() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let col_token = token_id.address();
+    token::StellarAssetClient::new(&env, &col_token).mint(&borrower, &100_000_i128);
+
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    client.deposit_collateral(&borrower, &10_000_i128);
+    client.draw_credit(&borrower, &5_000_i128);
+
+    // Pause the protocol.
+    client.pause_protocol();
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(!caps.can_deposit, "paused: can_deposit must be false");
+    assert!(!caps.can_withdraw, "paused: can_withdraw must be false");
+    assert!(!caps.can_partial_release, "paused: can_partial_release must be false");
+    // Balance and ratio are still reported correctly.
+    assert_eq!(caps.collateral_balance, 10_000_i128);
+}
+
+// ── Test 6: blocked borrower ─────────────────────────────────────────────────
+
+/// A blocked borrower must get all operation flags set to false.
+#[test]
+fn caps_blocked_borrower_all_blocked() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let col_token = token_id.address();
+    token::StellarAssetClient::new(&env, &col_token).mint(&borrower, &100_000_i128);
+
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    client.deposit_collateral(&borrower, &10_000_i128);
+
+    // Block the borrower.
+    client.block_borrower(&borrower);
+
+    let caps = collateral_capabilities(env, contract_id, borrower.clone());
+
+    assert!(!caps.can_deposit, "blocked: can_deposit must be false");
+    assert!(!caps.can_withdraw, "blocked: can_withdraw must be false");
+    assert!(!caps.can_partial_release, "blocked: can_partial_release must be false");
+}
+
+// ── Test 7: min_ratio_bps set and utilized → collateral_required ─────────────
+
+/// When `min_collateral_ratio_bps` is configured and the borrower has drawn,
+/// `collateral_required` must be `true`.
+#[test]
+fn caps_collateral_required_when_ratio_set_and_drawn() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let col_token = token_id.address();
+    token::StellarAssetClient::new(&env, &col_token).mint(&borrower, &100_000_i128);
+
+    client.set_min_collateral_ratio_bps(&15_000_u32);
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    client.deposit_collateral(&borrower, &20_000_i128);
+    client.draw_credit(&borrower, &5_000_i128);
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(caps.collateral_required, "ratio set + drawn: collateral_required must be true");
+    assert_eq!(caps.min_ratio_bps, 15_000_u32);
+}
+
+// ── Test 8: min_ratio_bps set but no draw → collateral_required false ────────
+
+/// When `min_collateral_ratio_bps` is set but the borrower has not drawn,
+/// `collateral_required` must be `false` (no debt means no enforcement).
+#[test]
+fn caps_collateral_required_false_when_no_draw() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+    client.set_min_collateral_ratio_bps(&15_000_u32);
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(!caps.collateral_required, "no draw: collateral_required must be false even with ratio set");
+    assert_eq!(caps.min_ratio_bps, 15_000_u32);
+}
+
+// ── Test 9: Closed credit line blocks operations ──────────────────────────────
+
+/// A permanently closed credit line must set all operation flags to false.
+#[test]
+fn caps_closed_credit_line_all_blocked() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    // Close without drawing (utilization = 0 allows direct close).
+    client.close_credit_line(&borrower);
+
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert!(!caps.can_deposit, "closed line: can_deposit must be false");
+    assert!(!caps.can_withdraw, "closed line: can_withdraw must be false");
+    assert!(!caps.can_partial_release, "closed line: can_partial_release must be false");
+}
+
+// ── Test 10: collateral_balance mirrors get_collateral ───────────────────────
+
+/// The `collateral_balance` field must equal what `get_collateral` returns
+/// directly.
+#[test]
+fn caps_collateral_balance_consistent_with_get_collateral() {
+    let (env, contract_id, client, _) = setup();
+    let borrower = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let col_token = token_id.address();
+    token::StellarAssetClient::new(&env, &col_token).mint(&borrower, &100_000_i128);
+
+    client.open_credit_line(&borrower, &50_000_i128, &500_u32, &30_u32);
+    client.deposit_collateral(&borrower, &7_500_i128);
+
+    let direct_balance = client.get_collateral(&borrower);
+    let caps = collateral_capabilities(env, contract_id, borrower);
+
+    assert_eq!(
+        caps.collateral_balance,
+        direct_balance,
+        "collateral_balance must match get_collateral"
+    );
+    assert_eq!(caps.collateral_balance, 7_500_i128);
+}

--- a/contracts/credit/src/types.rs
+++ b/contracts/credit/src/types.rs
@@ -720,6 +720,75 @@ pub struct PauseReason {
     pub actor: soroban_sdk::Address,
 }
 
+/// Read-only capabilities bitmap for collateral operations on a borrower's position.
+///
+/// Returned by the `capabilities()` view in `contracts/collateral/src/views.rs`.
+/// Lets off-chain clients and on-chain integrators inspect which collateral
+/// operations are currently permitted without simulating the full entrypoint.
+///
+/// # Semantics
+///
+/// Each `bool` field represents one collateral operation:
+/// - `true` — the operation is currently permitted (all preconditions pass).
+/// - `false` — the operation is blocked for the indicated reason.
+///
+/// Amount-dependent checks (minimum collateral ratio, exposure caps) are NOT
+/// evaluated because this view does not know the intended deposit/withdraw
+/// amount. A `true` value means the structural preconditions pass; the actual
+/// entrypoint may still revert if the supplied amount violates numeric limits.
+///
+/// # Security
+///
+/// Pure read-only view. No authentication required. No state mutations. TTL
+/// may be bumped on the borrower's persistent storage entry as a side-effect
+/// of reading the credit line, but this does not change logical state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CollateralCapabilities {
+    /// Whether the borrower can deposit additional collateral.
+    ///
+    /// `true` when:
+    /// - The protocol is not paused.
+    /// - The borrower's credit line exists and is not permanently `Closed`.
+    /// - The borrower is not on the blocked list.
+    pub can_deposit: bool,
+
+    /// Whether the borrower can withdraw collateral.
+    ///
+    /// `true` when:
+    /// - The protocol is not paused.
+    /// - The borrower's credit line exists and is not permanently `Closed`.
+    /// - The borrower is not on the blocked list.
+    /// - The borrower has a positive collateral balance (`> 0`).
+    ///
+    /// Amount-dependent checks (health factor ≥ `MinCollateralRatioBps`
+    /// post-withdrawal) are NOT evaluated here.
+    pub can_withdraw: bool,
+
+    /// Whether the borrower can perform a partial collateral release.
+    ///
+    /// `true` when all conditions for `can_withdraw` hold AND the borrower
+    /// has outstanding utilization (partial release only makes sense when
+    /// the position is actively borrowed against).
+    pub can_partial_release: bool,
+
+    /// Whether collateral is currently required for this borrower's position.
+    ///
+    /// `true` when the global `MinCollateralRatioBps` is set (> 0) and the
+    /// borrower has positive utilization. This signals to the borrower that
+    /// their draws are subject to collateral enforcement.
+    pub collateral_required: bool,
+
+    /// The borrower's current collateral balance in the protocol's accounting
+    /// unit (same units as `utilized_amount`). Zero when no collateral has
+    /// been deposited or when the borrower has no credit line.
+    pub collateral_balance: i128,
+
+    /// The configured minimum collateral ratio in basis points, or `0` when
+    /// collateral enforcement is disabled.
+    pub min_ratio_bps: u32,
+}
+
 /// Error categories for client-side grouping of [`ContractError`] variants.
 ///
 /// # Discriminant stability


### PR DESCRIPTION
Add read-only CollateralCapabilities bitmap for collateral (v7) — issue #861.

Changes:
- contracts/credit/src/types.rs: add CollateralCapabilities struct with six fields: can_deposit, can_withdraw, can_partial_release, collateral_required, collateral_balance, min_ratio_bps. Tagged #[contracttype] and documented.

- contracts/collateral/src/views.rs (new): collateral_capabilities() function that queries CreditClient for credit line, collateral balance, min ratio, pause state, and block state, then derives the capability flags without any amount-dependent checks.

- contracts/collateral/src/lib.rs: expose pub mod views and re-export collateral_capabilities at the crate root.

- contracts/collateral/tests/capabilities.rs (new): 10 focused integration tests covering: no credit line, active with no collateral, with collateral and no draw, with collateral and draw, paused protocol, blocked borrower, collateral_required when ratio set and drawn, no draw, closed line, and collateral_balance consistency with get_collateral.

- contracts/collateral/Cargo.toml: add capabilities test target.

closes #861