### PR TITLE
feat: cursor-based pagination for enumerate_credit_lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 resolver = "2"
-members = ["contracts/credit", "contracts/freeze"]
 members = [
     "contracts/credit",
     "contracts/risk",
@@ -10,7 +9,6 @@ members = [
     "contracts/lifecycle",
     "contracts/query",
     "contracts/freeze",
-    "contracts/risk",
     "gateway-contract/contracts/auction_contract",
 ]
 

--- a/contracts/accrual/tests/proptest.rs
+++ b/contracts/accrual/tests/proptest.rs
@@ -84,14 +84,14 @@ fn setup_env() -> (Env, CreditClient<'static>, std::vec::Vec<Address>) {
 
 /// Assert `0 <= accrued_interest <= utilized_amount` for every active line.
 fn assert_accrued_le_utilized(client: &CreditClient<'_>, label: &str) {
-    let mut cursor = None;
+    let mut cursor = 0_u32;
     loop {
-        let page = client.enumerate_credit_lines(&cursor, &8);
-        if page.is_empty() {
+        let (lines, next_cursor) = client.enumerate_credit_lines(&cursor, &8, &false);
+        if lines.is_empty() {
             break;
         }
-        for item in page.iter() {
-            let (_, line) = item;
+        for i in 0..lines.len() {
+            let line = lines.get(i).unwrap();
             assert!(
                 line.accrued_interest >= 0,
                 "{label}: accrued_interest is negative ({}) for borrower {:?}",
@@ -105,6 +105,10 @@ fn assert_accrued_le_utilized(client: &CreditClient<'_>, label: &str) {
                 line.utilized_amount,
                 line.borrower,
             );
+        }
+        match next_cursor {
+            Some(c) => cursor = c,
+            None => break,
         }
     }
 }

--- a/contracts/credit/src/lib.rs
+++ b/contracts/credit/src/lib.rs
@@ -1772,40 +1772,24 @@ impl Credit {
         crate::storage::get_credit_line_count(&env)
     }
 
-    /// Enumerate credit lines in stable insertion order.
+    /// Cursor-based pagination over all credit lines.
     ///
-    /// `start_after` is an exclusive cursor over the stable numeric id.
-    /// Results are capped by `MAX_ENUMERATION_LIMIT` for predictable cost.
+    /// Walks `CreditLineBorrowerById` starting at `cursor` (inclusive) and
+    /// yields up to `limit` lines. Returns `(lines, next_cursor)` where
+    /// `next_cursor` is `None` when the end of the enumeration space is reached.
+    ///
+    /// `limit` is capped at `MAX_ENUMERATION_LIMIT` (100) regardless of the
+    /// caller-supplied value. When `skip_closed` is `true`, lines with
+    /// `status == Closed` are omitted.
+    ///
+    /// No authentication required — this is a pure read.
     pub fn enumerate_credit_lines(
         env: Env,
-        start_after: Option<u32>,
+        cursor: u32,
         limit: u32,
-    ) -> Vec<(u32, CreditLineData)> {
-        let count = crate::storage::get_credit_line_count(&env);
-        let capped_limit = limit.min(MAX_ENUMERATION_LIMIT);
-        let mut out = Vec::new(&env);
-
-        if capped_limit == 0 || count == 0 {
-            return out;
-        }
-
-        let mut next_id = start_after.map(|id| id.saturating_add(1)).unwrap_or(0);
-        let mut returned = 0_u32;
-        while next_id < count && returned < capped_limit {
-            if let Some(borrower) = get_borrower_by_credit_line_id(&env, next_id) {
-                if let Some(line) = env
-                    .storage()
-                    .persistent()
-                    .get::<Address, CreditLineData>(&borrower)
-                {
-                    out.push_back((next_id, line));
-                    returned = returned.saturating_add(1);
-                }
-            }
-            next_id = next_id.saturating_add(1);
-        }
-
-        out
+        skip_closed: bool,
+    ) -> (soroban_sdk::Vec<CreditLineData>, Option<u32>) {
+        query::enumerate_credit_lines(env, cursor, limit, skip_closed)
     }
 
     pub fn suspend_credit_line(env: Env, borrower: Address) {

--- a/contracts/credit/src/query.rs
+++ b/contracts/credit/src/query.rs
@@ -1,8 +1,8 @@
-use crate::storage::grace_period_key;
+use crate::storage::{get_borrower_by_credit_line_id, grace_period_key, MAX_ENUMERATION_LIMIT};
 use crate::types::{
     CreditLineData, CreditStatus, GracePeriodConfig, ProtocolSummary, RepaymentSchedule,
 };
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Vec};
 
 /// Return the credit line for `borrower`, or `None` if no line exists.
 ///
@@ -209,4 +209,81 @@ pub fn is_delinquent(env: Env, borrower: Address) -> bool {
     let delinquent_after = schedule.next_due_ts.saturating_add(grace_seconds);
 
     env.ledger().timestamp() > delinquent_after
+}
+
+/// Cursor-based pagination over all credit lines.
+///
+/// Walks `CreditLineBorrowerById` starting at `cursor` (inclusive) and yields
+/// up to `limit` lines. Returns the collected lines together with a
+/// `next_cursor` that is `Some(id)` when more data remains, or `None` when the
+/// end of the enumeration space has been reached.
+///
+/// # Parameters
+///
+/// - `cursor`: Stable numeric id to start from (inclusive). Pass `0` for the
+///   first page.
+/// - `limit`: Maximum number of lines to return. Capped at
+///   `MAX_ENUMERATION_LIMIT` (100) regardless of the caller-supplied value.
+/// - `skip_closed`: When `true`, lines with `status == CreditStatus::Closed`
+///   are omitted from the result.
+///
+/// # Returns
+///
+/// A tuple `(lines, next_cursor)`:
+/// - `lines`: Soroban `Vec<CreditLineData>` for the current page.
+/// - `next_cursor`: `Some(id)` to fetch the next page, or `None` when this was
+///   the last page.
+///
+/// # Authentication
+///
+/// No authentication required. This is a pure read — it does not mutate any
+/// storage.
+///
+/// # Accrual note
+///
+/// Interest accrual is lazy. The returned `CreditLineData` reflects the last
+/// mutating call (draw, repay, suspend, etc.); pending interest since the last
+/// checkpoint is **not** applied by this query.
+pub fn enumerate_credit_lines(
+    env: Env,
+    cursor: u32,
+    limit: u32,
+    skip_closed: bool,
+) -> (Vec<CreditLineData>, Option<u32>) {
+    let count = crate::storage::get_credit_line_count(&env);
+    let capped_limit = limit.min(MAX_ENUMERATION_LIMIT);
+    let mut out: Vec<CreditLineData> = Vec::new(&env);
+
+    // Nothing to return: empty store, zero limit, or cursor past the end.
+    if capped_limit == 0 || count == 0 || cursor >= count {
+        return (out, None);
+    }
+
+    let mut next_id = cursor;
+    let mut returned = 0_u32;
+    while next_id < count && returned < capped_limit {
+        if let Some(borrower) = get_borrower_by_credit_line_id(&env, next_id) {
+            if let Some(line) = env
+                .storage()
+                .persistent()
+                .get::<Address, CreditLineData>(&borrower)
+            {
+                if !skip_closed || line.status != CreditStatus::Closed {
+                    out.push_back(line);
+                    returned = returned.saturating_add(1);
+                }
+            }
+        }
+        next_id = next_id.saturating_add(1);
+    }
+
+    // If we haven't exhausted the enumeration space, provide a cursor for the
+    // next page. Otherwise signal completion with `None`.
+    let next_cursor = if next_id < count {
+        Some(next_id)
+    } else {
+        None
+    };
+
+    (out, next_cursor)
 }

--- a/contracts/credit/tests/enumerate_credit_lines.rs
+++ b/contracts/credit/tests/enumerate_credit_lines.rs
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: MIT
 
-//! Tests for credit line enumeration with pagination.
+//! Tests for cursor-based pagination via `enumerate_credit_lines`.
+//!
+//! Acceptance criteria:
+//! - Cursor advances correctly
+//! - Limit is capped at `MAX_ENUMERATION_LIMIT` (100)
+//! - End-of-data returns `None` cursor
+//! - `skip_closed` filters out closed lines
 
 use creditra_credit::{Credit, CreditClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
 pub struct TestEnv {
     env: Env,
@@ -45,8 +51,9 @@ fn test_enumerate_empty_list() {
     let count = client.get_credit_line_count();
     assert_eq!(count, 0);
 
-    let lines = client.enumerate_credit_lines(&None, &10);
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &10, &false);
     assert_eq!(lines.len(), 0);
+    assert!(next_cursor.is_none());
 }
 
 #[test]
@@ -57,14 +64,12 @@ fn test_enumerate_single_credit_line() {
 
     test_env.open_credit_line(&borrower, 1000);
 
-    let count = client.get_credit_line_count();
-    assert_eq!(count, 1);
-
-    let lines = client.enumerate_credit_lines(&None, &10);
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &10, &false);
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines.get(0).unwrap().0, 0); // ID should be 0
-    assert_eq!(lines.get(0).unwrap().1.borrower, borrower);
-    assert_eq!(lines.get(0).unwrap().1.credit_limit, 1000);
+    assert!(next_cursor.is_none());
+
+    let line = lines.get(0).unwrap();
+    assert_eq!(line.credit_limit, 1000);
 }
 
 #[test]
@@ -79,101 +84,44 @@ fn test_enumerate_multiple_credit_lines() {
     test_env.open_credit_line(&borrower_b, 2000);
     test_env.open_credit_line(&borrower_c, 3000);
 
-    let count = client.get_credit_line_count();
-    assert_eq!(count, 3);
-
-    let lines = client.enumerate_credit_lines(&None, &10);
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &10, &false);
     assert_eq!(lines.len(), 3);
+    assert!(next_cursor.is_none());
 
     // Verify order (insertion order)
-    assert_eq!(lines.get(0).unwrap().0, 0);
-    assert_eq!(lines.get(0).unwrap().1.borrower, borrower_a);
-    assert_eq!(lines.get(0).unwrap().1.credit_limit, 1000);
-
-    assert_eq!(lines.get(1).unwrap().0, 1);
-    assert_eq!(lines.get(1).unwrap().1.borrower, borrower_b);
-    assert_eq!(lines.get(1).unwrap().1.credit_limit, 2000);
-
-    assert_eq!(lines.get(2).unwrap().0, 2);
-    assert_eq!(lines.get(2).unwrap().1.borrower, borrower_c);
-    assert_eq!(lines.get(2).unwrap().1.credit_limit, 3000);
+    assert_eq!(lines.get(0).unwrap().borrower, borrower_a);
+    assert_eq!(lines.get(0).unwrap().credit_limit, 1000);
+    assert_eq!(lines.get(1).unwrap().borrower, borrower_b);
+    assert_eq!(lines.get(1).unwrap().credit_limit, 2000);
+    assert_eq!(lines.get(2).unwrap().borrower, borrower_c);
+    assert_eq!(lines.get(2).unwrap().credit_limit, 3000);
 }
 
 #[test]
-fn test_enumerate_pagination_first_page() {
+fn test_enumerate_pagination_multiple_pages() {
     let test_env = TestEnv::new();
     let client = test_env.client();
 
     // Create 5 credit lines
-    let mut borrowers = Vec::new(&test_env.env);
     for _ in 0..5 {
-        borrowers.push_back(Address::generate(&test_env.env));
-    }
-
-    for i in 0..borrowers.len() {
-        let borrower = borrowers.get(i).unwrap();
+        let borrower = Address::generate(&test_env.env);
         test_env.open_credit_line(&borrower, 1000);
     }
 
-    // Get first 2
-    let page1 = client.enumerate_credit_lines(&None, &2);
+    // Page 1: cursor=0, limit=2 → expect 2 lines, next_cursor=Some(2)
+    let (page1, next1) = client.enumerate_credit_lines(&0, &2, &false);
     assert_eq!(page1.len(), 2);
-    assert_eq!(page1.get(0).unwrap().0, 0);
-    assert_eq!(page1.get(1).unwrap().0, 1);
-}
+    assert_eq!(next1, Some(2));
 
-#[test]
-fn test_enumerate_pagination_second_page() {
-    let test_env = TestEnv::new();
-    let client = test_env.client();
-
-    // Create 5 credit lines
-    let mut borrowers = Vec::new(&test_env.env);
-    for _ in 0..5 {
-        borrowers.push_back(Address::generate(&test_env.env));
-    }
-
-    for i in 0..borrowers.len() {
-        let borrower = borrowers.get(i).unwrap();
-        test_env.open_credit_line(&borrower, 1000);
-    }
-
-    // Get first page
-    let page1 = client.enumerate_credit_lines(&None, &2);
-    let last_id = page1.get(1).unwrap().0;
-
-    // Get second page using cursor
-    let page2 = client.enumerate_credit_lines(&Some(last_id), &2);
+    // Page 2: cursor=2, limit=2 → expect 2 lines, next_cursor=Some(4)
+    let (page2, next2) = client.enumerate_credit_lines(&next1.unwrap(), &2, &false);
     assert_eq!(page2.len(), 2);
-    assert_eq!(page2.get(0).unwrap().0, 2);
-    assert_eq!(page2.get(1).unwrap().0, 3);
-}
+    assert_eq!(next2, Some(4));
 
-#[test]
-fn test_enumerate_pagination_last_page_partial() {
-    let test_env = TestEnv::new();
-    let client = test_env.client();
-
-    // Create 5 credit lines
-    let mut borrowers = Vec::new(&test_env.env);
-    for _ in 0..5 {
-        borrowers.push_back(Address::generate(&test_env.env));
-    }
-
-    for i in 0..borrowers.len() {
-        let borrower = borrowers.get(i).unwrap();
-        test_env.open_credit_line(&borrower, 1000);
-    }
-
-    // Get pages of 2
-    let page1 = client.enumerate_credit_lines(&None, &2);
-    let page2 = client.enumerate_credit_lines(&Some(1), &2);
-    let page3 = client.enumerate_credit_lines(&Some(3), &2);
-
-    assert_eq!(page1.len(), 2);
-    assert_eq!(page2.len(), 2);
-    assert_eq!(page3.len(), 1); // Only one remaining
-    assert_eq!(page3.get(0).unwrap().0, 4);
+    // Page 3: cursor=4, limit=2 → expect 1 line, next_cursor=None
+    let (page3, next3) = client.enumerate_credit_lines(&next2.unwrap(), &2, &false);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(next3, None);
 }
 
 #[test]
@@ -181,16 +129,16 @@ fn test_enumerate_limit_capped_at_max() {
     let test_env = TestEnv::new();
     let client = test_env.client();
 
-    // Create 10 credit lines
-    for _ in 0..10 {
+    // Create 150 credit lines
+    for _ in 0..150 {
         let borrower = Address::generate(&test_env.env);
         test_env.open_credit_line(&borrower, 1000);
     }
 
-    // Request more than MAX_ENUMERATION_LIMIT (100)
-    // Should be capped
-    let lines = client.enumerate_credit_lines(&None, &200);
-    assert_eq!(lines.len(), 10); // Only 10 exist, so we get all 10
+    // Request limit > MAX_ENUMERATION_LIMIT (100) → capped to 100
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &200, &false);
+    assert_eq!(lines.len(), 100);
+    assert!(next_cursor.is_some());
 }
 
 #[test]
@@ -198,7 +146,6 @@ fn test_enumerate_deterministic_ordering() {
     let test_env = TestEnv::new();
     let client = test_env.client();
 
-    // Create credit lines in specific order
     let b1 = Address::generate(&test_env.env);
     let b2 = Address::generate(&test_env.env);
     let b3 = Address::generate(&test_env.env);
@@ -208,16 +155,17 @@ fn test_enumerate_deterministic_ordering() {
     test_env.open_credit_line(&b3, 3000);
 
     // Enumerate multiple times - should always return same order
-    let lines1 = client.enumerate_credit_lines(&None, &10);
-    let lines2 = client.enumerate_credit_lines(&None, &10);
-    let lines3 = client.enumerate_credit_lines(&None, &10);
+    let (lines1, _) = client.enumerate_credit_lines(&0, &10, &false);
+    let (lines2, _) = client.enumerate_credit_lines(&0, &10, &false);
+    let (lines3, _) = client.enumerate_credit_lines(&0, &10, &false);
 
+    assert_eq!(lines1.len(), 3);
     assert_eq!(lines1, lines2);
     assert_eq!(lines2, lines3);
 }
 
 #[test]
-fn test_enumerate_start_after_beyond_end() {
+fn test_enumerate_cursor_beyond_end() {
     let test_env = TestEnv::new();
     let client = test_env.client();
 
@@ -227,9 +175,10 @@ fn test_enumerate_start_after_beyond_end() {
         test_env.open_credit_line(&borrower, 1000);
     }
 
-    // Start after the last ID
-    let lines = client.enumerate_credit_lines(&Some(100), &10);
+    // Cursor beyond the last id → empty result, no next cursor
+    let (lines, next_cursor) = client.enumerate_credit_lines(&100, &10, &false);
     assert_eq!(lines.len(), 0);
+    assert!(next_cursor.is_none());
 }
 
 #[test]
@@ -237,16 +186,12 @@ fn test_enumerate_public_access() {
     let test_env = TestEnv::new();
     let client = test_env.client();
 
-    // Create a credit line
     let borrower = Address::generate(&test_env.env);
     test_env.open_credit_line(&borrower, 1000);
 
     // Anyone should be able to enumerate (no auth required for view functions)
-    let lines = client.enumerate_credit_lines(&None, &10);
+    let (lines, _) = client.enumerate_credit_lines(&0, &10, &false);
     assert_eq!(lines.len(), 1);
-
-    let count = client.get_credit_line_count();
-    assert_eq!(count, 1);
 }
 
 #[test]
@@ -254,19 +199,19 @@ fn test_enumerate_with_draws_and_repays() {
     let test_env = TestEnv::new();
     let client = test_env.client();
 
-    // Set up token for draws/repays
     let token_id = test_env
         .env
         .register_stellar_asset_contract_v2(Address::generate(&test_env.env));
     let token_address = token_id.address();
     client.set_liquidity_token(&token_address);
+    client.set_liquidity_source(&test_env.contract_id);
+    client.set_min_collateral_ratio_bps(&0);
     soroban_sdk::token::StellarAssetClient::new(&test_env.env, &token_address)
         .mint(&test_env.contract_id, &10000);
 
     let borrower = Address::generate(&test_env.env);
     test_env.open_credit_line(&borrower, 5000);
 
-    // Draw and repay shouldn't affect enumeration
     client.draw_credit(&borrower, &1000);
     soroban_sdk::token::Client::new(&test_env.env, &token_address).approve(
         &borrower,
@@ -276,7 +221,149 @@ fn test_enumerate_with_draws_and_repays() {
     );
     client.repay_credit(&borrower, &500);
 
-    let lines = client.enumerate_credit_lines(&None, &10);
+    let (lines, _) = client.enumerate_credit_lines(&0, &10, &false);
     assert_eq!(lines.len(), 1);
-    assert_eq!(lines.get(0).unwrap().1.utilized_amount, 500);
+    assert_eq!(lines.get(0).unwrap().utilized_amount, 500);
+}
+
+#[test]
+fn test_enumerate_skip_closed() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+    let admin = test_env.admin.clone();
+
+    let b1 = Address::generate(&test_env.env);
+    let b2 = Address::generate(&test_env.env);
+    let b3 = Address::generate(&test_env.env);
+
+    test_env.open_credit_line(&b1, 1000);
+    test_env.open_credit_line(&b2, 2000);
+    test_env.open_credit_line(&b3, 3000);
+
+    // Close b2
+    client.close_credit_line(&b2, &admin);
+
+    // Without skip_closed → all 3 lines returned
+    let (all_lines, _) = client.enumerate_credit_lines(&0, &10, &false);
+    assert_eq!(all_lines.len(), 3);
+
+    // With skip_closed → 2 lines (b2 omitted)
+    let (open_lines, _) = client.enumerate_credit_lines(&0, &10, &true);
+    assert_eq!(open_lines.len(), 2);
+    // Verify b2 is not in the result
+    for i in 0..open_lines.len() {
+        assert_ne!(open_lines.get(i).unwrap().borrower, b2);
+    }
+}
+
+#[test]
+fn test_enumerate_zero_limit() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+
+    let borrower = Address::generate(&test_env.env);
+    test_env.open_credit_line(&borrower, 1000);
+
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &0, &false);
+    assert_eq!(lines.len(), 0);
+    assert!(next_cursor.is_none());
+}
+
+#[test]
+fn test_enumerate_cursor_exact_end() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+
+    for _ in 0..3 {
+        let borrower = Address::generate(&test_env.env);
+        test_env.open_credit_line(&borrower, 1000);
+    }
+
+    // Cursor at count (= end) → empty
+    let (lines, next_cursor) = client.enumerate_credit_lines(&3, &10, &false);
+    assert_eq!(lines.len(), 0);
+    assert!(next_cursor.is_none());
+}
+
+#[test]
+fn test_enumerate_cursor_exact_last_item() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+
+    for _ in 0..3 {
+        let borrower = Address::generate(&test_env.env);
+        test_env.open_credit_line(&borrower, 1000);
+    }
+
+    // Cursor at id=2 (last item), limit=1 → returns 1 line, next_cursor=None
+    let (lines, next_cursor) = client.enumerate_credit_lines(&2, &1, &false);
+    assert_eq!(lines.len(), 1);
+    assert!(next_cursor.is_none());
+}
+
+#[test]
+fn test_enumerate_reaches_end_exactly() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+
+    for _ in 0..4 {
+        let borrower = Address::generate(&test_env.env);
+        test_env.open_credit_line(&borrower, 1000);
+    }
+
+    // Walk exactly to the end with page size 2
+    let (page1, next1) = client.enumerate_credit_lines(&0, &2, &false);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(next1, Some(2));
+
+    let (page2, next2) = client.enumerate_credit_lines(&next1.unwrap(), &2, &false);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(next2, None);
+}
+
+#[test]
+fn test_enumerate_skip_closed_all_closed() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+    let admin = test_env.admin.clone();
+
+    let b1 = Address::generate(&test_env.env);
+    let b2 = Address::generate(&test_env.env);
+
+    test_env.open_credit_line(&b1, 1000);
+    test_env.open_credit_line(&b2, 2000);
+
+    client.close_credit_line(&b1, &admin);
+    client.close_credit_line(&b2, &admin);
+
+    // All closed, skip_closed=true → empty
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &10, &true);
+    assert_eq!(lines.len(), 0);
+    assert!(next_cursor.is_none());
+}
+
+#[test]
+fn test_enumerate_skip_closed_cursor_advances_past_closed() {
+    let test_env = TestEnv::new();
+    let client = test_env.client();
+    let admin = test_env.admin.clone();
+
+    let b1 = Address::generate(&test_env.env);
+    let b2 = Address::generate(&test_env.env);
+    let b3 = Address::generate(&test_env.env);
+
+    test_env.open_credit_line(&b1, 1000);
+    test_env.open_credit_line(&b2, 2000);
+    test_env.open_credit_line(&b3, 3000);
+
+    // Close middle line
+    client.close_credit_line(&b2, &admin);
+
+    // skip_closed with limit=2 should skip b2 and return b1, b3
+    let (lines, next_cursor) = client.enumerate_credit_lines(&0, &2, &true);
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines.get(0).unwrap().borrower, b1);
+    assert_eq!(lines.get(1).unwrap().borrower, b3);
+    // next_cursor should be past b2 and b3
+    assert!(next_cursor.is_none());
 }

--- a/contracts/credit/tests/invariant_accrued_le_utilized.rs
+++ b/contracts/credit/tests/invariant_accrued_le_utilized.rs
@@ -126,14 +126,14 @@ fn setup_env() -> (Env, CreditClient<'static>, Address, Vec<Address>) {
 /// This is the single invariant under test. Any violation indicates that the
 /// capitalization arithmetic has produced an inconsistent state.
 fn assert_accrued_le_utilized(client: &CreditClient<'_>, step_label: &str) {
-    let mut cursor = None;
+    let mut cursor = 0_u32;
     loop {
-        let page = client.enumerate_credit_lines(&cursor, &8);
-        if page.is_empty() {
+        let (lines, next_cursor) = client.enumerate_credit_lines(&cursor, &8, &false);
+        if lines.is_empty() {
             break;
         }
-        for item in page.iter() {
-            let (id, line) = item;
+        for i in 0..lines.len() {
+            let line = lines.get(i).unwrap();
             assert!(
                 line.accrued_interest >= 0,
                 "{step_label}: accrued_interest is negative ({}) for borrower {:?}",
@@ -147,7 +147,10 @@ fn assert_accrued_le_utilized(client: &CreditClient<'_>, step_label: &str) {
                 line.utilized_amount,
                 line.borrower,
             );
-            cursor = Some(id);
+        }
+        match next_cursor {
+            Some(c) => cursor = c,
+            None => break,
         }
     }
 }

--- a/contracts/credit/tests/open_reopen_id_stable.rs
+++ b/contracts/credit/tests/open_reopen_id_stable.rs
@@ -17,19 +17,6 @@ fn setup(env: &Env) -> (CreditClient<'_>, Address) {
     (client, admin)
 }
 
-fn credit_line_id_for(client: &CreditClient<'_>, borrower: &Address) -> u32 {
-    let lines = client.enumerate_credit_lines(&None, &10);
-
-    for index in 0..lines.len() {
-        let (id, line) = lines.get(index).unwrap();
-        if line.borrower == *borrower {
-            return id;
-        }
-    }
-
-    panic!("borrower must have an enumerated credit line id");
-}
-
 fn assert_last_event_topic(env: &Env, expected: Symbol) {
     let events = env.events().all();
     let (_contract_id, topics, _data) = events.last().unwrap();
@@ -39,6 +26,29 @@ fn assert_last_event_topic(env: &Env, expected: Symbol) {
 
     assert_eq!(namespace, symbol_short!("credit"));
     assert_eq!(event_name, expected);
+}
+
+fn find_borrower_index(client: &CreditClient<'_>, target: &Address) -> usize {
+    let mut cursor = 0_u32;
+    let mut idx = 0_usize;
+    loop {
+        let (lines, next_cursor) = client.enumerate_credit_lines(&cursor, &10, &false);
+        if lines.is_empty() {
+            break;
+        }
+        for i in 0..lines.len() {
+            let line = lines.get(i).unwrap();
+            if line.borrower == *target {
+                return idx;
+            }
+            idx += 1;
+        }
+        match next_cursor {
+            Some(c) => cursor = c,
+            None => break,
+        }
+    }
+    panic!("borrower not found");
 }
 
 #[test]
@@ -55,13 +65,10 @@ fn reopen_closed_line_reuses_existing_nonzero_id() {
     client.open_credit_line(&borrower, &1_000_i128, &350_u32, &60_u32);
     assert_last_event_topic(&env, symbol_short!("opened"));
 
-    let original_id = credit_line_id_for(&client, &borrower);
     let original_count = client.get_credit_line_count();
-    assert_eq!(
-        original_id, 1,
-        "target borrower should exercise non-zero id path"
-    );
     assert_eq!(original_count, 2);
+    // The borrower is the second line opened → index 1
+    assert_eq!(find_borrower_index(&client, &borrower), 1);
 
     client.close_credit_line(&borrower, &admin);
     assert_last_event_topic(&env, symbol_short!("closed"));
@@ -73,6 +80,8 @@ fn reopen_closed_line_reuses_existing_nonzero_id() {
     let reopened = client.get_credit_line(&borrower).unwrap();
     assert_eq!(reopened.status, CreditStatus::Active);
     assert_eq!(reopened.credit_limit, 2_000);
+    // Count unchanged → ID reused (no new ID allocated)
     assert_eq!(client.get_credit_line_count(), original_count);
-    assert_eq!(credit_line_id_for(&client, &borrower), original_id);
+    // Borrower is still at index 1 in enumeration
+    assert_eq!(find_borrower_index(&client, &borrower), 1);
 }

--- a/contracts/credit/tests/proptest_accrual.rs
+++ b/contracts/credit/tests/proptest_accrual.rs
@@ -79,14 +79,14 @@ fn setup_env() -> (Env, CreditClient<'static>, std::vec::Vec<Address>) {
 
 /// Assert `0 <= accrued_interest <= utilized_amount` for every active line.
 fn assert_accrued_le_utilized(client: &CreditClient<'_>, label: &str) {
-    let mut cursor = None;
+    let mut cursor = 0_u32;
     loop {
-        let page = client.enumerate_credit_lines(&cursor, &8);
-        if page.is_empty() {
+        let (lines, next_cursor) = client.enumerate_credit_lines(&cursor, &8, &false);
+        if lines.is_empty() {
             break;
         }
-        for item in page.iter() {
-            let (_, line) = item;
+        for i in 0..lines.len() {
+            let line = lines.get(i).unwrap();
             assert!(
                 line.accrued_interest >= 0,
                 "{label}: accrued_interest is negative ({}) for borrower {:?}",
@@ -100,6 +100,10 @@ fn assert_accrued_le_utilized(client: &CreditClient<'_>, label: &str) {
                 line.utilized_amount,
                 line.borrower,
             );
+        }
+        match next_cursor {
+            Some(c) => cursor = c,
+            None => break,
         }
     }
 }

--- a/contracts/credit/tests/total_utilized_invariant.rs
+++ b/contracts/credit/tests/total_utilized_invariant.rs
@@ -140,22 +140,26 @@ fn setup_env() -> (Env, CreditClient<'static>, Address, Vec<Address>) {
 }
 
 fn assert_total_utilized_invariant(client: &CreditClient<'_>) {
-    let mut cursor = None;
+    let mut cursor = 0_u32;
     let mut enumerated = 0_u32;
     let mut recomputed_total = 0_i128;
     let expected_count = client.get_credit_line_count();
 
     loop {
-        let page = client.enumerate_credit_lines(&cursor, &PAGE_SIZE);
-        if page.is_empty() {
+        let (lines, next_cursor) = client.enumerate_credit_lines(&cursor, &PAGE_SIZE, &false);
+        if lines.is_empty() {
             break;
         }
+        enumerated += lines.len();
 
-        for item in page.iter() {
-            let (id, line) = item;
-            enumerated += 1;
+        for i in 0..lines.len() {
+            let line = lines.get(i).unwrap();
             recomputed_total += line.utilized_amount;
-            cursor = Some(id);
+        }
+
+        match next_cursor {
+            Some(c) => cursor = c,
+            None => break,
         }
     }
 

--- a/contracts/freeze/Cargo.toml
+++ b/contracts/freeze/Cargo.toml
@@ -3,20 +3,6 @@ name = "creditra-freeze"
 version = "0.1.0"
 edition = "2021"
 description = "Creditra freeze Soroban smart contract"
-
-[lib]
-crate-type = ["cdylib", "rlib"]
-
-[dependencies]
-soroban-sdk = { workspace = true }
-
-[dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
-[package]
-name = "creditra-freeze"
-version = "0.1.0"
-edition = "2021"
-description = "Creditra freeze auth-boundary integration tests"
 license = "MIT"
 keywords = ["soroban", "stellar", "freeze", "credit", "smart-contract"]
 categories = ["cryptography::cryptocurrencies", "finance", "no-std"]


### PR DESCRIPTION
Implement cursor-based pagination for `enumerate_credit_lines`, replacing the old offset-based API.

### Changes
- **API signature**: `enumerate_credit_lines(cursor: u32, limit: u32, skip_closed: bool) -> (Vec<CreditLineData>, Option<u32>)`
  - `cursor`: zero-based index to start from (was `Option<u32>` start_after)
  - `skip_closed`: if true, closed credit lines are filtered out
  - Returns: tuple of (lines, next_cursor) where next_cursor is `Some` if more data exists
- **Limit**: capped at `MAX_ENUMERATION_LIMIT` (100)
- **Tests**: 16 comprehensive cases (empty, single, multiple, pagination, limit cap, determinism, cursor edge cases, skip_closed, draws/repays)
- **All callers**: 6 test files updated to new API
- **Bug fixes**: duplicate `members` key in workspace Cargo.toml and duplicate `[package]` in freeze contract

Closes #501