### PR TITLE
test: query auth snapshot (v7)

### DIFF
--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1501,6 +1501,23 @@ impl Credit {
         lifecycle_views::capabilities(env, borrower)
     }
 
+    /// Return the query-subsystem capabilities bitmap for `borrower` (v7).
+    ///
+    /// Read-only view reporting which borrower-scoped query results are
+    /// currently meaningful: whether a credit line / repayment schedule
+    /// exists, whether the health factor is debt-sensitive, and whether
+    /// delinquency checks are applicable. See [`QueryCapabilities`] for the
+    /// exact precondition each flag mirrors.
+    ///
+    /// # Authentication
+    /// No authentication required. This is a pure read-only query.
+    ///
+    /// # Returns
+    /// A [`QueryCapabilities`] bitmap.
+    pub fn query_capabilities(env: Env, borrower: Address) -> QueryCapabilities {
+        query_views::capabilities(env, borrower)
+    }
+
     /// Deposit collateral tokens from the borrower into the contract.
     ///
     /// # Authorization

--- a/contracts/query/Cargo.toml
+++ b/contracts/query/Cargo.toml
@@ -27,6 +27,10 @@ path = "tests/events.rs"
 name = "capabilities"
 path = "tests/capabilities.rs"
 
+[[test]]
+name = "auth_snap"
+path = "tests/auth_snap.rs"
+
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 creditra-credit = { path = "../credit", features = [] }

--- a/contracts/query/README.md
+++ b/contracts/query/README.md
@@ -24,10 +24,27 @@ same pattern as [`contracts/lifecycle/src/views.rs`](../lifecycle/src/views.rs))
 | `delinquency_applicable` | Open line + utilization + schedule (mirrors `is_delinquent` gates) |
 | `is_delinquent` | Current delinquency status; always `false` when not applicable |
 
+## Auth snapshot (v7, issue #876)
+
+Every entrypoint on the query surface is a pure read — none of them call
+`require_auth`. [`tests/auth_snap.rs`](./tests/auth_snap.rs) pins that shape
+per entrypoint so a future change that silently adds an authorization
+requirement (breaking indexers/keepers that call these without a signer) is
+caught immediately, even under `mock_all_auths`. See that file's module
+doc for the full entrypoint table.
+
 ## Run tests
 
 ```bash
+# Capabilities view tests
 cargo test -p creditra-query --test capabilities
+
+# Auth snapshot tests
+cargo test -p creditra-query --test auth_snap
+
+# Full query test suite
+cargo test -p creditra-query
 ```
 
-See [`tests/capabilities.rs`](./tests/capabilities.rs).
+See [`tests/capabilities.rs`](./tests/capabilities.rs) and
+[`tests/auth_snap.rs`](./tests/auth_snap.rs).

--- a/contracts/query/src/lib.rs
+++ b/contracts/query/src/lib.rs
@@ -19,6 +19,12 @@
 //! relevant to the v7 query subsystem for CI stability guards.
 //! See [`tests/err_stab.rs`] for the pinning assertions.
 //!
+//! ## Auth snapshot
+//!
+//! Every query entrypoint is a pure read with no `require_auth` call. See
+//! [`tests/auth_snap.rs`] for the per-entrypoint pinning assertions that
+//! guard against a future entrypoint silently gaining an auth requirement.
+//!
 //! ## Query entrypoints covered
 //!
 //! - `get_credit_line` / `get_credit_line_summary`

--- a/contracts/query/tests/auth_snap.rs
+++ b/contracts/query/tests/auth_snap.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+
+//! Per-entrypoint auth snapshot for the query (v7) subsystem (#876).
+//!
+//! Every entrypoint on the v7 query surface is a pure, read-only view: no
+//! token CPIs, no storage mutation, and — critically — no `require_auth`.
+//! This file pins that shape so a future change that silently adds an
+//! authorization requirement to a query entrypoint (breaking off-chain
+//! indexers, keepers, and dashboards that call these without a signer) is
+//! caught immediately, even though `mock_all_auths` would otherwise paper
+//! over the regression.
+//!
+//! # Snapshot (query v7 surface)
+//!
+//! | Entrypoint                     | Required signer   | Auths recorded |
+//! |----------------------------------|--------------------|-----------------|
+//! | `get_credit_line`                | none (read-only)   | 0               |
+//! | `get_credit_line_summary`        | none (read-only)   | 0               |
+//! | `get_protocol_summary`           | none (read-only)   | 0               |
+//! | `get_repayment_schedule`         | none (read-only)   | 0               |
+//! | `get_health_factor`              | none (read-only)   | 0               |
+//! | `is_delinquent`                  | none (read-only)   | 0               |
+//! | `get_credit_lines_paginated`     | none (read-only)   | 0               |
+//! | `borrow_capabilities`            | none (read-only)   | 0               |
+//! | `query_capabilities`             | none (read-only)   | 0               |
+//!
+//! # Rules
+//! - Never weaken an existing assertion (e.g. dropping an
+//!   `env.auths().is_empty()` check).
+//! - If a query entrypoint ever gains a `require_auth` call, update the
+//!   table above alongside the assertion — that is a deliberate, reviewed
+//!   API change, not a silent regression.
+//!
+//! # See also
+//! - `creditra_credit::query` — the read-only query implementation.
+//! - `contracts/query/tests/capabilities.rs` — functional coverage of the
+//!   `query_capabilities` bitmap.
+//! - `contracts/freeze/tests/auth_snap.rs` — the analogous snapshot for the
+//!   freeze subsystem's state-changing entrypoints.
+
+use creditra_credit::{Credit, CreditClient};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{token, Address, Env};
+
+const START_TS: u64 = 10_000;
+
+/// Deploys a fresh contract, initializes `admin`, opens a credit line for
+/// `borrower`, draws against it, and configures a repayment schedule — with
+/// `mock_all_auths` enabled for the whole env.
+///
+/// Because `mock_all_auths` still records what was authorized (it only skips
+/// signature verification), `env.auths()` after the call under test reflects
+/// exactly what that call — and nothing from setup — required.
+fn setup_active(env: &Env) -> (CreditClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = START_TS);
+
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    let token_id = env.register_stellar_asset_contract_v2(Address::generate(env));
+    let token_address = token_id.address();
+    client.set_liquidity_token(&token_address);
+    token::StellarAssetClient::new(env, &token_address).mint(&contract_id, &1_000_000_i128);
+    client.set_min_collateral_ratio_bps(&0);
+    client.draw_credit(&borrower, &500_i128);
+    client.set_repayment_schedule(
+        &borrower,
+        &100_i128,
+        &2_592_000_u64,
+        &(START_TS + 2_592_000),
+    );
+
+    (client, admin, borrower)
+}
+
+/// Deploys a fresh contract and initializes `admin`, but opens no credit
+/// line — used to snapshot the "no data" branch of each entrypoint.
+fn setup_empty(env: &Env) -> (CreditClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = START_TS);
+
+    let admin = Address::generate(env);
+    let borrower = Address::generate(env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(env, &contract_id);
+    client.init(&admin);
+
+    (client, admin, borrower)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 1 — Active-line state: every query entrypoint records zero auths
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn get_credit_line_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let line = client.get_credit_line(&borrower);
+
+    assert!(line.is_some());
+    assert!(
+        env.auths().is_empty(),
+        "get_credit_line must not require any authorization"
+    );
+}
+
+#[test]
+fn get_credit_line_summary_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let summary = client.get_credit_line_summary(&borrower);
+
+    assert!(summary.is_some());
+    assert!(
+        env.auths().is_empty(),
+        "get_credit_line_summary must not require any authorization"
+    );
+}
+
+#[test]
+fn get_protocol_summary_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, _borrower) = setup_active(&env);
+
+    let _ = client.get_protocol_summary();
+
+    assert!(
+        env.auths().is_empty(),
+        "get_protocol_summary must not require any authorization"
+    );
+}
+
+#[test]
+fn get_repayment_schedule_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let schedule = client.get_repayment_schedule(&borrower);
+
+    assert!(schedule.is_some());
+    assert!(
+        env.auths().is_empty(),
+        "get_repayment_schedule must not require any authorization"
+    );
+}
+
+#[test]
+fn get_health_factor_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let hf = client.get_health_factor(&borrower);
+
+    assert_ne!(
+        hf,
+        u32::MAX,
+        "borrower has utilization; expect a finite health factor"
+    );
+    assert!(
+        env.auths().is_empty(),
+        "get_health_factor must not require any authorization"
+    );
+}
+
+#[test]
+fn is_delinquent_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let _ = client.is_delinquent(&borrower);
+
+    assert!(
+        env.auths().is_empty(),
+        "is_delinquent must not require any authorization"
+    );
+}
+
+#[test]
+fn get_credit_lines_paginated_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, _borrower) = setup_active(&env);
+
+    let page = client.get_credit_lines_paginated(&None, &10_u32);
+
+    assert_eq!(page.lines.len(), 1);
+    assert!(
+        env.auths().is_empty(),
+        "get_credit_lines_paginated must not require any authorization"
+    );
+}
+
+#[test]
+fn borrow_capabilities_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let _ = client.borrow_capabilities(&borrower);
+
+    assert!(
+        env.auths().is_empty(),
+        "borrow_capabilities must not require any authorization"
+    );
+}
+
+#[test]
+fn query_capabilities_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_active(&env);
+
+    let caps = client.query_capabilities(&borrower);
+
+    assert!(caps.has_credit_line);
+    assert!(
+        env.auths().is_empty(),
+        "query_capabilities must not require any authorization"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 2 — Empty state: no credit line still records zero auths
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn get_credit_line_on_missing_borrower_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_empty(&env);
+
+    let line = client.get_credit_line(&borrower);
+
+    assert!(line.is_none());
+    assert!(
+        env.auths().is_empty(),
+        "get_credit_line must not require any authorization even for an unknown borrower"
+    );
+}
+
+#[test]
+fn get_health_factor_on_missing_borrower_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_empty(&env);
+
+    let hf = client.get_health_factor(&borrower);
+
+    assert_eq!(hf, u32::MAX);
+    assert!(
+        env.auths().is_empty(),
+        "get_health_factor must not require any authorization even for an unknown borrower"
+    );
+}
+
+#[test]
+fn is_delinquent_on_missing_borrower_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_empty(&env);
+
+    let delinquent = client.is_delinquent(&borrower);
+
+    assert!(!delinquent);
+    assert!(
+        env.auths().is_empty(),
+        "is_delinquent must not require any authorization even for an unknown borrower"
+    );
+}
+
+#[test]
+fn query_capabilities_on_missing_borrower_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, borrower) = setup_empty(&env);
+
+    let caps = client.query_capabilities(&borrower);
+
+    assert!(!caps.has_credit_line);
+    assert!(
+        env.auths().is_empty(),
+        "query_capabilities must not require any authorization even for an unknown borrower"
+    );
+}
+
+#[test]
+fn get_protocol_summary_zero_state_requires_no_auth() {
+    let env = Env::default();
+    let (client, _admin, _borrower) = setup_empty(&env);
+
+    let summary = client.get_protocol_summary();
+
+    assert_eq!(summary.count, 0);
+    assert!(
+        env.auths().is_empty(),
+        "get_protocol_summary must not require any authorization on an empty protocol"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Section 3 — Edge case: zero mocked signers never satisfies a query call
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// These calls succeed with *no* signer at all (not even a mocked one),
+// proving the zero-auth snapshot above isn't an artifact of
+// `mock_all_auths` — the entrypoints genuinely never invoke `require_auth`.
+
+#[test]
+fn query_entrypoints_succeed_with_zero_signers_mocked() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = START_TS);
+
+    let admin = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let contract_id = env.register(Credit, ());
+    let client = CreditClient::new(&env, &contract_id);
+
+    // `init` and `open_credit_line` do not currently enforce `require_auth`
+    // (see `contracts/freeze/tests/auth_snap.rs` for the same observation on
+    // the freeze surface), so both succeed here without any mocked signer.
+    client.init(&admin);
+    client.open_credit_line(&borrower, &1_000_i128, &500_u32, &50_u32);
+
+    let _ = client.get_credit_line(&borrower);
+    let _ = client.get_credit_line_summary(&borrower);
+    let _ = client.get_protocol_summary();
+    let _ = client.get_repayment_schedule(&borrower);
+    let _ = client.get_health_factor(&borrower);
+    let _ = client.is_delinquent(&borrower);
+    let _ = client.get_credit_lines_paginated(&None, &10_u32);
+    let _ = client.borrow_capabilities(&borrower);
+    let _ = client.query_capabilities(&borrower);
+
+    assert!(
+        env.auths().is_empty(),
+        "the last query call must not have required any authorization"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `contracts/query/tests/auth_snap.rs`: a per-entrypoint auth snapshot for the v7 query surface, pinning that `get_credit_line`, `get_credit_line_summary`, `get_protocol_summary`, `get_repayment_schedule`, `get_health_factor`, `is_delinquent`, `get_credit_lines_paginated`, `borrow_capabilities`, and `query_capabilities` all record **zero** authorizations. Covered across an active-line state, an empty state, and a zero-mocked-signers run, so a future change that silently adds `require_auth` to a read-only query (breaking indexers/keepers that call these without a signer) is caught immediately — mirroring the pattern in `contracts/freeze/tests/auth_snap.rs`.
- Wires up the missing `query_capabilities` entrypoint in `Credit`'s `#[contractimpl]` block (`contracts/credit/src/lib.rs`), calling `query_views::capabilities` the same way `lifecycle_capabilities` calls `lifecycle_views::capabilities`. This was documented in `docs/PROTOCOL_SPEC.md` and had a functional test (`contracts/query/tests/capabilities.rs`), but was never actually exposed as a callable entrypoint on the contract — a gap my new auth-snapshot tests also depend on.
- Registers the new test target in `contracts/query/Cargo.toml` and documents the auth snapshot in `contracts/query/README.md` and the `creditra-query` crate doc.

Closes #876.

## ⚠️ Pre-existing, unrelated build breakage on `main`

Before writing any code I confirmed `cargo check -p creditra-credit` on `main` (tip: the just-merged `#1098`) currently fails with **112 compile errors** — duplicate `use` imports and even a duplicate `CreditLinesPage` struct definition (`types.rs:519` and `types.rs:713`) spread across `lib.rs`, `types.rs`, `borrow.rs`, `lifecycle.rs`, and others. This looks like merge-artifact damage, the same class of issue tracked separately in #787.

This means `cargo test` cannot currently succeed for `creditra-credit` or any crate that depends on it (including `creditra-query`), independent of this PR. I confirmed my changes don't add or change that error count (112 before and after), and I've statically reviewed every entrypoint call, argument order, and field name (`CreditLinesPage.lines`, etc.) against the real function signatures. `rustfmt --check` passes on the new test file.

I'm flagging this rather than fixing it here since it's out of scope for #876 and touches ~10 files with judgment calls about which duplicate is authoritative — happy to pick that up as a separate PR once prioritized.

## Test plan

- [ ] Once the `main` breakage above is resolved: `cargo test -p creditra-query --test auth_snap` — all 15 new tests pass
- [ ] `cargo test -p creditra-query` — full query suite (capabilities, err_stab, events, auth_snap) passes
- [x] `rustfmt --check contracts/query/tests/auth_snap.rs` — passes
- [x] Confirmed `cargo check -p creditra-credit` error count is unchanged (112) before/after this diff, i.e. no new errors introduced by `query_capabilities` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)