### PR TITLE
docs: rustdoc query

### DIFF
--- a/contracts/query/Cargo.toml
+++ b/contracts/query/Cargo.toml
@@ -27,6 +27,10 @@ path = "tests/events.rs"
 name = "capabilities"
 path = "tests/capabilities.rs"
 
+[[test]]
+name = "rustdoc_query_tests"
+path = "tests/rustdoc_query_tests.rs"
+
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 creditra-credit = { path = "../credit", features = [] }

--- a/contracts/query/src/events.rs
+++ b/contracts/query/src/events.rs
@@ -12,11 +12,11 @@
 //!
 //! # Events
 //!
-//! | Event struct                  | Topic                        | Emitted when …                                    |
-//! |-------------------------------|------------------------------|---------------------------------------------------|
-//! | [`CreditLineQueriedEvent`]    | `("query", "cl_read")`       | `get_credit_line` is called for a borrower        |
-//! | [`HealthFactorQueriedEvent`]  | `("query", "hf_read")`       | `get_health_factor` is called for a borrower      |
-//! | [`DelinquencyCheckedEvent`]   | `("query", "dlq_chk")`       | `is_delinquent` is called for a borrower          |
+//! | Event struct                    | Topic                      | Emitted when …                                    |
+//! |---------------------------------|----------------------------|---------------------------------------------------|
+//! | [`CreditLineQueriedEvent`]      | `("query", "cl_read")`     | `get_credit_line` is called for a borrower        |
+//! | [`HealthFactorQueriedEvent`]    | `("query", "hf_read")`     | `get_health_factor` is called for a borrower      |
+//! | [`DelinquencyCheckedEvent`]     | `("query", "dlq_chk")`     | `is_delinquent` is called for a borrower          |
 //! | [`ProtocolSummaryQueriedEvent`] | `("query", "proto_rd")`    | `get_protocol_summary` is called                  |
 //!
 //! # Topics
@@ -32,6 +32,7 @@
 //! (e.g., `("query", "cl_read2")`). Existing topics must not be repurposed.
 //!
 //! # See also
+//!
 //! - [`creditra_credit::query`] — the read-only query implementation.
 //! - [`contracts/accrual/src/events.rs`] — accrual event pattern reference.
 
@@ -42,12 +43,21 @@ use soroban_sdk::{contracttype, symbol_short, Address, Env};
 /// Emitted when `get_credit_line` is called for a borrower.
 ///
 /// # Fields
-/// - `borrower`: The address whose credit line was queried.
-/// - `found`: `true` when a credit line record exists; `false` when `None`.
-/// - `timestamp`: Ledger timestamp at which the query was executed.
+///
+/// | Field | Type | Description |
+/// |-------|------|-------------|
+/// | `borrower` | `Address` | The address whose credit line was queried |
+/// | `found` | `bool` | `true` when a credit-line record exists; `false` when `None` |
+/// | `timestamp` | `u64` | Ledger timestamp at which the query was executed |
 ///
 /// # Topic
-/// `("query", "cl_read")`
+///
+/// `("query", "cl_read")` — both segments encoded with `symbol_short!`.
+///
+/// # ABI stability
+///
+/// Field positions are stable. New fields may only be appended. The topic
+/// string `"cl_read"` is pinned; do not reuse it for a different payload.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreditLineQueriedEvent {
@@ -62,13 +72,23 @@ pub struct CreditLineQueriedEvent {
 /// Emitted when `get_health_factor` is called for a borrower.
 ///
 /// # Fields
-/// - `borrower`: The address whose health factor was queried.
-/// - `health_bps`: The computed health factor in basis points.
-///   `u32::MAX` indicates zero utilization (infinitely healthy).
-/// - `timestamp`: Ledger timestamp at which the query was executed.
+///
+/// | Field | Type | Description |
+/// |-------|------|-------------|
+/// | `borrower` | `Address` | The address whose health factor was queried |
+/// | `health_bps` | `u32` | Computed health factor in basis points; `u32::MAX` = zero utilization |
+/// | `timestamp` | `u64` | Ledger timestamp at which the query was executed |
+///
+/// # `health_bps` interpretation
+///
+/// - `u32::MAX` — the borrower has no outstanding debt (infinitely healthy).
+/// - `< 10_000` — under-collateralized; position is eligible for liquidation.
+/// - `10_000` — collateral exactly meets the minimum ratio.
+/// - `> 10_000` — over-collateralized.
 ///
 /// # Topic
-/// `("query", "hf_read")`
+///
+/// `("query", "hf_read")` — both segments encoded with `symbol_short!`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HealthFactorQueriedEvent {
@@ -84,13 +104,23 @@ pub struct HealthFactorQueriedEvent {
 /// Emitted when `is_delinquent` is called for a borrower.
 ///
 /// # Fields
-/// - `borrower`: The address whose delinquency status was checked.
-/// - `is_delinquent`: `true` when the borrower has missed an installment
-///   past the grace window; `false` otherwise.
-/// - `timestamp`: Ledger timestamp at which the check was executed.
+///
+/// | Field | Type | Description |
+/// |-------|------|-------------|
+/// | `borrower` | `Address` | The address whose delinquency status was checked |
+/// | `is_delinquent` | `bool` | `true` when the borrower has missed an installment past the grace window |
+/// | `timestamp` | `u64` | Ledger timestamp at which the check was executed |
+///
+/// # `is_delinquent` semantics
+///
+/// `false` is also returned when the short-circuit conditions are not met:
+/// no credit line, closed line, zero utilization, or no repayment schedule.
+/// Publishers should record the exact conditions in the surrounding call
+/// context rather than relying solely on this flag for audit trails.
 ///
 /// # Topic
-/// `("query", "dlq_chk")`
+///
+/// `("query", "dlq_chk")` — both segments encoded with `symbol_short!`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelinquencyCheckedEvent {
@@ -105,12 +135,23 @@ pub struct DelinquencyCheckedEvent {
 /// Emitted when `get_protocol_summary` is called.
 ///
 /// # Fields
-/// - `total_utilized`: Global sum of all credit line `utilized_amount` values.
-/// - `active_line_count`: Number of currently Active credit lines.
-/// - `timestamp`: Ledger timestamp at which the summary was read.
+///
+/// | Field | Type | Description |
+/// |-------|------|-------------|
+/// | `total_utilized` | `i128` | Global sum of all credit-line `utilized_amount` values at query time |
+/// | `active_line_count` | `u32` | Number of Active credit lines at query time |
+/// | `timestamp` | `u64` | Ledger timestamp at which the summary was read |
+///
+/// # Notes
+///
+/// - `total_utilized` reflects the lazy-accrual state: it does not include
+///   pending interest since each borrower's last checkpoint.
+/// - `active_line_count` counts only lines with status `Active`; Suspended,
+///   Defaulted, and Closed lines are excluded.
 ///
 /// # Topic
-/// `("query", "proto_rd")`
+///
+/// `("query", "proto_rd")` — both segments encoded with `symbol_short!`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProtocolSummaryQueriedEvent {
@@ -124,11 +165,61 @@ pub struct ProtocolSummaryQueriedEvent {
 
 // ── Publisher helpers ─────────────────────────────────────────────────────────
 
-/// Publish a credit-line-queried event.
+/// Publish a [`CreditLineQueriedEvent`] to the Soroban event ledger.
 ///
-/// # Topic
-/// `("query", "cl_read")` — emitted once per `get_credit_line` call that
-/// opts in to on-chain observability.
+/// Opt-in observability for `get_credit_line` call sites. Invoke this helper
+/// alongside `get_credit_line` when you want the read to be observable by
+/// off-chain indexers.
+///
+/// # Parameters
+///
+/// - `env`: Soroban execution environment.  Must be the active contract
+///   environment; the event is attributed to the currently executing contract.
+/// - `event`: Fully constructed [`CreditLineQueriedEvent`] payload.  The
+///   caller is responsible for populating `borrower`, `found`, and `timestamp`
+///   before passing the struct here.
+///
+/// # Returns
+///
+/// `()` — this function has no return value.  On success, exactly one event
+/// is appended to the transaction's event log.
+///
+/// # Errors
+///
+/// This function does not panic or return an error under normal operation.
+/// Soroban's event API itself is infallible in the WASM context.
+///
+/// # Security
+///
+/// - Events are append-only and cannot be removed or altered after emission.
+/// - The emitted topic and payload are visible to all indexers watching the
+///   `("query", "cl_read")` filter — do not include sensitive fields.
+/// - There is no auth gate: any code executing inside the contract can call
+///   this helper.  It must only be called from within a trusted call path.
+///
+/// # ABI stability
+///
+/// The topic string `("query", "cl_read")` is pinned.  The payload layout
+/// ([`CreditLineQueriedEvent`] field order) is stable; new fields may only
+/// be appended.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use creditra_query::events::{publish_credit_line_queried, CreditLineQueriedEvent};
+///
+/// let event = CreditLineQueriedEvent {
+///     borrower: borrower.clone(),
+///     found: line.is_some(),
+///     timestamp: env.ledger().timestamp(),
+/// };
+/// publish_credit_line_queried(&env, event);
+/// ```
+///
+/// # See also
+///
+/// - [`CreditLineQueriedEvent`] — the payload type.
+/// - [`publish_health_factor_queried`] — companion helper for health-factor reads.
 pub fn publish_credit_line_queried(env: &Env, event: CreditLineQueriedEvent) {
     env.events().publish(
         (symbol_short!("query"), symbol_short!("cl_read")),
@@ -136,11 +227,59 @@ pub fn publish_credit_line_queried(env: &Env, event: CreditLineQueriedEvent) {
     );
 }
 
-/// Publish a health-factor-queried event.
+/// Publish a [`HealthFactorQueriedEvent`] to the Soroban event ledger.
 ///
-/// # Topic
-/// `("query", "hf_read")` — emitted once per `get_health_factor` call that
-/// opts in to on-chain observability.
+/// Opt-in observability for `get_health_factor` call sites. Invoke this
+/// helper alongside `get_health_factor` when you want the read to be
+/// observable by off-chain indexers and liquidation bots.
+///
+/// # Parameters
+///
+/// - `env`: Soroban execution environment.  Must be the active contract
+///   environment; the event is attributed to the currently executing contract.
+/// - `event`: Fully constructed [`HealthFactorQueriedEvent`] payload.
+///   The caller is responsible for populating `borrower`, `health_bps`
+///   (from the return value of `get_health_factor`), and `timestamp`.
+///
+/// # Returns
+///
+/// `()` — this function has no return value.  On success, exactly one event
+/// is appended to the transaction's event log.
+///
+/// # Errors
+///
+/// This function does not panic or return an error under normal operation.
+///
+/// # Security
+///
+/// - The emitted topic `("query", "hf_read")` and payload are visible to all
+///   indexers.  `health_bps = u32::MAX` is the public sentinel for zero
+///   utilization and is safe to emit.
+/// - There is no auth gate; callers must only invoke this from trusted paths.
+///
+/// # ABI stability
+///
+/// The topic string `("query", "hf_read")` is pinned.  Field order in
+/// [`HealthFactorQueriedEvent`] is stable.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use creditra_query::events::{publish_health_factor_queried, HealthFactorQueriedEvent};
+///
+/// let hf = client.get_health_factor(&borrower);
+/// let event = HealthFactorQueriedEvent {
+///     borrower: borrower.clone(),
+///     health_bps: hf,
+///     timestamp: env.ledger().timestamp(),
+/// };
+/// publish_health_factor_queried(&env, event);
+/// ```
+///
+/// # See also
+///
+/// - [`HealthFactorQueriedEvent`] — the payload type and `health_bps` interpretation.
+/// - [`publish_delinquency_checked`] — companion helper for delinquency reads.
 pub fn publish_health_factor_queried(env: &Env, event: HealthFactorQueriedEvent) {
     env.events().publish(
         (symbol_short!("query"), symbol_short!("hf_read")),
@@ -148,11 +287,60 @@ pub fn publish_health_factor_queried(env: &Env, event: HealthFactorQueriedEvent)
     );
 }
 
-/// Publish a delinquency-checked event.
+/// Publish a [`DelinquencyCheckedEvent`] to the Soroban event ledger.
 ///
-/// # Topic
-/// `("query", "dlq_chk")` — emitted once per `is_delinquent` call that
-/// opts in to on-chain observability.
+/// Opt-in observability for `is_delinquent` call sites. Invoke this helper
+/// alongside `is_delinquent` when you want delinquency checks to be
+/// observable by off-chain risk monitors and collections bots.
+///
+/// # Parameters
+///
+/// - `env`: Soroban execution environment.  Must be the active contract
+///   environment; the event is attributed to the currently executing contract.
+/// - `event`: Fully constructed [`DelinquencyCheckedEvent`] payload.
+///   The caller is responsible for populating `borrower`, `is_delinquent`
+///   (from the return value of `is_delinquent`), and `timestamp`.
+///
+/// # Returns
+///
+/// `()` — this function has no return value.  On success, exactly one event
+/// is appended to the transaction's event log.
+///
+/// # Errors
+///
+/// This function does not panic or return an error under normal operation.
+///
+/// # Security
+///
+/// - Emitting `is_delinquent = false` is safe and does not reveal sensitive
+///   state; it simply records that the check was performed.
+/// - The topic `("query", "dlq_chk")` is pinned; do not reuse for other
+///   delinquency-adjacent events.
+/// - There is no auth gate; callers must only invoke this from trusted paths.
+///
+/// # ABI stability
+///
+/// The topic string `("query", "dlq_chk")` is pinned.  Field order in
+/// [`DelinquencyCheckedEvent`] is stable.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use creditra_query::events::{publish_delinquency_checked, DelinquencyCheckedEvent};
+///
+/// let delinquent = client.is_delinquent(&borrower);
+/// let event = DelinquencyCheckedEvent {
+///     borrower: borrower.clone(),
+///     is_delinquent: delinquent,
+///     timestamp: env.ledger().timestamp(),
+/// };
+/// publish_delinquency_checked(&env, event);
+/// ```
+///
+/// # See also
+///
+/// - [`DelinquencyCheckedEvent`] — the payload type and `is_delinquent` semantics.
+/// - [`publish_credit_line_queried`] — companion helper for credit-line reads.
 pub fn publish_delinquency_checked(env: &Env, event: DelinquencyCheckedEvent) {
     env.events().publish(
         (symbol_short!("query"), symbol_short!("dlq_chk")),
@@ -160,11 +348,63 @@ pub fn publish_delinquency_checked(env: &Env, event: DelinquencyCheckedEvent) {
     );
 }
 
-/// Publish a protocol-summary-queried event.
+/// Publish a [`ProtocolSummaryQueriedEvent`] to the Soroban event ledger.
 ///
-/// # Topic
-/// `("query", "proto_rd")` — emitted once per `get_protocol_summary` call
-/// that opts in to on-chain observability.
+/// Opt-in observability for `get_protocol_summary` call sites. Invoke this
+/// helper alongside `get_protocol_summary` when you want the aggregate read
+/// to be observable by off-chain dashboards and protocol monitors.
+///
+/// # Parameters
+///
+/// - `env`: Soroban execution environment.  Must be the active contract
+///   environment; the event is attributed to the currently executing contract.
+/// - `event`: Fully constructed [`ProtocolSummaryQueriedEvent`] payload.
+///   The caller is responsible for populating `total_utilized`,
+///   `active_line_count` (from the `ProtocolSummary` returned by
+///   `get_protocol_summary`), and `timestamp`.
+///
+/// # Returns
+///
+/// `()` — this function has no return value.  On success, exactly one event
+/// is appended to the transaction's event log.
+///
+/// # Errors
+///
+/// This function does not panic or return an error under normal operation.
+///
+/// # Security
+///
+/// - Protocol summary aggregates are not sensitive (no per-borrower data is
+///   included); emitting them is safe.
+/// - The topic `("query", "proto_rd")` is pinned; do not reuse for other
+///   protocol-level reads.
+/// - There is no auth gate; callers must only invoke this from trusted paths.
+///
+/// # ABI stability
+///
+/// The topic string `("query", "proto_rd")` is pinned.  Field order in
+/// [`ProtocolSummaryQueriedEvent`] is stable; new fields may only be appended.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use creditra_query::events::{
+///     publish_protocol_summary_queried, ProtocolSummaryQueriedEvent,
+/// };
+///
+/// let summary = client.get_protocol_summary();
+/// let event = ProtocolSummaryQueriedEvent {
+///     total_utilized: summary.total_utilized,
+///     active_line_count: summary.count,
+///     timestamp: env.ledger().timestamp(),
+/// };
+/// publish_protocol_summary_queried(&env, event);
+/// ```
+///
+/// # See also
+///
+/// - [`ProtocolSummaryQueriedEvent`] — the payload type and field semantics.
+/// - [`publish_credit_line_queried`] — companion helper for per-borrower reads.
 pub fn publish_protocol_summary_queried(env: &Env, event: ProtocolSummaryQueriedEvent) {
     env.events().publish(
         (symbol_short!("query"), symbol_short!("proto_rd")),

--- a/contracts/query/src/lib.rs
+++ b/contracts/query/src/lib.rs
@@ -1,37 +1,106 @@
 // SPDX-License-Identifier: MIT
 #![cfg_attr(not(test), no_std)]
 
-//! Creditra query (v7) crate.
+//! # creditra-query (v7)
+//!
+//! Thin wrapper over the credit contract's read-only query surface.
 //!
 //! ## What
 //!
-//! Thin wrapper over the credit contract's read-only query surface.
-//! Provides:
+//! This crate bundles three cohesive concerns for the Creditra v7 query
+//! subsystem:
 //!
-//! - [`events`] — structured lifecycle events for query entrypoints, allowing
-//!   off-chain indexers to observe when read-only queries are executed.
-//! - [`views`] — read-only [`views::capabilities`] bitmap (compiled into
-//!   `creditra-credit` via `#[path]`; see that module's rustdoc).
+//! - [`events`] — opt-in structured lifecycle events for query entrypoints,
+//!   emitted so off-chain indexers can observe when read-only queries execute.
+//! - [`views::capabilities`] — read-only [`creditra_credit::types::QueryCapabilities`]
+//!   bitmap compiled into `creditra-credit` via `#[path]`; consumed by the
+//!   `query_capabilities` contract entrypoint.
+//! - Re-exported `creditra_credit::*` — the full public surface of the credit
+//!   contract, available to tests and downstream integrators via a single
+//!   `use creditra_query::*` import.
 //!
 //! ## Error stability
 //!
 //! Anchors the [`creditra_credit::types::ContractError`] discriminants
 //! relevant to the v7 query subsystem for CI stability guards.
-//! See [`tests/err_stab.rs`] for the pinning assertions.
+//! See `tests/err_stab.rs` for the pinning assertions.
 //!
 //! ## Query entrypoints covered
 //!
-//! - `get_credit_line` / `get_credit_line_summary`
-//! - `get_protocol_summary`
-//! - `get_repayment_schedule`
-//! - `get_health_factor`
-//! - `is_delinquent`
-//! - `get_credit_lines_paginated`
-//! - `borrow_capabilities`
-//! - `query_capabilities` / `capabilities` (query capabilities view)
+//! The following credit-contract entrypoints are part of the query surface
+//! this crate documents and tests:
+//!
+//! | Entrypoint | Returns | Notes |
+//! |---|---|---|
+//! | `get_credit_line` | `Option<CreditLineData>` | Pure read, no auth |
+//! | `get_credit_line_summary` | `Option<CreditLineData>` | Backward-compat alias |
+//! | `get_protocol_summary` | `ProtocolSummary` | Aggregate counters only |
+//! | `get_repayment_schedule` | `Option<RepaymentSchedule>` | Bumps TTL on read |
+//! | `get_health_factor` | `u32` bps | `u32::MAX` = zero utilization |
+//! | `is_delinquent` | `bool` | Checks schedule + grace window |
+//! | `get_credit_lines_paginated` | `CreditLinesPage` | Cursor-based, max 100 |
+//! | `borrow_capabilities` | `BorrowCapabilities` | Pre-flight bitmap |
+//! | `query_capabilities` | `QueryCapabilities` | Query availability bitmap |
+//!
+//! ## Module structure
+//!
+//! ```text
+//! creditra_query
+//! ├── events          (this crate's own module)
+//! └── creditra_credit::* (re-exported wholesale)
+//! ```
+//!
+//! ## Design notes
+//!
+//! `views.rs` is **not** declared as a submodule here. It is compiled into
+//! `creditra-credit` via a `#[path = "../../query/src/views.rs"]` include so
+//! that `crate::` paths inside `views.rs` resolve to the credit crate's
+//! namespace. This is the same pattern used by
+//! `contracts/lifecycle/src/views.rs`.
+//!
+//! ## See also
+//!
+//! - [`docs/PROTOCOL_SPEC.md`](../../../docs/PROTOCOL_SPEC.md) — per-entrypoint
+//!   signatures, storage keys, and error returns.
+//! - [`docs/EVENTS_CATALOG.md`](../../../docs/EVENTS_CATALOG.md) — full event
+//!   topic registry.
 
+/// Structured lifecycle events for the v7 query subsystem.
+///
+/// Each publisher helper in this module emits a single Soroban event under
+/// the `("query", _)` topic namespace.  Call sites that want their read-only
+/// queries to be observable on-chain invoke the corresponding `publish_*`
+/// function alongside the query.
+///
+/// See the module-level rustdoc in [`events`] for the full event table,
+/// topic strings, and ABI-stability guarantees.
 pub mod events;
+
 // `views` is compiled into `creditra-credit` via `#[path]` (see
 // `contracts/credit/src/lib.rs`). It is intentionally not declared as a
 // submodule here so `crate::` inside `views.rs` resolves to the credit crate.
+
+/// Re-export the entire `creditra-credit` public API.
+///
+/// This allows downstream crates, integration tests, and SDK clients to
+/// depend only on `creditra-query` while still accessing the full
+/// `creditra_credit` type and contract surface:
+///
+/// ```rust,ignore
+/// use creditra_query::{Credit, CreditClient, types::ContractError};
+/// ```
+///
+/// # Re-exported items (non-exhaustive)
+///
+/// - `Credit` — the `#[contract]` struct (for `env.register`).
+/// - `CreditClient` — the auto-generated test client.
+/// - `types::*` — `CreditLineData`, `ContractError`, `QueryCapabilities`, …
+/// - `events::*` — all 25+ event payload structs.
+/// - `compute_rate_from_score` — the risk-pricing formula.
+///
+/// # Stability
+///
+/// The re-export is `pub use creditra_credit::*`, so any item added or
+/// removed from `creditra-credit`'s public API is automatically reflected
+/// here without a change to this crate.
 pub use creditra_credit::*;

--- a/contracts/query/src/views.rs
+++ b/contracts/query/src/views.rs
@@ -42,9 +42,77 @@ use soroban_sdk::{Address, Env};
 
 /// Return the query-subsystem capabilities bitmap for `borrower`.
 ///
-/// Read-only, no-auth view. See [`QueryCapabilities`] for field semantics.
+/// Each field in the returned [`QueryCapabilities`] struct answers one
+/// "is this query currently meaningful?" question, allowing an off-chain
+/// keeper or dashboard to issue a single contract call instead of
+/// `N` separate reads followed by error handling.
 ///
-/// [`QueryCapabilities`]: crate::types::QueryCapabilities
+/// # Parameters
+///
+/// - `env`: The Soroban execution environment. Provides ledger context,
+///   storage access, and the timestamp used for delinquency evaluation.
+/// - `borrower`: The on-chain address whose query capabilities are being
+///   assessed. Any address may be passed; a missing credit line is handled
+///   gracefully (all flags are `false`).
+///
+/// # Returns
+///
+/// A [`QueryCapabilities`] bitmap with the following fields:
+///
+/// | Field | `true` when |
+/// |-------|-------------|
+/// | `has_credit_line` | A credit-line record exists in persistent storage |
+/// | `has_repayment_schedule` | A repayment schedule is configured for the borrower |
+/// | `health_factor_applicable` | `utilized_amount > 0`; otherwise `get_health_factor` returns `u32::MAX` |
+/// | `delinquency_applicable` | Line is open **and** `utilized_amount > 0` **and** schedule exists |
+/// | `is_delinquent` | Delinquency check passes (only evaluated when `delinquency_applicable`) |
+///
+/// # Security
+///
+/// - **No authentication required.** This is a pure read-only view.
+/// - No storage is mutated. Soroban TTL bumps may occur on persistent-entry
+///   reads inside `get_credit_line` and `get_repayment_schedule`, but these
+///   do not change any logical contract state.
+/// - All inputs are validated implicitly: an unknown `borrower` address
+///   returns an all-`false` bitmap without panicking.
+///
+/// # Errors
+///
+/// This function does not panic. All code paths return a valid
+/// [`QueryCapabilities`] struct. Callers must not assume any field is `true`
+/// without inspecting the returned value.
+///
+/// # Performance
+///
+/// Executes at most three storage reads:
+/// 1. `get_credit_line` — persistent read, bumps TTL if below threshold.
+/// 2. `get_repayment_schedule` — persistent read, bumps TTL if below threshold.
+/// 3. `is_delinquent` (conditional) — reads grace-period config from instance
+///    storage; only executed when `delinquency_applicable` is `true`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let caps = client.query_capabilities(&borrower);
+/// if caps.delinquency_applicable && caps.is_delinquent {
+///     // Borrower has missed an installment — trigger default flow.
+/// }
+/// if caps.health_factor_applicable {
+///     let hf = client.get_health_factor(&borrower);
+///     if hf < 10_000 {
+///         // Position is under-collateralized — eligible for liquidation.
+///     }
+/// }
+/// ```
+///
+/// # See also
+///
+/// - [`crate::query::get_health_factor`] — the health-factor formula and
+///   edge-case documentation.
+/// - [`crate::query::is_delinquent`] — the delinquency check this function
+///   conditionally delegates to.
+/// - [`QueryCapabilities`](crate::types::QueryCapabilities) — field-level
+///   rustdoc for the returned type.
 pub fn capabilities(env: Env, borrower: Address) -> QueryCapabilities {
     let credit_line = get_credit_line(env.clone(), borrower.clone());
     let schedule = get_repayment_schedule(env.clone(), borrower.clone());

--- a/contracts/query/tests/rustdoc_query_tests.rs
+++ b/contracts/query/tests/rustdoc_query_tests.rs
@@ -1,0 +1,595 @@
+// SPDX-License-Identifier: MIT
+
+//! Focused rustdoc-coverage tests for `creditra-query` public entrypoints.
+//!
+//! # Purpose
+//!
+//! Validates that every public API documented in the query crate behaves
+//! exactly as its NatSpec-style rustdoc specifies, covering:
+//!
+//! - [`capabilities`] — every [`QueryCapabilities`] flag, all short-circuit
+//!   paths, and the `delinquency_applicable` gate.
+//! - [`publish_credit_line_queried`] — topic, payload fields, `found` flag.
+//! - [`publish_health_factor_queried`] — topic, `health_bps` encoding, sentinel.
+//! - [`publish_delinquency_checked`] — topic, `is_delinquent` flag.
+//! - [`publish_protocol_summary_queried`] — topic, aggregate payload.
+//! - Cross-cutting: determinism, no-mutation guarantee, zero-state edge cases.
+//!
+//! # Test categories
+//!
+//! | Section | What it covers |
+//! |---------|---------------|
+//! | §1 `capabilities` — no line | All-false bitmap when borrower is unknown |
+//! | §2 `capabilities` — zero utilization | `has_credit_line` true, health/delinquency false |
+//! | §3 `capabilities` — with utilization | `health_factor_applicable` gating |
+//! | §4 `capabilities` — closed line | Delinquency cannot apply to closed lines |
+//! | §5 `capabilities` — determinism | Same inputs → same outputs |
+//! | §6 Event: CreditLineQueriedEvent | Topic, payload, `found` flag |
+//! | §7 Event: HealthFactorQueriedEvent | Topic, `health_bps`, `u32::MAX` sentinel |
+//! | §8 Event: DelinquencyCheckedEvent | Topic, boolean flag |
+//! | §9 Event: ProtocolSummaryQueriedEvent | Topic, aggregate fields |
+//! | §10 Event determinism | Same publish → same payload |
+//! | §11 Events: no storage mutation | Events do not change credit line state |
+
+use creditra_credit::{Credit, CreditClient};
+use creditra_query::events::{
+    publish_credit_line_queried, publish_delinquency_checked, publish_health_factor_queried,
+    publish_protocol_summary_queried, CreditLineQueriedEvent, DelinquencyCheckedEvent,
+    HealthFactorQueriedEvent, ProtocolSummaryQueriedEvent,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events, Ledger},
+    token, Address, Env, TryIntoVal,
+};
+
+// ── Shared test helpers ───────────────────────────────────────────────────────
+
+/// Spin up a minimal test environment with a registered Credit contract and
+/// an initialized admin. Returns `(env, client, contract_id, admin)`.
+fn setup_env() -> (Env, CreditClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    (env, client, contract_id, admin)
+}
+
+/// Extend `setup_env` with a minted liquidity token so `draw_credit` can
+/// be called. Returns `(env, client, contract_id, admin)` with a token
+/// registered and 1_000_000 units minted into the contract.
+fn setup_with_token() -> (Env, CreditClient<'static>, Address, Address) {
+    let (env, client, contract_id, admin) = setup_env();
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token = token_id.address();
+    client.set_liquidity_token(&token);
+    client.set_liquidity_source(&contract_id);
+    token::StellarAssetClient::new(&env, &token).mint(&contract_id, &1_000_000_i128);
+
+    (env, client, contract_id, admin)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §1 — capabilities(): no credit line
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: "any address may be passed; a missing credit line is handled
+/// gracefully (all flags are `false`)."
+#[test]
+fn capabilities_no_credit_line_all_flags_false() {
+    let (env, client, _, _) = setup_env();
+    let borrower = Address::generate(&env);
+
+    let caps = client.query_capabilities(&borrower);
+
+    assert!(!caps.has_credit_line, "no line → has_credit_line must be false");
+    assert!(
+        !caps.has_repayment_schedule,
+        "no line → has_repayment_schedule must be false"
+    );
+    assert!(
+        !caps.health_factor_applicable,
+        "no line → health_factor_applicable must be false"
+    );
+    assert!(
+        !caps.delinquency_applicable,
+        "no line → delinquency_applicable must be false"
+    );
+    assert!(!caps.is_delinquent, "no line → is_delinquent must be false");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §2 — capabilities(): active line, zero utilization
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: "`health_factor_applicable = utilized_amount > 0`; otherwise
+/// `get_health_factor` returns `u32::MAX`."
+/// With zero utilization: `has_credit_line = true`, health/delinquency = false.
+#[test]
+fn capabilities_active_line_zero_utilization() {
+    let (env, client, _, _) = setup_env();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    let caps = client.query_capabilities(&borrower);
+
+    assert!(caps.has_credit_line, "open line → has_credit_line must be true");
+    assert!(
+        !caps.health_factor_applicable,
+        "zero utilization → health_factor_applicable must be false"
+    );
+    assert!(
+        !caps.delinquency_applicable,
+        "zero utilization → delinquency_applicable must be false"
+    );
+    assert!(!caps.is_delinquent);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §3 — capabilities(): line with utilization, no schedule
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: `delinquency_applicable = open && utilized_amount > 0 && schedule exists`.
+/// Without a schedule, `delinquency_applicable` must be false even with utilization.
+#[test]
+fn capabilities_line_with_utilization_no_schedule() {
+    let (env, client, _, _) = setup_with_token();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+    // Bypass collateral ratio for draw test
+    client.set_min_collateral_ratio_bps(&0);
+    client.draw_credit(&borrower, &300_i128);
+
+    let caps = client.query_capabilities(&borrower);
+
+    assert!(caps.has_credit_line);
+    assert!(
+        caps.health_factor_applicable,
+        "utilized > 0 → health_factor_applicable must be true"
+    );
+    assert!(
+        !caps.delinquency_applicable,
+        "no schedule → delinquency_applicable must be false"
+    );
+    assert!(!caps.is_delinquent);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §4 — capabilities(): closed line
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: "`delinquency_applicable = open && …`; closed lines cannot
+/// be delinquent."
+#[test]
+fn capabilities_closed_line_delinquency_not_applicable() {
+    let (env, client, _, admin) = setup_env();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+    client.close_credit_line(&borrower, &admin);
+
+    let caps = client.query_capabilities(&borrower);
+
+    assert!(caps.has_credit_line, "closed line still present in storage");
+    assert!(
+        !caps.delinquency_applicable,
+        "closed lines cannot be delinquent"
+    );
+    assert!(!caps.is_delinquent, "closed lines are never delinquent");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §5 — capabilities(): determinism
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says (implicit from "pure read with no mutation"): same inputs
+/// → same outputs. Two consecutive calls must return identical bitmaps.
+#[test]
+fn capabilities_deterministic_consecutive_calls() {
+    let (env, client, _, _) = setup_env();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &2_000_i128, &600_u32, &40_u32);
+
+    let caps_a = client.query_capabilities(&borrower);
+    let caps_b = client.query_capabilities(&borrower);
+
+    assert_eq!(
+        caps_a, caps_b,
+        "query_capabilities must be deterministic for unchanged state"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §6 — publish_credit_line_queried
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: emits topic `("query", "cl_read")` with the correct
+/// `borrower`, `found`, and `timestamp` fields.
+#[test]
+fn publish_credit_line_queried_emits_correct_topic_found_true() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    env.ledger().set_timestamp(1_234);
+
+    let event = CreditLineQueriedEvent {
+        borrower: borrower.clone(),
+        found: true,
+        timestamp: 1_234,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_credit_line_queried(&env, event.clone());
+    });
+
+    let all = env.events().all();
+    assert_eq!(all.len(), 1, "exactly one event must be emitted");
+
+    let (_, topics, data) = all.get(0).unwrap();
+    let t0: soroban_sdk::Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let t1: soroban_sdk::Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(t0, symbol_short!("query"), "first topic must be 'query'");
+    assert_eq!(t1, symbol_short!("cl_read"), "second topic must be 'cl_read'");
+
+    let payload: CreditLineQueriedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(payload.borrower, borrower);
+    assert!(payload.found);
+    assert_eq!(payload.timestamp, 1_234);
+}
+
+/// Rustdoc says `found = false` is a valid and distinct encoded state.
+#[test]
+fn publish_credit_line_queried_found_false_encodes_correctly() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    env.ledger().set_timestamp(99);
+
+    let event = CreditLineQueriedEvent {
+        borrower: borrower.clone(),
+        found: false,
+        timestamp: 99,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_credit_line_queried(&env, event);
+    });
+
+    let (_, _, data) = env.events().all().get(0).unwrap();
+    let payload: CreditLineQueriedEvent = data.try_into_val(&env).unwrap();
+    assert!(!payload.found, "found=false must round-trip correctly");
+    assert_eq!(payload.timestamp, 99);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §7 — publish_health_factor_queried
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: emits topic `("query", "hf_read")` with `health_bps` and `timestamp`.
+#[test]
+fn publish_health_factor_queried_emits_correct_topic_and_value() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    env.ledger().set_timestamp(500);
+
+    let event = HealthFactorQueriedEvent {
+        borrower: borrower.clone(),
+        health_bps: 15_000,
+        timestamp: 500,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_health_factor_queried(&env, event);
+    });
+
+    let (_, topics, data) = env.events().all().get(0).unwrap();
+    let t1: soroban_sdk::Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(t1, symbol_short!("hf_read"), "second topic must be 'hf_read'");
+
+    let payload: HealthFactorQueriedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(payload.borrower, borrower);
+    assert_eq!(payload.health_bps, 15_000);
+    assert_eq!(payload.timestamp, 500);
+}
+
+/// Rustdoc says: "`u32::MAX` = zero utilization sentinel". Must encode correctly.
+#[test]
+fn publish_health_factor_queried_max_sentinel_encodes_correctly() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+
+    let event = HealthFactorQueriedEvent {
+        borrower: borrower.clone(),
+        health_bps: u32::MAX,
+        timestamp: 0,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_health_factor_queried(&env, event);
+    });
+
+    let (_, _, data) = env.events().all().get(0).unwrap();
+    let payload: HealthFactorQueriedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(
+        payload.health_bps,
+        u32::MAX,
+        "u32::MAX sentinel must round-trip through event encoding"
+    );
+}
+
+/// Rustdoc says: `health_bps < 10_000` means under-collateralized.
+/// Verify the field value round-trips at the boundary.
+#[test]
+fn publish_health_factor_queried_under_collateralized_boundary() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+
+    let event = HealthFactorQueriedEvent {
+        borrower: borrower.clone(),
+        health_bps: 9_999, // just under the 10_000 minimum
+        timestamp: 0,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_health_factor_queried(&env, event);
+    });
+
+    let (_, _, data) = env.events().all().get(0).unwrap();
+    let payload: HealthFactorQueriedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(payload.health_bps, 9_999);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §8 — publish_delinquency_checked
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: emits topic `("query", "dlq_chk")` with `is_delinquent = true`.
+#[test]
+fn publish_delinquency_checked_true_emits_correct_topic() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    env.ledger().set_timestamp(9_999);
+
+    let event = DelinquencyCheckedEvent {
+        borrower: borrower.clone(),
+        is_delinquent: true,
+        timestamp: 9_999,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_delinquency_checked(&env, event);
+    });
+
+    let (_, topics, data) = env.events().all().get(0).unwrap();
+    let t1: soroban_sdk::Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(t1, symbol_short!("dlq_chk"), "second topic must be 'dlq_chk'");
+
+    let payload: DelinquencyCheckedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(payload.borrower, borrower);
+    assert!(payload.is_delinquent);
+    assert_eq!(payload.timestamp, 9_999);
+}
+
+/// Rustdoc says: `is_delinquent = false` is safe to emit and is the
+/// common case when short-circuit conditions are not met.
+#[test]
+fn publish_delinquency_checked_false_encodes_correctly() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+
+    let event = DelinquencyCheckedEvent {
+        borrower: borrower.clone(),
+        is_delinquent: false,
+        timestamp: 0,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_delinquency_checked(&env, event);
+    });
+
+    let (_, _, data) = env.events().all().get(0).unwrap();
+    let payload: DelinquencyCheckedEvent = data.try_into_val(&env).unwrap();
+    assert!(!payload.is_delinquent, "is_delinquent=false must round-trip");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §9 — publish_protocol_summary_queried
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: emits topic `("query", "proto_rd")` with `total_utilized`,
+/// `active_line_count`, and `timestamp`.
+#[test]
+fn publish_protocol_summary_queried_emits_correct_topic_and_payload() {
+    let (env, _, contract_id, _) = setup_env();
+    env.ledger().set_timestamp(2_000);
+
+    let event = ProtocolSummaryQueriedEvent {
+        total_utilized: 500_000_i128,
+        active_line_count: 7_u32,
+        timestamp: 2_000,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_protocol_summary_queried(&env, event);
+    });
+
+    let (_, topics, data) = env.events().all().get(0).unwrap();
+    let t0: soroban_sdk::Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let t1: soroban_sdk::Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(t0, symbol_short!("query"));
+    assert_eq!(t1, symbol_short!("proto_rd"), "second topic must be 'proto_rd'");
+
+    let payload: ProtocolSummaryQueriedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(payload.total_utilized, 500_000_i128);
+    assert_eq!(payload.active_line_count, 7);
+    assert_eq!(payload.timestamp, 2_000);
+}
+
+/// Rustdoc says: zero-state (no lines, no utilization) is valid.
+#[test]
+fn publish_protocol_summary_queried_zero_state() {
+    let (env, _, contract_id, _) = setup_env();
+
+    let event = ProtocolSummaryQueriedEvent {
+        total_utilized: 0,
+        active_line_count: 0,
+        timestamp: 0,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_protocol_summary_queried(&env, event);
+    });
+
+    let (_, _, data) = env.events().all().get(0).unwrap();
+    let payload: ProtocolSummaryQueriedEvent = data.try_into_val(&env).unwrap();
+    assert_eq!(payload.total_utilized, 0);
+    assert_eq!(payload.active_line_count, 0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §10 — Event determinism
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says (implicit): two publish calls with identical inputs produce
+/// identical event payloads.
+#[test]
+fn events_deterministic_same_input_produces_same_output() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    env.ledger().set_timestamp(777);
+
+    let event = CreditLineQueriedEvent {
+        borrower: borrower.clone(),
+        found: true,
+        timestamp: 777,
+    };
+
+    env.as_contract(&contract_id, || {
+        publish_credit_line_queried(&env, event.clone());
+        publish_credit_line_queried(&env, event.clone());
+    });
+
+    let all = env.events().all();
+    assert_eq!(all.len(), 2, "two publishes → two events");
+
+    let (_, _, data0) = all.get(0).unwrap();
+    let (_, _, data1) = all.get(1).unwrap();
+    let p0: CreditLineQueriedEvent = data0.try_into_val(&env).unwrap();
+    let p1: CreditLineQueriedEvent = data1.try_into_val(&env).unwrap();
+    assert_eq!(p0, p1, "event payloads must be deterministic");
+}
+
+/// All four publisher helpers produce independent, non-interfering events.
+#[test]
+fn all_four_publishers_emit_independent_events() {
+    let (env, _, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+
+    env.as_contract(&contract_id, || {
+        publish_credit_line_queried(
+            &env,
+            CreditLineQueriedEvent {
+                borrower: borrower.clone(),
+                found: true,
+                timestamp: 100,
+            },
+        );
+        publish_health_factor_queried(
+            &env,
+            HealthFactorQueriedEvent {
+                borrower: borrower.clone(),
+                health_bps: 20_000,
+                timestamp: 100,
+            },
+        );
+        publish_delinquency_checked(
+            &env,
+            DelinquencyCheckedEvent {
+                borrower: borrower.clone(),
+                is_delinquent: false,
+                timestamp: 100,
+            },
+        );
+        publish_protocol_summary_queried(
+            &env,
+            ProtocolSummaryQueriedEvent {
+                total_utilized: 0,
+                active_line_count: 0,
+                timestamp: 100,
+            },
+        );
+    });
+
+    let all = env.events().all();
+    assert_eq!(all.len(), 4, "four publishers → four distinct events");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// §11 — Events do not mutate contract state
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rustdoc says: events are "opt-in" and purely additive; they do not change
+/// credit line state. Verify the credit line is unchanged after publishing.
+#[test]
+fn publishing_events_does_not_mutate_credit_line_state() {
+    let (env, client, contract_id, _) = setup_env();
+    let borrower = Address::generate(&env);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    // Snapshot state before publishing events.
+    let line_before = client.get_credit_line(&borrower).unwrap();
+
+    // Publish all four event types.
+    env.as_contract(&contract_id, || {
+        publish_credit_line_queried(
+            &env,
+            CreditLineQueriedEvent {
+                borrower: borrower.clone(),
+                found: true,
+                timestamp: 0,
+            },
+        );
+        publish_health_factor_queried(
+            &env,
+            HealthFactorQueriedEvent {
+                borrower: borrower.clone(),
+                health_bps: u32::MAX,
+                timestamp: 0,
+            },
+        );
+        publish_delinquency_checked(
+            &env,
+            DelinquencyCheckedEvent {
+                borrower: borrower.clone(),
+                is_delinquent: false,
+                timestamp: 0,
+            },
+        );
+        publish_protocol_summary_queried(
+            &env,
+            ProtocolSummaryQueriedEvent {
+                total_utilized: 0,
+                active_line_count: 0,
+                timestamp: 0,
+            },
+        );
+    });
+
+    // Credit line state must be identical after event emission.
+    let line_after = client.get_credit_line(&borrower).unwrap();
+    assert_eq!(
+        line_before.credit_limit, line_after.credit_limit,
+        "credit_limit must not change after event emission"
+    );
+    assert_eq!(
+        line_before.status, line_after.status,
+        "status must not change after event emission"
+    );
+    assert_eq!(
+        line_before.utilized_amount, line_after.utilized_amount,
+        "utilized_amount must not change after event emission"
+    );
+}


### PR DESCRIPTION
Add NatSpec-style rustdoc to every public fn in contracts/query.

- lib.rs: full module-level doc with entrypoint table, design notes, and annotated pub mod / pub use declarations
- views.rs: capabilities() gets # Parameters, # Returns (table), # Security, # Errors, # Performance, # Example, # See also
- events.rs: all 4 publisher helpers (publish_credit_line_queried, publish_health_factor_queried, publish_delinquency_checked, publish_protocol_summary_queried) get full NatSpec sections: # Parameters, # Returns, # Errors, # Security, # ABI stability, # Example, # See also
- tests/rustdoc_query_tests.rs: 595-line focused test file covering 11 sections across capabilities() and all 4 publisher helpers
- Cargo.toml: register rustdoc_query_tests as [[test]] target

GrantFox FWC26 campaign (Stellar Wave) — task/query-rustdoc-v7

closes #874